### PR TITLE
Fixed Spelling Mistake in Mobile.cs

### DIFF
--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -5371,7 +5371,7 @@ namespace Server
 			return null;
 		}
 
-		public Mobile FindMostTotalDamger(bool allowSelf)
+		public Mobile FindMostTotalDamager(bool allowSelf)
 		{
 			return GetDamagerFrom(FindMostTotalDamageEntry(allowSelf));
 		}
@@ -5402,7 +5402,7 @@ namespace Server
 			return mostTotal;
 		}
 
-		public Mobile FindLeastTotalDamger(bool allowSelf)
+		public Mobile FindLeastTotalDamager(bool allowSelf)
 		{
 			return GetDamagerFrom(FindLeastTotalDamageEntry(allowSelf));
 		}


### PR DESCRIPTION
FindMostTotalDamger -> FindMostTotalDamager
FindLeastTotalDamger -> FindLeastTotalDamager

No mentions of either in code so will work fine. Will require recompile of core.