### PR TITLE
Introducing Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /Scripts/Output
 /Logs
 /Backups
+/Cache
 /Saves
 /Web
 /Docs

--- a/Scripts/Commands/GenCategorization.cs
+++ b/Scripts/Commands/GenCategorization.cs
@@ -360,8 +360,9 @@ namespace Server.Commands
             {
                 Type type = ScriptCompiler.FindTypeByName(split[i].Trim());
 
-                if (type == null && Core.Debug)
-                    Console.WriteLine("Match type not found ('{0}')", split[i].Trim());
+                if (type == null)
+			if (Core.Debug)
+                    		Console.WriteLine("Match type not found ('{0}')", split[i].Trim());
                 else
                     list.Add(type);
             }

--- a/Scripts/Commands/GenCategorization.cs
+++ b/Scripts/Commands/GenCategorization.cs
@@ -43,8 +43,15 @@ namespace Server.Commands
         public static void RebuildCategorization_OnCommand(CommandEventArgs e)
         {
             CategoryEntry root = new CategoryEntry(null, "Add Menu", new CategoryEntry[] { Items, Mobiles });
-
-            Export(root, "Data/objects.xml", "Objects");
+            
+            if (!File.Exists("Cache/objects.xml"))
+            {
+                Export(root, "Data/objects.xml", "Objects");
+            }
+			else
+			{
+				Export(root, "Cache/objects.xml", "Objects");
+			}
 
             e.Mobile.SendMessage("Categorization menu rebuilt.");
         }

--- a/Scripts/Commands/GenCategorization.cs
+++ b/Scripts/Commands/GenCategorization.cs
@@ -48,6 +48,13 @@ namespace Server.Commands
 
             e.Mobile.SendMessage("Categorization menu rebuilt.");
         }
+        
+        public static void RebuildCategorization()
+        {
+            CategoryEntry root = new CategoryEntry(null, "Add Menu", new CategoryEntry[] { Items, Mobiles });
+
+            Export(root, "Cache/objects.xml", "Objects");
+        }
 
         public static void RecurseFindCategories(CategoryEntry ce, ArrayList list)
         {

--- a/Scripts/Commands/GenCategorization.cs
+++ b/Scripts/Commands/GenCategorization.cs
@@ -360,7 +360,7 @@ namespace Server.Commands
             {
                 Type type = ScriptCompiler.FindTypeByName(split[i].Trim());
 
-                if (type == null)
+                if (type == null && Core.Debug)
                     Console.WriteLine("Match type not found ('{0}')", split[i].Trim());
                 else
                     list.Add(type);

--- a/Scripts/Gumps/CategorizedAddGump.cs
+++ b/Scripts/Gumps/CategorizedAddGump.cs
@@ -134,14 +134,23 @@ namespace Server.Gumps
 
         public static CAGCategory Root
         {
-            get
-            {
-                if (m_Root == null)
-                    m_Root = Load("Data/objects.xml");
-
-                return m_Root;
-            }
-        }
+			get
+			{
+				if ( m_Root == null )
+				{
+					if (!File.Exists("Cache/objects.xml"))
+					{
+						m_Root = Load("Data/objects.xml");
+					}
+					else
+					{
+						m_Root = Load("Cache/objects.xml");
+					}
+				}
+				
+				return m_Root;
+			}
+		}
         public string Title
         {
             get

--- a/Scripts/Misc/Cache.cs
+++ b/Scripts/Misc/Cache.cs
@@ -38,7 +38,7 @@ namespace Server.Cache
 						bin.Write((ushort)yMax);
 					}
 				Utility.PushColor(ConsoleColor.Green);
-				Console.WriteLine("done");
+				Console.WriteLine("done. This requires a restart to take effect.");
 				Utility.PopColor();
 				bin.Close();	
 			}
@@ -52,12 +52,12 @@ namespace Server.Cache
 			if(!File.Exists("Cache/objects.xml"))
 			{
 				Utility.PushColor(ConsoleColor.Yellow);
-				Console.WriteLine("Cache: Generating objects.xml...");
+				Console.Write("Cache: Generating objects.xml...");
 				Utility.PopColor();
 				Cache.CreateFolder();
 				Categorization.RebuildCategorization();
 				Utility.PushColor(ConsoleColor.Green);
-				Console.WriteLine("done");
+				Console.WriteLine("done. This requires a restart to take effect.");
 				Utility.PopColor();
 			}
 		}

