### PR TITLE
Regions: additional AllowXXX methods

### DIFF
--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -786,7 +786,7 @@ namespace Server.Mobiles
 			EventSink.Disconnected += EventSink_Disconnected;
 
             #region Enchanced Client
-            EventSink.TargetedSkill += Targeted_Skill;  
+            EventSink.TargetedSkill += Targeted_Skill;
             EventSink.TargetedItemUse += Targeted_Item;
             #endregion
 
@@ -946,7 +946,7 @@ namespace Server.Mobiles
                 }
 
                 bool setitem = item is ISetItem;
-                
+
                 Resistances[0] += setitem ? ((ISetItem)item).SetResistBonus(ResistanceType.Physical) : item.PhysicalResistance;
                 Resistances[1] += setitem ? ((ISetItem)item).SetResistBonus(ResistanceType.Fire) : item.FireResistance;
                 Resistances[2] += setitem ? ((ISetItem)item).SetResistBonus(ResistanceType.Cold) : item.ColdResistance;
@@ -3303,7 +3303,7 @@ namespace Server.Mobiles
 			}
 			return false;
 		}
-		
+
 		public override bool Criminal
         	{
             		get
@@ -3328,7 +3328,7 @@ namespace Server.Mobiles
 			{
 				state.CancelAllTrades();
 			}
-			
+
 			if (Criminal)
                 		BuffInfo.RemoveBuff(this, BuffIcon.CriminalStatus);
 
@@ -3492,7 +3492,7 @@ namespace Server.Mobiles
 					killer = ((BaseCreature)m).ControlMaster as PlayerMobile;
 				}
 			}
-			
+
 			if (m_NonAutoreinsuredItems > 0)
 			{
 				SendLocalizedMessage(1061115);
@@ -5225,11 +5225,11 @@ namespace Server.Mobiles
                     if (m_CollectionTitles[num] is int && !silent)
                     {
                         SendLocalizedMessage(1074008, "#" + (int)m_CollectionTitles[num]);
-                        // You change your Reward Title to "~1_TITLE~".	
+                        // You change your Reward Title to "~1_TITLE~".
                     }
                     else if (m_CollectionTitles[num] is string && !silent)
                     {
-                        SendLocalizedMessage(1074008, (string)m_CollectionTitles[num]); // You change your Reward Title to "~1_TITLE~".	
+                        SendLocalizedMessage(1074008, (string)m_CollectionTitles[num]); // You change your Reward Title to "~1_TITLE~".
                     }
                 }
                 else if (!silent)
@@ -5609,7 +5609,7 @@ namespace Server.Mobiles
                 //TODO: Figure an efficient way to naming the creature, pluralized!!!
                 /*if (m_EnemyOfOneType != null)
                 {
-                    BuffInfo.AddBuff(this.Caster, new BuffInfo(BuffIcon.EnemyOfOne, 1075653, 1075654, TimeSpan.FromMinutes(delay), this.Caster, 
+                    BuffInfo.AddBuff(this.Caster, new BuffInfo(BuffIcon.EnemyOfOne, 1075653, 1075654, TimeSpan.FromMinutes(delay), this.Caster,
                         String.Format("{0}\t{1}\t{2}\t{3}", "50", )));
                 }*/
 
@@ -6566,7 +6566,7 @@ namespace Server.Mobiles
 
 		public void ClaimAutoStabledPets()
 		{
-			if (!Core.SE || m_AutoStabled.Count <= 0)
+			if (!Core.SE || !this.Region.AllowAutoClaim(this) || m_AutoStabled.Count <= 0)
 			{
 				return;
 			}

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -6507,9 +6507,11 @@ namespace Server.Mobiles
         public ExploringTheDeepQuestChain ExploringTheDeepQuest { get { return m_ExploringTheDeepQuest; } set { m_ExploringTheDeepQuest = value; } }
         #endregion
 
+        public static bool PetAutoStable { get { return Core.SE; } }
+
         public void AutoStablePets()
 		{
-			if (Core.SE && AllFollowers.Count > 0)
+			if (PetAutoStable && AllFollowers.Count > 0)
 			{
 				for (int i = m_AllFollowers.Count - 1; i >= 0; --i)
 				{
@@ -6566,7 +6568,7 @@ namespace Server.Mobiles
 
 		public void ClaimAutoStabledPets()
 		{
-			if (!Core.SE || !this.Region.AllowAutoClaim(this) || m_AutoStabled.Count <= 0)
+			if (!PetAutoStable || !this.Region.AllowAutoClaim(this) || m_AutoStabled.Count <= 0)
 			{
 				return;
 			}

--- a/Scripts/Regions/Jail.cs
+++ b/Scripts/Regions/Jail.cs
@@ -10,6 +10,11 @@ namespace Server.Regions
         {
         }
 
+        public override bool AllowAutoClaim( Mobile from )
+        {
+            return false;
+        }
+
         public override bool AllowBeneficial(Mobile from, Mobile target)
         {
             if (from.IsPlayer())

--- a/Scripts/Spells/Gargoyle/SpellDefinitions/FlySpell.cs
+++ b/Scripts/Spells/Gargoyle/SpellDefinitions/FlySpell.cs
@@ -92,7 +92,11 @@ namespace Server.Spells
             this.Caster.Flying = false;
             BuffInfo.RemoveBuff(this.Caster, BuffIcon.Fly);
 
-			if (Factions.Sigil.ExistsOn(Caster))
+            if (!Caster.Region.AllowFlying(Caster))
+            {
+                Caster.SendMessage("You may not fly here.");
+            }
+			else if (Factions.Sigil.ExistsOn(Caster))
 			{
 				Caster.SendLocalizedMessage(1061632); // You can't do that while carrying the sigil.
 			}

--- a/Server/Region.cs
+++ b/Server/Region.cs
@@ -706,6 +706,22 @@ namespace Server
 			return true;
 		}
 
+	    public virtual bool AllowAutoClaim(Mobile from)
+	    {
+	        if (m_Parent != null)
+	            return m_Parent.AllowAutoClaim( from );
+
+	        return true;
+	    }
+
+	    public virtual bool AllowFlying(Mobile from)
+	    {
+	        if (m_Parent != null)
+	            return m_Parent.AllowFlying(from);
+
+	        return true;
+	    }
+
 		public virtual bool AllowHousing(Mobile from, Point3D p)
 		{
 			if (m_Parent != null)


### PR DESCRIPTION
This pull request adds the following overridable methods to the `Region` class:
- `AllowFlying`, which determines whether a player can start flying or not inside the region.
- `AllowAutoClaim`, which determines whether the pet auto claim functionality should be triggered when the player logs in inside the region.

The following bugs are also fixed:
- Fixed bug that allowed players to auto claim their pets upon login while inside jail.

The following code tweaks are added:
- Introduces property `PetAutoStable` in `PlayerMobile` class, to control whether the pet auto stable functionality is enabled or not.