### PR TITLE
Fixes ServUO build in mono for 64 bit environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,14 @@ SDKPATH=${CURPATH}/Ultima
 REFS=System.Drawing.dll
 NOWARNS=0618,0219,0414,1635
 
+# Detect whether we are on 64 bit environment or not
+LBITS := $(shell getconf LONG_BIT)
+ifeq ($(LBITS),64)
+  MONO=mono64
+else
+  MONO=mono
+endif
+
 PHONY : default build clean run
 
 default: run
@@ -30,5 +38,5 @@ ServUO.MONO.exe: Ultima.dll Server/*.cs
 
 ServUO.sh: ServUO.MONO.exe
 	echo "#!/bin/sh" > ${CURPATH}/ServUO.sh
-	echo "mono ${CURPATH}/ServUO.MONO.exe" >> ${CURPATH}/ServUO.sh
+	echo "${MONO} ${CURPATH}/ServUO.MONO.exe" >> ${CURPATH}/ServUO.sh
 	chmod a+x ${CURPATH}/ServUO.sh

--- a/Server/Network/Compression.cs
+++ b/Server/Network/Compression.cs
@@ -337,21 +337,20 @@ namespace Server.Network
 			internal static extern string zlibVersion();
 
 			[DllImport("libz")]
-			internal static extern ZLibError compress(byte[] dest, ref ulong destLength, byte[] source, int sourceLength);
+			internal static extern ZLibError compress(byte[] dest, ref long destLength, byte[] source, long sourceLength);
 
 			[DllImport("libz")]
-			internal static extern ZLibError compress2(
-				byte[] dest, ref ulong destLength, byte[] source, int sourceLength, ZLibQuality quality);
+			internal static extern ZLibError compress2(byte[] dest, ref long destLength, byte[] source, long sourceLength, ZLibQuality quality);
 
 			[DllImport("libz")]
-			internal static extern ZLibError uncompress(byte[] dest, ref ulong destLen, byte[] source, int sourceLen);
+			internal static extern ZLibError uncompress(byte[] dest, ref long destLen, byte[] source, long sourceLen);
 		}
 
 		public string Version { get { return SafeNativeMethods.zlibVersion(); } }
 
 		public ZLibError Compress(byte[] dest, ref int destLength, byte[] source, int sourceLength)
 		{
-			ulong destLengthLong = (ulong)destLength;
+			long destLengthLong = destLength;
 			ZLibError z = SafeNativeMethods.compress(dest, ref destLengthLong, source, sourceLength);
 			destLength = (int)destLengthLong;
 			return z;
@@ -359,7 +358,7 @@ namespace Server.Network
 
 		public ZLibError Compress(byte[] dest, ref int destLength, byte[] source, int sourceLength, ZLibQuality quality)
 		{
-			ulong destLengthLong = (ulong)destLength;
+			long destLengthLong = destLength;
 			ZLibError z = SafeNativeMethods.compress2(dest, ref destLengthLong, source, sourceLength, quality);
 			destLength = (int)destLengthLong;
 			return z;
@@ -367,7 +366,7 @@ namespace Server.Network
 
 		public ZLibError Decompress(byte[] dest, ref int destLength, byte[] source, int sourceLength)
 		{
-			ulong destLengthLong = (ulong)destLength;
+			long destLengthLong = destLength;
 			ZLibError z = SafeNativeMethods.uncompress(dest, ref destLengthLong, source, sourceLength);
 			destLength = (int)destLengthLong;
 			return z;


### PR DESCRIPTION
This pull request fixes ServUO build for 64 bit environments by adding the following changes:
- Changes Makefile to use `mono64` bin to run ServUO.exe if detected 64 bit environment.
- Fixes types in signature of `CompressorUnix64` class methods (it was throwing `System.DllNotFoundException` due to type mismatch)

I've tested this PR with OSX+Mono setup. Here are the details of my setup:
Mac OS X:
```
$ system_profiler SPSoftwareDataType
Software:

    System Software Overview:

      System Version: macOS 10.12.3 (16D30)
      Kernel Version: Darwin 16.4.0
```

Mono:
```
$ mono64 --version
Mono JIT compiler version 4.8.0 (mono-4.8.0-branch/8f6d0f6 Thu Mar  9 12:07:34 EST 2017)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
	TLS:           normal
	SIGSEGV:       altstack
	Notification:  kqueue
	Architecture:  amd64
	Disabled:      none
	Misc:          softdebug
	LLVM:          yes(3.6.0svn-mono-master/8b1520c)
	GC:            sgen
```

I've not checked with mono on Linux/Windows or other possible setups, atm it's impossible for me :( Could you give it a try before merging?