--- a/Scripts/Misc/Cache.cs
+++ b/Scripts/Misc/Cache.cs
@@ -17,8 +17,10 @@ namespace Server.Cache
 		public static void Initialize()
 		{	
 			if((Ultima.Files.MulPath["artlegacymul.uop"] != null || (Ultima.Files.MulPath["art.mul"] != null && Ultima.Files.MulPath["artidx.mul"] != null)) && !File.Exists("Cache/Bounds.bin"))
-			{		
-				Console.WriteLine("Cache: Generating Bounds.bin");
+			{	
+				Utility.PushColor(ConsoleColor.Yellow);
+				Console.Write("Cache: Generating Bounds.bin...");
+				
 				Cache.CreateFolder();
 				FileStream fs = new FileStream( "Cache/Bounds.bin", FileMode.Create, FileAccess.Write );
 			
@@ -35,6 +37,9 @@ namespace Server.Cache
 						bin.Write((ushort)xMax);
 						bin.Write((ushort)yMax);
 					}
+				Utility.PushColor(ConsoleColor.Green);
+				Console.WriteLine("done");
+				Utility.PopColor();
 				bin.Close();	
 			}
 		}
@@ -46,9 +51,14 @@ namespace Server.Cache
 		{	
 			if(!File.Exists("Cache/objects.xml"))
 			{
-				Console.WriteLine("Cache: Generating objects.xml");
+				Utility.PushColor(ConsoleColor.Yellow);
+				Console.WriteLine("Cache: Generating objects.xml...");
+				Utility.PopColor();
 				Cache.CreateFolder();
 				Categorization.RebuildCategorization();
+				Utility.PushColor(ConsoleColor.Green);
+				Console.WriteLine("done");
+				Utility.PopColor();
 			}
 		}
 	}

--- a/Scripts/Misc/Cache.cs
+++ b/Scripts/Misc/Cache.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using Server.Commands;
+
+namespace Server.Cache
+{
+	public class Cache
+	{
+				public static void CreateFolder()
+				{
+					Directory.CreateDirectory("Cache");
+				}
+	}
+	
+	public class Bounds
+	{
+		public static void Initialize()
+		{	
+			if((Ultima.Files.MulPath["artlegacymul.uop"] != null || (Ultima.Files.MulPath["art.mul"] != null && Ultima.Files.MulPath["artidx.mul"] != null)) && !File.Exists("Cache/Bounds.bin"))
+			{		
+				Console.WriteLine("Cache: Generating Bounds.bin");
+				Cache.CreateFolder();
+				FileStream fs = new FileStream( "Cache/Bounds.bin", FileMode.Create, FileAccess.Write );
+			
+				BinaryWriter bin = new BinaryWriter( fs );
+			
+				int xMin, yMin, xMax, yMax;
+						
+					for ( int i = 0; i < Ultima.Art.GetMaxItemID(); ++i )
+					{
+						Ultima.Art.Measure(Item.GetBitmap(i), out xMin, out yMin, out xMax, out yMax);
+						
+						bin.Write((ushort)xMin);
+						bin.Write((ushort)yMin);
+						bin.Write((ushort)xMax);
+						bin.Write((ushort)yMax);
+					}
+				bin.Close();	
+			}
+		}
+	}
+	
+	public class Objects
+	{
+		public static void Initialize()
+		{	
+			if(!File.Exists("Cache/objects.xml"))
+			{
+				Console.WriteLine("Cache: Generating objects.xml");
+				Cache.CreateFolder();
+				Categorization.RebuildCategorization();
+			}
+		}
+	}
+}

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -8351,6 +8351,9 @@
     <Compile Include="Misc\BuffIcons.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Misc\Cache.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Misc\CharacterCreation.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Scripts/Services/XmlSpawner/XmlSpawner Core/XmlUtils/XmlCategorizedAddGump.cs
