### PR TITLE
Familiar AI Fix/Revamp v3

### DIFF
--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -581,7 +581,7 @@ namespace Server.Mobiles
 
 									if (m_Mobile.CheckControlChance(e.Mobile))
 									{
-										
+
 										m_Mobile.ControlOrder = OrderType.Guard;
                                         m_Mobile.ControlTarget = null;
 									}
@@ -710,7 +710,7 @@ namespace Server.Mobiles
 									{
                                         m_Mobile.ControlOrder = OrderType.Guard;
                                         m_Mobile.ControlTarget = null;
-										
+
 									}
 
 									return;
@@ -1178,6 +1178,15 @@ namespace Server.Mobiles
 				case OrderType.Transfer:
 					return DoOrderTransfer();
 
+				case OrderType.Aggro:
+					return DoOrderAggro();
+
+				case OrderType.Heel:
+					return DoOrderHeel();
+
+				case OrderType.Fetch:
+					return DoOrderFetch();
+
 				default:
 					return false;
 			}
@@ -1232,7 +1241,6 @@ namespace Server.Mobiles
 					m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
-
 					m_Mobile.Warmode = true;
 					m_Mobile.Combatant = null;
 					break;
@@ -1269,7 +1277,6 @@ namespace Server.Mobiles
 					m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
-
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
@@ -1277,7 +1284,27 @@ namespace Server.Mobiles
 					m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
