### PR TITLE
- Bugfixes

### DIFF
--- a/Scripts/Gumps/Guilds/New Guild System/GuildInfoGump.cs
+++ b/Scripts/Gumps/Guilds/New Guild System/GuildInfoGump.cs
@@ -68,9 +68,9 @@ namespace Server.Guilds
             if (isLeader)
                 this.AddButton(40, 313, 0x4B9, 0x4BA, 5, GumpButtonType.Reply, 0);	//Website Edit button
 
-            this.AddCheck(65, 370, 0xD2, 0xD3, this.player.DisplayGuildTitle, 0);
+            /*this.AddCheck(65, 370, 0xD2, 0xD3, this.player.DisplayGuildTitle, 0);
             this.AddHtmlLocalized(95, 370, 150, 26, 1063085, 0x0, false, false); // Show Guild Title
-            this.AddBackground(450, 370, 100, 26, 0x2486);
+            this.AddBackground(450, 370, 100, 26, 0x2486);*/
 
             this.AddButton(455, 375, 0x845, 0x846, 7, GumpButtonType.Reply, 0);
             this.AddHtmlLocalized(480, 373, 60, 26, 3006115, (this.m_IsResigning) ? 0x5000 : 0, false, false); // Resign

--- a/Scripts/Gumps/TitlesMenu.cs
+++ b/Scripts/Gumps/TitlesMenu.cs
@@ -207,9 +207,9 @@ namespace Server.Gumps
             List<string> fameKarma = Titles.GetFameKarmaEntries(User);
 
             AddHtmlLocalized(55, 190, 160, 16, 1115031, 0xFFFF, false, false); // Fame/Karma
