### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Addons/LighthouseAddon.cs
+++ b/Scripts/Items/Addons/LighthouseAddon.cs
@@ -51,7 +51,8 @@ namespace Server.Items
                         return AddonFitResult.Blocked;
                 }
 
-                from.SendLocalizedMessage(1154596); // Ships placed by this account will now be linked to this lighthouse when they decay. Lost ships will be  found in your house moving crate.
+                if (from != null)
+                    from.SendLocalizedMessage(1154596); // Ships placed by this account will now be linked to this lighthouse when they decay. Lost ships will be  found in your house moving crate.
             }
 
             return result;

--- a/Scripts/Items/Artifacts/Equipment/Clothing/CrimsonCincture.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/CrimsonCincture.cs
@@ -1,7 +1,9 @@
 using System;
+using Server.Engines.Craft;
 
 namespace Server.Items
 {
+    [Alterable(typeof(DefTailoring), typeof(GargishCrimsonCincture))]
     public class CrimsonCincture : HalfApron, ITokunoDyable
 	{
 		public override bool IsArtifact { get { return true; } }
@@ -39,6 +41,47 @@ namespace Server.Items
         {
             base.Deserialize(reader);
 			
+            int version = reader.ReadInt();
+        }
+    }
+
+    public class GargishCrimsonCincture : GargoyleHalfApron, ITokunoDyable
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public GargishCrimsonCincture()
+            : base()
+        {
+            this.Hue = 0x485;
+
+            this.Attributes.BonusDex = 5;
+            this.Attributes.BonusHits = 10;
+            this.Attributes.RegenHits = 2;
+        }
+
+        public GargishCrimsonCincture(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int LabelNumber
+        {
+            get
+            {
+                return 1075043;
+            }
+        }// Crimson Cincture
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
             int version = reader.ReadInt();
         }
     }

--- a/Scripts/Items/Equipment/Weapons/ElvenSpellblade.cs
+++ b/Scripts/Items/Equipment/Weapons/ElvenSpellblade.cs
@@ -3,7 +3,7 @@ using Server.Engines.Craft;
 
 namespace Server.Items
 {
-    [Alterable(typeof(DefBlacksmithy), typeof(DualPointedSpear))]
+    [Alterable(typeof(DefBlacksmithy), typeof(DualPointedSpear), true)]
     [FlipableAttribute(0x2D20, 0x2D2C)]
     public class ElvenSpellblade : BaseKnife
     {

--- a/Scripts/Items/Internal/PrismOfLightTeleporters.cs
+++ b/Scripts/Items/Internal/PrismOfLightTeleporters.cs
@@ -132,7 +132,11 @@ namespace Server.Items
             if (m.Player)
             {
                 if (Utility.RandomBool())
-                    m.MoveToWorld(new Point3D(6523, 71, -10), m.Map);
+                {
+                    Point3D p = new Point3D(6523, 71, -10);
+                    Server.Mobiles.BaseCreature.TeleportPets(m, p, m.Map);
+                    m.MoveToWorld(p, m.Map);
+                }
 				
                 this.Delete();
                 return false;

--- a/Scripts/Mobiles/NPCs/Sam.cs
+++ b/Scripts/Mobiles/NPCs/Sam.cs
@@ -69,8 +69,13 @@ namespace Server.Items
             this.Donations.Add(new CollectionItem(typeof(Fish), 0x9CC, 1074939, 0x0, 1));										
             this.Donations.Add(new CollectionItem(typeof(FishingPole), 0xDC0, 1011406, 0x0, 2));				
             this.Donations.Add(new CollectionItem(typeof(BrownBook), 0xFEF, 1074906, 0x0, 3));
-            this.Donations.Add(new CollectionItem(typeof(TanBook), 0xFF0, 1074906, 0x0, 3));								
-			
+            this.Donations.Add(new CollectionItem(typeof(TanBook), 0xFF0, 1074906, 0x0, 3));
+
+            #region High Seas
+            Donations.Add(new CollectionItem(typeof(Lobster), 17619, 1096491, 0x0, 10));
+            Donations.Add(new CollectionItem(typeof(Crab), 17617, 1096490, 0x0, 10));
+            #endregion
+
             int[] hues = new int[] { 0x1E0, 0x190, 0x151 };			
             this.Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendBodySash), 0x1541, 1073346, 0x190, 100000.0, hues));
             this.Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendFeatheredHat), 0x171A, 1073347, 0x190, 100000.0, hues));

--- a/Scripts/Quests/Eodon/Valley of One Quest/Questers.cs
+++ b/Scripts/Quests/Eodon/Valley of One Quest/Questers.cs
@@ -153,7 +153,7 @@ namespace Server.Mobiles
 
         [Constructable]
         public SakkhraHighChieftess()
-            : base(BaseEodonTribesman.GetRandomName(), "the sakkhra high cheiftess")
+            : base(BaseEodonTribesman.GetRandomName(), "the sakkhra high chieftess")
         {
         }
 
@@ -195,6 +195,9 @@ namespace Server.Mobiles
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
+
+            if (Title != "the sakkhra high chieftess")
+                Title = "the sakkhra high chieftess";
         }
     }
 
