### PR TITLE
Runic Tool DI Fix

### DIFF
--- a/Scripts/Items/- BaseClasses/BaseRunicTool.cs
+++ b/Scripts/Items/- BaseClasses/BaseRunicTool.cs
@@ -224,7 +224,10 @@ namespace Server.Items
                             break;
                         }
                     case 3:
-                        ApplyAttribute(primary, min, max, AosAttribute.WeaponDamage, 1, 50);
+						int dmgMin = primary.WeaponDamage;
+						int dmgMax = Math.Max(dmgMin, 50);
+						primary.WeaponDamage = 0;
+                        ApplyAttribute(primary, min, max, AosAttribute.WeaponDamage, dmgMin, dmgMax);
                         break;
                     case 4:
                         ApplyAttribute(primary, min, max, AosAttribute.DefendChance, 1, 15);

--- a/Scripts/Items/- BaseClasses/BaseWeapon.cs
+++ b/Scripts/Items/- BaseClasses/BaseWeapon.cs
@@ -3126,33 +3126,36 @@ namespace Server.Items
 
 			int bonus = VirtualDamageBonus;
 
-			switch (m_Quality)
+			if (!Core.AOS)
 			{
-				case WeaponQuality.Low:
-					bonus -= 20;
-					break;
-				case WeaponQuality.Exceptional:
-					bonus += 20;
-					break;
-			}
+				switch (m_Quality)
+				{
+					case WeaponQuality.Low:
+						bonus -= 20;
+						break;
+					case WeaponQuality.Exceptional:
+						bonus += 20;
+						break;
+				}
 
-			switch (m_DamageLevel)
-			{
-				case WeaponDamageLevel.Ruin:
-					bonus += 15;
-					break;
-				case WeaponDamageLevel.Might:
-					bonus += 20;
-					break;
-				case WeaponDamageLevel.Force:
-					bonus += 25;
-					break;
-				case WeaponDamageLevel.Power:
-					bonus += 30;
-					break;
-				case WeaponDamageLevel.Vanq:
-					bonus += 35;
-					break;
+				switch (m_DamageLevel)
+				{
+					case WeaponDamageLevel.Ruin:
+						bonus += 15;
+						break;
+					case WeaponDamageLevel.Might:
+						bonus += 20;
+						break;
+					case WeaponDamageLevel.Force:
+						bonus += 25;
+						break;
+					case WeaponDamageLevel.Power:
+						bonus += 30;
+						break;
+					case WeaponDamageLevel.Vanq:
+						bonus += 35;
+						break;
+				}
 			}
 
 			return bonus;
@@ -5470,6 +5473,11 @@ namespace Server.Items
 					Hue = 0;
 				}
 
+				if (Quality == WeaponQuality.Exceptional)
+				{
+					Attributes.WeaponDamage += 35;
+				}
+
 				if (!craftItem.ForceNonExceptional)
 				{
 					if (tool is BaseRunicTool)
@@ -5478,18 +5486,11 @@ namespace Server.Items
 					}
 				}
 
-				if (Quality == WeaponQuality.Exceptional)
-				{
-					Attributes.WeaponDamage += 15;
-				}
-
 				if (Core.ML)
 				{
 					Attributes.WeaponDamage += (int)(from.Skills.ArmsLore.Value / 20);
 					from.CheckSkill(SkillName.ArmsLore, 0, 100);
 				}
-
-				Attributes.WeaponDamage = Math.Min(Attributes.WeaponDamage, 50);
 			}
 			else if (tool is BaseRunicTool)
 			{

--- a/Scripts/Items/- BaseClasses/BaseWeapon.cs
+++ b/Scripts/Items/- BaseClasses/BaseWeapon.cs
@@ -5458,12 +5458,10 @@ namespace Server.Items
 
 			if (Core.AOS)
 			{
-				#region Mondain's Legacy
 				if (!craftItem.ForceNonExceptional)
 				{
 					Resource = CraftResources.GetFromType(typeRes);
 				}
-				#endregion
 
 				CraftContext context = craftSystem.GetContext(from);
 
@@ -5472,7 +5470,6 @@ namespace Server.Items
 					Hue = 0;
 				}
 
-				// Mondain's Legacy Mod
 				if (!craftItem.ForceNonExceptional)
 				{
 					if (tool is BaseRunicTool)
@@ -5483,31 +5480,19 @@ namespace Server.Items
 
 				if (Quality == WeaponQuality.Exceptional)
 				{
-					if (Attributes.WeaponDamage > 35)
-					{
-						Attributes.WeaponDamage -= 20;
-					}
-					else
-					{
-						Attributes.WeaponDamage = 15;
-					}
-
-					if (Core.ML)
-					{
-						Attributes.WeaponDamage += (int)(from.Skills.ArmsLore.Value / 20);
-
-						if (Attributes.WeaponDamage > 50)
-						{
-							Attributes.WeaponDamage = 50;
-						}
-
-						from.CheckSkill(SkillName.ArmsLore, 0, 100);
-					}
+					Attributes.WeaponDamage += 15;
 				}
+
+				if (Core.ML)
+				{
+					Attributes.WeaponDamage += (int)(from.Skills.ArmsLore.Value / 20);
+					from.CheckSkill(SkillName.ArmsLore, 0, 100);
+				}
+
+				Attributes.WeaponDamage = Math.Min(Attributes.WeaponDamage, 50);
 			}
 			else if (tool is BaseRunicTool)
 			{
-				// Mondain's Legacy Mod
 				if (craftItem != null && !craftItem.ForceNonExceptional)
 				{
 					CraftResource thisResource = CraftResources.GetFromType(typeRes);
@@ -5592,7 +5577,6 @@ namespace Server.Items
 				}
 			}
 
-			#region Mondain's Legacy
 			if (craftItem != null && !craftItem.ForceNonExceptional)
 			{
 				CraftResourceInfo resInfo = CraftResources.GetInfo(m_Resource);
@@ -5646,7 +5630,6 @@ namespace Server.Items
 
 			return quality;
 		}
-		#endregion
 
 		#region Mondain's Legacy Sets
 		public override bool OnDragLift(Mobile from)


### PR DESCRIPTION
Fixes #171 and tested. Not quite 100% OSI accurate. I've noticed on OSI DI tends to roll about 1/3 of the time, and our current implementation of Scale seems to favor the high side where as OSI favors the low. I'd call it good enough for now without drastically changing the expected behavior for existing shards.