### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Consumables/SoulStone.cs
+++ b/Scripts/Items/Consumables/SoulStone.cs
@@ -503,6 +503,12 @@ namespace Server.Items
                             {
                                 bc.ControlTarget = null;
                                 bc.ControlOrder = OrderType.None;
+
+                                if (bc is BaseMount && ((BaseMount)bc).Rider == from)
+                                {
+                                    from.SendLocalizedMessage(1042317); // You may not ride at this time
+                                    ((BaseMount)bc).Rider = null;
+                                }
                             }
                         }
                     }

--- a/Scripts/Items/Equipment/Armor/BaseArmor.cs
+++ b/Scripts/Items/Equipment/Armor/BaseArmor.cs
@@ -2376,12 +2376,14 @@ namespace Server.Items
                     return false;
                 }
 
+                bool morph = from.FindItemOnLayer(Layer.Earrings) is MorphEarrings;
+
                 if (from.Race == Race.Gargoyle && !this.CanBeWornByGargoyles)
                 {
                     from.SendLocalizedMessage(1111708); // Gargoyles can't wear this.
                     return false;
                 }
-                if (this.RequiredRace != null && from.Race != this.RequiredRace)
+                if (this.RequiredRace != null && from.Race != this.RequiredRace && !morph)
                 {
                     if (this.RequiredRace == Race.Elf)
                         from.SendLocalizedMessage(1072203); // Only Elves may use this.

--- a/Scripts/Items/Equipment/Clothing/BaseClothing.cs
+++ b/Scripts/Items/Equipment/Clothing/BaseClothing.cs
@@ -636,6 +636,8 @@ namespace Server.Items
                     return false;
                 }
 
+                bool morph = from.FindItemOnLayer(Layer.Earrings) is MorphEarrings;
+
                 #region Stygian Abyss
                 if (from.Race == Race.Gargoyle && !this.CanBeWornByGargoyles)
                 {
@@ -643,7 +645,7 @@ namespace Server.Items
                     return false;
                 }
                 #endregion