@@ -204,7 +207,7 @@ namespace Server.Mobiles
 
         [Constructable]
         public UraliHighChieftess()
-            : base(BaseEodonTribesman.GetRandomName(), "the urali high cheiftess")
+            : base(BaseEodonTribesman.GetRandomName(), "the urali high chieftess")
         {
         }
 
@@ -247,6 +250,9 @@ namespace Server.Mobiles
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
+
+            if (Title != "the urali high chieftess")
+                Title = "the urali high chieftess";
         }
     }
 
@@ -256,7 +262,7 @@ namespace Server.Mobiles
 
         [Constructable]
         public JukariHighChief()
-            : base(BaseEodonTribesman.GetRandomName(), "the jukari high cheif")
+            : base(BaseEodonTribesman.GetRandomName(), "the jukari high chief")
         {
         }
 
@@ -295,6 +301,9 @@ namespace Server.Mobiles
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
+
+            if (Title != "the jukari high chief")
+                Title = "the jukari high chief";
         }
     }
 
@@ -304,7 +313,7 @@ namespace Server.Mobiles
 
         [Constructable]
         public KurakHighChief()
-            : base(BaseEodonTribesman.GetRandomName(), "the kurak high cheif")
+            : base(BaseEodonTribesman.GetRandomName(), "the kurak high chief")
         {
         }
 
@@ -344,6 +353,9 @@ namespace Server.Mobiles
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
+
+            if (Title != "the kurak high chief")
+                Title = "the kurak high chief";
         }
     }
 
@@ -353,7 +365,7 @@ namespace Server.Mobiles
 
         [Constructable]
         public BarakoHighChief()
-            : base(BaseEodonTribesman.GetRandomName(), "the barako high cheif")
+            : base(BaseEodonTribesman.GetRandomName(), "the barako high chief")
         {
         }
 
@@ -395,6 +407,9 @@ namespace Server.Mobiles
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
+
+            if (Title != "the barako high chief")
+                Title = "the barako high chief";
         }
     }
 }

