### PR TITLE
MilitiaCanoneer.cs: Typo fix

### DIFF
--- a/Scripts/Mobiles/NPCs/MilitiaCanoneer.cs
+++ b/Scripts/Mobiles/NPCs/MilitiaCanoneer.cs
@@ -9,7 +9,7 @@ namespace Server.Engines.Quests.Haven
         private bool m_Active;
         [Constructable]
         public MilitiaCanoneer()
-            : base("the Militia Canoneer")
+            : base("the Militia Cannoneer")
         {
             this.m_Active = true;
         }


### PR DESCRIPTION
-Fixed cannoneer to proper spelling, at least in the visible title.