### PR TITLE
Magic Drake Wing lifespan increased to 90 seconds.

### DIFF
--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Items.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Items.cs
@@ -795,7 +795,7 @@ namespace Server.Engines.Shadowguard
 	
 	public class MagicDrakeWing : BaseDecayingItem
 	{
-		public override int Lifespan { get { return 60; } }
+		public override int Lifespan { get { return 90; } }
 		public override int LabelNumber { get { return 1156233; } } // Magic Drake Wing
 
         [Constructable]


### PR DESCRIPTION
According to Publish 90 updates, Magic Drake Wing lifespan should be 90 seconds.
https://uo.com/wiki/ultima-online-wiki/publish-notes/publish-90/