--- a/Scripts/Services/CommunityCollections/BaseCollectionItem.cs
+++ b/Scripts/Services/CommunityCollections/BaseCollectionItem.cs
@@ -253,7 +253,7 @@ namespace Server.Items
         #region IComunityCollection
         public virtual void Donate(PlayerMobile player, CollectionItem item, int amount)
         {
-            int points = (int)(amount * item.Points);
+            int points = (int)Math.Round(amount * item.Points);
 		
             player.AddCollectionPoints(this.CollectionID, points);
 			

--- a/Scripts/Services/CommunityCollections/BaseCollectionMobile.cs
+++ b/Scripts/Services/CommunityCollections/BaseCollectionMobile.cs
@@ -330,7 +330,7 @@ namespace Server.Mobiles
         #region IComunityCollection
         public virtual void Donate(PlayerMobile player, CollectionItem item, int amount)
         {
-            int points = (int)(amount * item.Points);
+            int points = (int)Math.Round(amount * item.Points);
 		
             player.AddCollectionPoints(this.CollectionID, points);
 			

--- a/Scripts/Services/Craft/Core/CraftGump.cs
+++ b/Scripts/Services/Craft/Core/CraftGump.cs
@@ -167,7 +167,6 @@ namespace Server.Engines.Craft
                 int resIndex = (context == null ? -1 : context.LastResourceIndex);
 
                 Type resourceType = craftSystem.CraftSubRes.ResType;
-                Type resourceType2 = GetAltType(resourceType);
 
                 if (resIndex > -1)
                 {
@@ -178,6 +177,7 @@ namespace Server.Engines.Craft
                     resourceType = subResource.ItemType;
                 }
 
+                Type resourceType2 = GetAltType(resourceType);
                 int resourceCount = 0;
 
                 if (from.Backpack != null)
@@ -318,6 +318,16 @@ namespace Server.Engines.Craft
 
                     for (int j = 0; j < items.Length; ++j)
                         resourceCount += items[j].Amount;
+
+                    Type alt = GetAltType(subResource.ItemType);
+
+                    if (alt != null)
+                    {
+                        Item[] items2 = m_From.Backpack.FindItemsByType(alt, true);
+
+                        for (int j = 0; j < items2.Length; ++j)
+                            resourceCount += items2[j].Amount;
+                    }
                 }
 
                 this.AddButton(220, 70 + (index * 20), 4005, 4007, GetButtonID(5, i), GumpButtonType.Reply, 0);

--- a/Scripts/Services/Craft/Core/CraftGumpItem.cs
+++ b/Scripts/Services/Craft/Core/CraftGumpItem.cs
@@ -118,6 +118,8 @@ namespace Server.Engines.Craft
                     return 1072651; // * Requires the "Mondain's Legacy" expansion
                 case Expansion.SA:
                     return 1094732; // * Requires the "Stygian Abyss" expansion
+                case Expansion.HS:
+                    return 1116296; // * Requires the "High Seas" booster
                 case Expansion.TOL:
                     return 1155876; // * Requires the "Time of Legends" expansion.
                 default:

--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -350,14 +350,22 @@ namespace Server.Engines.Craft
 
 		private static readonly Type[][] m_TypesTable = new[]
 		{
-			new[] {typeof(Board), typeof(Log)}, new[] {typeof(HeartwoodBoard), typeof(HeartwoodLog)},
-			new[] {typeof(BloodwoodBoard), typeof(BloodwoodLog)}, new[] {typeof(FrostwoodBoard), typeof(FrostwoodLog)},
-			new[] {typeof(OakBoard), typeof(OakLog)}, new[] {typeof(AshBoard), typeof(AshLog)},
-			new[] {typeof(YewBoard), typeof(YewLog)}, new[] {typeof(Leather), typeof(Hides)},
-			new[] {typeof(SpinedLeather), typeof(SpinedHides)}, new[] {typeof(HornedLeather), typeof(HornedHides)},
-			new[] {typeof(BarbedLeather), typeof(BarbedHides)}, new[] {typeof(BlankMap), typeof(BlankScroll)},
-			new[] {typeof(Cloth), typeof(UncutCloth), typeof(AbyssalCloth)}, new[] {typeof(CheeseWheel), typeof(CheeseWedge)},
-			new[] {typeof(Pumpkin), typeof(SmallPumpkin)}, new[] {typeof(WoodenBowlOfPeas), typeof(PewterBowlOfPeas)},
+			new[] {typeof(Board), typeof(Log)}, 
+            new[] {typeof(HeartwoodBoard), typeof(HeartwoodLog)},
+			new[] {typeof(BloodwoodBoard), typeof(BloodwoodLog)}, 
+            new[] {typeof(FrostwoodBoard), typeof(FrostwoodLog)},
+			new[] {typeof(OakBoard), typeof(OakLog)}, 
+            new[] {typeof(AshBoard), typeof(AshLog)},
+			new[] {typeof(YewBoard), typeof(YewLog)}, 
+            new[] {typeof(Leather), typeof(Hides)},
+			new[] {typeof(SpinedLeather), typeof(SpinedHides)}, 
+            new[] {typeof(HornedLeather), typeof(HornedHides)},
+			new[] {typeof(BarbedLeather), typeof(BarbedHides)}, 
+            new[] {typeof(BlankMap), typeof(BlankScroll)},
+			new[] {typeof(Cloth), typeof(UncutCloth), typeof(AbyssalCloth)},
+            new[] {typeof(CheeseWheel), typeof(CheeseWedge)},
+			new[] {typeof(Pumpkin), typeof(SmallPumpkin)}, 
+            new[] {typeof(WoodenBowlOfPeas), typeof(PewterBowlOfPeas)},
             new[] { typeof( CrystallineFragments ), typeof( BrokenCrystals ), typeof( ShatteredCrystals ), typeof( ScatteredCrystals ), typeof( CrushedCrystals ), typeof( JaggedCrystals ), typeof( AncientPotteryFragments ) },
             new[] { typeof( RedScales ), typeof( BlueScales ), typeof( BlackScales ), typeof( YellowScales ), typeof( GreenScales ), typeof( WhiteScales ), typeof( MedusaDarkScales ), typeof( MedusaLightScales ) }
 		};

--- a/Scripts/Services/Craft/DefAlchemy.cs
+++ b/Scripts/Services/Craft/DefAlchemy.cs
@@ -363,7 +363,7 @@ namespace Server.Engines.Craft
             #region High Seas
             if (Core.HS)
             {
-                index = AddCraft(typeof(Potash), 1044495, 1116319, 0.0, 50.0, typeof(Log), 1044041, 1, 1044253);
+                index = AddCraft(typeof(Potash), 1044495, 1116319, 0.0, 50.0, typeof(Board), 1044041, 1, 1044253);
                 AddRes(index, typeof(BaseBeverage), 1024088, 1, 1044253);
                 SetNeededExpansion(index, Expansion.HS);
             }

--- a/Scripts/Services/Craft/DefCooking.cs
+++ b/Scripts/Services/Craft/DefCooking.cs
@@ -240,7 +240,7 @@ namespace Server.Engines.Craft
             #region High Seas
             if (Core.HS)
             {
-                index = AddCraft(typeof(Charcoal), 1044496, 1116303, 0.0, 50.0, typeof(Log), 1044041, 1, 1044351);
+                index = AddCraft(typeof(Charcoal), 1044496, 1116303, 0.0, 50.0, typeof(Board), 1044041, 1, 1044351);
                 SetUseAllRes(index, true);
                 SetNeedHeat(index, true);
                 SetNeededExpansion(index, Expansion.HS);


### PR DESCRIPTION
- fixed lighthouse crash
- Altering items should now carry all properties over. I still need a list of artifacts/special items that can be altered.
- prism of light tele now teleports pets
- Community collections should now let players donate gold from their accounts
- Community Collection Britannia Waters now accepts HS fish/lobsters/crabs
- Fixed type with quest giver chiefs
- Added proper hue to HS Expansion requirement in craft menu
- Charcoal can now be made with logs and/or boards
- Craft menu resource count display now shows the proper amount, ie logs and boards combined
