### PR TITLE
Update Virulent.cs

### DIFF
--- a/Scripts/Mobiles/Normal/Virulent.cs
+++ b/Scripts/Mobiles/Normal/Virulent.cs
@@ -3,14 +3,14 @@ using Server.Items;
 
 namespace Server.Mobiles
 {
-    [CorpseName("a dread spider corpse")]
+    [CorpseName("a Virulent corpse")]
     public class Virulent : BaseCreature
     {
         [Constructable]
         public Virulent()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a Virulent";
+            this.Name = "Virulent";
             this.Body = 11;
             this.Hue = 0x8FF;
             this.BaseSoundID = 1170;


### PR DESCRIPTION
Virulent is named mobile, and should also be moved to that directory. Should the corpse names of these named versions of basic creature mobiles be 'an X corpse' or 'the remains of X'? It's not listed on stratics or uoguide, and I've seen both. 'an X corpse' is more common, so I've used that here.