### PR TITLE
bug fixes

### DIFF
--- a/Data/Decoration/Stygian Abyss/Ter Mur/Tomb Of King.cfg
+++ b/Data/Decoration/Stygian Abyss/Ter Mur/Tomb Of King.cfg
@@ -46,6 +46,14 @@ Static 0x19AB
 Blocker 0x21A4
 519 919 39
 
+
+Blocker 0x21A2
+33 207 0
+34 207 0
+35 207 0
+36 207 0
+37 207 0
+
 Moongate 0xF6C (Target=(946, 70, 75); TargetMap=TerMur)
 37 28 3
 

--- a/Scripts/Multis/Boats/BaseBoat.cs
+++ b/Scripts/Multis/Boats/BaseBoat.cs
@@ -27,6 +27,11 @@ namespace Server.Multis
 
         //private static TimeSpan BoatDecayDelay = TimeSpan.FromDays( 9.0 );
 
+        public static BaseBoat FindBoatAt(IEntity entity)
+        {
+            return FindBoatAt(entity, entity.Map);
+        }
+
         public static BaseBoat FindBoatAt(IPoint2D loc, Map map)
         {
             if (map == null || map == Map.Internal)
@@ -685,6 +690,11 @@ namespace Server.Multis
                 else if (m_TillerMan is Item)
                     ((Item)m_TillerMan).InvalidateProperties();
             }
+        }
+
+        public virtual bool HasAccess(Mobile from)
+        {
+            return true;
         }
 
         public bool StartMove(Direction dir, bool fast)

--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -1115,8 +1115,8 @@ namespace Server.Engines.Craft
 		private CraftSystem m_System;
 
 		#region Plant Pigments
-		private PlantHue m_PlantHue = PlantHue.Plain;
-		private PlantPigmentHue m_PlantPigmentHue = PlantPigmentHue.Plain;
+		private PlantHue m_PlantHue = PlantHue.None;
+		private PlantPigmentHue m_PlantPigmentHue = PlantPigmentHue.None;
 		#endregion
 
 		private void OnResourceConsumed(Item item, int amount)
@@ -1690,7 +1690,9 @@ namespace Server.Engines.Craft
                             ((IPigmentHue)item).PigmentHue = PlantPigmentHueInfo.HueFromPlantHue(m_PlantHue);
                     }
                     else if (m_PlantPigmentHue != PlantPigmentHue.None && item is IPigmentHue)
+                    {
                         ((IPigmentHue)item).PigmentHue = m_PlantPigmentHue;
+                    }
 
                     CraftContext context = craftSystem.GetContext(from);
 

--- a/Scripts/Services/Expansions/High Seas/Multis/BaseGalleon.cs
+++ b/Scripts/Services/Expansions/High Seas/Multis/BaseGalleon.cs
@@ -485,7 +485,12 @@ namespace Server.Multis
             return m_SecurityEntry.IsPublic;
         }
 
-        public bool HasAccess(Mobile from)
+        public override bool CanCommand(Mobile m)
+        {
+            return GetSecurityLevel(m) >= SecurityLevel.Crewman;
+        }
+
+        public override bool HasAccess(Mobile from)
         {
             if(Owner == null || (Scuttled && IsEnemy(from))/* || (Owner is BaseCreature && !Owner.Alive)*/)
                 return true;

--- a/Scripts/Services/Expansions/High Seas/Multis/MooringLine.cs
+++ b/Scripts/Services/Expansions/High Seas/Multis/MooringLine.cs
@@ -65,7 +65,7 @@ namespace Server.Items
                 {
                     if (!from.Alive)
                         from.SendLocalizedMessage(1060190); //You cannot do that while dead!
-                    else if (boat is BaseGalleon && m_Boat is RowBoat && ((RowBoat)m_Boat).HasAccess(from))
+                    else if (m_Boat is RowBoat && ((RowBoat)m_Boat).HasAccess(from))
                         canMove = true;
                     else if (boat is RowBoat && m_Boat is BaseGalleon && ((BaseGalleon)m_Boat).HasAccess(from))
                         canMove = true;

--- a/Scripts/Services/Expansions/High Seas/Multis/Rowboat.cs
+++ b/Scripts/Services/Expansions/High Seas/Multis/Rowboat.cs
@@ -136,7 +136,7 @@ namespace Server.Multis
             return item == this || item == m_Line || item == m_Rudder || item is RudderHandle;
         }
 
-        public bool HasAccess(Mobile from)
+        public override bool HasAccess(Mobile from)
         {
             if (from.AccessLevel > AccessLevel.Player || this.Owner == null)
                 return true;

--- a/Scripts/Services/Expansions/Time Of Legends/Mobiles/DragonTurtleHatchling.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Mobiles/DragonTurtleHatchling.cs
@@ -52,6 +52,8 @@ namespace Server.Mobiles
 
         public override void OnAfterTame(Mobile tamer)
         {
+            SkillsCap = this.Skills.Total;
+
             foreach (Skill sk in this.Skills)
             {
                 if (sk.Base > 0)

--- a/Scripts/Services/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/RunicReforging/RunicReforging.cs
@@ -315,7 +315,7 @@ namespace Server.Items
                     if (playermade || item is BaseRanged)
                         list.Remove(col);
                 }
-                else if (list.Contains(col) && col.Attribute is AosWeaponAttributes && (AosWeaponAttribute)col.Attribute == AosWeaponAttribute.ReactiveParalyze)
+                else if (list.Contains(col) && col.Attribute is AosWeaponAttribute && (AosWeaponAttribute)col.Attribute == AosWeaponAttribute.ReactiveParalyze)
                 {
                     if (!(item is BaseWeapon && item is BaseShield) && item.Layer != Layer.TwoHanded)
                         list.Remove(col);

--- a/Scripts/Spells/Seventh/GateTravel.cs
+++ b/Scripts/Spells/Seventh/GateTravel.cs
@@ -184,7 +184,20 @@ namespace Server.Spells.Seventh
             public override void UseGate(Mobile m)
             {
                 if (m_LinkedGate == null || !(m_LinkedGate is GateTravelSpell.InternalItem) || !((GateTravelSpell.InternalItem)m_LinkedGate).BoatGate || !m_LinkedGate.Deleted)
+                {
+                    if (m_LinkedGate != null && ((GateTravelSpell.InternalItem)m_LinkedGate).BoatGate)
+                    {
+                        BaseBoat boat = BaseBoat.FindBoatAt(m_LinkedGate);
+
+                        if(boat != null && !boat.HasAccess(m))
+                        {
+                            m.SendLocalizedMessage(1116617); //You do not have permission to board this ship.
+                            return;
+                        }
+                    }
+
                     base.UseGate(m);
+                }
                 else
                     m.SendMessage("The other gate no longer exists.");
             }


### PR DESCRIPTION
- Added LOS blockers in Tomb of Kings for world Create
- You can now board row boats from any other type of boat, as long as you have access to the rowboat
- only crewmembers+ can give galleon commands
- Non-accessed players can no longer to through gates that lead to a galleon
- fixed shadowguard exploit
- fixed reactive paralyze appearing on 1 handed weapons
- Natural Dyes now hold the proper plant pigment when crafted