### PR TITLE
Fixes part 2 of closed #649

### DIFF
--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -4603,13 +4603,13 @@ namespace Server
 							}
 
 							int oldAmount = item.Amount;
-							//item.Amount = amount; //Set in LiftItemDupe
 
-							if (amount < oldAmount)
-							{
-								LiftItemDupe(item, amount);
-							}
-							//item.Dupe( oldAmount - amount );
+                            Item oldStack = null;
+
+                            if (amount < oldAmount)
+                            {
+                                oldStack = LiftItemDupe(item, amount);
+                            }
 
 							Map map = from.Map;
 
@@ -4651,7 +4651,7 @@ namespace Server
 							Map fixMap = item.Map;
 							bool shouldFix = (item.Parent == null);
 
-							item.RecordBounce();
+							item.RecordBounce(oldStack);
 							item.OnItemLifted(from, item);
 							item.Internalize();
 


### PR DESCRIPTION
Fixes dropping any amount from a stack and the bounce back to the original stack (for all stacked items, not just scrolls). This intentionally does not use Serialization, any items caught in that state will fall through to the old default of dropping back into its parent container or world location.