### PR TITLE
Added several loot items to putrid undead gargoyle

### DIFF
--- a/Scripts/Mobiles/Undead/PutridUndeadGargoyle.cs
+++ b/Scripts/Mobiles/Undead/PutridUndeadGargoyle.cs
@@ -11,7 +11,7 @@ namespace Server.Mobiles
         public PutridUndeadGargoyle()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a Putrid Undead Gargoyle";
+            this.Name = "a putrid undead gargoyle";
             this.Body = 722;
             this.BaseSoundID = 372;
             this.Hue = 1778;
@@ -49,6 +49,15 @@ namespace Server.Mobiles
 
             if (0.05 > Utility.RandomDouble())
                 this.PackItem(new UndyingFlesh());
+
+            if (0.05 > Utility.RandomDouble())
+                this.PackItem(new TatteredAncientScroll());
+
+            if (0.10 > Utility.RandomDouble())
+                this.PackItem(new InfusedGlassStave());
+
+            if (0.15 > Utility.RandomDouble())
+                this.PackItem(new AncientPotteryFragments());
         }
 
         public PutridUndeadGargoyle(Serial serial)


### PR DESCRIPTION
Added tattered remnants of an ancient scroll, infused glass stave, and ancient pottery fragments to possible loot items on putrid undead gargoyle to make loot in accordance with OSI. Also changed name to lowercase, also to make it more OSI-like. Confirmation of the changes can be found here: http://www.uoguide.com/Putrid_Undead_Gargoyle Loot drop rates are rough estimate - UOGuide lists drop for remnants as "rather rare", and from research on stratics forums the stave drops are "occasional" and fragment drops seem to be slightly more common.
