### PR TITLE
Fixed Enemy of One recast behavior

### DIFF
--- a/Scripts/Spells/Chivalry/EnemyOfOne.cs
+++ b/Scripts/Spells/Chivalry/EnemyOfOne.cs
@@ -70,26 +70,31 @@ namespace Server.Spells.Chivalry
                 Timer t = (Timer)m_Table[this.Caster];
 
                 if (t != null)
-                    t.Stop();
+				{
+					t.Stop();
+					Expire_Callback(this.Caster);
+				}
+				else
+				{
+					double delay = (double)this.ComputePowerValue(1) / 60;
 
-                double delay = (double)this.ComputePowerValue(1) / 60;
+					// TODO: Should caps be applied?
+					if (delay < 1.5)
+						delay = 1.5;
+					else if (delay > 3.5)
+						delay = 3.5;
 
-                // TODO: Should caps be applied?
-                if (delay < 1.5)
-                    delay = 1.5;
-                else if (delay > 3.5)
-                    delay = 3.5;
+					m_Table[this.Caster] = Timer.DelayCall(TimeSpan.FromMinutes(delay), new TimerStateCallback(Expire_Callback), this.Caster);
 
-                m_Table[this.Caster] = Timer.DelayCall(TimeSpan.FromMinutes(delay), new TimerStateCallback(Expire_Callback), this.Caster);
+					if (this.Caster is PlayerMobile)
+					{
+						((PlayerMobile)this.Caster).EnemyOfOneType = null;
+						((PlayerMobile)this.Caster).WaitingForEnemy = true;
 
-                if (this.Caster is PlayerMobile)
-                {
-                    ((PlayerMobile)this.Caster).EnemyOfOneType = null;
-                    ((PlayerMobile)this.Caster).WaitingForEnemy = true;
-
-                    BuffInfo.AddBuff(this.Caster, new BuffInfo(BuffIcon.EnemyOfOne, 1075653, 1044111, TimeSpan.FromMinutes(delay), this.Caster));
-                }
-            }
+						BuffInfo.AddBuff(this.Caster, new BuffInfo(BuffIcon.EnemyOfOne, 1075653, 1044111, TimeSpan.FromMinutes(delay), this.Caster));
+					}
+				}
+			}
 
             this.FinishSequence();
         }


### PR DESCRIPTION
Fixes #199 Before EoO on recast would clear the EoO type, refresh the timer and allow the player to get another EoO type. On OSI recasting EoO only clears the type. This patch matches OSI behavior.