### PR TITLE
Trade Deal SSI value corrected.

### DIFF
--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -582,7 +582,7 @@ namespace Server
 
                 #region City Loyalty
                 if (CityLoyaltySystem.HasTradeDeal(m, TradeDeal.GuildOfAssassins))
-                    value += 1;
+                    value += 5;
                 #endregion
 
                 #region SA


### PR DESCRIPTION
According to https://www.servuo.com/threads/wrong-ssi-bonus-value-for-city-trade-deal.5902/ value changed to 5.