### PR TITLE
Shadowguard Pirate hitpoints updated to 1200

### DIFF
--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
@@ -19,7 +19,7 @@ namespace Server.Engines.Shadowguard
 			SetDex( 151, 165 );
 			SetInt( 161, 175 );
 
-            SetHits(2000, 2250);
+            SetHits(1200);
  
 			SetDamage( 15, 21 );
  


### PR DESCRIPTION
If a throw is successful it does 300 damage. Four bottles will defeat a normal pirate.
http://www.uoguide.com/Shadowguard

That means max hitpoint of a normal pirate should be 1200 max.