### PR TITLE
Bug Fixes, CreateWorld Gump functionality

### DIFF
--- a/Scripts/Commands/DecorateSA.cs
+++ b/Scripts/Commands/DecorateSA.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Commands;
+using Server.Items;
 
 namespace Server
 {
@@ -26,7 +27,10 @@ namespace Server
             Decorate.Generate("sa", "Data/Decoration/Stygian Abyss/Ter Mur", Map.TerMur);
 			Decorate.Generate("sa", "Data/Decoration/Stygian Abyss/Trammel", Map.Trammel);
 			Decorate.Generate("sa", "Data/Decoration/Stygian Abyss/Felucca", Map.Felucca);
-			
+
+            NavreysController.GenNavery(e.Mobile);
+            Server.Engines.CannedEvil.PrimevalLichPuzzle.GenLichPuzzle(e.Mobile);
+
             e.Mobile.SendMessage("Stygian Abyss world generation complete.");
         }
     }

--- a/Scripts/Items/Artifacts/Equipment/Armor/Sets/Ranger/RangerArms.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/Sets/Ranger/RangerArms.cs
@@ -1,10 +1,13 @@
 using System;
+using Server.Engines.Craft;
 
 namespace Server.Items
 {
     [FlipableAttribute(0x13dc, 0x13d4)]
-    public class RangerArms : BaseArmor
+    public class RangerArms : BaseArmor, IRepairable
     {
+        public CraftSystem RepairSystem { get { return DefTailoring.CraftSystem; } }
+
 		public override bool IsArtifact { get { return true; } }
         [Constructable]
         public RangerArms()

--- a/Scripts/Items/Artifacts/Equipment/Armor/Sets/Ranger/RangerChest.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/Sets/Ranger/RangerChest.cs
@@ -1,10 +1,13 @@
 using System;
+using Server.Engines.Craft;
 
 namespace Server.Items
 {
     [FlipableAttribute(0x13db, 0x13e2)]
-    public class RangerChest : BaseArmor
+    public class RangerChest : BaseArmor, IRepairable
     {
+        public CraftSystem RepairSystem { get { return DefTailoring.CraftSystem; } }
+
 		public override bool IsArtifact { get { return true; } }
         [Constructable]
         public RangerChest()

--- a/Scripts/Items/Artifacts/Equipment/Armor/Sets/Ranger/RangerGloves.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/Sets/Ranger/RangerGloves.cs
@@ -1,10 +1,13 @@
 using System;
+using Server.Engines.Craft;
 
 namespace Server.Items
 {
     [FlipableAttribute(0x13d5, 0x13dd)]
-    public class RangerGloves : BaseArmor
+    public class RangerGloves : BaseArmor, IRepairable
     {
+        public CraftSystem RepairSystem { get { return DefTailoring.CraftSystem; } }
+
 		public override bool IsArtifact { get { return true; } }
         [Constructable]
         public RangerGloves()

--- a/Scripts/Items/Artifacts/Equipment/Armor/Sets/Ranger/RangerGorget.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/Sets/Ranger/RangerGorget.cs
@@ -1,9 +1,12 @@
 using System;
+using Server.Engines.Craft;
 
 namespace Server.Items
 {
-    public class RangerGorget : BaseArmor
+    public class RangerGorget : BaseArmor, IRepairable
     {
+        public CraftSystem RepairSystem { get { return DefTailoring.CraftSystem; } }
+
 		public override bool IsArtifact { get { return true; } }
         [Constructable]
         public RangerGorget()

--- a/Scripts/Items/Artifacts/Equipment/Armor/Sets/Ranger/RangerLegs.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/Sets/Ranger/RangerLegs.cs
@@ -1,10 +1,13 @@
 using System;
+using Server.Engines.Craft;
 
 namespace Server.Items
 {
     [FlipableAttribute(0x13da, 0x13e1)]
-    public class RangerLegs : BaseArmor
+    public class RangerLegs : BaseArmor, IRepairable
     {
+        public CraftSystem RepairSystem { get { return DefTailoring.CraftSystem; } }
+
 		public override bool IsArtifact { get { return true; } }
         [Constructable]
         public RangerLegs()

--- a/Scripts/Items/Artifacts/Equipment/Clothing/ConjurersGarb.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/ConjurersGarb.cs
@@ -3,7 +3,7 @@ using System;
 namespace Server.Items
 {
     [Flipable(0x1F03, 0x1F04)]
-    public class ConjureresGarb : BaseOuterTorso
+    public class ConjureresGarb : BaseOuterTorso, ITokunoDyable
 	{
 		public override bool IsArtifact { get { return true; } }
         [Constructable]
@@ -16,9 +16,6 @@ namespace Server.Items
 			this.Attributes.DefendChance = 5;
 			this.Attributes.Luck = 140;
 			this.Attributes.RegenMana = 2;
-           
-			
-			// TODO: Supports arcane?
         }
 
         public ConjureresGarb(Serial serial)
@@ -27,6 +24,8 @@ namespace Server.Items
         }
 
         // Conjurer's Garb
+        public override int LabelNumber { get { return 1114052; } }
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Artifacts/Equipment/Clothing/ConjurersGarbHarbringer.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/ConjurersGarbHarbringer.cs
@@ -3,9 +3,10 @@ using System;
 namespace Server.Items
 {
     [Flipable(0x1F03, 0x1F04)]
-    public class ConjureresGarbHarbringer : BaseOuterTorso
+    public class ConjureresGarbHarbringer : BaseOuterTorso, ITokunoDyable
 	{
 		public override bool IsArtifact { get { return true; } }
+
         [Constructable]
         public ConjureresGarbHarbringer()
             : base(0x1F03, 0x486)
@@ -23,7 +24,6 @@ namespace Server.Items
         {
         }
 
-        // Conjurer's Garb on Harbringer
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Artifacts/Equipment/Spellbooks/ConjurersGrimoire.cs
+++ b/Scripts/Items/Artifacts/Equipment/Spellbooks/ConjurersGrimoire.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Server.Items
 {
-    public class ConjurersGrimoire : Spellbook
+    public class ConjurersGrimoire : Spellbook, ITokunoDyable
     {
         public override bool IsArtifact { get { return true; } }
         public override int LabelNumber { get { return 1094799; } } // Conjurer's Grimoire

--- a/Scripts/Items/Artifacts/Equipment/Spellbooks/ScrappersCompendium.cs
+++ b/Scripts/Items/Artifacts/Equipment/Spellbooks/ScrappersCompendium.cs
@@ -3,7 +3,7 @@ using Server.Engines.Craft;
 
 namespace Server.Items
 {
-    public class ScrappersCompendium : Spellbook
+    public class ScrappersCompendium : Spellbook, ITokunoDyable
 	{
 		public override bool IsArtifact { get { return true; } }
         [Constructable]

--- a/Scripts/Items/Artifacts/Talismans/ConjurersTrinket.cs
+++ b/Scripts/Items/Artifacts/Talismans/ConjurersTrinket.cs
@@ -3,7 +3,7 @@ using Server.Mobiles;
 
 namespace Server.Items
 {
-    public class ConjurersTrinket : BaseTalisman
+    public class ConjurersTrinket : BaseTalisman, ITokunoDyable
     {
         public override bool IsArtifact { get { return true; } }
         public override int LabelNumber { get { return 1094800; } } // Conjurer's Trinket

--- a/Scripts/Items/Equipment/Armor/BaseArmor.cs
+++ b/Scripts/Items/Equipment/Armor/BaseArmor.cs
@@ -581,7 +581,8 @@ namespace Server.Items
                 if (armor.ArmorAttributes.MageArmor > 1 || armor is WoodlandArms || armor is WoodlandChest || armor is WoodlandGloves || armor is WoodlandLegs || armor is WoodlandGorget || armor is BaseShield)
                     continue;
 
-                if (armor.MaterialType == ArmorMaterialType.Studded || armor.MaterialType == ArmorMaterialType.Bone)
+                else if (armor.MaterialType == ArmorMaterialType.Studded || armor.MaterialType == ArmorMaterialType.Bone ||
+                    armor is GargishStoneKilt || armor is GargishStoneLegs || armor is GargishStoneChest || armor is GargishStoneArms)
                     toReduce += 3;
                 else if (armor.MaterialType >= ArmorMaterialType.Ringmail)
                     toReduce += 1;

--- a/Scripts/Items/Functional/PrimevalLichPuzzle.cs
+++ b/Scripts/Items/Functional/PrimevalLichPuzzle.cs
@@ -212,23 +212,28 @@ namespace Server.Engines.CannedEvil
         [Description("Generates the Primeval Lich lever puzzle.")]
         public static void GenLichPuzzle_OnCommand(CommandEventArgs e)
         {
+            GenLichPuzzle(e.Mobile);
+        }
+
+        public static void GenLichPuzzle(Mobile m)
+        {
             if (null != m_Instance)
             {
-                e.Mobile.SendMessage("Primeval Lich lever puzzle already exists: please delete the existing one first ...");
+                m.SendMessage("Primeval Lich lever puzzle already exists: please delete the existing one first ...");
                 return;
             }
 
-            e.Mobile.SendMessage("Generating Primeval Lich lever puzzle...");
-            PrimevalLichPuzzle control = new PrimevalLichPuzzle(e.Mobile);
+            m.SendMessage("Generating Primeval Lich lever puzzle...");
+            PrimevalLichPuzzle control = new PrimevalLichPuzzle(m);
             if (null == control || control.Deleted)
-			{
-				e.Mobile.SendMessage(33, "There was a problem generating the puzzle.");
-			}
-			else
-			{
-				e.Mobile.SendMessage("The puzzle was successfully generated.");
-				WeakEntityCollection.Add("primevallich", control);
-			}
+            {
+                m.SendMessage(33, "There was a problem generating the puzzle.");
+            }
+            else
+            {
+                m.SendMessage("The puzzle was successfully generated.");
+                WeakEntityCollection.Add("primevallich", control);
+            }
         }
 
         // static hook for the ChampionSpawn code to update the puzzle state

--- a/Scripts/Misc/WeakEntityCollection.cs
+++ b/Scripts/Misc/WeakEntityCollection.cs
@@ -150,6 +150,11 @@ namespace Server
 			return col;
 		}
 
+        public static bool HasCollection(string name)
+        {
+            return name != null && _Collections.ContainsKey(name);
+        }
+
 		public static void Add(string key, IEntity entity)
 		{
 			if (entity == null || entity.Deleted)

--- a/Scripts/Regions/HouseRegion.cs
+++ b/Scripts/Regions/HouseRegion.cs
@@ -3,6 +3,8 @@ using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
 using Server.Multis;
+using System.Collections.Generic;
+using Server.ContextMenus;
 
 namespace Server.Regions
 {
@@ -12,6 +14,7 @@ namespace Server.Regions
         public static TimeSpan CombatHeatDelay = TimeSpan.FromSeconds(30.0);
         private readonly BaseHouse m_House;
         private bool m_Recursion;
+
         public HouseRegion(BaseHouse house)
             : base(null, house.Map, HousePriority, GetArea(house))
         {
@@ -180,6 +183,32 @@ namespace Server.Regions
             }
 
             return true;
+        }
+
+        public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list, Item item)
+        {
+            if (m_House.IsOwner(from) && item.Parent == null && m_House.IsLockedDown(item))
+            {
+                list.Add(new SimpleContextMenuEntry(from, 1153880, m => // Retrieve
+                    {
+                        if (BaseHouse.FindHouseAt(m) == m_House && m_House.IsOwner(m))
+                        {
+                            if (m.Backpack == null || !m.Backpack.CheckHold(m, item, false))
+                            {
+                                m.SendLocalizedMessage(1153881); // Your pack cannot hold this
+                            }
+                            else
+                            {
+                                m_House.Release(m, item);
+                                m.Backpack.DropItem(item);
+                            }
+                        }
+                        else
+                        {
+                            m.SendLocalizedMessage(1153882); // You do not own that.
+                        }
+                    }, 8));
+            }
         }
 
         public override bool OnDecay(Item item)

--- a/Scripts/Services/CleanUpBritannia/Items/DuelistsEdge.cs
+++ b/Scripts/Services/CleanUpBritannia/Items/DuelistsEdge.cs
@@ -2,8 +2,8 @@ using System;
 using Server.Mobiles;
 
 namespace Server.Items
-{ 
-    public class DuelistsEdge : BaseTalisman
+{
+    public class DuelistsEdge : BaseTalisman, ITokunoDyable
     {
         [Constructable]
         public DuelistsEdge()

--- a/Scripts/Services/CleanUpBritannia/Items/LuckyCharm.cs
+++ b/Scripts/Services/CleanUpBritannia/Items/LuckyCharm.cs
@@ -2,8 +2,8 @@ using System;
 using Server.Mobiles;
 
 namespace Server.Items
-{ 
-    public class LuckyCharm : BaseTalisman
+{
+    public class LuckyCharm : BaseTalisman, ITokunoDyable
     {
         [Constructable]
         public LuckyCharm()

--- a/Scripts/Services/CleanUpBritannia/Items/MysticsMemento.cs
+++ b/Scripts/Services/CleanUpBritannia/Items/MysticsMemento.cs
@@ -2,8 +2,8 @@ using System;
 using Server.Mobiles;
 
 namespace Server.Items
-{ 
-    public class MysticsMemento : BaseTalisman
+{
+    public class MysticsMemento : BaseTalisman, ITokunoDyable
     {
         [Constructable]
         public MysticsMemento()

--- a/Scripts/Services/CleanUpBritannia/Items/NecromancersPhylactery.cs
+++ b/Scripts/Services/CleanUpBritannia/Items/NecromancersPhylactery.cs
@@ -2,8 +2,8 @@ using System;
 using Server.Mobiles;
 
 namespace Server.Items
-{ 
-    public class NecromancersPhylactery : BaseTalisman
+{
+    public class NecromancersPhylactery : BaseTalisman, ITokunoDyable
     {
         [Constructable]
         public NecromancersPhylactery()

--- a/Scripts/Services/CleanUpBritannia/Items/SoldiersMedal.cs
+++ b/Scripts/Services/CleanUpBritannia/Items/SoldiersMedal.cs
@@ -2,8 +2,8 @@ using System;
 using Server.Mobiles;
 
 namespace Server.Items
-{ 
-    public class SoldiersMedal : BaseTalisman
+{
+    public class SoldiersMedal : BaseTalisman, ITokunoDyable
     {
         [Constructable]
         public SoldiersMedal()

--- a/Scripts/Services/CleanUpBritannia/Items/WizardsCurio.cs
+++ b/Scripts/Services/CleanUpBritannia/Items/WizardsCurio.cs
@@ -3,7 +3,7 @@ using Server.Mobiles;
 
 namespace Server.Items
 { 
-    public class WizardsCurio : BaseTalisman
+    public class WizardsCurio : BaseTalisman, ITokunoDyable
     {
         [Constructable]
         public WizardsCurio()

--- a/Scripts/Services/Expansions/High Seas/Multis/MooringLine.cs
+++ b/Scripts/Services/Expansions/High Seas/Multis/MooringLine.cs
@@ -28,6 +28,7 @@ namespace Server.Items
                 return;
 
             BaseBoat boat = BaseBoat.FindBoatAt(from, from.Map);
+
             int range = boat != null && boat == this.Boat ? 3 : 8;
             bool canMove = false;
 

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Controller.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Controller.cs
@@ -110,6 +110,17 @@ namespace Server.Engines.Shadowguard
             });
         }
 
+        public void CompleteRoof(Mobile m)
+        {
+            if (Table != null && Table.ContainsKey(m))
+            {
+                Table.Remove(m);
+
+                if (Table.Count == 0)
+                    Table = null;
+            }
+        }
+
         public void OnEncounterComplete(ShadowguardEncounter encounter, bool expired)
         {
             Encounters.Remove(encounter);
@@ -141,16 +152,9 @@ namespace Server.Engines.Shadowguard
         public void AddToTable(Mobile m, EncounterType encounter)
         {
             if (encounter == EncounterType.Roof)
-            {
-                if (Table != null && Table.ContainsKey(m))
-                {
-                    Table.Remove(m);
+                return;
 
-                    if (Table.Count == 0)
-                        Table = null;
-                }
-            }
-            else if (Table != null && Table.ContainsKey(m))
+            if (Table != null && Table.ContainsKey(m))
             {
                 if ((Table[m] & encounter) == 0)
                     Table[m] |= encounter;

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Encounters.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Encounters.cs
@@ -1351,7 +1351,14 @@ namespace Server.Engines.Shadowguard
 		public override void CheckEncounter()
 		{
 		}
-		
+
+        public override void CompleteEncounter()
+        {
+            base.CompleteEncounter();
+
+            Controller.CompleteRoof(PartyLeader);
+        }
+
 		public override void OnCreatureKilled(BaseCreature bc)
 		{
 			if(Bosses != null && bc is ShadowguardBoss && bc == CurrentBoss)

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/ShadowguardEncounter.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/ShadowguardEncounter.cs
@@ -22,6 +22,7 @@ namespace Server.Engines.Shadowguard
 
         [CommandProperty(AccessLevel.GameMaster)]
         public Point3D StartLoc { get { return Def.StartLoc; } }
+
         public Point3D[] SpawnPoints { get { return Def.SpawnPoints; } }
         public Rectangle2D[] SpawnRecs { get { return Def.SpawnRecs; } }
 
@@ -41,13 +42,24 @@ namespace Server.Engines.Shadowguard
         public ShadowguardInstance Instance { get; set; }
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public bool ForceEnd
+        public bool ForceExpire
         {
             get { return false; }
             set
             {
                 if (value)
                     Expire();
+            }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public bool ForceComplete
+        {
+            get { return false; }
+            set
+            {
+                if (value)
+                    CompleteEncounter();
             }
         }
 
@@ -144,7 +156,7 @@ namespace Server.Engines.Shadowguard
 		{
 			if(m == null || !m.Alive || !m.InRange(Controller.Location, 25) || m.NetState == null)
 			{
-				Reset();
+				Reset(true);
 			}
 			else
 			{
@@ -210,9 +222,14 @@ namespace Server.Engines.Shadowguard
                     Reset(true);
                 });
 		}
+
+        private bool _Completed;
 		
 		public virtual void CompleteEncounter()
 		{
+            if (_Completed)
+                return;
+
 			Timer.DelayCall(ResetDuration, () =>
                 {
                     Reset();
@@ -222,6 +239,8 @@ namespace Server.Engines.Shadowguard
                 SendPartyMessage(1156250); // Congratulations! You have bested Shadowguard and prevented Minax from exploiting the Time Gate! You will be teleported out in a few minutes.
             else
                 SendPartyMessage(1156244); //You have bested this tower of Shadowguard! You will be teleported out of the tower in 60 seconds!
+
+            _Completed = true;
 		}
 		
 		public virtual void Reset(bool expired = false)

--- a/Scripts/Services/PointsSystems/BlackthornData.cs
+++ b/Scripts/Services/PointsSystems/BlackthornData.cs
@@ -86,17 +86,11 @@ namespace Server.Engines.Points
                 writer.Write(kvp.Key);
                 writer.Write(kvp.Value);
             }
-
-            if (!PointsSystem.BlackthornHasSaved)
-                PointsSystem.BlackthornHasSaved = true;
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            if (!PointsSystem.BlackthornHasSaved)
-                return;
 
             int version = reader.ReadInt();
 

--- a/Scripts/Services/PointsSystems/PointsSystem.cs
+++ b/Scripts/Services/PointsSystems/PointsSystem.cs
@@ -275,9 +275,7 @@ namespace Server.Engines.Points
                 FilePath,
                 writer =>
                 {
-                    writer.Write((int)1);
-
-                    writer.Write(BlackthornHasSaved);
+                    writer.Write((int)2);
 
                     writer.Write(Systems.Count);
                     Systems.ForEach(s =>
@@ -296,7 +294,8 @@ namespace Server.Engines.Points
 				{
 					int version = reader.ReadInt();
 
-                    BlackthornHasSaved = version == 0 ? false : reader.ReadBool();
+                    if (version < 2)
+                        reader.ReadBool();
 
 					int count = reader.ReadInt();
 					for(int i = 0; i < count; i++)
@@ -308,8 +307,6 @@ namespace Server.Engines.Points
 					}	
 				});
 		}
-
-        public static bool BlackthornHasSaved { get; set; }
 
         public static List<PointsSystem> Systems { get; set; }
 

--- a/Scripts/Services/Underworld/Navrey's Lair/NavreysController.cs
+++ b/Scripts/Services/Underworld/Navrey's Lair/NavreysController.cs
@@ -17,17 +17,22 @@ namespace Server.Items
         [Usage("GenNavrey")]
         private static void GenNavrey_Command(CommandEventArgs e)
         {
+            GenNavery(e.Mobile);
+        }
+
+        public static void GenNavery(Mobile m)
+        {
             if (Check())
             {
-                e.Mobile.SendMessage("Navrey spawner is already present.");
+                m.SendMessage("Navrey spawner is already present.");
             }
             else
             {
-                e.Mobile.SendMessage("Creating Navrey Night-Eyes Lair...");
+                m.SendMessage("Creating Navrey Night-Eyes Lair...");
 
                 NavreysController controller = new NavreysController();
 
-                e.Mobile.SendMessage("Generation completed!");
+                m.SendMessage("Generation completed!");
             }
         }
 

--- a/Scripts/Spells/Skill Masteries/Core/SkillMasteryPrimer.cs
+++ b/Scripts/Spells/Skill Masteries/Core/SkillMasteryPrimer.cs
@@ -16,6 +16,8 @@ namespace Server.Items
         [CommandProperty(AccessLevel.GameMaster)]
         public int Volume { get; set; }
 
+        public override bool ForceShowProperties { get { return true; } }
+
         [Constructable]
         public SkillMasteryPrimer(SkillName skill, int volume) : base(7714)
         {

--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -1600,6 +1600,11 @@ namespace Server
             {
                 ((Mobile)m_Parent).GetChildContextMenuEntries(from, list, this);
             }
+
+            if (from.Region != null)
+            {
+                from.Region.GetContextMenuEntries(from, list, this);
+            }
         }
 
         public virtual bool VerifyMove(Mobile from)

--- a/Server/Region.cs
+++ b/Server/Region.cs
@@ -916,6 +916,10 @@ namespace Server
 			return true;
 		}
 
+        public virtual void GetContextMenuEntries(Mobile from, List<Server.ContextMenus.ContextMenuEntry> list, Item item)
+        {
+        }
+
 		public virtual bool AllowSpawn()
 		{
 			if (m_Parent != null)


### PR DESCRIPTION
- Added functionality to Create World Gump where it will tell you if the selections have already been created.
- Removed Lich puzzle from create world gump and added it to DecorateSA
- added IRepairable/DefTailoring to RangerArmor
- Added ITokunoDyeable to Conjurer's items and ScrappersCompendium/reward talismans
- Stone Armor now counts as 3 inherent LMC
- Added context menu option in Region.cs for items
- Added Retrieve context context menu to items lcoked down. They will only be available the house owner/Staff
- Fixed various exploits in Shadowguard
- added force show props to SkillMasteryPrimer

***REquires Core Recompile!***