### PR TITLE
fix issue with improperly placed string literal in datapath.

### DIFF
--- a/Config/DataPath.cfg
+++ b/Config/DataPath.cfg
@@ -4,5 +4,7 @@
 # on non-Windows systems.
 #CustomPath=C:\Program Files (x86)\Electronic Arts\Ultima Online Classic
 
-# If true all data paths other than CustomPath will be ignored.
+# If true all data paths other than CustomPath will be ignored. 
+# Highly Recommended if you set a custom client above to prevent multiple
+# instances of the client being loaded.
 IgnoreStandardPaths=False

--- a/Config/DataPath.cfg
+++ b/Config/DataPath.cfg
@@ -2,7 +2,7 @@
 # custom data path. Otherwise ServUO will look for the client in the default
 # Windows installation directories. Note that this is *required* when running
 # on non-Windows systems.
-@CustomPath=..\muls
+#CustomPath=C:\Program Files (x86)\Electronic Arts\Ultima Online Classic
 
 # If true all data paths other than CustomPath will be ignored.
 IgnoreStandardPaths=False

--- a/Scripts/Misc/DataPath.cs
+++ b/Scripts/Misc/DataPath.cs
@@ -14,7 +14,7 @@ namespace Server.Misc
         * Example:
         *  private static string CustomPath = @"C:\Program Files\Ultima Online";
         */
-        private static readonly string CustomPath = Config.Get("DataPath.CustomPath", null);
+        private static readonly string CustomPath = Config.Get(@"DataPath.CustomPath", null);
         private static readonly bool IgnoreStandardPaths = Config.Get("DataPath.IgnoreStandardPaths", false);
         /* The following is a list of files which a required for proper execution:
         * 


### PR DESCRIPTION
Config file was not properly treating the literal string resulting in the wrong client being loaded when multiple client installs on a system.