+++ b/Scripts/Services/XmlSpawner/XmlSpawner Core/XmlUtils/XmlCategorizedAddGump.cs
@@ -164,7 +164,7 @@ namespace Server.Gumps
 
 				}
 				} catch (Exception ex){
-                    Console.WriteLine("XmlCategorizedAddGump: Corrupted Data/objects.xml file detected. Not all XmlCAG objects loaded. {0}", ex); 
+                    Console.WriteLine("XmlCategorizedAddGump: Corrupted Data/objects.xml or Cache/objects.xml file detected. Not all XmlCAG objects loaded. {0}", ex); 
                 }
 
 
@@ -180,8 +180,17 @@ namespace Server.Gumps
 			get
 			{
 				if ( m_Root == null )
-					m_Root = Load( "Data/objects.xml" );
-
+				{
+					if (!File.Exists("Cache/objects.xml"))
+					{
+						m_Root = Load("Data/objects.xml");
+					}
+					else
+					{
+						m_Root = Load("Cache/objects.xml");
+					}
+				}
+				
 				return m_Root;
 			}
 		}

--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -1047,9 +1047,12 @@ namespace Server
             }
             catch
             {
-                Utility.PushColor(ConsoleColor.Red);
-                Console.WriteLine("Ultima Art: Unable to read client files.");
-                Utility.PopColor();
+		if (Core.Debug)
+		{
+                	Utility.PushColor(ConsoleColor.Red);
+                	Console.WriteLine("Ultima Art: Unable to read client files.");
+                	Utility.PopColor();
+		}
             }
 
             return null;

--- a/Server/ItemBounds.cs
+++ b/Server/ItemBounds.cs
@@ -16,36 +16,53 @@ namespace Server
 		private static readonly Rectangle2D[] m_Bounds;
 
 		public static Rectangle2D[] Table { get { return m_Bounds; } }
+		
+		private static string m_Path = "Cache/Bounds.bin";
+		
+		private static string m_LegacyPath = "Data/Binary/Bounds.bin";
 
 		static ItemBounds()
 		{
 			m_Bounds = new Rectangle2D[TileData.ItemTable.Length];
-
-			if (File.Exists("Data/Binary/Bounds.bin"))
+			
+			if (File.Exists(m_Path))
 			{
-				using (FileStream fs = new FileStream("Data/Binary/Bounds.bin", FileMode.Open, FileAccess.Read, FileShare.Read))
+				ReadItemBounds(m_Path);
+				if (Core.Debug)
+						Console.WriteLine("Using generated Bounds.bin");
+			}
+			else if (!File.Exists(m_Path))
+			{
+				ReadItemBounds(m_LegacyPath);
+				if (Core.Debug)
+						Console.WriteLine("Using Generic Bounds.bin");
+			}
+			else
+			{
+				Console.WriteLine("Warning: Bounds.bin does not exist");
+			}
+		}
+			
+			
+		private static void ReadItemBounds(string Path)
+		{
+				using (FileStream fs = new FileStream(Path, FileMode.Open, FileAccess.Read, FileShare.Read))
 				{
 					BinaryReader bin = new BinaryReader(fs);
 
 					int count = Math.Min(m_Bounds.Length, (int)(fs.Length / 8));
-
+					
 					for (int i = 0; i < count; ++i)
 					{
 						int xMin = bin.ReadInt16();
 						int yMin = bin.ReadInt16();
 						int xMax = bin.ReadInt16();
 						int yMax = bin.ReadInt16();
-
+										
 						m_Bounds[i].Set(xMin, yMin, (xMax - xMin) + 1, (yMax - yMin) + 1);
 					}
-
 					bin.Close();
 				}
-			}
-			else
-			{
-				Console.WriteLine("Warning: Data/Binary/Bounds.bin does not exist");
-			}
 		}
 	}
 }


### PR DESCRIPTION
Introducing the Cache.

When the Server is started the first time:
if art files are available a cache folder is created and generating Bounds.bin
if not Data/Binary/Bounds.bin is used
if Cache/objects.xml is not available its been generated
deleting cache folder forces regeneration
deleting cache.cs completely disables the cache and default files are loaded.

Why this makes sense?

Art files are updated by osi and custom shards regulary, so the new bounds can be generated manually and it does not require a ServUO Developer to regenerate the file regulary.


Alternative would be:
Adding Rebuild Bounds.bin to AdminGump Maintenance Category and rebuild it in place.

https://github.com/ServUO/ServUO/pull/1745

Simply reject the one you didn't like.