### PR TITLE
Fix mysticism spells namespace

### DIFF
--- a/Scripts/Items/Equipment/Spellbooks/Spellbook.cs
+++ b/Scripts/Items/Equipment/Spellbooks/Spellbook.cs
@@ -16,7 +16,7 @@ using Server.Network;
 using Server.Spells;
 using Server.Targeting;
 using Server.Mobiles;
-using Server.Spells.Mystic;
+using Server.Spells.Mysticism;
 #endregion
 
 namespace Server.Items

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -1161,7 +1161,7 @@ namespace Server.Items
 				}
 
 				ImmolatingWeaponSpell.StopImmolating(this);
-                Spells.Mystic.EnchantSpell.OnWeaponRemoved(this, m);
+                Spells.Mysticism.EnchantSpell.OnWeaponRemoved(this, m);
 
 				m.CheckStatTimers();
 
@@ -5230,11 +5230,11 @@ namespace Server.Items
             #region Stygian Abyss
             if (EnchantedWeilder != null)
             {
-                if (Server.Spells.Mystic.EnchantSpell.IsUnderSpellEffects(EnchantedWeilder, this))
+                if (Server.Spells.Mysticism.EnchantSpell.IsUnderSpellEffects(EnchantedWeilder, this))
                 {
-                    bonus = Server.Spells.Mystic.EnchantSpell.BonusAttribute(EnchantedWeilder);
-                    enchantBonus = Server.Spells.Mystic.EnchantSpell.BonusValue(EnchantedWeilder);
-                    fcMalus = Server.Spells.Mystic.EnchantSpell.CastingMalus(EnchantedWeilder, this);
+                    bonus = Server.Spells.Mysticism.EnchantSpell.BonusAttribute(EnchantedWeilder);
+                    enchantBonus = Server.Spells.Mysticism.EnchantSpell.BonusValue(EnchantedWeilder);
+                    fcMalus = Server.Spells.Mysticism.EnchantSpell.CastingMalus(EnchantedWeilder, this);
                 }
             }
             #endregion

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -260,8 +260,8 @@ namespace Server
 
             if (totalDamage > 0)
             {
-                Spells.Mystic.SpellPlagueSpell.OnMobileDamaged(m);
-                Spells.Mystic.SleepSpell.OnDamage(m);
+                Spells.Mysticism.SpellPlagueSpell.OnMobileDamaged(m);
+                Spells.Mysticism.SleepSpell.OnDamage(m);
             }
             #endregion
 
@@ -531,7 +531,7 @@ namespace Server
                     value -= 30;
 
                 #region SA
-                if (TransformationSpellHelper.UnderTransformation(m, typeof(Spells.Mystic.StoneFormSpell)))
+                if (TransformationSpellHelper.UnderTransformation(m, typeof(Spells.Mysticism.StoneFormSpell)))
                     value -= 10;
 
                 if (m is PlayerMobile && m.Race == Race.Gargoyle)
@@ -589,10 +589,10 @@ namespace Server
                 #endregion
 
                 #region SA
-                if (Spells.Mystic.SleepSpell.IsUnderSleepEffects(m))
+                if (Spells.Mysticism.SleepSpell.IsUnderSleepEffects(m))
                     value -= 2;
 
-                if (TransformationSpellHelper.UnderTransformation(m, typeof(Spells.Mystic.StoneFormSpell)))
+                if (TransformationSpellHelper.UnderTransformation(m, typeof(Spells.Mysticism.StoneFormSpell)))
                     value -= 2;
                 #endregion
             }
@@ -604,7 +604,7 @@ namespace Server
                 value -= ThunderstormSpell.GetCastRecoveryMalus(m);
 
                 #region SA
-                if (Spells.Mystic.SleepSpell.IsUnderSleepEffects(m))
+                if (Spells.Mysticism.SleepSpell.IsUnderSleepEffects(m))
                     value -= 3;
                 #endregion
             }
@@ -641,10 +641,10 @@ namespace Server
                 #endregion
 
                 #region SA
-                if (Spells.Mystic.SleepSpell.IsUnderSleepEffects(m))
+                if (Spells.Mysticism.SleepSpell.IsUnderSleepEffects(m))
                     value -= 45;
 
-                if (TransformationSpellHelper.UnderTransformation(m, typeof(Spells.Mystic.StoneFormSpell)))
+                if (TransformationSpellHelper.UnderTransformation(m, typeof(Spells.Mysticism.StoneFormSpell)))
                     value -= 10;
 
                 if (MudPie.IsUnderEffects(m))
