### PR TITLE
BaseVendor Purchase Overflow

### DIFF
--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -8,6 +8,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+
 using Server.Accounting;
 using Server.ContextMenus;
 using Server.Engines.BulkOrders;
@@ -1124,7 +1126,7 @@ namespace Server.Mobiles
 			List<BuyItemResponse> validBuy,
 			ref int controlSlots,
 			ref bool fullPurchase,
-			ref int totalCost)
+			ref double totalCost)
 		{
 			int amount = buy.Amount;
 
@@ -1150,7 +1152,7 @@ namespace Server.Mobiles
 				return;
 			}
 
-			totalCost += bii.Price * amount;
+			totalCost += (double)bii.Price * amount;
 			validBuy.Add(buy);
 		}
 
@@ -1259,9 +1261,9 @@ namespace Server.Mobiles
 
 			UpdateBuyInfo();
 
-			var buyInfo = GetBuyInfo();
+			//var buyInfo = GetBuyInfo();
 			var info = GetSellInfo();
-			int totalCost = 0;
+			var totalCost = 0.0;
 			var validBuy = new List<BuyItemResponse>(list.Count);
 			Container cont;
 			bool bought = false;
@@ -1307,7 +1309,7 @@ namespace Server.Mobiles
 							{
 								if (ssi.IsResellable(item))
 								{
-									totalCost += ssi.GetBuyPriceFor(item) * amount;
+									totalCost += (double)ssi.GetBuyPriceFor(item) * amount;
 									validBuy.Add(buy);
 									break;
 								}
@@ -1348,7 +1350,7 @@ namespace Server.Mobiles
 			}
 
 			bought = buyer.AccessLevel >= AccessLevel.GameMaster;
-			int discount = 0;
+			var discount = 0.0;
 			cont = buyer.Backpack;
 
 			if (Core.SA && HasHonestyDiscount)
@@ -1368,47 +1370,119 @@ namespace Server.Mobiles
 						discountPc = 0;
 						break;
 				}
-				discount = totalCost - (int)(totalCost * (1 - discountPc));
+				discount = totalCost - (totalCost * (1.0 - discountPc));
 				totalCost -= discount;
 			}
 
 			if (!bought && cont != null)
 			{
-				if (cont.ConsumeTotal(typeof(Gold), totalCost))
+				if (totalCost <= Int32.MaxValue)
 				{
-					bought = true;
-
-					if (discount > 0)
+					if (cont.ConsumeTotal(typeof(Gold), (int)totalCost))
 					{
-						SayTo(buyer, 1151517, discount.ToString());
-					}
-				}
-			}
-
-			if (!bought &&(totalCost >= 2000 ||AccountGold.Enabled))
-			{
-				if (Banker.Withdraw(buyer, totalCost))
-				{
-					bought = true;
-					fromBank = true;
-
-					if (discount > 0)
-					{
-						SayTo(buyer, 1151517, discount.ToString());
+						bought = true;
 					}
 				}
 				else
 				{
+					var items = cont.FindItemsByType<Gold>();
+					var total = items.Aggregate(0.0, (c, o) => c + o.Amount);
+
+					if (total >= totalCost)
+					{
+						total = totalCost;
+
+						foreach (var o in items)
+						{
+							if (o.Amount >= total)
+							{
+								o.Consume((int)total);
+								total = 0;
+							}
+							else
+							{
+								total -= o.Amount;
+								o.Delete();
+							}
+
+							if (total <= 0)
+							{
+								break;
+							}
+						}
+
+						bought = true;
+					}
+				}
+			}
+
+			if (totalCost >= 2000)
+			{
+				if (!bought)
+				{
+					if (totalCost <= Int32.MaxValue)
+					{
+						if (Banker.Withdraw(buyer, (int)totalCost))
+						{
+							bought = true;
+							fromBank = true;
+						}
+					}
+					else if (buyer.Account != null && AccountGold.Enabled)
+					{
+						if (buyer.Account.WithdrawCurrency(totalCost / AccountGold.CurrencyThreshold))
+						{
+							bought = true;
+							fromBank = true;
+						}
+					}
+				}
+
+				if (!bought)
+				{
 					cont = buyer.FindBankNoCreate();
 
-					if (cont != null && cont.ConsumeTotal(typeof(Gold), totalCost))
+					if (cont != null)
 					{
-						bought = true;
-						fromBank = true;
-
-						if (discount > 0)
+						if (totalCost <= Int32.MaxValue)
 						{
-							SayTo(buyer, 1151517, discount.ToString());
+							if (cont.ConsumeTotal(typeof(Gold), (int)totalCost))
+							{
+								bought = true;
+								fromBank = true;
+							}
+						}
+						else
+						{
+							var items = cont.FindItemsByType<Gold>();
+							var total = items.Aggregate(0.0, (c, o) => c + o.Amount);
+
+							if (total >= totalCost)
+							{
+								total = totalCost;
+
+								foreach (var o in items)
+								{
+									if (o.Amount >= total)
+									{
+										o.Consume((int)total);
+										total = 0;
+									}
+									else
+									{
+										total -= o.Amount;
+										o.Delete();
+									}
+
+									if (total <= 0)
+									{
+										break;
+									}
+								}
+
+								bought = true;
+								fromBank = true;
+							}
 						}
 					}
 				}
@@ -1421,6 +1495,11 @@ namespace Server.Mobiles
 				SayTo(buyer, totalCost >= 2000 ? 500191 : 500192);
 
 				return false;
+			}
+
+			if (discount > 0)
+			{
+				SayTo(buyer, 1151517, discount.ToString());
 			}
 
 			buyer.PlaySound(0x32);
@@ -1509,6 +1588,11 @@ namespace Server.Mobiles
 					}
 				}
 			} //foreach
+
+			if (discount > 0)
+			{
+				SayTo(buyer, 1151517, discount.ToString());
+			}
 
 			if (fullPurchase)
 			{


### PR DESCRIPTION
+ Proposed solution to the Int32 total purchase price overflow issue.

Using the Double data type to aggregate the total cost of all items in a purchase and avoid overflowing Int32.