### PR TITLE
Fame titles on makers mark

### DIFF
--- a/Scripts/Items/- BaseClasses/BaseArmor.cs
+++ b/Scripts/Items/- BaseClasses/BaseArmor.cs
@@ -2438,7 +2438,7 @@ namespace Server.Items
             #endregion
 
             if (this.m_Crafter != null)
-				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 
             #region Factions
             if (this.m_FactionState != null)

--- a/Scripts/Items/- BaseClasses/BaseArmor.cs
+++ b/Scripts/Items/- BaseClasses/BaseArmor.cs
@@ -5,6 +5,7 @@ using Server.Engines.Craft;
 using Server.Engines.XmlSpawner2;
 using Server.Factions;
 using Server.Network;
+using Server.Mobiles;
 using AMA = Server.Items.ArmorMeditationAllowance;
 using AMT = Server.Items.ArmorMaterialType;
 
@@ -2437,7 +2438,7 @@ namespace Server.Items
             #endregion
 
             if (this.m_Crafter != null)
-                list.Add(1050043, this.m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
 
             #region Factions
             if (this.m_FactionState != null)

--- a/Scripts/Items/- BaseClasses/BaseClothing.cs
+++ b/Scripts/Items/- BaseClasses/BaseClothing.cs
@@ -4,6 +4,7 @@ using Server.ContextMenus;
 using Server.Engines.Craft;
 using Server.Factions;
 using Server.Network;
+using Server.Mobiles;
 
 namespace Server.Items
 {
@@ -1064,7 +1065,7 @@ namespace Server.Items
             #endregion
 			
             if (this.m_Crafter != null)
-                list.Add(1050043, this.m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
 
             #region Factions
             if (this.m_FactionState != null)

--- a/Scripts/Items/- BaseClasses/BaseClothing.cs
+++ b/Scripts/Items/- BaseClasses/BaseClothing.cs
@@ -1065,7 +1065,7 @@ namespace Server.Items
             #endregion
 			
             if (this.m_Crafter != null)
-				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 
             #region Factions
             if (this.m_FactionState != null)

--- a/Scripts/Items/- BaseClasses/BaseHarvestTool.cs
+++ b/Scripts/Items/- BaseClasses/BaseHarvestTool.cs
@@ -131,7 +131,7 @@ namespace Server.Items
 
 			if (m_Crafter != null)
 			{
-				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				LabelTo(from, 1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 			}
         }
 

--- a/Scripts/Items/- BaseClasses/BaseHarvestTool.cs
+++ b/Scripts/Items/- BaseClasses/BaseHarvestTool.cs
@@ -112,10 +112,6 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            // Makers mark not displayed on OSI
-            //if ( m_Crafter != null )
-            //	list.Add( 1050043, m_Crafter.Name ); // crafted by ~1_NAME~
-
             if (this.m_Quality == ToolQuality.Exceptional)
                 list.Add(1060636); // exceptional
 
@@ -132,6 +128,11 @@ namespace Server.Items
             this.DisplayDurabilityTo(from);
 
             base.OnSingleClick(from);
+
+			if (m_Crafter != null)
+			{
+				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+			}
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Scripts/Items/- BaseClasses/BaseInstrument.cs
+++ b/Scripts/Items/- BaseClasses/BaseInstrument.cs
@@ -422,7 +422,7 @@ namespace Server.Items
             base.GetProperties(list);
 
             if (this.m_Crafter != null)
-                list.Add(1050043, this.m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
 
             if (this.m_Quality == InstrumentQuality.Exceptional)
                 list.Add(1060636); // exceptional

--- a/Scripts/Items/- BaseClasses/BaseInstrument.cs
+++ b/Scripts/Items/- BaseClasses/BaseInstrument.cs
@@ -422,7 +422,7 @@ namespace Server.Items
             base.GetProperties(list);
 
             if (this.m_Crafter != null)
-				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 
             if (this.m_Quality == InstrumentQuality.Exceptional)
                 list.Add(1060636); // exceptional

--- a/Scripts/Items/- BaseClasses/BaseJewel.cs
+++ b/Scripts/Items/- BaseClasses/BaseJewel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Server.ContextMenus;
 using Server.Engines.Craft;
+using Server.Mobiles;
 
 namespace Server.Items
 {
@@ -635,7 +636,7 @@ namespace Server.Items
                 list.Add(1063341); // exceptional
 
             if (this.m_Crafter != null)
-                list.Add(1050043, this.m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
             #endregion
 
             #region Mondain's Legacy Sets
@@ -793,6 +794,16 @@ namespace Server.Items
                 list.Add(1060639, "{0}\t{1}", this.m_HitPoints, this.m_MaxHitPoints); // durability ~1_val~ / ~2_val~
         }
 
+		public override void OnSingleClick(Mobile from)
+		{
+			base.OnSingleClick(from);
+
+			if (m_Crafter != null)
+			{
+				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+			}
+		}
+        
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/- BaseClasses/BaseJewel.cs
+++ b/Scripts/Items/- BaseClasses/BaseJewel.cs
@@ -636,7 +636,7 @@ namespace Server.Items
                 list.Add(1063341); // exceptional
 
             if (this.m_Crafter != null)
-				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
             #endregion
 
             #region Mondain's Legacy Sets
@@ -800,7 +800,7 @@ namespace Server.Items
 
 			if (m_Crafter != null)
 			{
-				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				LabelTo(from, 1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 			}
 		}
         

--- a/Scripts/Items/- BaseClasses/BaseQuiver.cs
+++ b/Scripts/Items/- BaseClasses/BaseQuiver.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Engines.Craft;
+using Server.Mobiles;
 
 namespace Server.Items
 {
@@ -399,7 +400,7 @@ namespace Server.Items
             base.GetProperties(list);
 				
             if (this.m_Crafter != null)
-                list.Add(1050043, this.m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
 
             if (this.m_Quality == ClothingQuality.Exceptional)
                 list.Add(1063341); // exceptional
@@ -550,7 +551,16 @@ namespace Server.Items
             }
             #endregion
         }
-		
+		public override void OnSingleClick(Mobile from)
+		{
+			base.OnSingleClick(from);
+
+			if (m_Crafter != null)
+			{
+				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+			}
+		}
+        
         private static void SetSaveFlag(ref SaveFlag flags, SaveFlag toSet, bool setIf)
         {
             if (setIf)

--- a/Scripts/Items/- BaseClasses/BaseQuiver.cs
+++ b/Scripts/Items/- BaseClasses/BaseQuiver.cs
@@ -400,7 +400,7 @@ namespace Server.Items
             base.GetProperties(list);
 				
             if (this.m_Crafter != null)
-				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 
             if (this.m_Quality == ClothingQuality.Exceptional)
                 list.Add(1063341); // exceptional
@@ -557,7 +557,7 @@ namespace Server.Items
 
 			if (m_Crafter != null)
 			{
-				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				LabelTo(from, 1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 			}
 		}
         

--- a/Scripts/Items/- BaseClasses/BaseTool.cs
+++ b/Scripts/Items/- BaseClasses/BaseTool.cs
@@ -151,11 +151,6 @@ namespace Server.Items
             this.DisplayDurabilityTo(from);
 
             base.OnSingleClick(from);
-
-			if (m_Crafter != null)
-			{
-				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
-			}
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Scripts/Items/- BaseClasses/BaseTool.cs
+++ b/Scripts/Items/- BaseClasses/BaseTool.cs
@@ -1,6 +1,7 @@
 using System;
 using Server.Engines.Craft;
 using Server.Network;
+using Server.Mobiles;
 
 namespace Server.Items
 {
@@ -114,10 +115,6 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            // Makers mark not displayed on OSI
-            //if ( m_Crafter != null )
-            //	list.Add( 1050043, m_Crafter.Name ); // crafted by ~1_NAME~
-
             if (this.m_Quality == ToolQuality.Exceptional)
                 list.Add(1060636); // exceptional
 
@@ -154,6 +151,11 @@ namespace Server.Items
             this.DisplayDurabilityTo(from);
 
             base.OnSingleClick(from);
+
+			if (m_Crafter != null)
+			{
+				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+			}
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Scripts/Items/- BaseClasses/BaseWeapon.cs
+++ b/Scripts/Items/- BaseClasses/BaseWeapon.cs
@@ -4709,7 +4709,7 @@ namespace Server.Items
 
 			if (m_Crafter != null)
 			{
-				list.Add(1050043, m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
 			}
 
 			#region Factions

--- a/Scripts/Items/- BaseClasses/BaseWeapon.cs
+++ b/Scripts/Items/- BaseClasses/BaseWeapon.cs
@@ -4709,7 +4709,7 @@ namespace Server.Items
 
 			if (m_Crafter != null)
 			{
-				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 			}
 
 			#region Factions

--- a/Scripts/Items/Construction/Chairs/Benchs.cs
+++ b/Scripts/Items/Construction/Chairs/Benchs.cs
@@ -1,10 +1,11 @@
 using System;
 
+
 namespace Server.Items
 {
     [Furniture]
     [Flipable(0xB2D, 0xB2C)]
-    public class WoodenBench : Item
+    public class WoodenBench : CraftableFurniture
     {
         [Constructable]
         public WoodenBench()

--- a/Scripts/Items/Construction/Chairs/Chairs.cs
+++ b/Scripts/Items/Construction/Chairs/Chairs.cs
@@ -4,7 +4,7 @@ namespace Server.Items
 {
     [Furniture]
     [Flipable(0xB4F, 0xB4E, 0xB50, 0xB51)]
-    public class FancyWoodenChairCushion : Item
+    public class FancyWoodenChairCushion : CraftableFurniture
     {
         [Constructable]
         public FancyWoodenChairCushion()
@@ -38,7 +38,7 @@ namespace Server.Items
 
     [Furniture]
     [Flipable(0xB53, 0xB52, 0xB54, 0xB55)]
-    public class WoodenChairCushion : Item
+    public class WoodenChairCushion : CraftableFurniture
     {
         [Constructable]
         public WoodenChairCushion()
@@ -72,7 +72,7 @@ namespace Server.Items
 
     [Furniture]
     [Flipable(0xB57, 0xB56, 0xB59, 0xB58)]
-    public class WoodenChair : Item
+    public class WoodenChair : CraftableFurniture
     {
         [Constructable]
         public WoodenChair()
@@ -106,7 +106,7 @@ namespace Server.Items
 
     [Furniture]
     [Flipable(0xB5B, 0xB5A, 0xB5C, 0xB5D)]
-    public class BambooChair : Item
+    public class BambooChair : CraftableFurniture
     {
         [Constructable]
         public BambooChair()
@@ -171,7 +171,7 @@ namespace Server.Items
 
     [DynamicFliping]
     [Flipable(0x2DE3, 0x2DE4, 0x2DE5, 0x2DE6)]
-    public class OrnateElvenChair : Item
+    public class OrnateElvenChair : CraftableFurniture
     {
         [Constructable]
         public OrnateElvenChair()
@@ -202,7 +202,7 @@ namespace Server.Items
 
     [DynamicFliping]
     [Flipable(0x2DEB, 0x2DEC, 0x2DED, 0x2DEE)]
-    public class BigElvenChair : Item
+    public class BigElvenChair : CraftableFurniture
     {
         [Constructable]
         public BigElvenChair()
@@ -232,7 +232,7 @@ namespace Server.Items
 
     [DynamicFliping]
     [Flipable(0x2DF5, 0x2DF6)]
-    public class ElvenReadingChair : Item
+    public class ElvenReadingChair : CraftableFurniture
     {
         [Constructable]
         public ElvenReadingChair()

--- a/Scripts/Items/Construction/Chairs/Stools.cs
+++ b/Scripts/Items/Construction/Chairs/Stools.cs
@@ -3,7 +3,7 @@ using System;
 namespace Server.Items
 {
     [Furniture]
-    public class Stool : Item
+    public class Stool : CraftableFurniture
     {
         [Constructable]
         public Stool()
@@ -36,7 +36,7 @@ namespace Server.Items
     }
 
     [Furniture]
-    public class FootStool : Item
+    public class FootStool : CraftableFurniture
     {
         [Constructable]
         public FootStool()

--- a/Scripts/Items/Construction/Chairs/Thrones.cs
+++ b/Scripts/Items/Construction/Chairs/Thrones.cs
@@ -4,7 +4,7 @@ namespace Server.Items
 {
     [Furniture]
     [Flipable(0xB32, 0xB33)]
-    public class Throne : Item
+    public class Throne : CraftableFurniture
     {
         [Constructable]
         public Throne()
@@ -38,7 +38,7 @@ namespace Server.Items
 
     [Furniture]
     [Flipable(0xB2E, 0xB2F, 0xB31, 0xB30)]
-    public class WoodenThrone : Item
+    public class WoodenThrone : CraftableFurniture
     {
         [Constructable]
         public WoodenThrone()

--- a/Scripts/Items/Construction/Tables/Tables.cs
+++ b/Scripts/Items/Construction/Tables/Tables.cs
@@ -3,7 +3,7 @@ using System;
 namespace Server.Items
 {
     [Furniture]
-    public class ElegantLowTable : Item
+    public class ElegantLowTable : CraftableFurniture
     {
         [Constructable]
         public ElegantLowTable()
@@ -33,7 +33,7 @@ namespace Server.Items
     }
 
     [Furniture]
-    public class PlainLowTable : Item
+    public class PlainLowTable : CraftableFurniture
     {
         [Constructable]
         public PlainLowTable()
@@ -64,7 +64,7 @@ namespace Server.Items
 
     [Furniture]
     [Flipable(0xB90, 0xB7D)]
-    public class LargeTable : Item
+    public class LargeTable : CraftableFurniture
     {
         [Constructable]
         public LargeTable()
@@ -98,7 +98,7 @@ namespace Server.Items
 
     [Furniture]
     [Flipable(0xB35, 0xB34)]
-    public class Nightstand : Item
+    public class Nightstand : CraftableFurniture
     {
         [Constructable]
         public Nightstand()
@@ -132,7 +132,7 @@ namespace Server.Items
 
     [Furniture]
     [Flipable(0xB8F, 0xB7C)]
-    public class YewWoodTable : Item
+    public class YewWoodTable : CraftableFurniture
     {
         [Constructable]
         public YewWoodTable()

--- a/Scripts/Items/Construction/Tables/WritingTable.cs
+++ b/Scripts/Items/Construction/Tables/WritingTable.cs
@@ -4,7 +4,7 @@ namespace Server.Items
 {
     [Furniture]
     [Flipable(0xB4A, 0xB49, 0xB4B, 0xB4C)]
-    public class WritingTable : Item
+    public class WritingTable : CraftableFurniture
     {
         [Constructable]
         public WritingTable()

--- a/Scripts/Items/Deeds/DragonBardingDeed.cs
+++ b/Scripts/Items/Deeds/DragonBardingDeed.cs
@@ -74,7 +74,7 @@ namespace Server.Items
             base.GetProperties(list);
 
             if (this.m_Exceptional && this.m_Crafter != null)
-				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
         }
 		public override void OnSingleClick(Mobile from)
 		{
@@ -82,7 +82,7 @@ namespace Server.Items
 
 			if (m_Crafter != null)
 			{
-				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				LabelTo(from, 1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 			}
 		}
         

--- a/Scripts/Items/Deeds/DragonBardingDeed.cs
+++ b/Scripts/Items/Deeds/DragonBardingDeed.cs
@@ -74,9 +74,18 @@ namespace Server.Items
             base.GetProperties(list);
 
             if (this.m_Exceptional && this.m_Crafter != null)
-                list.Add(1050043, this.m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
         }
+		public override void OnSingleClick(Mobile from)
+		{
+			base.OnSingleClick(from);
 
+			if (m_Crafter != null)
+			{
+				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+			}
+		}
+        
         public override void OnDoubleClick(Mobile from)
         {
             if (this.IsChildOf(from.Backpack))

--- a/Scripts/Items/Furniture/CraftableFurniture.cs
+++ b/Scripts/Items/Furniture/CraftableFurniture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Server.Engines.Craft;
+using Server.Mobiles;
 
 namespace Server.Items
 {
@@ -86,7 +87,7 @@ namespace Server.Items
             base.AddWeightProperty(list);
 
             if (this.ShowCraferName && this.m_Crafter != null)
-                list.Add(1050043, this.m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
 
             if (this.m_Quality == ItemQuality.Exceptional)
                 list.Add(1060636); // exceptional
@@ -101,7 +102,16 @@ namespace Server.Items
             if (info != null && info.Number > 0)
                 list.Add(info.Number);
         }
+		public override void OnSingleClick(Mobile from)
+		{
+			base.OnSingleClick(from);
 
+			if (m_Crafter != null)
+			{
+				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+			}
+		}
+        
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Furniture/CraftableFurniture.cs
+++ b/Scripts/Items/Furniture/CraftableFurniture.cs
@@ -87,7 +87,7 @@ namespace Server.Items
             base.AddWeightProperty(list);
 
             if (this.ShowCraferName && this.m_Crafter != null)
-				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 
             if (this.m_Quality == ItemQuality.Exceptional)
                 list.Add(1060636); // exceptional
@@ -108,7 +108,7 @@ namespace Server.Items
 
 			if (m_Crafter != null)
 			{
-				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				LabelTo(from, 1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 			}
 		}
         

--- a/Scripts/Items/Skill Items/Magical/Runebook.cs
+++ b/Scripts/Items/Skill Items/Magical/Runebook.cs
@@ -335,7 +335,7 @@ namespace Server.Items
                 list.Add(1063341); // exceptional
 
             if (this.m_Crafter != null)
-                list.Add(1050043, this.m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
 
             if (this.m_Description != null && this.m_Description.Length > 0)
                 list.Add(this.m_Description);
@@ -366,7 +366,7 @@ namespace Server.Items
             base.OnSingleClick(from);
 
             if (this.m_Crafter != null)
-                this.LabelTo(from, 1050043, this.m_Crafter.Name);
+				this.LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name);
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Scripts/Items/Skill Items/Magical/Runebook.cs
+++ b/Scripts/Items/Skill Items/Magical/Runebook.cs
@@ -335,7 +335,7 @@ namespace Server.Items
                 list.Add(1063341); // exceptional
 
             if (this.m_Crafter != null)
-				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 
             if (this.m_Description != null && this.m_Description.Length > 0)
                 list.Add(this.m_Description);
@@ -366,7 +366,7 @@ namespace Server.Items
             base.OnSingleClick(from);
 
             if (this.m_Crafter != null)
-				this.LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name);
+				this.LabelTo(from, 1050043, m_Crafter.TitleName);
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Scripts/Items/Skill Items/Magical/Spellbook.cs
+++ b/Scripts/Items/Skill Items/Magical/Spellbook.cs
@@ -15,6 +15,7 @@ using Server.Multis;
 using Server.Network;
 using Server.Spells;
 using Server.Targeting;
+using Server.Mobiles;
 #endregion
 
 namespace Server.Items
@@ -632,7 +633,7 @@ namespace Server.Items
 
 			if (m_Crafter != null)
 			{
-				list.Add(1050043, m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
 			}
 
 			m_AosSkillBonuses.GetProperties(list);
@@ -786,7 +787,7 @@ namespace Server.Items
 
 			if (m_Crafter != null)
 			{
-				LabelTo(from, 1050043, m_Crafter.Name); // crafted by ~1_NAME~
+				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
 			}
 
 			LabelTo(from, 1042886, m_Count.ToString());

--- a/Scripts/Items/Skill Items/Magical/Spellbook.cs
+++ b/Scripts/Items/Skill Items/Magical/Spellbook.cs
@@ -633,7 +633,7 @@ namespace Server.Items
 
 			if (m_Crafter != null)
 			{
-				list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 			}
 
 			m_AosSkillBonuses.GetProperties(list);
@@ -787,7 +787,7 @@ namespace Server.Items
 
 			if (m_Crafter != null)
 			{
-				LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				LabelTo(from, 1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 			}
 
 			LabelTo(from, 1042886, m_Count.ToString());

--- a/Scripts/Items/Skill Items/Misc/RepairDeed.cs
+++ b/Scripts/Items/Skill Items/Misc/RepairDeed.cs
@@ -127,7 +127,7 @@ namespace Server.Items
             base.GetProperties(list);
 
             if (this.m_Crafter != null)
-                list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+                list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
             //On OSI it says it's exceptional.  Intentional difference.
         }
 
@@ -139,7 +139,7 @@ namespace Server.Items
             this.LabelTo(from, 1061133, String.Format("{0}\t{1}", GetSkillTitle(this.m_SkillLevel).ToString(), RepairSkillInfo.GetInfo(this.m_Skill).Name)); // A repair service contract from ~1_SKILL_TITLE~ ~2_SKILL_NAME~.
 
             if (this.m_Crafter != null)
-				this.LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
+				this.LabelTo(from, 1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Scripts/Items/Skill Items/Misc/RepairDeed.cs
+++ b/Scripts/Items/Skill Items/Misc/RepairDeed.cs
@@ -127,7 +127,7 @@ namespace Server.Items
             base.GetProperties(list);
 
             if (this.m_Crafter != null)
-                list.Add(1050043, this.m_Crafter.RawNameWithTitle); // crafted by ~1_NAME~
+                list.Add(1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
             //On OSI it says it's exceptional.  Intentional difference.
         }
 

--- a/Scripts/Items/Skill Items/Misc/RepairDeed.cs
+++ b/Scripts/Items/Skill Items/Misc/RepairDeed.cs
@@ -127,7 +127,7 @@ namespace Server.Items
             base.GetProperties(list);
 
             if (this.m_Crafter != null)
-                list.Add(1050043, this.m_Crafter.Name); // crafted by ~1_NAME~
+                list.Add(1050043, this.m_Crafter.RawNameWithTitle); // crafted by ~1_NAME~
             //On OSI it says it's exceptional.  Intentional difference.
         }
 
@@ -139,7 +139,7 @@ namespace Server.Items
             this.LabelTo(from, 1061133, String.Format("{0}\t{1}", GetSkillTitle(this.m_SkillLevel).ToString(), RepairSkillInfo.GetInfo(this.m_Skill).Name)); // A repair service contract from ~1_SKILL_TITLE~ ~2_SKILL_NAME~.
 
             if (this.m_Crafter != null)
-                this.LabelTo(from, 1050043, this.m_Crafter.Name); // crafted by ~1_NAME~
+				this.LabelTo(from, 1050043, m_Crafter is PlayerMobile ? ((PlayerMobile)m_Crafter).RawNameWithTitle : m_Crafter.Name); // crafted by ~1_NAME~
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Scripts/Misc/CurrentExpansion.cs
+++ b/Scripts/Misc/CurrentExpansion.cs
@@ -15,7 +15,7 @@ namespace Server
 {
 	public class CurrentExpansion
 	{
-		public static readonly Expansion Expansion = Expansion.None;
+		public static readonly Expansion Expansion = Expansion.TOL;
 
 		[CallPriority(Int32.MinValue)]
 		public static void Configure()

--- a/Scripts/Misc/CurrentExpansion.cs
+++ b/Scripts/Misc/CurrentExpansion.cs
@@ -15,7 +15,7 @@ namespace Server
 {
 	public class CurrentExpansion
 	{
-		public static readonly Expansion Expansion = Expansion.TOL;
+		public static readonly Expansion Expansion = Expansion.None;
 
 		[CallPriority(Int32.MinValue)]
 		public static void Configure()

--- a/Scripts/Misc/Titles.cs
+++ b/Scripts/Misc/Titles.cs
@@ -150,43 +150,44 @@ namespace Server.Misc
 
         public static string[] HarrowerTitles = new string[] { "Spite", "Opponent", "Hunter", "Venom", "Executioner", "Annihilator", "Champion", "Assailant", "Purifier", "Nullifier" };
 
+        public static string ComputeFameTitle(Mobile beheld)
+        {
+            int fame = beheld.Fame;
+            int karma = beheld.Karma;
+
+            for (int i = 0; i < m_FameEntries.Length; ++i)
+            {
+                FameEntry fe = m_FameEntries[i];
+
+                if (fame <= fe.m_Fame || i == (m_FameEntries.Length - 1))
+                {
+                    KarmaEntry[] karmaEntries = fe.m_Karma;
+
+                    for (int j = 0; j < karmaEntries.Length; ++j)
+                    {
+                        KarmaEntry ke = karmaEntries[j];
+
+                        if (karma <= ke.m_Karma || j == (karmaEntries.Length - 1))
+                        {
+                            return String.Format(ke.m_Title, beheld.Name, beheld.Female ? "Lady" : "Lord");
+                        }
+                    }
+
+                    return String.Empty;
+                }
+            }
+            return String.Empty;
+        }
+
         public static string ComputeTitle(Mobile beholder, Mobile beheld)
         {
             StringBuilder title = new StringBuilder();
 
-            int fame = beheld.Fame;
-            int karma = beheld.Karma;
+            bool showSkillTitle = beheld.ShowFameTitle && ((beholder == beheld) || (beheld.Fame >= 5000));
 
-            bool showSkillTitle = beheld.ShowFameTitle && ((beholder == beheld) || (fame >= 5000));
-
-            /*if ( beheld.Kills >= 5 )
+			if (beheld.ShowFameTitle || (beholder == beheld))
             {
-            title.AppendFormat( beheld.Fame >= 10000 ? "The Murderer {1} {0}" : "The Murderer {0}", beheld.Name, beheld.Female ? "Lady" : "Lord" );
-            }
-            else*/if (beheld.ShowFameTitle || (beholder == beheld))
-            {
-                for (int i = 0; i < m_FameEntries.Length; ++i)
-                {
-                    FameEntry fe = m_FameEntries[i];
-
-                    if (fame <= fe.m_Fame || i == (m_FameEntries.Length - 1))
-                    {
-                        KarmaEntry[] karmaEntries = fe.m_Karma;
-
-                        for (int j = 0; j < karmaEntries.Length; ++j)
-                        {
-                            KarmaEntry ke = karmaEntries[j];
-
-                            if (karma <= ke.m_Karma || j == (karmaEntries.Length - 1))
-                            {
-                                title.AppendFormat(ke.m_Title, beheld.Name, beheld.Female ? "Lady" : "Lord");
-                                break;
-                            }
-                        }
-
-                        break;
-                    }
-                }
+                title.Append(ComputeFameTitle(beheld));
             }
             else
             {

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -560,6 +560,20 @@ namespace Server.Mobiles
 		[CommandProperty(AccessLevel.GameMaster)]
 		public DateTime PeacedUntil { get { return m_PeacedUntil; } set { m_PeacedUntil = value; } }
 
+		[CommandProperty(AccessLevel.Decorator)]
+		public string RawNameWithTitle
+		{
+			get
+			{
+				string title = Titles.ComputeFameTitle(this);
+				if (title.Length > 0)
+				{
+					return String.Format("{0} {1}", title, RawName);
+				}
+				return RawName;
+			}
+		}
+
 		#region Scroll of Alacrity
 		[CommandProperty(AccessLevel.GameMaster)]
 		public DateTime AcceleratedStart { get; set; }

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -566,11 +566,7 @@ namespace Server.Mobiles
 			get
 			{
 				string title = Titles.ComputeFameTitle(this);
-				if (title.Length > 0)
-				{
-					return String.Format("{0} {1}", title, RawName);
-				}
-				return RawName;
+				return title.Length > 0 ? title : RawName;
 			}
 		}
 

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -561,7 +561,7 @@ namespace Server.Mobiles
 		public DateTime PeacedUntil { get { return m_PeacedUntil; } set { m_PeacedUntil = value; } }
 
 		[CommandProperty(AccessLevel.Decorator)]
-		public string RawNameWithTitle
+		public override string TitleName
 		{
 			get
 			{

--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -385,7 +385,7 @@ namespace Server.Engines.Craft
 			typeof(BambooChair), typeof(WoodenChair), typeof(FancyWoodenChairCushion), typeof(WoodenChairCushion),
 			typeof(Nightstand), typeof(LargeTable), typeof(WritingTable), typeof(YewWoodTable), typeof(PlainLowTable),
 			typeof(ElegantLowTable), typeof(Dressform), typeof(BasePlayerBB), typeof(BaseContainer), typeof(BarrelStaves),
-			typeof(BarrelLid)
+			typeof(BarrelLid), typeof(Clippers)
 		};
 
 		private static Type[] m_NeverColorTable = new[] {typeof(OrcHelm)};

--- a/Scripts/Services/PlantSystem/Clippers.cs
+++ b/Scripts/Services/PlantSystem/Clippers.cs
@@ -104,7 +104,7 @@ namespace Server.Items
 			//Makers mark not displayed on OSI
 			if (_Crafter != null)
 			{
-				list.Add(1050043, _Crafter.RawName); // crafted by ~1_NAME~
+				list.Add(1050043, _Crafter is PlayerMobile ? ((PlayerMobile)_Crafter).RawNameWithTitle : _Crafter.Name); // crafted by ~1_NAME~
 			}
 
 			if (_Quality == ToolQuality.Exceptional)
@@ -113,6 +113,16 @@ namespace Server.Items
 			}
 
 			list.Add(1060584, _UsesRemaining.ToString(CultureInfo.InvariantCulture)); // uses remaining: ~1_val~
+		}
+
+		public override void OnSingleClick(Mobile from)
+		{
+			base.OnSingleClick(from);
+
+			if (_Crafter != null)
+			{
+				LabelTo(from, 1050043, _Crafter is PlayerMobile ? ((PlayerMobile)_Crafter).RawNameWithTitle : _Crafter.Name); // crafted by ~1_NAME~
+			}
 		}
 
 		public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)

--- a/Scripts/Services/PlantSystem/Clippers.cs
+++ b/Scripts/Services/PlantSystem/Clippers.cs
@@ -104,7 +104,7 @@ namespace Server.Items
 			//Makers mark not displayed on OSI
 			if (_Crafter != null)
 			{
-				list.Add(1050043, _Crafter is PlayerMobile ? ((PlayerMobile)_Crafter).RawNameWithTitle : _Crafter.Name); // crafted by ~1_NAME~
+				list.Add(1050043, _Crafter.TitleName); // crafted by ~1_NAME~
 			}
 
 			if (_Quality == ToolQuality.Exceptional)
@@ -121,7 +121,7 @@ namespace Server.Items
 
 			if (_Crafter != null)
 			{
-				LabelTo(from, 1050043, _Crafter is PlayerMobile ? ((PlayerMobile)_Crafter).RawNameWithTitle : _Crafter.Name); // crafted by ~1_NAME~
+				LabelTo(from, 1050043, _Crafter.TitleName); // crafted by ~1_NAME~
 			}
 		}
 

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -9078,6 +9078,15 @@ namespace Server
 		public string RawName { get { return m_Name; } set { Name = value; } }
 
 		[CommandProperty(AccessLevel.Decorator)]
+		public virtual string TitleName
+		{
+			get
+			{
+				return m_Name;
+			}
+		}
+
+		[CommandProperty(AccessLevel.Decorator)]
 		public string Name
 		{
 			get

--- a/Server/Network/Packets.cs
+++ b/Server/Network/Packets.cs
@@ -555,7 +555,7 @@ namespace Server.Network
 			var attrs = info.Attributes;
 
 			EnsureCapacity(
-				17 + (info.Crafter == null ? 0 : 6 + info.Crafter.Name == null ? 0 : info.Crafter.Name.Length) +
+				17 + (info.Crafter == null ? 0 : 6 + info.Crafter.TitleName == null ? 0 : info.Crafter.TitleName.Length) +
 				(info.Unidentified ? 4 : 0) + (attrs.Length * 6));
 
 			m_Stream.Write((short)0x10);
@@ -565,7 +565,7 @@ namespace Server.Network
 
 			if (info.Crafter != null)
 			{
-				string name = info.Crafter.Name;
+				string name = info.Crafter.TitleName;
 
 				m_Stream.Write(-3);
 

--- a/Server/Serialization.cs
+++ b/Server/Serialization.cs
@@ -30,6 +30,7 @@ namespace Server
 		public abstract decimal ReadDecimal();
 		public abstract long ReadLong();
 		public abstract ulong ReadULong();
+		public abstract int PeekInt();
 		public abstract int ReadInt();
 		public abstract uint ReadUInt();
 		public abstract short ReadShort();
@@ -1347,6 +1348,24 @@ namespace Server
 		public override ulong ReadULong()
 		{
 			return m_File.ReadUInt64();
+		}
+
+		public override int PeekInt()
+		{
+			int value = 0;
+			long returnTo = m_File.BaseStream.Position;
+
+			try
+			{
+				value = m_File.ReadInt32();
+			}
+			catch(EndOfStreamException e)
+			{
+				// Ignore this exception, the defalut value 0 will be returned
+			}
+
+			m_File.BaseStream.Seek(returnTo, SeekOrigin.Begin);
+			return value;
 		}
 
 		public override int ReadInt()


### PR DESCRIPTION
Fixes #194. Tested with hover menus and single-click. This required some deserialization trickery to get furniture to work right without copy-and-pasting code everywhere. Basically I made all the player-craftable furniture inherit from CraftableFurniture instead of directly from Item. Due to this there is now an extra deserialize() call in their desierialization chain. To compensate for this I had to add a PeekInt() method to the GenericReader interface and do some version numbering shekanery. But it will now load a save with legacy items just fine.

The only thing I could not figure out is Clippers in single-click mode. They still open a menu and do not seem to invoke OnSingleClick(). This item was never intended for pre-AoS era clients anyway, so I'm not sure it is a problem right now.