@@ -681,7 +681,7 @@ namespace Server
                 #endregion
 
                 #region SA
-                if (Spells.Mystic.SleepSpell.IsUnderSleepEffects(m))
+                if (Spells.Mysticism.SleepSpell.IsUnderSleepEffects(m))
                     value -= 45;
 
                 if (m.Race == Race.Gargoyle)

--- a/Scripts/Mobiles/AI/MageAI.cs
+++ b/Scripts/Mobiles/AI/MageAI.cs
@@ -11,7 +11,7 @@ using Server.Spells.Sixth;
 using Server.Spells.Third;
 using Server.Spells.Eighth;
 using Server.Spells.Necromancy;
-using Server.Spells.Mystic;
+using Server.Spells.Mysticism;
 using Server.Spells.Spellweaving;
 using Server.Targeting;
 

--- a/Scripts/Mobiles/AI/MysticAI.cs
+++ b/Scripts/Mobiles/AI/MysticAI.cs
@@ -1,7 +1,7 @@
 using System;
 using Server;
 using System.Collections.Generic;
-using Server.Spells.Mystic;
+using Server.Spells.Mysticism;
 using Server.Spells;
 using Server.Targeting;
 

--- a/Scripts/Mobiles/AI/Omni AI/OmniAI Mysicism.cs
+++ b/Scripts/Mobiles/AI/Omni AI/OmniAI Mysicism.cs
@@ -1,6 +1,6 @@
 using System;
 using Server.Spells;
-using Server.Spells.Mystic;
+using Server.Spells.Mysticism;
 
 namespace Server.Mobiles
 {

--- a/Scripts/Mobiles/AI/Omni AI/OmniAI Shared.cs
+++ b/Scripts/Mobiles/AI/Omni AI/OmniAI Shared.cs
@@ -5,7 +5,7 @@ using Server.Spells;
 using Server.Spells.Chivalry;
 using Server.Spells.First;
 using Server.Spells.Fourth;
-using Server.Spells.Mystic;
+using Server.Spells.Mysticism;
 using Server.Spells.Second;
 
 namespace Server.Mobiles

--- a/Scripts/Mobiles/Normal/GargishOutcast.cs
+++ b/Scripts/Mobiles/Normal/GargishOutcast.cs
@@ -1,6 +1,6 @@
 using System;
 using Server;
-using Server.Spells.Mystic;
+using Server.Spells.Mysticism;
 using Server.Items;
 using Server.Spells;
 

--- a/Scripts/Mobiles/Normal/GargishRouser.cs
+++ b/Scripts/Mobiles/Normal/GargishRouser.cs
@@ -1,6 +1,6 @@
 using System;
 using Server;
-using Server.Spells.Mystic;
+using Server.Spells.Mysticism;
 using Server.Items;
 using Server.Spells;
 

--- a/Scripts/Mobiles/Normal/VoidManesfistation.cs
+++ b/Scripts/Mobiles/Normal/VoidManesfistation.cs
@@ -1,6 +1,6 @@
 using System;
 using Server;
-using Server.Spells.Mystic;
+using Server.Spells.Mysticism;
 using Server.Items;
 using Server.Spells;
 

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -889,7 +889,7 @@ namespace Server.Mobiles
             int max = base.GetMaxResistance(type);
 
             #region SA
-            max += Spells.Mystic.StoneFormSpell.GetMaxResistMod(this);
+            max += Spells.Mysticism.StoneFormSpell.GetMaxResistMod(this);
             #endregion
 
             max += BaseArmor.GetRefinedResist(this, type);

--- a/Scripts/Services/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/RunicReforging/RunicReforging.cs
@@ -100,7 +100,7 @@ namespace Server.Items
                 goodtogo = false;
             else if (item.LootType == LootType.Blessed || item.LootType == LootType.Newbied)
                 goodtogo = false;
-            else if (item is BaseWeapon && Server.Spells.Mystic.EnchantSpell.IsUnderSpellEffects(from, (BaseWeapon)item))
+            else if (item is BaseWeapon && Server.Spells.Mysticism.EnchantSpell.IsUnderSpellEffects(from, (BaseWeapon)item))
                 goodtogo = false;
             else if (item is BaseWeapon && ((BaseWeapon)item).FocusWeilder != null)
                 goodtogo = false;

--- a/Scripts/Skills/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Skills/Imbuing/Core/Imbuing.cs
@@ -66,7 +66,7 @@ namespace Server.SkillHandlers
                 from.SendLocalizedMessage(1079575);  // The item must be in your backpack to imbue it.
             else if (item.LootType == LootType.Blessed || item.LootType == LootType.Newbied)
                 from.SendLocalizedMessage(1080438);  // You cannot imbue a blessed item.
-            else if (item is BaseWeapon && Spells.Mystic.EnchantSpell.IsUnderSpellEffects(from, (BaseWeapon)item))
+            else if (item is BaseWeapon && Spells.Mysticism.EnchantSpell.IsUnderSpellEffects(from, (BaseWeapon)item))
                 from.SendLocalizedMessage(1080130);  // You cannot imbue an item that is currently enchanted.
             else if (item is BaseWeapon && ((BaseWeapon)item).FocusWeilder != null)
                 from.SendLocalizedMessage(1080444);  //You cannot imbue an item that is under the effects of the ninjitsu focus attack ability.
@@ -121,7 +121,7 @@ namespace Server.SkillHandlers
                 if (message)
                     from.SendLocalizedMessage(1080421);  // You cannot unravel the magic of a blessed item.
             }
