### PR TITLE
- Fixed splintering weapon where players were not returning to normal…

### DIFF
--- a/Data/teleporters.csv
+++ b/Data/teleporters.csv
@@ -44,8 +44,8 @@
 5466,1804,12,Felucca,5593,1840,-3,Felucca,False
 5466,1805,12,Felucca,5593,1841,-3,Felucca,False
 5466,1806,12,Felucca,5593,1842,-3,Felucca,False
-5594,1840,-9,Felucca,5467,1804,7,Felucca,False
-5594,1841,-9,Felucca,5467,1805,7,Felucca,False
+5594,1840,-8,Felucca,5467,1804,7,Felucca,False
+5594,1841,-8,Felucca,5467,1805,7,Felucca,False
 5824,631,5,Felucca,2041,215,14,Felucca,True
 5825,631,5,Felucca,2042,215,14,Felucca,True
 5825,631,5,Felucca,2043,215,14,Felucca,True
@@ -332,8 +332,8 @@
 5466,1804,12,Trammel,5593,1840,-3,Trammel,False
 5466,1805,12,Trammel,5593,1841,-3,Trammel,False
 5466,1806,12,Trammel,5593,1842,-3,Trammel,False
-5594,1840,-9,Trammel,5467,1804,7,Trammel,False
-5594,1841,-9,Trammel,5467,1805,7,Trammel,False
+5594,1840,-8,Trammel,5467,1804,7,Trammel,False
+5594,1841,-8,Trammel,5467,1805,7,Trammel,False
 5824,631,5,Trammel,2041,215,14,Trammel,True
 5825,631,5,Trammel,2042,215,14,Trammel,True
 5825,631,5,Trammel,2043,215,14,Trammel,True

--- a/Scripts/Abilities/SAPropEffects.cs
+++ b/Scripts/Abilities/SAPropEffects.cs
@@ -507,7 +507,6 @@ namespace Server.Items
             if (m_Level > 4)
             {
                 EndBleed(m_Bleeder, true);
-                EndForceWalk(m_Bleeder);
                 RemoveEffects();
                 BuffInfo.RemoveBuff(this.Mobile, BuffIcon.SplinteringEffect);
                 return;
@@ -559,6 +558,8 @@ namespace Server.Items
         {
             if (message)
                 m.SendLocalizedMessage(1060167); // The bleeding wounds have healed, you are no longer bleeding!
+
+            EndForceWalk(m_Bleeder);
 
             m_Bleeding = false;
         }

--- a/Scripts/Items/Equipment/Clothing/Shoes.cs
+++ b/Scripts/Items/Equipment/Clothing/Shoes.cs
@@ -54,7 +54,6 @@ namespace Server.Items
 
     #endregion
 
-    [Alterable(typeof(DefTailoring), typeof(LeatherTalons), true)]
     public abstract class BaseShoes : BaseClothing
     {
         public BaseShoes(int itemID)
@@ -112,6 +111,7 @@ namespace Server.Items
         }
     }
 
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
     [Flipable(0x2307, 0x2308)]
     public class FurBoots : BaseShoes
     {
@@ -148,6 +148,7 @@ namespace Server.Items
         }
     }
 
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
     [FlipableAttribute(0x170b, 0x170c)]
     public class Boots : BaseShoes
     {
@@ -192,6 +193,7 @@ namespace Server.Items
         }
     }
 
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
     [Flipable]
     public class ThighBoots : BaseShoes, IArcaneEquip
     {
@@ -343,6 +345,7 @@ namespace Server.Items
         }
     }
 
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
     [FlipableAttribute(0x170f, 0x1710)]
     public class Shoes : BaseShoes
     {
@@ -387,6 +390,7 @@ namespace Server.Items
         }
     }
 
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
     [FlipableAttribute(0x170d, 0x170e)]
     public class Sandals : BaseShoes
     {
@@ -436,6 +440,7 @@ namespace Server.Items
         }
     }
 
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
     [Flipable(0x2797, 0x27E2)]
     public class NinjaTabi : BaseShoes
     {
@@ -472,6 +477,7 @@ namespace Server.Items
         }
     }
 
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
     [Flipable(0x2796, 0x27E1)]
     public class SamuraiTabi : BaseShoes
     {
@@ -508,6 +514,7 @@ namespace Server.Items
         }
     }
 
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
     [Flipable(0x2796, 0x27E1)]
     public class Waraji : BaseShoes
     {
@@ -544,6 +551,7 @@ namespace Server.Items
         }
     }
 
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
     [FlipableAttribute(0x2FC4, 0x317A)]
     public class ElvenBoots : BaseShoes
     {
@@ -601,6 +609,7 @@ namespace Server.Items
         }
     }
 
