### PR TITLE
Fixed casting errors in LightningStrike.cs

### DIFF
--- a/Scripts/Spells/Bushido/LightningStrike.cs
+++ b/Scripts/Spells/Bushido/LightningStrike.cs
@@ -54,8 +54,11 @@ namespace Server.Spells.Bushido
             bool isValid = base.Validate(from);
             if (isValid)
             {
-                PlayerMobile ThePlayer = from as PlayerMobile;
-                ThePlayer.ExecutesLightningStrike = this.BaseMana;
+                var ThePlayer = from as PlayerMobile;
+                if(ThePlayer != null)
+                {
+                    ThePlayer.ExecutesLightningStrike = this.BaseMana;
+                }
             }
             return isValid;
         }
@@ -90,8 +93,11 @@ namespace Server.Spells.Bushido
 
         public override void OnClearMove(Mobile attacker)
         {
-            PlayerMobile ThePlayer = attacker as PlayerMobile; // this can be deletet if the PlayerMobile parts are moved to Server.Mobile 
-            ThePlayer.ExecutesLightningStrike = 0;
+            var ThePlayer = attacker as PlayerMobile; // this can be deletet if the PlayerMobile parts are moved to Server.Mobile 
+            if(ThePlayer != null)
+            {
+                ThePlayer.ExecutesLightningStrike = 0;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #181. Verified by using the same recreation procedure in the issue. Was able to see the lightning strike graphics and no crashes.