-            else if (item is BaseWeapon && Spells.Mystic.EnchantSpell.IsUnderSpellEffects(from, (BaseWeapon)item))
+            else if (item is BaseWeapon && Spells.Mysticism.EnchantSpell.IsUnderSpellEffects(from, (BaseWeapon)item))
             {
                 if (message)
                     from.SendLocalizedMessage(1080427);  // You cannot magically unravel an item that is currently enchanted.

--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -21,7 +21,7 @@ using Server.Spells.Spellweaving;
 using Server.Targeting;
 using Server.Spells.SkillMasteries;
 using System.Reflection;
-using Server.Spells.Mystic;
+using Server.Spells.Mysticism;
 #endregion
 
 namespace Server.Spells

--- a/Scripts/Spells/Gargoyle/SpellDefinitions/FlySpell.cs
+++ b/Scripts/Spells/Gargoyle/SpellDefinitions/FlySpell.cs
@@ -101,7 +101,7 @@ namespace Server.Spells
 				Caster.SendLocalizedMessage(1061628); // You can't do that while polymorphed.
 			}
 			else if (Ninjitsu.AnimalForm.UnderTransformation(Caster) ||
-				Mystic.StoneFormSpell.IsEffected(Caster) ||
+				Mysticism.StoneFormSpell.IsEffected(Caster) ||
 				(TransformationSpellHelper.UnderTransformation(Caster) && !TransformationSpellHelper.UnderTransformation(Caster, typeof(Spells.Necromancy.VampiricEmbraceSpell))) ||
                 (Caster.IsBodyMod && !Caster.Body.IsHuman))
 			{

--- a/Scripts/Spells/Initializer.cs
+++ b/Scripts/Spells/Initializer.cs
@@ -164,22 +164,22 @@ namespace Server.Spells
 
                 if (Core.SA)
                 {
-                    Register(677, typeof(Mystic.NetherBoltSpell));
-                    Register(678, typeof(Mystic.HealingStoneSpell));
-                    Register(679, typeof(Mystic.PurgeMagicSpell));
-                    Register(680, typeof(Mystic.EnchantSpell));
-                    Register(681, typeof(Mystic.SleepSpell));
-                    Register(682, typeof(Mystic.EagleStrikeSpell));
-                    Register(683, typeof(Mystic.AnimatedWeaponSpell));
-                    Register(684, typeof(Mystic.StoneFormSpell));
-                    Register(685, typeof(Mystic.SpellTriggerSpell));
-                    Register(686, typeof(Mystic.MassSleepSpell));
-                    Register(687, typeof(Mystic.CleansingWindsSpell));
-                    Register(688, typeof(Mystic.BombardSpell));
-                    Register(689, typeof(Mystic.SpellPlagueSpell));
-                    Register(690, typeof(Mystic.HailStormSpell));
-                    Register(691, typeof(Mystic.NetherCycloneSpell));
-                    Register(692, typeof(Mystic.RisingColossusSpell));
+                    Register(677, typeof(Mysticism.NetherBoltSpell));
+                    Register(678, typeof(Mysticism.HealingStoneSpell));
+                    Register(679, typeof(Mysticism.PurgeMagicSpell));
+                    Register(680, typeof(Mysticism.EnchantSpell));
+                    Register(681, typeof(Mysticism.SleepSpell));
+                    Register(682, typeof(Mysticism.EagleStrikeSpell));
+                    Register(683, typeof(Mysticism.AnimatedWeaponSpell));
+                    Register(684, typeof(Mysticism.StoneFormSpell));
+                    Register(685, typeof(Mysticism.SpellTriggerSpell));
+                    Register(686, typeof(Mysticism.MassSleepSpell));
+                    Register(687, typeof(Mysticism.CleansingWindsSpell));
+                    Register(688, typeof(Mysticism.BombardSpell));
+                    Register(689, typeof(Mysticism.SpellPlagueSpell));
+                    Register(690, typeof(Mysticism.HailStormSpell));
+                    Register(691, typeof(Mysticism.NetherCycloneSpell));
+                    Register(692, typeof(Mysticism.RisingColossusSpell));
 
                     Register(700, typeof(SkillMasteries.InspireSpell));
                     Register(701, typeof(SkillMasteries.InvigorateSpell));

--- a/Scripts/Spells/Mysticism/MysticSpell.cs
+++ b/Scripts/Spells/Mysticism/MysticSpell.cs
@@ -1,11 +1,8 @@
 using System;
 using Server;
-using Server.Items;
-using Server.Mobiles;
-using Server.Spells;
 using Server.Targeting;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
     public abstract class MysticSpell : Spell
     {

--- a/Scripts/Spells/Mysticism/SpellDefinitions/AnimatedWeaponSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/AnimatedWeaponSpell.cs
@@ -1,7 +1,7 @@
 using System;
 using Server.Mobiles;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class AnimatedWeaponSpell : MysticSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
@@ -1,7 +1,7 @@
 using System;
 using Server.Targeting;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class BombardSpell : MysticSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/CleansingWindsSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/CleansingWindsSpell.cs
@@ -7,7 +7,7 @@ using Server.Spells.Necromancy;
 using Server.Targeting;
 using Server.Engines.PartySystem;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class CleansingWindsSpell : MysticSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
@@ -5,7 +5,7 @@ using Server.Mobiles;
 using Server.Spells;
 using Server.Targeting;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class EagleStrikeSpell : MysticSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/EnchantGump.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/EnchantGump.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using Server.Items;
 using Server.Network;
 using System.Collections.Generic;
-using Server.Spells.Mystic;
+using Server.Spells.Mysticism;
 using Server.Spells;
 
 namespace Server.Gumps

--- a/Scripts/Spells/Mysticism/SpellDefinitions/EnchantSpell .cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/EnchantSpell .cs
@@ -7,7 +7,7 @@ using Server.Mobiles;
 using Server.Spells;
 using Server.Network;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class EnchantSpell : MysticSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/HailStormSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/HailStormSpell.cs
@@ -7,7 +7,7 @@ using Server.Mobiles;
 using Server.Spells;
 using Server.Targeting;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
     public class HailStormSpell : MysticSpell
     {

--- a/Scripts/Spells/Mysticism/SpellDefinitions/HealingStoneSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/HealingStoneSpell.cs
@@ -5,7 +5,7 @@ using Server.Mobiles;
 using Server.Spells;
 using Server.Targeting;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class HealingStoneSpell : MysticSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/MassSleepSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/MassSleepSpell.cs
@@ -7,7 +7,7 @@ using Server.Targeting;
 using System.Collections.Generic;
 using Server.Network;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class MassSleepSpell : MysticSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/MysticTransformationSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/MysticTransformationSpell.cs
@@ -5,7 +5,7 @@ using Server;
 using Server.Spells.Fifth;
 using Server.Spells.Seventh;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public abstract class MysticTransformationSpell : MysticSpell, ITransformationSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
@@ -1,7 +1,7 @@
 using System;
 using Server.Targeting;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class NetherBoltSpell : MysticSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherCycloneSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherCycloneSpell.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Server.Items;
 using Server.Targeting;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class NetherCycloneSpell : MysticSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/PurgeMagicSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/PurgeMagicSpell.cs
@@ -12,7 +12,7 @@ using Server.Spells.Fourth;
 using Server.Spells.Fifth;
 using Server.Spells.Ninjitsu;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
     public enum BuffType
     {

--- a/Scripts/Spells/Mysticism/SpellDefinitions/RisingColossusSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/RisingColossusSpell.cs
@@ -5,7 +5,7 @@ using Server.Mobiles;
 using Server.Spells;
 using Server.Targeting;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class RisingColossusSpell : MysticSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/SleepSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/SleepSpell.cs
@@ -7,7 +7,7 @@ using Server.Targeting;
 using System.Collections.Generic;
 using Server.Network;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class SleepSpell : MysticSpell
 	{
@@ -52,7 +52,7 @@ namespace Server.Spells.Mystic
                 double duration = ((Caster.Skills[CastSkill].Value + Caster.Skills[DamageSkill].Value) / 20) + 2;
                 duration -= target.Skills[SkillName.MagicResist].Value / 10;
 
-                if (duration <= 0 || Server.Spells.Mystic.StoneFormSpell.CheckImmunity(target))
+                if (duration <= 0 || StoneFormSpell.CheckImmunity(target))
                 {
                     Caster.SendLocalizedMessage(1080136); //Your target resists sleep.
                     target.SendLocalizedMessage(1080137); //You resist sleep.

--- a/Scripts/Spells/Mysticism/SpellDefinitions/SpellPlague.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/SpellPlague.cs
@@ -5,7 +5,7 @@ using Server.Mobiles;
 using Server.Targeting;
 using System.Collections.Generic;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
     public class SpellPlagueSpell : MysticSpell
     {

--- a/Scripts/Spells/Mysticism/SpellDefinitions/SpellTriggerSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/SpellTriggerSpell.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using Server.ContextMenus;
 using Server.Network;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class SpellTriggerSpell : MysticSpell
 	{

--- a/Scripts/Spells/Mysticism/SpellDefinitions/StoneForm.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/StoneForm.cs
@@ -6,7 +6,7 @@ using Server.Items;
 using Server.Targeting;
 using Server.Mobiles;
 
-namespace Server.Spells.Mystic
+namespace Server.Spells.Mysticism
 {
 	public class StoneFormSpell : MysticTransformationSpell
 	{
@@ -83,7 +83,7 @@ namespace Server.Spells.Mystic
 
         public static int GetMaxResistMod(PlayerMobile pm)
         {
-            if (TransformationSpellHelper.UnderTransformation(pm, typeof(Spells.Mystic.StoneFormSpell)))
+            if (TransformationSpellHelper.UnderTransformation(pm, typeof(StoneFormSpell)))
             {
                 int prim = (int)pm.Skills[SkillName.Mysticism].Value;
                 int sec = (int)pm.Skills[SkillName.Imbuing].Value;
@@ -98,7 +98,7 @@ namespace Server.Spells.Mystic
 
         public static bool CheckImmunity(Mobile from)
         {
-            if (TransformationSpellHelper.UnderTransformation(from, typeof(Spells.Mystic.StoneFormSpell)))
+            if (TransformationSpellHelper.UnderTransformation(from, typeof(StoneFormSpell)))
             {
                 int prim = (int)from.Skills[SkillName.Mysticism].Value;
                 int sec = (int)from.Skills[SkillName.Imbuing].Value;

--- a/Scripts/Spells/Necromancy/Strangle.cs
+++ b/Scripts/Spells/Necromancy/Strangle.cs
@@ -99,7 +99,7 @@ namespace Server.Spells.Necromancy
             m.FixedParticles(0x36CB, 1, 9, 9911, 67, 5, EffectLayer.Head);
             m.FixedParticles(0x374A, 1, 17, 9502, 1108, 4, (EffectLayer)255);
 
-            if (Server.Spells.Mystic.StoneFormSpell.CheckImmunity(m))
+            if (Server.Spells.Mysticism.StoneFormSpell.CheckImmunity(m))
             {
                 Caster.SendLocalizedMessage(1095250); // Your target resists strangle.
             }


### PR DESCRIPTION
This pull request changes the name of the namespace which contains the Mysticism spells from `Server.Spells.Mystic` to `Server.Spells.Mysticism`.

The reason for this change is **consistency with other spell types**, where the namespace name is the **skill name** rather than the profession title (for instance, prefer `Server.Spells.Chivalry` over `Server.Spells.Paladin` for Chivalry spells or `Server.Spells.Bushido` over `Server.Spells.Samurai` for Bushido spells.

I've come across this typo while trying to adapt a script based on other RunUO fork to ServUO; implementations of Mysticism in other emulators already use the proposed namespace name, so my guess is that this change will also help developers to migrate scripts between RunUO forks.
