### PR TITLE
SafeFileHandle patch

### DIFF
--- a/Server/TileMatrix.cs
+++ b/Server/TileMatrix.cs
@@ -436,11 +436,8 @@ namespace Server
 
 					fixed (StaticTile* pTiles = staTiles)
 					{
-#if !MONO
 						NativeReader.Read(m_Statics.SafeFileHandle.DangerousGetHandle(), pTiles, length);
-#else
-						NativeReader.Read( m_Statics.Handle, pTiles, length );
-#endif
+
 						if (m_Lists == null)
 						{
 							m_Lists = new TileList[8][];
@@ -523,11 +520,7 @@ namespace Server
 
 				fixed (LandTile* pTiles = tiles)
 				{
-#if !MONO
 					NativeReader.Read(m_Map.SafeFileHandle.DangerousGetHandle(), pTiles, 192);
-#else
-					NativeReader.Read( m_Map.Handle, pTiles, 192 );
-#endif
 				}
 
 				return tiles;

--- a/Server/TileMatrixPatch.cs
+++ b/Server/TileMatrixPatch.cs
@@ -86,11 +86,7 @@ namespace Server
 
 						fixed (LandTile* pTiles = tiles)
 						{
-#if !MONO
 							NativeReader.Read(fsData.SafeFileHandle.DangerousGetHandle(), pTiles, 192);
-#else
-							NativeReader.Read( fsData.Handle, pTiles, 192 );
-#endif
 						}
 
 						matrix.SetLandBlock(x, y, tiles);
@@ -160,11 +156,8 @@ namespace Server
 
 							fixed (StaticTile* pTiles = staTiles)
 							{
-#if !MONO
 								NativeReader.Read(fsData.SafeFileHandle.DangerousGetHandle(), pTiles, length);
-#else
-								NativeReader.Read( fsData.Handle, pTiles, length );
-#endif
+								
 								StaticTile* pCur = pTiles, pEnd = pTiles + tileCount;
 
 								while (pCur < pEnd)


### PR DESCRIPTION
Change TileMatrix.cs and TileMatrixPatch.cs.

I didn't see any reason for mono behaving different.

Tested on ArchLinux without any issues.

https://developer.xamarin.com/api/type/Microsoft.Win32.SafeHandles.SafeFileHandle/