### PR TITLE
Crafted items go tool's pack

### DIFF
--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -1540,7 +1540,14 @@ namespace Server.Engines.Craft
                     }
 					#endregion
 
-					from.AddToBackpack(item);
+					if (tool.Parent is Container) {
+						Container cntnr = (Container) tool.Parent;
+						cntnr.TryDropItem(from, item, false);
+					}
+					else
+					{
+						from.AddToBackpack(item);
+					}
 
 					EventSink.InvokeCraftSuccess(new CraftSuccessEventArgs(from, item, tool));
 

--- a/Scripts/Services/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/RunicReforging/RunicReforging.cs
@@ -1297,6 +1297,11 @@ namespace Server.Items
         {
             if (item is BaseWeapon || item is BaseArmor || item is BaseJewel || item is BaseHat)
             {
+		if (item is BaseWeapon && Utility.Random(6) == 1)
+		{
+			BaseWeapon weapon = (BaseWeapon) item;
+			BaseRunicTool.GetElementalDamages(weapon);
+		}
                 GenerateRandomItem(item, killer, Math.Max(100, GetDifficultyFor(creature)), LootPack.GetLuckChanceForKiller(creature), ReforgedPrefix.None, ReforgedSuffix.None);
                 return true;
             }


### PR DESCRIPTION
On official shards if you craft an item using the crafting system the resulting item should end up in the container that the tool used to do the crafting is in.