### PR TITLE
Gargoyles pickaxe hue fix

### DIFF
--- a/Scripts/Items/Skill Items/Harvest Tools/GargoylesPickaxe.cs
+++ b/Scripts/Items/Skill Items/Harvest Tools/GargoylesPickaxe.cs
@@ -151,8 +151,11 @@ namespace Server.Items
 
             int version = reader.ReadInt();
 			
-            if (this.Hue == 0x973)
+            if (this.Hue == 0x973 ||
+                this.Hue == 0)
+            {
                 this.Hue = 0x76c;
+            }
         }
     }
 }

--- a/Scripts/Items/Skill Items/Harvest Tools/GargoylesPickaxe.cs
+++ b/Scripts/Items/Skill Items/Harvest Tools/GargoylesPickaxe.cs
@@ -18,6 +18,7 @@ namespace Server.Items
             this.Weight = 11.0;
             this.UsesRemaining = uses;
             this.ShowUsesRemaining = true;
+		 this.Hue = 0x76c;
         }
 
         public GargoylesPickaxe(Serial serial)
@@ -151,7 +152,7 @@ namespace Server.Items
             int version = reader.ReadInt();
 			
             if (this.Hue == 0x973)
-                this.Hue = 0x0;
+                this.Hue = 0x76c;
         }
     }
 }


### PR DESCRIPTION
Creates Gargoyles Pickaxes with the correct hue, and corrects the hue of any previously created pickaxes on load. Fixes #187