-
+					m_Mobile.Warmode = false;
+					m_Mobile.Combatant = null;
+					break;
+				case OrderType.Aggro:
+					m_Mobile.DebugSay("I aggro for my master");
+					m_Mobile.CurrentSpeed = 0.1;
+					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
+					m_Mobile.Warmode = true;
+					m_Mobile.Combatant = null;
+					break;
+				case OrderType.Heel:
+					m_Mobile.DebugSay("I heel to my master");
+					m_Mobile.CurrentSpeed = 0.01;
+					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
+					m_Mobile.Warmode = false;
+					m_Mobile.Combatant = null;
+					break;
+				case OrderType.Fetch:
+					m_Mobile.DebugSay("I fetch for my master");
+					m_Mobile.CurrentSpeed = 0.3;
+					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
@@ -1325,7 +1352,7 @@ namespace Server.Mobiles
 
 					if (WalkMobileRange(m_Mobile.ControlMaster, 1, bRun, 0, 1))
 					{
-						if (m_Mobile.Combatant is Mobile && !m_Mobile.Combatant.Deleted && 
+						if (m_Mobile.Combatant is Mobile && !m_Mobile.Combatant.Deleted &&
                             m_Mobile.Combatant.Alive && (!(m_Mobile.Combatant is Mobile) || !((Mobile)m_Mobile.Combatant).IsDeadBondedPet))
 						{
 							m_Mobile.Warmode = true;
@@ -1398,27 +1425,6 @@ namespace Server.Mobiles
 
 			if (distance < 1 || distance > 15)
 			{
-				if (distance < 1 && target.X == 1076 && target.Y == 450 && (m_Mobile is HordeMinionFamiliar))
-				{
-					PlayerMobile pm = m_Mobile.ControlMaster as PlayerMobile;
-
-					if (pm != null)
-					{
-						QuestSystem qs = pm.Quest;
-
-						if (qs is DarkTidesQuest)
-						{
-							QuestObjective obj = qs.FindObjective(typeof(FetchAbraxusScrollObjective));
-
-							if (obj != null && !obj.Completed)
-							{
-								m_Mobile.AddToBackpack(new ScrollOfAbraxus());
-								obj.Complete();
-							}
-						}
-					}
-				}
-
 				m_Mobile.TargetLocation = null;
 				return false; // At the target or too far away
 			}
@@ -2070,6 +2076,191 @@ namespace Server.Mobiles
 			return true;
 		}
 
+		private bool m_LastHidden;
+
+		public virtual bool DoOrderHeel()
+		{
+			return CheckFamiliar();
+		}
+
+		public virtual bool DoOrderAggro()
+		{
+			return CheckFamiliar();
+		}
+
+		public virtual bool CheckFamiliar()
+		{
+			// Part 1: Delete Familiar check
+			Mobile master = m_Mobile.ControlMaster;
+			Map map = m_Mobile.Map;
+
+			if (master == null || master.Deleted)
+			{
+
+				if (map != null && map != Map.Internal)
+				{
+					Container pack = m_Mobile.Backpack;
+
+					if (pack != null)
+					{
+						var list = new List<Item>(pack.Items);
+
+						for (int i = 0; i < list.Count; ++i)
+						{
+							list[i].MoveToWorld(m_Mobile.Location, map);
+						}
+
+					}
+					Effects.SendLocationParticles(
+						EffectItem.Create(m_Mobile.Location, map, EffectItem.DefaultDuration), 0x3728, 1, 13, 2100, 3, 5042, 0);
+					m_Mobile.PlaySound(0x201);
+				}
+				m_Mobile.Delete();
+				return false;
+			}
+
+			// Part 2: Teleport to master check
+			Point3D m_Loc = Point3D.Zero;
+
+			if (map != master.Map)
+			{
+				m_Mobile.Map = master.Map;
+				m_Mobile.SetLocation(master.Location, true);
+			}
+			else if (!m_Mobile.InRange(master.Location, m_Mobile.RangePerception))
+			{
+				int range = (int)(m_Mobile.RangeHome / 2 + 1);
+				int x = (m_Mobile.X > master.X) ? (master.X + range) : (master.X - range);
+				int y = (m_Mobile.Y > master.Y) ? (master.Y + range) : (master.Y - range);
+
+				for (int i = 0; i < 10; i++)
+				{
+					m_Loc.X = x + Utility.RandomMinMax(-1, 1);
+					m_Loc.Y = y + Utility.RandomMinMax(-1, 1);
+
+					m_Loc.Z = map.GetAverageZ(m_Loc.X, m_Loc.Y);
+
+					if (map.CanSpawnMobile(m_Loc))
+					{
+						break;
+					}
+
+					m_Loc = master.Location;
+				}
+
+				m_Mobile.SetLocation(m_Loc, true);
+			}
+
+			//Part 3: Attack master's target check
+			IDamageable combatant = m_Mobile.Combatant;
+			IDamageable mc = master.Combatant;
+
+			// Don't attack your familiar!
+			if (mc == m_Mobile)
+			{
+				master.Combatant = null;
+				mc = null;
+			}
+
+			// Don't attack my master!
+			if (combatant == master)
+			{
+				m_Mobile.Combatant = null;
+				combatant = null;
+			}
+
+			// Only attack my master's combatant, and only if he's in range
+			if (mc != null && ((BaseFamiliar)m_Mobile).AttacksMastersTarget && master.InRange(mc.Location, m_Mobile.RangeHome))
+			{
+				combatant = m_Mobile.Combatant = mc;
+			}
+			else
+			{
+				combatant = m_Mobile.Combatant = null;
+			}
+
+			bool bRun;
+
+			// Do I lack a combatant?
+			if (combatant == null)
+			{
+				m_Mobile.ControlTarget = m_Mobile.ControlMaster;
+
+				bRun = ((int)m_Mobile.GetDistanceToSqrt(master) > 5);
+				if (WalkMobileRange(master, 1, bRun, 0, 1))
+				{
+					m_Mobile.Direction = m_Mobile.GetDirectionTo(master);
+				}
+
+				if (m_LastHidden != master.Hidden)
+				{
+					m_Mobile.Hidden = m_LastHidden = master.Hidden;
+				}
+
+				if (m_Mobile.ControlOrder != OrderType.Heel)
+				{
+					m_Mobile.ControlOrder = OrderType.Heel;
+				}
+
+				return true;
+			}
+
+			m_Mobile.ControlTarget = combatant;
+
+			bRun = ((int)m_Mobile.GetDistanceToSqrt(combatant) > 5);
+			if (MoveTo(combatant, bRun, m_Mobile.RangeFight))
+			{
+				m_Mobile.Direction = m_Mobile.GetDirectionTo(combatant);
+			}
+
+			if (m_Mobile.ControlOrder != OrderType.Aggro)
+			{
+				m_Mobile.ControlOrder = OrderType.Aggro;
+			}
+
+			return true;
+		}
+
+		public virtual bool DoOrderFetch()
+		{
+			IPoint2D target = m_Mobile.TargetLocation;
+
+			if (target == null)
+			{
+				m_Mobile.ControlOrder = OrderType.Heel;
+				return false; // Creature is not being herded
+			}
+
+			double distance = m_Mobile.GetDistanceToSqrt(target);
+
+			if (distance < 1 && target.X == 1076 && target.Y == 450 && (m_Mobile is HordeMinionFamiliar))
+			{
+				PlayerMobile pm = m_Mobile.ControlMaster as PlayerMobile;
+
+				if (pm != null)
+				{
+					QuestSystem qs = pm.Quest;
+
+					if (qs is DarkTidesQuest)
+					{
+						QuestObjective obj = qs.FindObjective(typeof(FetchAbraxusScrollObjective));
+
+						if (obj != null && !obj.Completed)
+						{
+							m_Mobile.AddToBackpack(new ScrollOfAbraxus());
+							obj.Complete();
+							m_Mobile.TargetLocation = null;
+							m_Mobile.ControlTarget = pm;
+							m_Mobile.ControlOrder = OrderType.Heel;
+						}
+					}
+				}
+			}
+
+			DoMove(m_Mobile.GetDirectionTo(target));
+			return true;
+		}
+
 		public virtual bool DoBardPacified()
 		{
 			if (DateTime.UtcNow < m_Mobile.BardEndTime)
@@ -2322,10 +2513,10 @@ namespace Server.Mobiles
 			{
 				d |= Direction.Running;
 			}
-            
+
 			// This makes them always move one step, never any direction changes
 			m_Mobile.Direction = d;
-            
+
 			m_NextMove += delay;
 
 			if (Core.TickCount - m_NextMove > 0)
@@ -2644,12 +2835,12 @@ namespace Server.Mobiles
 
 		/*
         *  Walk at range distance from mobile
-        * 
+        *
         *	iSteps : Number of steps
         *	bRun   : Do we run
         *	iWantDistMin : The minimum distance we want to be
         *  iWantDistMax : The maximum distance we want to be
-        * 
+        *
         */
 
 		public virtual bool WalkMobileRange(IPoint3D p, int iSteps, bool bRun, int iWantDistMin, int iWantDistMax)
@@ -2737,13 +2928,13 @@ namespace Server.Mobiles
 
 		/*
         * Here we check to acquire a target from our surronding
-        * 
+        *
         *  iRange : The range
         *  acqType : A type of acquire we want (closest, strongest, etc)
         *  bPlayerOnly : Don't bother with other creatures or NPCs, want a player
         *  bFacFriend : Check people in my faction
         *  bFacFoe : Check people in other factions
-        * 
+        *
         */
 
 		public virtual bool AcquireFocusMob(int iRange, FightMode acqType, bool bPlayerOnly, bool bFacFriend, bool bFacFoe)

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -996,6 +996,103 @@ namespace Server.Mobiles
         public virtual OppositionGroup OppositionGroup { get { return null; } }
         public virtual bool IsMilitiaFighter { get { return false; } }
 
+        // Opposition List stuff
+        public virtual OppositionType OppositionList{ get{ return OppositionType.None ; } } // What opposition list am I in?
+
+        public enum OppositionType
+        {
+            None,
+            Terathan,
+            Ophidian,
+            Savage,
+            Orc,
+            Fey,
+            Undead
+        }
+
+        public virtual bool OppositionListEnemy(Mobile m)
+        {
+            // Target must be BaseCreature
+            if (!(m is BaseCreature))
+            {
+                return false;
+            }
+
+            BaseCreature c = (BaseCreature)m;
+
+            // Target must have an OppositionType
+            if (c.OppositionList == OppositionType.None)
+            {
+                return false;
+            }
+
+            // Pick my OppositionType
+            switch (OppositionList)
+            {
+                case OppositionType.Terathan: return m_TerathanEnemy(c.OppositionList);
+                case OppositionType.Ophidian: return m_OphidianEnemy(c.OppositionList);
+                case OppositionType.Savage: return m_SavageEnemy(c.OppositionList);
+                case OppositionType.Orc: return m_OrcEnemy(c.OppositionList);
+                case OppositionType.Fey: return m_FeyEnemy(c.OppositionList);
+                case OppositionType.Undead: return m_UndeadEnemy(c.OppositionList);
+                default: return false;
+            }
+        }
+
+        private bool m_TerathanEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Ophidian: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_OphidianEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Terathan: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_SavageEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Orc: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_OrcEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Savage: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_FeyEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Undead: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_UndeadEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Fey: return true;
+                default: return false;
+            }
+        }
+
         #region Friends
         public List<Mobile> Friends { get { return m_Friends; } }
 
@@ -1026,9 +1123,7 @@ namespace Server.Mobiles
 
 		public virtual bool IsFriend(Mobile m)
 		{
-			OppositionGroup g = OppositionGroup;
-
-			if (g != null && g.IsEnemy(this, m))
+			if (OppositionList != OppositionType.None && OppositionListEnemy(m))
 			{
 				return false;
 			}
@@ -1108,9 +1203,7 @@ namespace Server.Mobiles
 				return a.IsEnemy(m);
 			}
 
-			OppositionGroup g = OppositionGroup;
-
-			if (g != null && g.IsEnemy(this, m))
+			if (OppositionList != OppositionType.None && OppositionListEnemy(m))
 			{
 				return true;
 			}
@@ -3874,7 +3967,7 @@ namespace Server.Mobiles
 
             if (aggressor.ChangingCombatant && (m_bControlled || m_bSummoned) &&
                 (ct == OrderType.Come || (!Core.ML && ct == OrderType.Stay) || ct == OrderType.Stop || ct == OrderType.None ||
-                ct == OrderType.Follow))
+                 ct == OrderType.Follow))
             {
                 ControlTarget = aggressor;
                 ControlOrder = OrderType.Attack;

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -996,103 +996,6 @@ namespace Server.Mobiles
         public virtual OppositionGroup OppositionGroup { get { return null; } }
         public virtual bool IsMilitiaFighter { get { return false; } }
 
-        // Opposition List stuff
-        public virtual OppositionType OppositionList{ get{ return OppositionType.None ; } } // What opposition list am I in?
-
-        public enum OppositionType
-        {
-            None,
-            Terathan,
-            Ophidian,
-            Savage,
-            Orc,
-            Fey,
-            Undead
-        }
-
-        public virtual bool OppositionListEnemy(Mobile m)
-        {
-            // Target must be BaseCreature
-            if (!(m is BaseCreature))
-            {
-                return false;
-            }
-
-            BaseCreature c = (BaseCreature)m;
-
-            // Target must have an OppositionType
-            if (c.OppositionList == OppositionType.None)
-            {
-                return false;
-            }
-
-            // Pick my OppositionType
-            switch (OppositionList)
-            {
-                case OppositionType.Terathan: return m_TerathanEnemy(c.OppositionList);
-                case OppositionType.Ophidian: return m_OphidianEnemy(c.OppositionList);
-                case OppositionType.Savage: return m_SavageEnemy(c.OppositionList);
-                case OppositionType.Orc: return m_OrcEnemy(c.OppositionList);
-                case OppositionType.Fey: return m_FeyEnemy(c.OppositionList);
-                case OppositionType.Undead: return m_UndeadEnemy(c.OppositionList);
-                default: return false;
-            }
-        }
-
-        private bool m_TerathanEnemy(OppositionType egroup)
-        {
-            switch (egroup)
-            {
-                case OppositionType.Ophidian: return true;
-                default: return false;
-            }
-        }
-
-        private bool m_OphidianEnemy(OppositionType egroup)
-        {
-            switch (egroup)
-            {
-                case OppositionType.Terathan: return true;
-                default: return false;
-            }
-        }
-
-        private bool m_SavageEnemy(OppositionType egroup)
-        {
-            switch (egroup)
-            {
-                case OppositionType.Orc: return true;
-                default: return false;
-            }
-        }
-
-        private bool m_OrcEnemy(OppositionType egroup)
-        {
-            switch (egroup)
-            {
-                case OppositionType.Savage: return true;
-                default: return false;
-            }
-        }
-
-        private bool m_FeyEnemy(OppositionType egroup)
-        {
-            switch (egroup)
-            {
-                case OppositionType.Undead: return true;
-                default: return false;
-            }
-        }
-
-        private bool m_UndeadEnemy(OppositionType egroup)
-        {
-            switch (egroup)
-            {
-                case OppositionType.Fey: return true;
-                default: return false;
-            }
-        }
-
         #region Friends
         public List<Mobile> Friends { get { return m_Friends; } }
 
@@ -1123,7 +1026,9 @@ namespace Server.Mobiles
 
 		public virtual bool IsFriend(Mobile m)
 		{
-			if (OppositionList != OppositionType.None && OppositionListEnemy(m))
+			OppositionGroup g = OppositionGroup;
+
+			if (g != null && g.IsEnemy(this, m))
 			{
 				return false;
 			}
@@ -1203,7 +1108,9 @@ namespace Server.Mobiles
 				return a.IsEnemy(m);
 			}
 
-			if (OppositionList != OppositionType.None && OppositionListEnemy(m))
+			OppositionGroup g = OppositionGroup;
+
+			if (g != null && g.IsEnemy(this, m))
 			{
 				return true;
 			}
@@ -3937,12 +3844,10 @@ namespace Server.Mobiles
 
             if (m_AI != null)
             {
-                // Pre-ML creatures could be distracted from these orders by attackers too
                 if (!Core.ML || (ct != OrderType.Follow && ct != OrderType.Stop && ct != OrderType.Stay))
                 {
                     m_AI.OnAggressiveAction(aggressor);
                 }
-                // In ML, Follow, Stop, and Stay will not fight at all
                 else
                 {
                     DebugSay("I'm being attacked but my master told me not to fight.");

--- a/Scripts/Mobiles/Summons/BaseFamiliar.cs
+++ b/Scripts/Mobiles/Summons/BaseFamiliar.cs
@@ -15,8 +15,6 @@ namespace Server.Mobiles
 {
 	public abstract class BaseFamiliar : BaseCreature
 	{
-		private bool m_LastHidden;
-
 		public BaseFamiliar()
 			: base(AIType.AI_Melee, FightMode.Closest, 10, 1, -1, -1)
 		{ }
@@ -29,127 +27,11 @@ namespace Server.Mobiles
 		public override Poison PoisonImmune { get { return Poison.Lethal; } }
 		public override bool Commandable { get { return false; } }
 		public override bool PlayerRangeSensitive { get { return false; } }
-
-        public virtual bool AttacksMastersTarget { get { return true; } }
-
-		public virtual void RangeCheck()
-		{
-			if (!Deleted && ControlMaster != null && !ControlMaster.Deleted)
-			{
-				int range = (RangeHome - 2);
-
-				if (!InRange(ControlMaster.Location, RangeHome))
-				{
-					Mobile master = ControlMaster;
-
-					Point3D m_Loc = Point3D.Zero;
-
-					if (Map == master.Map)
-					{
-						int x = (X > master.X) ? (master.X + range) : (master.X - range);
-						int y = (Y > master.Y) ? (master.Y + range) : (master.Y - range);
-
-						for (int i = 0; i < 10; i++)
-						{
-							m_Loc.X = x + Utility.RandomMinMax(-1, 1);
-							m_Loc.Y = y + Utility.RandomMinMax(-1, 1);
-
-							m_Loc.Z = Map.GetAverageZ(m_Loc.X, m_Loc.Y);
-
-							if (Map.CanSpawnMobile(m_Loc))
-							{
-								break;
-							}
-
-							m_Loc = master.Location;
-						}
-
-						if (!Deleted)
-						{
-							SetLocation(m_Loc, true);
-						}
-					}
-				}
-			}
-		}
+		public virtual bool AttacksMastersTarget { get { return true; } }
 
 		public override void OnThink()
 		{
-			Mobile master = ControlMaster;
-
-			if (Deleted)
-			{
-				return;
-			}
-
-			if (master == null || master.Deleted)
-			{
-				DropPackContents();
-				EndRelease(null);
-				return;
-			}
-
-            if (AttacksMastersTarget)
-            {
-                if (Combatant == null)
-                {
-                    if (master.Combatant != null)
-                    {
-                        Combatant = master.Combatant;
-                    }
-                }
-                else
-                {
-                    if (Combatant.Deleted)
-                    {
-                        Combatant = null;
-                    }
-
-                    return;
-                }
-            }
-
-			RangeCheck();
-
-			if (m_LastHidden != master.Hidden)
-			{
-				Hidden = m_LastHidden = master.Hidden;
-			}
-
-			if (AIObject != null && AIObject.WalkMobileRange(master, 5, true, 1, 1))
-			{
-                if ((master.Combatant !=null) && (InRange(master.Combatant, 1)))
-                {
-		            Warmode = master.Warmode;
-		            Combatant = master.Combatant;
-
-		            CurrentSpeed = 0.10;
-			    }
-
-                if ((master.Combatant !=null) && (!InRange(master.Combatant, 1)))
-                {
-                    Warmode = false;
-                    FocusMob = null;
-                    Combatant = null;
-                    CurrentSpeed = 0.01;
-                }
-
-                if (master.Combatant == null)
-                {
-                    Warmode = false;
-                    FocusMob = null;
-                    Combatant = null;
-                    CurrentSpeed = 0.01;
-                }
-            }
-			else
-			{
-				Warmode = false;
-				FocusMob = null;
-                Combatant = null;
-
-				CurrentSpeed = .01;
-			}
+			return;
 		}
 
 		public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)

--- a/Scripts/Mobiles/Summons/BaseFamiliar.cs
+++ b/Scripts/Mobiles/Summons/BaseFamiliar.cs
@@ -27,7 +27,7 @@ namespace Server.Mobiles
 		public override Poison PoisonImmune { get { return Poison.Lethal; } }
 		public override bool Commandable { get { return false; } }
 		public override bool PlayerRangeSensitive { get { return false; } }
-		public virtual bool AttacksMastersTarget { get { return true; } }
+		public virtual bool AttacksMastersTarget { get { return false; } }
 
 		public override void OnThink()
 		{

--- a/Scripts/Quests/DarkTides/Objectives.cs
+++ b/Scripts/Quests/DarkTides/Objectives.cs
@@ -230,6 +230,7 @@ namespace Server.Engines.Quests.Necro
                 {
                     this.System.From.SendLocalizedMessage(1060113); // You instinctively will your familiar to fetch the scroll for you.
                     hmf.TargetLocation = new Point2D(1076, 450);
+                    hmf.ControlOrder = OrderType.Fetch;
                 }
             }
         }


### PR DESCRIPTION
Associated Thread: [Familiar AI Fix/Revamp](https://www.servuo.com/threads/familiar-ai-fix-revamp.6961/)
This pull is designed to clear out and streamline the kludge that is Familiar AI.

Before being merged to master, this pull should definitely be tested, preferably have confirmation in OSI behavior fidelity, and any necessary refinement to correct if either of the previous two have issues.

-Fixes bug that usually cause familiar to be unable to work properly for the Dark Tides quest. (Though the AI rarely takes a bit to get around the wall)
-Familiars ONLY attack their master's current combatant.
-Familiars ONLY attack creatures within RangeHome (default 10) of master.
--Sanity Check: If master is attacking familiar, or vise-versa, set attacker's combatant to null. (Masters don't attack their familiars, familiars don't attack their masters)
-No support for Archer/Mage familiars. (all familiars are Melee)
-While not attacking, familiars follow their master.
-Familiars teleport to their master if they're on another map.
-Familiars teleport nearer to their master if they're more than RangePerception (default 16) apart.

v2:
-Brought code into line with Master.
-Fixed a a bug causing familiar to not attack anything not attacking itself
--Reduced setting of OrderType to only when necessary
-Changed AggressiveAction() familiar behavior to abort early on
-Various incidental Trims

v3:
-Brought code into line with Master.
-Fixed Familiar Powersliding issues.
-Fixed AttacksMastersTarget default to false in BaseFamiliar