### PR TITLE
Allow creatures to run when using faster AI speeds

### DIFF
--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -2313,10 +2313,18 @@ namespace Server.Mobiles
 				return MoveResult.BadState;
 			}
 
+			int delay = (int)(TransformMoveDelay(m_Mobile.CurrentSpeed) * 1000);
+
+			var mounted = m_Mobile.Mounted || m_Mobile.Flying;
+			var running = (mounted && delay <= Mobile.RunMount) || (!mounted && delay <= Mobile.RunFoot);
+
+			if (running)
+			{
+				d |= Direction.Running;
+			}
+            
 			// This makes them always move one step, never any direction changes
 			m_Mobile.Direction = d;
-
-			int delay = (int)(TransformMoveDelay(m_Mobile.CurrentSpeed) * 1000);
             
 			m_NextMove += delay;
 


### PR DESCRIPTION
When creatures move too fast, they tend to skip around the screen.
This fix will resolve that by including the Direction.Running flag if the creature movement speed is below the running threshold.