-                else if (this.RequiredRace != null && from.Race != this.RequiredRace)
+                else if (this.RequiredRace != null && from.Race != this.RequiredRace && !morph)
                 {
                     if (this.RequiredRace == Race.Elf)
                         from.SendLocalizedMessage(1072203); // Only Elves may use this.

--- a/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
+++ b/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
@@ -553,12 +553,14 @@ namespace Server.Items
 
             if (from.AccessLevel < AccessLevel.GameMaster)
             {
+                bool morph = from.FindItemOnLayer(Layer.Earrings) is MorphEarrings;
+
                 if (from.Race == Race.Gargoyle && !this.CanBeWornByGargoyles)
                 {
                     from.SendLocalizedMessage(1111708); // Gargoyles can't wear this.
                     return false;
                 }
-                else if (this.RequiredRace != null && from.Race != this.RequiredRace)
+                else if (this.RequiredRace != null && from.Race != this.RequiredRace && !morph)
                 {
                     if (this.RequiredRace == Race.Elf)
                         from.SendLocalizedMessage(1072203); // Only Elves may use this.

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -947,6 +947,8 @@ namespace Server.Items
                 }
             }
 
+            bool morph = from.FindItemOnLayer(Layer.Earrings) is MorphEarrings;
+
 			#region Stygian Abyss
 			if (from.Race == Race.Gargoyle && !CanBeWornByGargoyles && from.IsPlayer())
 			{
@@ -955,7 +957,7 @@ namespace Server.Items
 			}
 			#endregion
 
-			if (RequiredRace != null && from.Race != RequiredRace)
+			if (RequiredRace != null && from.Race != RequiredRace && !morph)
 			{
 				if (RequiredRace == Race.Elf)
 				{
@@ -1787,10 +1789,19 @@ namespace Server.Items
 
 			if (!blocked)
 			{
-                Layer randomLayer = _DamageLayers[Utility.Random(_DamageLayers.Length)];
-                Item armorItem = defender.FindItemOnLayer(randomLayer);
+                Layer randomLayer = Layer.FirstValid;
+                Item armorItem = null;
 
-				IWearableDurability armor = armorItem as IWearableDurability;
+                for (int i = 0; i < 10; i++)
+                {
+                    randomLayer = _DamageLayers[Utility.Random(_DamageLayers.Length)];
+                    armorItem = defender.FindItemOnLayer(randomLayer);
+
+                    if (armorItem is IWearableDurability)
+                        break;
+                }
+
+                IWearableDurability armor = armorItem as IWearableDurability;
 
 				if (armor != null)
 				{
@@ -1814,6 +1825,7 @@ namespace Server.Items
             Layer.OuterTorso,
             Layer.Ring,
             Layer.Bracelet,
+            Layer.Earrings,
             Layer.Neck,
             Layer.Neck,
             Layer.Gloves,

--- a/Scripts/Items/Tools/BaseRunicTool.cs
+++ b/Scripts/Items/Tools/BaseRunicTool.cs
@@ -422,7 +422,7 @@ namespace Server.Items
             if (groups.Length == 0)
                 return SlayerName.None;
 
-            SlayerGroup group = groups[Utility.Random(groups.Length - 1)]; //-1 To Exclude the Fey Slayer which appears ONLY on a certain artifact.
+            SlayerGroup group = groups[Utility.Random(6)]; //-1 To Exclude the Fey Slayer which appears ONLY on a certain artifact.
             SlayerEntry entry;
 
             if (group.Entries.Length == 0 || 10 > Utility.Random(100)) // 10% chance to do super slayer

--- a/Scripts/Mobiles/Bosses/BaseChampion.cs
+++ b/Scripts/Mobiles/Bosses/BaseChampion.cs
@@ -37,7 +37,7 @@ namespace Server.Mobiles
 
         public virtual bool CanGivePowerscrolls { get { return true; } }
 
-        public static void GivePowerScrollTo(Mobile m)
+        public static void GivePowerScrollTo(Mobile m, BaseChampion champ)
         {
             if (m == null)	//sanity
                 return;
@@ -64,7 +64,7 @@ namespace Server.Mobiles
                 {
                     Mobile prot = pm.JusticeProtectors[j];
 
-                    if (prot.Map != m.Map || prot.Kills >= 5 || prot.Criminal || !JusticeVirtue.CheckMapRegion(m, prot))
+                    if (prot.Map != m.Map || prot.Kills >= 5 || prot.Criminal || !JusticeVirtue.CheckMapRegion(m, prot) || !prot.InRange(champ, 100))
                         continue;
 
                     int chance = 0;
@@ -160,7 +160,7 @@ namespace Server.Mobiles
             {
                 DamageStore ds = rights[i];
 
-                if (ds.m_HasRight)
+                if (ds.m_HasRight && InRange(ds.m_Mobile, 100) && ds.m_Mobile.Map == this.Map)
                     toGive.Add(ds.m_Mobile);
             }
 
@@ -201,7 +201,7 @@ namespace Server.Mobiles
             {
                 Mobile m = toGive[i % toGive.Count];
 
-                GivePowerScrollTo(m);
+                GivePowerScrollTo(m, this);
             }
         }
 

--- a/Scripts/Mobiles/Bosses/Navery/Navrey.cs
+++ b/Scripts/Mobiles/Bosses/Navery/Navrey.cs
@@ -79,7 +79,7 @@ namespace Server.Mobiles
         }
  
         public override double TeleportChance { get { return 0; } }
-	public override bool AlwaysMurderer { get { return true; } }
+	    public override bool AlwaysMurderer { get { return true; } }
         public override Poison PoisonImmune { get { return Poison.Parasitic; } }
         public override Poison HitPoison { get { return Poison.Lethal; } }
         public override int Meat { get { return 1; } }
@@ -106,7 +106,7 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            AddLoot(LootPack.AosSuperBoss, 9);
+            AddLoot(LootPack.AosSuperBoss, 3);
         }
 
         public override void OnDeath(Container c)
@@ -122,10 +122,10 @@ namespace Server.Mobiles
             if (Utility.RandomBool())
                 c.AddItem(new UntranslatedAncientTome());
 
-            if (Utility.RandomBool())
+            if (0.1 >= Utility.RandomDouble())
                 c.AddItem(ScrollofTranscendence.CreateRandom(30, 30));
 
-            if (Utility.RandomBool())
+            if (0.1 >= Utility.RandomDouble())
                 c.AddItem(new TatteredAncientScroll());            
 
             if (Utility.RandomDouble() < 0.10)

--- a/Scripts/Mobiles/Normal/RagingGrizzlyBear.cs
+++ b/Scripts/Mobiles/Normal/RagingGrizzlyBear.cs
@@ -3,7 +3,6 @@ using System;
 namespace Server.Mobiles
 {
     [CorpseName("a grizzly bear corpse")]
-    [TypeAlias("Server.Mobiles.Grizzlybear")]
     public class RagingGrizzlyBear : BaseCreature
     {
         [Constructable]

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -1148,6 +1148,8 @@ namespace Server.Mobiles
 					}
 					#endregion
 
+                    bool morph = from.FindItemOnLayer(Layer.Earrings) is MorphEarrings;
+
 					if (item is BaseWeapon)
 					{
 						BaseWeapon weapon = (BaseWeapon)item;
@@ -1166,7 +1168,7 @@ namespace Server.Mobiles
 						{
 							drop = true;
 						}
-						else if (weapon.RequiredRace != null && weapon.RequiredRace != Race)
+                        else if (weapon.RequiredRace != null && weapon.RequiredRace != Race && !morph)
 						{
 							drop = true;
 						}
@@ -1199,7 +1201,7 @@ namespace Server.Mobiles
 						{
 							drop = true;
 						}
-						else if (armor.RequiredRace != null && armor.RequiredRace != Race)
+                        else if (armor.RequiredRace != null && armor.RequiredRace != Race && !morph)
 						{
 							drop = true;
 						}
@@ -1259,7 +1261,7 @@ namespace Server.Mobiles
 						{
 							drop = true;
 						}
-						else if (clothing.RequiredRace != null && clothing.RequiredRace != Race)
+                        else if (clothing.RequiredRace != null && clothing.RequiredRace != Race && !morph)
 						{
 							drop = true;
 						}

--- a/Scripts/Services/Expansions/High Seas/Multis/BaseGalleon.cs
+++ b/Scripts/Services/Expansions/High Seas/Multis/BaseGalleon.cs
@@ -487,7 +487,7 @@ namespace Server.Multis
 
         public bool HasAccess(Mobile from)
         {
-            if(Owner == null || (Scuttled && IsEnemy(from)) || (Owner is BaseCreature && !Owner.Alive))
+            if(Owner == null || (Scuttled && IsEnemy(from))/* || (Owner is BaseCreature && !Owner.Alive)*/)
                 return true;
 
             return GetSecurityLevel(from) !=  SecurityLevel.Denied;

--- a/Scripts/Services/Peerless/PeerlessAltar.cs
+++ b/Scripts/Services/Peerless/PeerlessAltar.cs
@@ -272,7 +272,7 @@ namespace Server.Items
                     break;
             }
 
-            FinishSequence();
+            Timer.DelayCall(TimeSpan.FromSeconds(10), FinishSequence);
         }
 
         public virtual bool IsKey(Item item)
@@ -316,7 +316,8 @@ namespace Server.Items
 
         public virtual void AddFighter(Mobile fighter)
         {
-            m_Fighters.Add(fighter);
+            if(!m_Fighters.Contains(fighter))
+                m_Fighters.Add(fighter);
 
             IPooledEnumerable eable = fighter.GetMobilesInRange(5);
             foreach (Mobile m in eable)
@@ -358,7 +359,7 @@ namespace Server.Items
                 {
                     Mobile m = info.Mobile;
 
-                    if (m.InRange(from.Location, 15) && CanEnter(m))
+                    if (m.InRange(from.Location, 25) && CanEnter(m))
                     {
                         if (m == from)
                             AddFighter(from);

--- a/Scripts/Services/RunicReforging/RandomItemGenerator.cs
+++ b/Scripts/Services/RunicReforging/RandomItemGenerator.cs
@@ -11,11 +11,19 @@ namespace Server.Mobiles
         public static int FeluccaLuckBonus { get; private set; }
         public static int FeluccaBudgetBonus { get; private set; }
 
+        public static int MaxBaseBudget { get; private set; }
+        public static int MinBaseBudget { get; private set; }
+        public static int MaxProps { get; private set; }
+
         public static void Configure()
         {
             Enabled = Config.Get("Loot.Enabled", true);
             FeluccaLuckBonus = Config.Get("Loot.FeluccaLuckBonus", 1000);
             FeluccaBudgetBonus = Config.Get("Loot.FeluccaBudgetBonus", 100);
+
+            MaxBaseBudget = Config.Get("Loot.MaxBaseBudget", 900);
+            MinBaseBudget = Config.Get("Loot.MinBaseBudget", 150);
+            MaxProps = Config.Get("Loot.MaxProps", 9);
         }
 
         private RandomItemGenerator()

--- a/Scripts/Services/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/RunicReforging/RunicReforging.cs
@@ -310,11 +310,6 @@ namespace Server.Items
                     if (!(item is BaseWeapon) || (((BaseWeapon)item).PrimaryAbility != WeaponAbility.BleedAttack && ((BaseWeapon)item).SecondaryAbility != WeaponAbility.BleedAttack))
                         list.Remove(col);
                 }
-                /*else if (list.Contains(col) && col.Attribute is string && (string)col.Attribute == "BalancedWeapon")
-                {
-                    if (!(item is BaseRanged))
-                        list.Remove(col);
-                }*/
                 else if (list.Contains(col) && col.Attribute is AosWeaponAttribute && (AosWeaponAttribute)col.Attribute == AosWeaponAttribute.SplinteringWeapon)
                 {
                     if (playermade || item is BaseRanged)
@@ -384,11 +379,6 @@ namespace Server.Items
                         budget -= weight;
                     }
                 }
-                /*else if (str == "BalancedWeapon" && item is BaseRanged)
-                {
-                    ((BaseRanged)item).Balanced = true;
-                    budget -= 100;
-                }*/
                 else if (str == "WeaponVelocity" && item is BaseRanged)
                 {
                     int value = CalculateValue(attribute, min, max, perclow, perchigh, ref budget, luckchance, true);
@@ -399,9 +389,6 @@ namespace Server.Items
 			}
 			else if (attribute is AosAttribute)
 			{
-                //if ((AosAttribute)attribute == AosAttribute.Luck && item is BaseRanged)
-                //    max = 180;
-
                 int value = CalculateValue(attribute, min, max, perclow, perchigh, ref budget, luckchance, true);
                 AosAttributes attrs = GetAosAttributes(item);
 
@@ -436,9 +423,6 @@ namespace Server.Items
             {
                 int value = CalculateValue(attribute, min, max, perclow, perchigh, ref budget, luckchance, true);
                 AosArmorAttributes attrs = GetAosArmorAttributes(item);
-
-                if (item is BaseArmor) attrs = ((BaseArmor)item).ArmorAttributes;
-                else if (item is BaseClothing) attrs = ((BaseClothing)item).ClothingAttributes;
 
                 if (attrs != null && value > 0 && attrs[(AosArmorAttribute)attribute] == 0)
                 {
@@ -1512,8 +1496,11 @@ namespace Server.Items
                     }
                 }
 
-                if (basebudget > 800)
-                    basebudget = 800;
+                if (basebudget > RandomItemGenerator.MaxBaseBudget)
+                    basebudget = RandomItemGenerator.MaxBaseBudget;
+
+                if (basebudget < RandomItemGenerator.MinBaseBudget)
+                    basebudget = RandomItemGenerator.MinBaseBudget;
 
                 // base budget range
                 int divisor = GetDivisor(basebudget);
@@ -1528,12 +1515,6 @@ namespace Server.Items
                 }
 
                 TryApplyRandomDisadvantage(item, ref budget);
-
-                if (budget > MaxBudget)
-                    budget = MaxBudget;
-
-                if (budget < 150)
-                    budget = 150;
 
                 bool powerful = budget >= 550;
 
@@ -1568,7 +1549,7 @@ namespace Server.Items
                 }
                 else
                 {
-                    int maxmods = Math.Min(9, budget / Utility.RandomMinMax(100, 140));
+                    int maxmods = Math.Min(RandomItemGenerator.MaxProps, budget / Utility.RandomMinMax(100, 140));
                     int minmods = Math.Max(4, maxmods - 1);
                     mods = Utility.RandomMinMax(minmods, maxmods);
 
@@ -2524,7 +2505,7 @@ namespace Server.Items
 		{
 			AosAttribute.SpellChanneling,
 			AosAttribute.DefendChance,
-			AosAttribute.AttackChance,
+			//AosAttribute.AttackChance,
 			AosAttribute.CastSpeed,
 			AosAttribute.ReflectPhysical,
 			AosArmorAttribute.LowerStatReq,

--- a/Scripts/Services/ViceVsVirtue/Items/Rewards/MorphEarrings.cs
+++ b/Scripts/Services/ViceVsVirtue/Items/Rewards/MorphEarrings.cs
@@ -3,9 +3,11 @@ using Server;
 using System.Collections.Generic;
 using Server.Mobiles;
 using Server.Items;
+using Server.Engines.VvV;
 
-namespace Server.Engines.VvV
+namespace Server.Items
 {
+    [TypeAlias("Server.Engines.VvV.MorphEarrings")]
     public class MorphEarrings : GoldEarrings
 	{
         public override int LabelNumber
@@ -16,9 +18,57 @@ namespace Server.Engines.VvV
             }
         }
 
+        [Constructable]
         public MorphEarrings()
         {
             IsVvVItem = true;
+        }
+
+        public override void OnRemoved(object parent)
+        {
+            base.OnRemoved(parent);
+
+            if (parent is Mobile)
+            {
+                ValidateEquipment((Mobile)parent);
+            }
+        }
+
+        private void ValidateEquipment(Mobile m)
+        {
+            if (m == null)
+                return;
+
+            Race race = m.Race;
+            bool didDrop = false;
+
+            foreach (Item item in m.Items)
+            {
+                bool drop = false;
+
+                if (item is BaseArmor && ((BaseArmor)item).RequiredRace != null && ((BaseArmor)item).RequiredRace != race)
+                    drop = true;
+                else if (item is BaseWeapon && ((BaseWeapon)item).RequiredRace != null && ((BaseWeapon)item).RequiredRace != race)
+                    drop = true;
+                else if (item is BaseJewel && ((BaseJewel)item).RequiredRace != null && ((BaseJewel)item).RequiredRace != race)
+                    drop = true;
+                else if (item is BaseClothing && ((BaseClothing)item).RequiredRace != null && ((BaseClothing)item).RequiredRace != race)
+                    drop = true;
+
+                if (drop)
+                {
+                    if (!didDrop)
+                        didDrop = true;
+
+                    if (m.Backpack == null || !m.Backpack.TryDropItem(m, item, false))
+                    {
+                        m.BankBox.DropItem(item);
+                    }
+                }
+            }
+
+            if (didDrop)
+                m.SendLocalizedMessage(500647); // Some equipment has been moved to your backpack.
         }
 
         public MorphEarrings(Serial serial)

--- a/Scripts/Services/ViceVsVirtue/Items/VvVAltar.cs
+++ b/Scripts/Services/ViceVsVirtue/Items/VvVAltar.cs
@@ -229,7 +229,7 @@ namespace Server.Engines.VvV
             {
                 VvVPlayerEntry entry;
 
-                if (ViceVsVirtueSystem.IsVvV(m, out entry, false, true))
+                if (m.Alive && ViceVsVirtueSystem.IsVvV(m, out entry, false, true))
                 {
                     count++;
 


### PR DESCRIPTION
- Added support for morph earrings
- Fixed slayer drop as regular loot, no more eodon slayer
- Added 100 tile range check to champion for powerscroll drop, including protector
- decreased drop chances for SOT on Navery
- Fixed GrizzlyBear turning into RagingGrizzlyBear
- Pirate/Merchant ships now must be scuttled to board them
- Fixed issue where ghosts were given credit at the VvV Altar
- Added Config settings for new loot generator
- Fixed peerless master key issue where it would not let players back in the boss encounter