+    [Alterable(typeof(DefTailoring), typeof(LeatherTalons))]
     public class JesterShoes : BaseShoes
     {
         public override int LabelNumber { get { return 1109617; } } // Jester Shoes

--- a/Scripts/Mobiles/Bosses/SlasherOfVeils.cs
+++ b/Scripts/Mobiles/Bosses/SlasherOfVeils.cs
@@ -187,7 +187,7 @@ namespace Server.Mobiles
         {
             base.OnMovement(m, oldLocation);
 
-            if (this.m_NextTerror < DateTime.UtcNow && m != null && this.InRange(m.Location, 10) && m.IsPlayer())
+            if (this.m_NextTerror < DateTime.UtcNow && m != null && this.InRange(m.Location, 10) && m.IsPlayer() && m.Alive)
             {
                 m.Frozen = true;
                 m.SendLocalizedMessage(1080342, this.Name, 33); // Terror slices into your very being, destroying any chance of resisting ~1_name~ you might have had

--- a/Scripts/Services/ChampionSystem/ChampionSkullBrazier.cs
+++ b/Scripts/Services/ChampionSystem/ChampionSkullBrazier.cs
@@ -64,7 +64,7 @@ namespace Server.Engines.CannedEvil
         {
             get
             {
-                return 1049488 + (int)this.m_Type;
+                return 1049489 + (int)this.m_Type;
             }
         }
         public override void OnDoubleClick(Mobile from)

--- a/Scripts/Services/Craft/Core/CraftGump.cs
+++ b/Scripts/Services/Craft/Core/CraftGump.cs
@@ -307,7 +307,7 @@ namespace Server.Engines.Craft
                     CraftContext context = this.m_CraftSystem.GetContext(this.m_From);
 
                     this.AddButton(220, 260, 4005, 4007, GetButtonID(6, 4), GumpButtonType.Reply, 0);
-                    this.AddHtmlLocalized(263, 253, 200, 18, (context == null || !context.DoNotColor) ? 1061591 : 1061590, LabelColor, false, false);
+                    this.AddHtmlLocalized(255, 260, 200, 18, (context == null || !context.DoNotColor) ? 1061591 : 1061590, LabelColor, false, false);
                 }
 
                 int resourceCount = 0;

--- a/Scripts/Services/Craft/Core/Enhance.cs
+++ b/Scripts/Services/Craft/Core/Enhance.cs
@@ -2,6 +2,7 @@ using System;
 using Server.Items;
 using Server.Targeting;
 using Server.Mobiles;
+using System.Collections.Generic;
 
 namespace Server.Engines.Craft
 {
@@ -21,6 +22,27 @@ namespace Server.Engines.Craft
 
     public class Enhance
     {
+        private static Dictionary<Type, CraftSystem> _SpecialTable;
+
+        public static void Initialize()
+        {
+            _SpecialTable = new Dictionary<Type, CraftSystem>();
+
+            _SpecialTable[typeof(ClockworkLeggings)] = DefBlacksmithy.CraftSystem;
+            _SpecialTable[typeof(GargishClockworkLeggings)] = DefBlacksmithy.CraftSystem;
+        }
+
+        private static bool IsSpecial(Item item, CraftSystem system)
+        {
+            foreach (KeyValuePair<Type, CraftSystem> kvp in _SpecialTable)
+            {
+                if (kvp.Key == item.GetType() && kvp.Value == system)
+                    return true;
+            }
+
+            return false;
+        }
+
         public static EnhanceResult Invoke(Mobile from, CraftSystem craftSystem, BaseTool tool, Item item, CraftResource resource, Type resType, ref object resMessage)
         {
             if (item == null)
@@ -52,8 +74,15 @@ namespace Server.Engines.Craft
 
             CraftItem craftItem = craftSystem.CraftItems.SearchFor(item.GetType());
 
+            if (IsSpecial(item, craftSystem))
+            {
+                craftItem = craftSystem.CraftItems.SearchForSubclass(item.GetType());
+            }
+            
             if (craftItem == null || craftItem.Resources.Count == 0)
+            {
                 return EnhanceResult.BadItem;
+            }
 
             #region Mondain's Legacy
             if (craftItem.ForceNonExceptional)

--- a/Scripts/Services/ExploringTheDeep/Mobiles/IceWyrm.cs
+++ b/Scripts/Services/ExploringTheDeep/Mobiles/IceWyrm.cs
@@ -22,6 +22,8 @@ namespace Server.Mobiles
 
             Timer SelfDeleteTimer = new InternalSelfDeleteTimer(this);
             SelfDeleteTimer.Start();
+
+            Tamable = false;
         }
 
         public static IceWyrm Spawn(Point3D platLoc, Map platMap)
@@ -109,6 +111,9 @@ namespace Server.Mobiles
 
             Timer SelfDeleteTimer = new InternalSelfDeleteTimer(this);
             SelfDeleteTimer.Start();
+
+            if (Tamable)
+                Tamable = false;
         }
     }
 }

--- a/Scripts/Services/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/RunicReforging/RunicReforging.cs
@@ -685,7 +685,7 @@ namespace Server.Items
 		private static Dictionary<Type, CraftSystem> m_AllowableTable = new Dictionary<Type, CraftSystem>();
 		private static Dictionary<int, NamedInfoCol[][]> m_PrefixSuffixInfo = new Dictionary<int, NamedInfoCol[][]>();
 		
-        public static void Initialize()
+        public static void Configure()
         {
             Server.Commands.CommandSystem.Register("GetCreatureScore", AccessLevel.GameMaster, e =>
                 {

--- a/Scripts/Skills/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Skills/Imbuing/Core/Imbuing.cs
@@ -150,6 +150,9 @@ namespace Server.SkillHandlers
             if (item == null)
                 return true;
 
+            if (IsSpecialImbuable(item))
+                return false;
+
 			if (item.IsArtifact)
 				return true;
 
@@ -181,6 +184,20 @@ namespace Server.SkillHandlers
 
             return true;
         }
+
+        private static bool IsSpecialImbuable(Item item)
+        {
+            foreach (Type type in _SpecialImbuable)
+                if (item.GetType() == type)
+                    return true;
+
+            return false;
+        }
+
+        private static Type[] _SpecialImbuable =
+        {
+            typeof(ClockworkLeggings), typeof(GargishClockworkLeggings)
+        };
 
         public static double GetSuccessChance(Mobile from, Item item, int totalItemWeight, int propWeight, out double dif)
         {

--- a/Spawns/termur.xml
+++ b/Spawns/termur.xml
@@ -252,48 +252,6 @@
     <Objects2>Beninort/Name/Beninort:MX=1:SB=0:RT=0:TO=0:KL=0:RK=0:CA=1:DN=-1:DX=-1:SP=1:PR=-1</Objects2>
   </Points>
   <Points>
-    <Name>PerfectTimingSpawner2</Name>
-    <UniqueId>09e23b3d-65fe-4bcd-80e3-bc4a9f8cb10e</UniqueId>
-    <Map>TerMur</Map>
-    <X>825</X>
-    <Y>484</Y>
-    <Width>10</Width>
-    <Height>10</Height>
-    <CentreX>830</CentreX>
-    <CentreY>489</CentreY>
-    <CentreZ>-15</CentreZ>
-    <Range>5</Range>
-    <MaxCount>1</MaxCount>
-    <MinDelay>5</MinDelay>
-    <MaxDelay>10</MaxDelay>
-    <DelayInSec>False</DelayInSec>
-    <Duration>0</Duration>
-    <DespawnTime>0</DespawnTime>
-    <ProximityRange>-1</ProximityRange>
-    <ProximityTriggerSound>500</ProximityTriggerSound>
-    <TriggerProbability>1</TriggerProbability>
-    <InContainer>False</InContainer>
-    <MinRefractory>0</MinRefractory>
-    <MaxRefractory>0</MaxRefractory>
-    <TODStart>0</TODStart>
-    <TODEnd>0</TODEnd>
-    <TODMode>0</TODMode>
-    <KillReset>1</KillReset>
-    <ExternalTriggering>False</ExternalTriggering>
-    <SequentialSpawning>-1</SequentialSpawning>
-    <AllowGhostTriggering>False</AllowGhostTriggering>
-    <AllowNPCTriggering>False</AllowNPCTriggering>
-    <SpawnOnTrigger>False</SpawnOnTrigger>
-    <SmartSpawning>True</SmartSpawning>
-    <TickReset>False</TickReset>
-    <Team>0</Team>
-    <Amount>1</Amount>
-    <IsGroup>False</IsGroup>
-    <IsRunning>True</IsRunning>
-    <IsHomeRangeRelative>True</IsHomeRangeRelative>
-    <Objects2>sutek:MX=1:SB=0:RT=0:TO=0:KL=0:RK=0:CA=1:DN=-1:DX=-1:SP=1:PR=-1</Objects2>
-  </Points>
-  <Points>
     <Name>Ansikart</Name>
     <UniqueId>0b051cbe-1858-4248-86b6-88a165590cab</UniqueId>
     <Map>TerMur</Map>
@@ -748,7 +706,7 @@
     <SpawnOnTrigger>False</SpawnOnTrigger>
     <SmartSpawning>False</SmartSpawning>
     <TickReset>False</TickReset>
-    <Team>1</Team>
+    <Team>0</Team>
     <Amount>1</Amount>
     <IsGroup>False</IsGroup>
     <IsRunning>True</IsRunning>
@@ -6508,7 +6466,7 @@
     <SpawnOnTrigger>False</SpawnOnTrigger>
     <SmartSpawning>False</SmartSpawning>
     <TickReset>False</TickReset>
-    <Team>1</Team>
+    <Team>0</Team>
     <Amount>1</Amount>
     <IsGroup>False</IsGroup>
     <IsRunning>True</IsRunning>
@@ -6634,7 +6592,7 @@
     <SpawnOnTrigger>False</SpawnOnTrigger>
     <SmartSpawning>False</SmartSpawning>
     <TickReset>False</TickReset>
-    <Team>1</Team>
+    <Team>0</Team>
     <Amount>1</Amount>
     <IsGroup>False</IsGroup>
     <IsRunning>True</IsRunning>


### PR DESCRIPTION
- Fixed splintering weapon where players were not returning to normal speed
- special shoes can no longer be altered
- Slasher of veils terrorize no longer effects ghosts
- Fixed names on harrower skull braziers
- Clockwork Leggings can now be enhanced/imbued
- Ice Wyrms can no longer be tamed
- Fixed crash with peerless altars
- Peerless altars no longer reset if it was active during last Save
- Fixed vaious issues with spawners/teleporters. This will only effect during world load, so if you have an existing shard, I suggest you fix these issues manually