### PR TITLE
Prevents using multiple DataPath when CustomPath is or not set

### DIFF
--- a/Config/DataPath.cfg
+++ b/Config/DataPath.cfg
@@ -3,8 +3,3 @@
 # Windows installation directories. Note that this is *required* when running
 # on non-Windows systems.
 #CustomPath=C:\Program Files (x86)\Electronic Arts\Ultima Online Classic
-
-# If true all data paths other than CustomPath will be ignored. 
-# Highly Recommended if you set a custom client above to prevent multiple
-# instances of the client being loaded.
-IgnoreStandardPaths=False

--- a/Scripts/Misc/DataPath.cs
+++ b/Scripts/Misc/DataPath.cs
@@ -15,7 +15,6 @@ namespace Server.Misc
         *  private static string CustomPath = @"C:\Program Files\Ultima Online";
         */
         private static readonly string CustomPath = Config.Get(@"DataPath.CustomPath", null);
-        private static readonly bool IgnoreStandardPaths = Config.Get("DataPath.IgnoreStandardPaths", false);
         /* The following is a list of files which a required for proper execution:
         * 
         * Multi.idx
@@ -34,9 +33,10 @@ namespace Server.Misc
         public static void Configure()
         {
             if (CustomPath != null)
+	    {
                 Core.DataDirectories.Add(CustomPath);
-
-            if (!IgnoreStandardPaths)
+	    }
+	    else
             {
                 string pathUO = GetPath(@"Origin Worlds Online\Ultima Online\1.0", "ExePath");
                 string pathTD = GetPath(@"Origin Worlds Online\Ultima Online Third Dawn\1.0", "ExePath"); //These refer to 2D & 3D, not the Third Dawn expansion
@@ -44,34 +44,33 @@ namespace Server.Misc
                 string pathSA = GetPath(@"Electronic Arts\EA Games\Ultima Online Stygian Abyss Classic", "InstallDir");
                 string pathHS = GetPath(@"Electronic Arts\EA Games\Ultima Online Classic", "InstallDir");
 
-                if (pathUO != null)
-                    Core.DataDirectories.Add(pathUO);
+                if (pathUO != null && Core.DataDirectories == null)
+                    Core.DataDirectories.Add(pathHS);
 
-                if (pathTD != null)
-                    Core.DataDirectories.Add(pathTD);
-
-                if (pathKR != null)
-                    Core.DataDirectories.Add(pathKR);
-
-                if (pathSA != null)
+                if (pathTD != null && Core.DataDirectories == null)
                     Core.DataDirectories.Add(pathSA);
 
-                if (pathHS != null)
-                    Core.DataDirectories.Add(pathHS);
-            }
+                if (pathKR != null && Core.DataDirectories == null)
+                    Core.DataDirectories.Add(pathKR);
 
-            if (Core.DataDirectories.Count == 0 && !Core.Service)
-            {
-                Console.WriteLine("Enter the Ultima Online directory:");
+                if (pathSA != null && Core.DataDirectories == null)
+                    Core.DataDirectories.Add(pathTD);
+
+                if (pathHS != null && Core.DataDirectories == null)
+                    Core.DataDirectories.Add(pathUO);
+                
+		if (!Core.Service && Core.DataDirectories == null)
+		{
+		Console.WriteLine("Enter the Ultima Online directory:");
                 Console.Write("> ");
 
                 Core.DataDirectories.Add(Console.ReadLine());
+		}
             }
-
-	        foreach (var dir in Core.DataDirectories)
-	        {
-		        Ultima.Files.SetMulPath(dir);
-	        }
+	Ultima.Files.SetMulPath(Core.DataDirectories[0]);
+	Utility.PushColor(ConsoleColor.DarkYellow);
+	Console.WriteLine("DataPath: " + Core.DataDirectories[0]);
+	Utility.PopColor();
         }
 
         private static string GetPath(string subName, string keyName)


### PR DESCRIPTION
Prevents using multiple DataPath when CustomPath is or not set

Using CustomPath
if not set
using latest Expansion found
if not found
Prompt for path

Prevents using file from every folder found, this is unpredictable.

![data](https://cloud.githubusercontent.com/assets/1109954/22605308/998c3e56-ea4f-11e6-8241-d04004e8fbab.png)
