### PR TITLE
Fix for 0 gold bug

### DIFF
--- a/Scripts/Mobiles/BaseCreature.cs
+++ b/Scripts/Mobiles/BaseCreature.cs
@@ -3373,8 +3373,11 @@ namespace Server.Mobiles
 					return TeachResult.NotEnoughFreePoints;
 				}
 
-				// Partial refund if needed
-				m.Backpack.TryDropItem(m, new Gold(maxPointsToLearn - pointsToLearn), false);
+                // Partial refund if needed
+                if (maxPointsToLearn > pointsToLearn)
+                {
+                    m.Backpack.TryDropItem(m, new Gold(maxPointsToLearn - pointsToLearn), false);
+                }
 				theirSkill.BaseFixedPoint = baseToSet;
 			}
 


### PR DESCRIPTION
Fix for 0 Gold bug.  Giving a NPC the exact amount of gold to train a skill to max they could offer would return a broken 0 gold coin to player.