### PR TITLE
Healing Changes

### DIFF
--- a/Scripts/Items/Skill Items/Misc/Bandage.cs
+++ b/Scripts/Items/Skill Items/Misc/Bandage.cs
@@ -543,7 +543,7 @@ namespace Server.Items
 			return BeginHeal(healer, patient, false);
 		}
 
-		public static BandageContext BeginHeal(Mobile healer, Mobile patient, bool enhanced)
+		public static BandageContext BeginHeal(Mobile healer, Mobile patient, bool enhanced) // TODO: Implement Pub 71 healing changes
 		{
 			bool isDeadPet = (patient is BaseCreature && ((BaseCreature)patient).IsDeadPet);
 
@@ -578,6 +578,11 @@ namespace Server.Items
 					if (Core.AOS)
 					{
 						seconds = 5.0 + (0.5 * ((double)(120 - dex) / 10)); // TODO: Verify algorithm
+
+						if (seconds > 8.0)
+						{
+							seconds = 8.0;
+						}
 					}
 					else
 					{

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -2504,11 +2504,11 @@ namespace Server.Mobiles
 			}
 			else if (from != null && from.Player)
 			{
-				disruptThreshold = 18;
+				disruptThreshold = 19;
 			}
 			else
 			{
-				disruptThreshold = 25;
+				disruptThreshold = 26;
 			}
 
 			if (amount > disruptThreshold)


### PR DESCRIPTION
--Updated interruption damage thresholds to reflect OSI values
--Bandage healing delay is now capped at 8 seconds per OSI
--TODO: Implement Publish 71 healing changes : per OSI healing should check halfway through the timer for bleeds/poisons and attempt to cure them. Full details in link below.
--Info verification: http://www.uoguide.com/Healing and http://www.uoguide.com/Publish_71