### PR TITLE
Crafted Items drop in tool's Pack

### DIFF
--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -1540,7 +1540,13 @@ namespace Server.Engines.Craft
                     }
 					#endregion
 
+					if (tool.Parent is Container) {
+					Container cntnr = (Container) tool.Parent;
+                                        cntnr.TryDropItem(from, item, false);
+					}
+					else {
 					from.AddToBackpack(item);
+					}
 
 					EventSink.InvokeCraftSuccess(new CraftSuccessEventArgs(from, item, tool));
 


### PR DESCRIPTION
On official shards you can craft items directly to the container the tool used is in.