-            AddCallbackButton(20, 190, 4005, 4007, (int)TitleCategory.FameKarma, GumpButtonType.Reply, 0, b =>
+            AddCallbackButton(20, 190, 4005, 4007, 1, GumpButtonType.Reply, 0, b =>
                 {
-                    Category = (TitleCategory)b.ButtonID;
+                    Category = TitleCategory.FameKarma;
                     Reset();
                     Refresh();
                 });
@@ -224,19 +224,19 @@ namespace Server.Gumps
                     AddPage(page);
 
                     AddHtmlLocalized(260, 70, 160, 16, 1154764, 0xFFFF, false, false); // (DEFAULT)
-                    AddCallbackButton(225, 70, 4005, 4007, 100, GumpButtonType.Reply, 0, b =>
+                    AddCallbackButton(225, 70, 4005, 4007, 2, GumpButtonType.Reply, 0, b =>
                     {
                         ShowingDescription = true;
-                        TitleSelected = 100;
+                        TitleSelected = 1500;
                         Refresh();
                     });
 
                     for (int i = 0; i < fameKarma.Count; i++)
                     {
                         AddHtml(260, 92 + (index * 22), 245, 16, Color("#FFFFFF", fameKarma[i]), false, false);
-                        AddCallbackButton(225, 92 + (index * 22), 4005, 4007, 150 + i, GumpButtonType.Reply, 0, b =>
+                        AddCallbackButton(225, 92 + (index * 22), 4005, 4007, 3 + i, GumpButtonType.Reply, 0, b =>
                         {
-                            TitleSelected = b.ButtonID - 150;
+                            TitleSelected = b.ButtonID - 3;
                             ShowingDescription = true;
                             Refresh();
                         });
@@ -249,7 +249,7 @@ namespace Server.Gumps
                 {
                     string title = null;
 
-                    if (fameKarma.Count == 0 || TitleSelected == 100)
+                    if (fameKarma.Count == 0 || TitleSelected == 1500)
                         AddHtmlLocalized(275, 240, 160, 32, 1154764, 0xFFFF, false, false); // (DEFAULT)
                     else
                     {
@@ -265,7 +265,7 @@ namespace Server.Gumps
                     AddHtmlLocalized(225, 275, 200, 16, 1115035, 0xFFFF, false, false); // Do you wish to apply this title?
 
                     AddHtmlLocalized(480, 275, 80, 16, 1011046, 0xFFFF, false, false); // APPLY
-                    AddCallbackButton(445, 275, 4005, 4007, 101, GumpButtonType.Reply, 0, b =>
+                    AddCallbackButton(445, 275, 4005, 4007, 99, GumpButtonType.Reply, 0, b =>
                         {
                             if (TitleSelected >= 0 && TitleSelected < fameKarma.Count)
                                 title = fameKarma[TitleSelected];
@@ -285,9 +285,9 @@ namespace Server.Gumps
         private void BuildPaperdollSuffix()
         {
             AddHtmlLocalized(55, 190, 160, 16, 1115030, 0xFFFF, false, false); // Skills
-            AddCallbackButton(20, 190, 4005, 4007, (int)TitleCategory.Skills, GumpButtonType.Reply, 0, b =>
+            AddCallbackButton(20, 190, 4005, 4007, 100, GumpButtonType.Reply, 0, b =>
             {
-                Category = (TitleCategory)b.ButtonID;
+                Category = TitleCategory.Skills;
                 Reset();
                 Refresh();
             });
@@ -297,9 +297,9 @@ namespace Server.Gumps
             if (info != null && info.HasChampionTitle(User))
             {
                 AddHtmlLocalized(55, 212, 160, 16, 1115032, 0xFFFF, false, false); // Monster
-                AddCallbackButton(20, 212, 4005, 4007, (int)TitleCategory.Champion, GumpButtonType.Reply, 0, b =>
+                AddCallbackButton(20, 212, 4005, 4007, 101, GumpButtonType.Reply, 0, b =>
                 {
-                    Category = (TitleCategory)b.ButtonID;
+                    Category = TitleCategory.Champion;
                     Reset();
                     Refresh();
                 });
@@ -320,9 +320,9 @@ namespace Server.Gumps
                             continue;
 
                         AddHtml(260, 70 + (index * 22), 245, 16, Color("#FFFFFF", Titles.GetSkillTitle(User, sk)), false, false);
-                        AddCallbackButton(225, 70 + (index * 22), 4005, 4007, sk.Info.SkillID + 200, GumpButtonType.Reply, 0, b =>
+                        AddCallbackButton(225, 70 + (index * 22), 4005, 4007, sk.Info.SkillID + 102, GumpButtonType.Reply, 0, b =>
                             {
-                                TitleSelected = b.ButtonID - 200;
+                                TitleSelected = b.ButtonID - 102;
                                 ShowingDescription = true;
                                 Refresh();
                             });
@@ -343,7 +343,7 @@ namespace Server.Gumps
                     AddHtmlLocalized(225, 275, 200, 16, 1115035, 0xFFFF, false, false); // Do you wish to apply this title?
 
                     AddHtmlLocalized(480, 275, 80, 16, 1011046, 0xFFFF, false, false); // APPLY
-                    AddCallbackButton(445, 275, 4005, 4007, 2500, GumpButtonType.Reply, 0, b =>
+                    AddCallbackButton(445, 275, 4005, 4007, 199, GumpButtonType.Reply, 0, b =>
                     {
                         AddHtmlLocalized(225, 315, 200, 16, 1115036, 0xFFFF, false, false); // TITLE APPLIED
                         str = Titles.GetSkillTitle(User, User.Skills[(SkillName)TitleSelected]);
@@ -438,9 +438,9 @@ namespace Server.Gumps
         private void BuildOverheadName()
         {
             AddHtmlLocalized(55, 190, 160, 16, 1115030, 0xFFFF, false, false); // Skills
-            AddCallbackButton(20, 190, 4005, 4007, (int)TitleCategory.Skills, GumpButtonType.Reply, 0, b =>
+            AddCallbackButton(20, 190, 4005, 4007, 300, GumpButtonType.Reply, 0, b =>
             {
-                Category = (TitleCategory)b.ButtonID;
+                Category = TitleCategory.Skills;
                 ShowingDescription = false;
                 TitleClearing = false;
                 Refresh();
@@ -451,9 +451,9 @@ namespace Server.Gumps
             if (g != null)
             {
                 AddHtmlLocalized(55, 212, 160, 16, 1115033, 0xFFFF, false, false); // GUILD
-                AddCallbackButton(20, 212, 4005, 4007, (int)TitleCategory.Guild, GumpButtonType.Reply, 0, b =>
+                AddCallbackButton(20, 212, 4005, 4007, 301, GumpButtonType.Reply, 0, b =>
                 {
-                    Category = (TitleCategory)b.ButtonID;
+                    Category = TitleCategory.Guild;
                     ShowingDescription = false;
                     TitleClearing = false;
                     Refresh();
@@ -475,9 +475,9 @@ namespace Server.Gumps
                             continue;
 
                         AddHtml(260, 70 + (index * 22), 245, 16, Color("#FFFFFF", "the " + sk.Info.Title), false, false);
-                        AddCallbackButton(225, 70 + (index * 22), 4005, 4007, sk.Info.SkillID + 300, GumpButtonType.Reply, 0, b =>
+                        AddCallbackButton(225, 70 + (index * 22), 4005, 4007, sk.Info.SkillID + 302, GumpButtonType.Reply, 0, b =>
                         {
-                            TitleSelected = b.ButtonID - 300;
+                            TitleSelected = b.ButtonID - 302;
                             ShowingDescription = true;
                             Refresh();
                         });
@@ -526,7 +526,7 @@ namespace Server.Gumps
                     AddHtmlLocalized(225, 275, 200, 16, 1115035, 0xFFFF, false, false); // Do you wish to apply this title?
 
                     AddHtmlLocalized(480, 275, 80, 16, 1011046, 0xFFFF, false, false); // APPLY
-                    AddCallbackButton(445, 275, 4005, 4007, 401, GumpButtonType.Reply, 0, b =>
+                    AddCallbackButton(445, 275, 4005, 4007, 399, GumpButtonType.Reply, 0, b =>
                     {
                         AddHtmlLocalized(225, 315, 200, 16, 1115036, 0xFFFF, false, false); // TITLE APPLIED
                         title = "the " + User.Skills[(SkillName)TitleSelected].Info.Title;
@@ -557,13 +557,13 @@ namespace Server.Gumps
                     AddHtmlLocalized(225, 275, 200, 16, 1115035, 0xFFFF, false, false); // Do you wish to apply this title?
 
                     AddHtmlLocalized(480, 275, 80, 16, 1011046, 0xFFFF, false, false); // APPLY
-                    AddCallbackButton(445, 275, 4005, 4007, 402, GumpButtonType.Reply, 0, b =>
+                    AddCallbackButton(445, 275, 4005, 4007, 399, GumpButtonType.Reply, 0, b =>
                         {
                             AddHtmlLocalized(225, 315, 200, 16, 1115036, 0xFFFF, false, false); // TITLE APPLIED
                             Refresh(false);
 
                             User.OverheadSkillTitle = null;
-                            User.DisplayGuildTitle = true;
+                            User.ShowGuildAbbreviation = true;
                         });
                 }
             }
@@ -573,10 +573,12 @@ namespace Server.Gumps
         {
             int y = 190;
 
+            Guild guild = User.Guild as Guild;
+
             AddHtmlLocalized(55, y, 160, 16, 1115030, 0xFFFF, false, false); // Skills
-            AddCallbackButton(20, y, 4005, 4007, (int)TitleCategory.Skills, GumpButtonType.Reply, 0, b =>
+            AddCallbackButton(20, y, 4005, 4007, 400, GumpButtonType.Reply, 0, b =>
             {
-                Category = (TitleCategory)b.ButtonID;
+                Category = TitleCategory.Skills;
                 ShowingDescription = false;
                 TitleClearing = false;
                 Refresh();
@@ -584,12 +586,26 @@ namespace Server.Gumps
 
             y += 22;
 
+            if (guild != null && User.GuildTitle != null)
+            {
+                AddHtmlLocalized(55, y, 160, 16, 1115033, 0xFFFF, false, false); // GUILD
+                AddCallbackButton(20, y, 4005, 4007, 401, GumpButtonType.Reply, 0, b =>
+                {
+                    Category = TitleCategory.Guild;
+                    ShowingDescription = false;
+                    TitleClearing = false;
+                    Refresh();
+                });
+
+                y += 22;
+            }
+
             if (User.CollectionTitles != null && User.CollectionTitles.Count > 0)
             {
                 AddHtmlLocalized(55, y, 160, 16, 1115034, 0xFFFF, false, false); // Rewards
-                AddCallbackButton(20, y, 4005, 4007, (int)TitleCategory.RewardTitles, GumpButtonType.Reply, 0, b =>
+                AddCallbackButton(20, y, 4005, 4007, 402, GumpButtonType.Reply, 0, b =>
                 {
-                    Category = (TitleCategory)b.ButtonID;
+                    Category = TitleCategory.RewardTitles;
                     ShowingDescription = false;
                     TitleClearing = false;
                     Refresh();
@@ -603,9 +619,9 @@ namespace Server.Gumps
             if (vetTitles != null && vetTitles.Count > 0)
             {
                 AddHtml(55, y, 160, 16, Color("#FFFFFF", "Veterans"), false, false); // Rewards
-                AddCallbackButton(20, y, 4005, 4007, (int)TitleCategory.Veteran, GumpButtonType.Reply, 0, b =>
+                AddCallbackButton(20, y, 4005, 4007, 403, GumpButtonType.Reply, 0, b =>
                 {
-                    Category = (TitleCategory)b.ButtonID;
+                    Category = TitleCategory.Veteran;
                     ShowingDescription = false;
                     TitleClearing = false;
                     Refresh();
@@ -627,9 +643,9 @@ namespace Server.Gumps
                             continue;
 
                         AddHtml(260, 70 + (index * 22), 245, 16, Color("#FFFFFF", Titles.GetSkillTitle(User, sk)), false, false);
-                        AddCallbackButton(225, 70 + (index * 22), 4005, 4007, sk.Info.SkillID + 400, GumpButtonType.Reply, 0, b =>
+                        AddCallbackButton(225, 70 + (index * 22), 4005, 4007, sk.Info.SkillID + 404, GumpButtonType.Reply, 0, b =>
                         {
-                            TitleSelected = b.ButtonID - 400;
+                            TitleSelected = b.ButtonID - 404;
                             ShowingDescription = true;
                             Refresh();
                         });
@@ -655,10 +671,48 @@ namespace Server.Gumps
                         title = Titles.GetSkillTitle(User, User.Skills[(SkillName)TitleSelected]);
                         User.SubtitleSkillTitle = title;
 
+                        User.SelectCollectionTitle(-1, true);
+                        User.DisplayGuildTitle = false;
+
                         Refresh(false);
                     });
                 }
             }
+            else if (Category == TitleCategory.Guild && guild != null && User.GuildTitle != null)
+            {
+                if (!ShowingDescription || TitleSelected == -1)
+                {
+                    AddHtml(260, 70, 245, 16, Color("#FFFFFF", String.Format("{0}, {1}", Utility.FixHtml(User.GuildTitle), Utility.FixHtml(guild.Name))), false, false);
+                    AddCallbackButton(225, 70, 4005, 4007, 500, GumpButtonType.Reply, 0, b =>
+                    {
+                        TitleSelected = 1;
+                        ShowingDescription = true;
+                        Refresh();
+                    });
+                }
+                else
+                {
+                    AddHtmlLocalized(225, 70, 270, 140, 1115039, 0xFFFF, false, false); // This is a custom guild title assigned by your guild leader.
+                    AddHtmlLocalized(225, 220, 160, 16, 1115029, 0xFFFF, false, false); // Subtitle
+                    AddHtml(275, 240, 245, 16, Color("#FFFFFF", String.Format("{0}, {1}", Utility.FixHtml(User.GuildTitle), Utility.FixHtml(guild.Name))), false, false);
+
+                    AddHtmlLocalized(225, 275, 200, 16, 1115035, 0xFFFF, false, false); // Do you wish to apply this title?
+
+                    AddHtmlLocalized(480, 275, 80, 16, 1011046, 0xFFFF, false, false); // APPLY
+                    AddCallbackButton(445, 275, 4005, 4007, 599, GumpButtonType.Reply, 0, b =>
+                    {
+                        AddHtmlLocalized(225, 315, 200, 16, 1115036, 0xFFFF, false, false); // TITLE APPLIED
+                        User.DisplayGuildTitle = true;
+
+                        if (User.SubtitleSkillTitle != null)
+                            User.SubtitleSkillTitle = null;
+
+                        User.SelectCollectionTitle(-1, true);
+
+                        Refresh(false);
+                    });
+                }
+            }  
             else if (Category == TitleCategory.RewardTitles && User.CollectionTitles != null && User.CollectionTitles.Count > 0)
             {
                 if (!ShowingDescription || TitleSelected == -1)
@@ -677,9 +731,9 @@ namespace Server.Gumps
                         else if (title is string)
                             AddHtml(260, 70 + (index * 22), 245, 16, Color("#FFFFFF", (string)title), false, false);
 
-                        AddCallbackButton(225, 70 + (index * 22), 4005, 4007, i + 500, GumpButtonType.Reply, 0, b =>
+                        AddCallbackButton(225, 70 + (index * 22), 4005, 4007, i + 600, GumpButtonType.Reply, 0, b =>
                         {
-                            TitleSelected = b.ButtonID - 500;
+                            TitleSelected = b.ButtonID - 600;
                             ShowingDescription = true;
                             Refresh();
                         });
@@ -708,12 +762,17 @@ namespace Server.Gumps
                     AddHtmlLocalized(225, 275, 200, 16, 1115035, 0xFFFF, false, false); // Do you wish to apply this title?
 
                     AddHtmlLocalized(480, 275, 80, 16, 1011046, 0xFFFF, false, false); // APPLY
-                    AddCallbackButton(445, 275, 4005, 4007, 550, GumpButtonType.Reply, 0, b =>
+                    AddCallbackButton(445, 275, 4005, 4007, 699, GumpButtonType.Reply, 0, b =>
                     {
                         AddHtmlLocalized(225, 315, 200, 16, 1115036, 0xFFFF, false, false); // TITLE APPLIED
                         Refresh(false);
 
                         User.SelectCollectionTitle(TitleSelected, true);
+
+                        if (User.SubtitleSkillTitle != null)
+                            User.SubtitleSkillTitle = null;
+
+                        User.DisplayGuildTitle = false;
                     });
                 }
             }
@@ -729,9 +788,9 @@ namespace Server.Gumps
                     for (int i = 0; i < vetTitles.Count; i++)
                     {
                         AddHtmlLocalized(260, 70 + (index * 22), 245, 16, vetTitles[i].Title, 0xFFFF, false, false);
-                        AddCallbackButton(225, 70 + (index * 22), 4005, 4007, i + 600, GumpButtonType.Reply, 0, b =>
+                        AddCallbackButton(225, 70 + (index * 22), 4005, 4007, i + 700, GumpButtonType.Reply, 0, b =>
                             {
-                                TitleSelected = b.ButtonID - 600;
+                                TitleSelected = b.ButtonID - 700;
                                 ShowingDescription = true;
                                 Refresh();
                             });
@@ -752,7 +811,7 @@ namespace Server.Gumps
                     AddHtmlLocalized(225, 275, 200, 16, 1115035, 0xFFFF, false, false); // Do you wish to apply this title?
 
                     AddHtmlLocalized(480, 275, 80, 16, 1011046, 0xFFFF, false, false); // APPLY
-                    AddCallbackButton(445, 275, 4005, 4007, 650, GumpButtonType.Reply, 0, b =>
+                    AddCallbackButton(445, 275, 4005, 4007, 799, GumpButtonType.Reply, 0, b =>
                     {
                         AddHtmlLocalized(225, 315, 200, 16, 1115036, 0xFFFF, false, false); // TITLE APPLIED
                         title = vetTitles[TitleSelected];
@@ -795,9 +854,9 @@ namespace Server.Gumps
                 case TitleType.PaperdollSuffix:
                     return User.PaperdollSkillTitle != null || User.CurrentChampTitle != null;
                 case TitleType.OverheadName:
-                    return User.OverheadSkillTitle != null || User.DisplayGuildTitle;
+                    return User.OverheadSkillTitle != null || User.ShowGuildAbbreviation;
                 case TitleType.SubTitles:
-                    return User.SubtitleSkillTitle != null || User.SelectedTitle > -1 || User.CurrentVeteranTitle > 0;
+                    return User.SubtitleSkillTitle != null || User.SelectedTitle > -1 || User.CurrentVeteranTitle > 0 || User.DisplayGuildTitle;
             }
 
             return false;
@@ -814,11 +873,13 @@ namespace Server.Gumps
                 case TitleType.OverheadName:
                     User.OverheadSkillTitle = null;
                     User.DisplayGuildTitle = false;
+                    User.ShowGuildAbbreviation = false;
                     break;
                 case TitleType.SubTitles:
                     User.SubtitleSkillTitle = null;
                     User.SelectCollectionTitle(-1, true);
                     User.CurrentVeteranTitle = -1;
+                    User.DisplayGuildTitle = false;
                     break;
             }
 

--- a/Scripts/Items/Equipment/Armor/BaseArmor.cs
+++ b/Scripts/Items/Equipment/Armor/BaseArmor.cs
@@ -2997,7 +2997,7 @@ namespace Server.Items
                     this.m_AosAttributes.WeaponDamage += attrInfo.ArmorDamage;
                     this.m_AosAttributes.AttackChance += attrInfo.ArmorHitChance;
                     this.m_AosAttributes.RegenHits += attrInfo.ArmorRegenHits;
-                    this.m_AosArmorAttributes.MageArmor += attrInfo.ArmorMage;
+                    //this.m_AosArmorAttributes.MageArmor += attrInfo.ArmorMage;
                 }
                 else
                 {

--- a/Scripts/Items/Equipment/Armor/GargishClothArmor.cs
+++ b/Scripts/Items/Equipment/Armor/GargishClothArmor.cs
@@ -36,6 +36,8 @@ namespace Server.Items
 
         public override void OnAdded(object parent)
         {
+            base.OnAdded(parent);
+
             if (parent is Mobile)
             {
                 if (((Mobile)parent).Female)
@@ -194,6 +196,8 @@ namespace Server.Items
 
         public override void OnAdded(object parent)
         {
+            base.OnAdded(parent);
+
             if (parent is Mobile)
             {
                 if (((Mobile)parent).Female)
@@ -352,6 +356,8 @@ namespace Server.Items
 
         public override void OnAdded(object parent)
         {
+            base.OnAdded(parent);
+
             if (parent is Mobile)
             {
                 if (((Mobile)parent).Female)
@@ -511,6 +517,8 @@ namespace Server.Items
 
         public override void OnAdded(object parent)
         {
+            base.OnAdded(parent);
+
             if (parent is Mobile)
             {
                 if (((Mobile)parent).Female)

--- a/Scripts/Items/Equipment/Clothing/Arms.cs
+++ b/Scripts/Items/Equipment/Clothing/Arms.cs
@@ -38,6 +38,8 @@ namespace Server.Items
         }
         public override void OnAdded(object parent)
         {
+            base.OnAdded(parent);
+
             if (parent is Mobile)
             {
                 if (((Mobile)parent).Female)

--- a/Scripts/Items/Equipment/Clothing/OuterLegs.cs
+++ b/Scripts/Items/Equipment/Clothing/OuterLegs.cs
@@ -217,6 +217,8 @@ namespace Server.Items
         }
         public override void OnAdded(object parent)
         {
+            base.OnAdded(parent);
+
             if (parent is Mobile)
             {
                 if (((Mobile)parent).Female)

--- a/Scripts/Items/Equipment/Clothing/Pants.cs
+++ b/Scripts/Items/Equipment/Clothing/Pants.cs
@@ -358,6 +358,8 @@ namespace Server.Items
 
         public override void OnAdded(object parent)
         {
+            base.OnAdded(parent);
+
             if (parent is Mobile)
             {
                 if (((Mobile)parent).Female)

--- a/Scripts/Items/Equipment/Clothing/Shirts.cs
+++ b/Scripts/Items/Equipment/Clothing/Shirts.cs
@@ -266,6 +266,8 @@ namespace Server.Items
         }
         public override void OnAdded(object parent)
         {
+            base.OnAdded(parent);
+
             if (parent is Mobile)
             {
                 if (((Mobile)parent).Female)

--- a/Scripts/Mobiles/Named/Flurry.cs
+++ b/Scripts/Mobiles/Named/Flurry.cs
@@ -11,7 +11,7 @@ namespace Server.Mobiles
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
             this.Name = "Flurry";
-            this.Body = 0x4F2;
+            this.Body = 13;
             this.Hue = 3;
             this.BaseSoundID = 655;
 

--- a/Scripts/Services/Craft/Core/Enhance.cs
+++ b/Scripts/Services/Craft/Core/Enhance.cs
@@ -317,7 +317,7 @@ namespace Server.Engines.Craft
                                 armor.Attributes.WeaponDamage += attributes.ArmorDamage;
                                 armor.Attributes.AttackChance += attributes.ArmorHitChance;
                                 armor.Attributes.RegenHits += attributes.ArmorRegenHits;				
-                                armor.ArmorAttributes.MageArmor += attributes.ArmorMage;
+                                //armor.ArmorAttributes.MageArmor += attributes.ArmorMage;
                             }
                             else
                             {

--- a/Scripts/Services/New Magincia/Magincia Bazaar/Core/MaginciaPlotAuction.cs
+++ b/Scripts/Services/New Magincia/Magincia Bazaar/Core/MaginciaPlotAuction.cs
@@ -202,7 +202,7 @@ namespace Server.Engines.NewMagincia
 				
 				if(m != winner)
 				{
-					if(!Banker.Deposit(m, kvp.Value.Amount) && m.Backpack != null)
+					if(!Banker.Deposit(m, kvp.Value.Amount, true) && m.Backpack != null)
 					{
 						int total = kvp.Value.Amount;
 						

--- a/Scripts/Services/New Magincia/Magincia Bazaar/Mobiles/WarehouseSuperintendent.cs
+++ b/Scripts/Services/New Magincia/Magincia Bazaar/Mobiles/WarehouseSuperintendent.cs
@@ -183,33 +183,13 @@ namespace Server.Engines.NewMagincia
         {
             int amount = entry.Funds;
 
-            if (amount > 0)
+            if (Banker.Deposit(from, amount, true))
             {
-                while (amount > 60000)
-                {
-                    BankCheck check = new BankCheck(60000);
-
-                    if (from.Backpack == null || !from.Backpack.TryDropItem(from, check, false))
-                    {
-                        check.Delete();
-                        return false;
-                    }
-                    else
-                        amount -= 60000;
-                }
-
-                BankCheck check2 = new BankCheck(amount);
-
-                if (from.Backpack == null || !from.Backpack.TryDropItem(from, check2, false))
-                {
-                    check2.Delete();
-                    return false;
-                }
-                else
-                    entry.Funds -= amount;
+                entry.Funds = 0;
+                return true;
             }
 
-            return true;
+            return false;
         }
 		
 		public void TryPayBackfee(Mobile from, string text, StorageEntry entry)

--- a/Scripts/Services/Revamped Dungeons/Shame Revamped/Items/WhetstoneOfEnervation.cs
+++ b/Scripts/Services/Revamped Dungeons/Shame Revamped/Items/WhetstoneOfEnervation.cs
@@ -15,7 +15,7 @@ namespace Server.Items
         }
 
         [Constructable]
-        public WhetstoneOfEnervation(int amount) : base(0x423A)
+        public WhetstoneOfEnervation(int amount) : base(0x1368)
         {
             this.Hue = 1458;
             this.Weight = 1;
@@ -39,7 +39,7 @@ namespace Server.Items
                             if(!wep.IsChildOf(m.Backpack))
                                 m.SendLocalizedMessage(1042001); // That must be in your pack for you to use it.
                             else if (wep.TimesImbued > 0)
-                                m.SendLocalizedMessage(1149667); // Invalid target.
+                                m.SendLocalizedMessage(1046439); // Invalid target.
                             else if (wep.Attributes.WeaponDamage > 0)
                             {
                                 wep.Attributes.WeaponDamage = 0;
@@ -48,10 +48,10 @@ namespace Server.Items
                                 this.Consume();
                             }
                             else
-                                m.SendLocalizedMessage(1149667); // Invalid target.
+                                m.SendLocalizedMessage(1046439); // Invalid target.
                         }
                         else
-                            m.SendLocalizedMessage(1149667); // Invalid target.
+                            m.SendLocalizedMessage(1046439); // Invalid target.
                     });
             }
             else
@@ -75,6 +75,9 @@ namespace Server.Items
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
+
+            if (ItemID != 0x1368)
+                ItemID = 0x1368;
         }
     }
 }

--- a/Scripts/Spells/Seventh/MassDispel.cs
+++ b/Scripts/Spells/Seventh/MassDispel.cs
@@ -54,7 +54,7 @@ namespace Server.Spells.Seventh
                     IPooledEnumerable eable = map.GetMobilesInRange(new Point3D(p), 8);
 
                     foreach (Mobile m in eable)
-                        if (m is BaseCreature && (m as BaseCreature).IsDispellable && this.Caster.CanBeHarmful(m, false))
+                        if (m is BaseCreature && (m as BaseCreature).IsDispellable && (((BaseCreature)m).SummonMaster == this.Caster || this.Caster.CanBeHarmful(m, false)))
                             targets.Add(m);
 
                     eable.Free();

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -753,7 +753,6 @@ namespace Server
 		private bool m_CanSwim, m_CantWalk;
 		private int m_TithingPoints;
 		private bool m_DisplayGuildTitle;
-        private string m_OverheadSkillTitle;
 		private Mobile m_GuildFealty;
 		private DateTime[] m_StuckMenuUses;
 		private Timer m_ExpireCombatant;
@@ -1135,14 +1134,7 @@ namespace Server
 
 			BaseGuild guild = m_Guild;
 
-            if (m_OverheadSkillTitle != null)
-            {
-                if (suffix.Length > 0)
-                    suffix = String.Format("{0} {1}", suffix, m_OverheadSkillTitle);
-                else
-                    suffix = String.Format("{0}", m_OverheadSkillTitle);
-            }
-            else if (guild != null && m_Player && m_DisplayGuildTitle)
+            if (guild != null && m_Player && m_DisplayGuildTitle)
             {
                 if (suffix.Length > 0)
                     suffix = String.Format("{0} [{1}]", suffix, Utility.FixHtml(guild.Abbreviation));
@@ -9046,20 +9038,6 @@ namespace Server
 				InvalidateProperties();
 			}
 		}
-
-        [CommandProperty(AccessLevel.GameMaster)]
-        public string OverheadSkillTitle
-        {
-            get
-            {
-                return m_OverheadSkillTitle;
-            }
-            set
-            {
-                m_OverheadSkillTitle = value;
-                InvalidateProperties();
-            }
-        }
 
 		[CommandProperty(AccessLevel.Decorator)]
 		public Mobile GuildFealty { get { return m_GuildFealty; } set { m_GuildFealty = value; } }


### PR DESCRIPTION
- Fixed various bugs with titles menu, added guild section to Subtitle
- Reverted Mobile.cs title and overrid it in PlayerMobile (needs another core recompile)
- Took out "show guild title" in guild menu
- Added command to FillableCOntainer for those shards with containers that have content type set to 'none'
- Tailor/smith/carpentry fillable contianers will now drop refinement components
- Took out mage armor from appearing on frostwood crafted/enhanced Armor
- Fixed bugs on gargish armor where stats wouldnt regenerate
- Chest of sending no longer takes powder of translocation, it now auto generates charged every 12 +- hours
- Fixed the way gold refunded in magincia bizaar system
- Runic Reforging now follows tables provided in UO Stratics, per EA
- Dispel/mass dispel can now be used on your own summons
- Whetstone of enervation now has correct itemid