### PR TITLE
Replacing OppositionGroup with OppositionList v1.1

### DIFF
--- a/Scripts/Mobiles/Bosses/LordOaks.cs
+++ b/Scripts/Mobiles/Bosses/LordOaks.cs
@@ -8,43 +8,44 @@ namespace Server.Mobiles
     {
         private Mobile m_Queen;
         private bool m_SpawnedQueen;
+
         [Constructable]
         public LordOaks()
             : base(AIType.AI_Mage, FightMode.Evil)
         {
-            this.Body = 175;
-            this.Name = "Lord Oaks";
+            Body = 175;
+            Name = "Lord Oaks";
 
-            this.SetStr(403, 850);
-            this.SetDex(101, 150);
-            this.SetInt(503, 800);
+            SetStr(403, 850);
+            SetDex(101, 150);
+            SetInt(503, 800);
 
-            this.SetHits(3000);
-            this.SetStam(202, 400);
+            SetHits(3000);
+            SetStam(202, 400);
 
-            this.SetDamage(21, 33);
+            SetDamage(21, 33);
 
-            this.SetDamageType(ResistanceType.Physical, 75);
-            this.SetDamageType(ResistanceType.Fire, 25);
+            SetDamageType(ResistanceType.Physical, 75);
+            SetDamageType(ResistanceType.Fire, 25);
 
-            this.SetResistance(ResistanceType.Physical, 85, 90);
-            this.SetResistance(ResistanceType.Fire, 60, 70);
-            this.SetResistance(ResistanceType.Cold, 60, 70);
-            this.SetResistance(ResistanceType.Poison, 80, 90);
-            this.SetResistance(ResistanceType.Energy, 80, 90);
+            SetResistance(ResistanceType.Physical, 85, 90);
+            SetResistance(ResistanceType.Fire, 60, 70);
+            SetResistance(ResistanceType.Cold, 60, 70);
+            SetResistance(ResistanceType.Poison, 80, 90);
+            SetResistance(ResistanceType.Energy, 80, 90);
 
-            this.SetSkill(SkillName.Anatomy, 75.1, 100.0);
-            this.SetSkill(SkillName.EvalInt, 120.1, 130.0);
-            this.SetSkill(SkillName.Magery, 120.0);
-            this.SetSkill(SkillName.Meditation, 120.1, 130.0);
-            this.SetSkill(SkillName.MagicResist, 100.5, 150.0);
-            this.SetSkill(SkillName.Tactics, 100.0);
-            this.SetSkill(SkillName.Wrestling, 100.0);
+            SetSkill(SkillName.Anatomy, 75.1, 100.0);
+            SetSkill(SkillName.EvalInt, 120.1, 130.0);
+            SetSkill(SkillName.Magery, 120.0);
+            SetSkill(SkillName.Meditation, 120.1, 130.0);
+            SetSkill(SkillName.MagicResist, 100.5, 150.0);
+            SetSkill(SkillName.Tactics, 100.0);
+            SetSkill(SkillName.Wrestling, 100.0);
 
-            this.Fame = 22500;
-            this.Karma = 22500;
+            Fame = 22500;
+            Karma = 22500;
 
-            this.VirtualArmor = 100;
+            VirtualArmor = 100;
         }
 
         public LordOaks(Serial serial)
@@ -52,13 +53,6 @@ namespace Server.Mobiles
         {
         }
 
-        public override ChampionSkullType SkullType
-        {
-            get
-            {
-                return ChampionSkullType.Enlightenment;
-            }
-        }
         public override Type[] UniqueList
         {
             get
@@ -66,6 +60,7 @@ namespace Server.Mobiles
                 return new Type[] { typeof(OrcChieftainHelm) };
             }
         }
+
         public override Type[] SharedList
         {
             get
@@ -81,6 +76,7 @@ namespace Server.Mobiles
                 };
             }
         }
+
         public override Type[] DecorativeList
         {
             get
@@ -93,6 +89,7 @@ namespace Server.Mobiles
                 };
             }
         }
+
         public override MonsterStatuetteType[] StatueTypes
         {
             get
@@ -100,68 +97,35 @@ namespace Server.Mobiles
                 return new MonsterStatuetteType[] { };
             }
         }
-        public override bool AutoDispel
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override bool CanFly
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override bool BardImmune
-        {
-            get
-            {
-                return !Core.SE;
-            }
-        }
-        public override bool Unprovokable
-        {
-            get
-            {
-                return Core.SE;
-            }
-        }
-        public override bool Uncalmable
-        {
-            get
-            {
-                return Core.SE;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Deadly;
-            }
-        }
+
+        public override bool AutoDispel{ get{ return true; } }
+        public override bool BardImmune{ get{ return !Core.SE; } }
+        public override bool CanFly{ get{ return true; } }
+        public override bool Uncalmable{ get{ return Core.SE; } }
+        public override bool Unprovokable{ get{ return Core.SE; } }
+        public override ChampionSkullType SkullType{ get{ return ChampionSkullType.Enlightenment; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Fey; } }
+        public override Poison PoisonImmune{ get{ return Poison.Deadly; } }
+
+        public override int GetAngerSound(){ return 0x2F8; }
+        public override int GetIdleSound(){ return 0x2F8; }
+        public override int GetAttackSound(){ return Utility.Random(0x2F5, 2); }
+        public override int GetHurtSound(){ return 0x2F9; }
+        public override int GetDeathSound(){ return 0x2F7; }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.UltraRich, 5);
+            AddLoot(LootPack.UltraRich, 5);
         }
 
         public void SpawnPixies(Mobile target)
         {
-            Map map = this.Map;
+            Map map = Map;
 
             if (map == null)
                 return;
 
-            this.Say(1042154); // You shall never defeat me as long as I have my queen!
+            Say(1042154); // You shall never defeat me as long as I have my queen!
 
             int newPixies = Utility.RandomMinMax(3, 6);
 
@@ -169,20 +133,20 @@ namespace Server.Mobiles
             {
                 Pixie pixie = new Pixie();
 
-                pixie.Team = this.Team;
+                pixie.Team = Team;
                 pixie.FightMode = FightMode.Closest;
 
                 bool validLocation = false;
-                Point3D loc = this.Location;
+                Point3D loc = Location;
 
                 for (int j = 0; !validLocation && j < 10; ++j)
                 {
-                    int x = this.X + Utility.Random(3) - 1;
-                    int y = this.Y + Utility.Random(3) - 1;
+                    int x = X + Utility.Random(3) - 1;
+                    int y = Y + Utility.Random(3) - 1;
                     int z = map.GetAverageZ(x, y);
 
-                    if (validLocation = map.CanFit(x, y, this.Z, 16, false, false))
-                        loc = new Point3D(x, y, this.Z);
+                    if (validLocation = map.CanFit(x, y, Z, 16, false, false))
+                        loc = new Point3D(x, y, Z);
                     else if (validLocation = map.CanFit(x, y, z, 16, false, false))
                         loc = new Point3D(x, y, z);
                 }
@@ -192,64 +156,39 @@ namespace Server.Mobiles
             }
         }
 
-        public override int GetAngerSound()
-        {
-            return 0x2F8;
-        }
-
-        public override int GetIdleSound()
-        {
-            return 0x2F8;
-        }
-
-        public override int GetAttackSound()
-        {
-            return Utility.Random(0x2F5, 2);
-        }
-
-        public override int GetHurtSound()
-        {
-            return 0x2F9;
-        }
-
-        public override int GetDeathSound()
-        {
-            return 0x2F7;
-        }
-
         public void CheckQueen()
         {
-            if (this.Map == null)
+            if (Map == null)
                 return;
 
-            if (!this.m_SpawnedQueen)
+            if (!m_SpawnedQueen)
             {
-                this.Say(1042153); // Come forth my queen!
+                Say(1042153); // Come forth my queen!
 
-                this.m_Queen = new Silvani();
+                m_Queen = new Silvani();
 
-                ((BaseCreature)this.m_Queen).Team = this.Team;
+                ((BaseCreature)m_Queen).Team = Team;
 
-                this.m_Queen.MoveToWorld(this.Location, this.Map);
+                m_Queen.MoveToWorld(Location, Map);
 
-                this.m_SpawnedQueen = true;
+                m_SpawnedQueen = true;
             }
-            else if (this.m_Queen != null && this.m_Queen.Deleted)
+            else if (m_Queen != null && m_Queen.Deleted)
             {
-                this.m_Queen = null;
+                m_Queen = null;
             }
         }
 
         public override void AlterDamageScalarFrom(Mobile caster, ref double scalar)
         {
-            this.CheckQueen();
+            CheckQueen();
 
-            if (this.m_Queen != null)
+            if (m_Queen != null)
             {
                 scalar *= 0.1;
 
                 if (0.1 >= Utility.RandomDouble())
-                    this.SpawnPixies(caster);
+                    SpawnPixies(caster);
             }
         }
 
@@ -287,10 +226,10 @@ namespace Server.Mobiles
         {
             base.OnGotMeleeAttack(attacker);
 
-            this.CheckQueen();
+            CheckQueen();
 
-            if (this.m_Queen != null && 0.1 >= Utility.RandomDouble())
-                this.SpawnPixies(attacker);
+            if (m_Queen != null && 0.1 >= Utility.RandomDouble())
+                SpawnPixies(attacker);
 
             /*attacker.Damage(Utility.Random(20, 10), this);
             attacker.Stam -= Utility.Random(20, 10);
@@ -303,8 +242,8 @@ namespace Server.Mobiles
 
             writer.Write((int)0); // version
 
-            writer.Write(this.m_Queen);
-            writer.Write(this.m_SpawnedQueen);
+            writer.Write(m_Queen);
+            writer.Write(m_SpawnedQueen);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -317,8 +256,8 @@ namespace Server.Mobiles
             {
                 case 0:
                     {
-                        this.m_Queen = reader.ReadMobile();
-                        this.m_SpawnedQueen = reader.ReadBool();
+                        m_Queen = reader.ReadMobile();
+                        m_SpawnedQueen = reader.ReadBool();
 
                         break;
                     }

--- a/Scripts/Mobiles/Bosses/Silvani.cs
+++ b/Scripts/Mobiles/Bosses/Silvani.cs
@@ -8,38 +8,38 @@ namespace Server.Mobiles
         public Silvani()
             : base(AIType.AI_Mage, FightMode.Evil, 18, 1, 0.1, 0.2)
         {
-            this.Name = "Silvani";
-            this.Body = 176;
-            this.BaseSoundID = 0x467;
+            Name = "Silvani";
+            Body = 176;
+            BaseSoundID = 0x467;
 
-            this.SetStr(253, 400);
-            this.SetDex(157, 850);
-            this.SetInt(503, 800);
+            SetStr(253, 400);
+            SetDex(157, 850);
+            SetInt(503, 800);
 
-            this.SetHits(600);
+            SetHits(600);
 
-            this.SetDamage(27, 38);
+            SetDamage(27, 38);
 
-            this.SetDamageType(ResistanceType.Physical, 75);
-            this.SetDamageType(ResistanceType.Cold, 25);
+            SetDamageType(ResistanceType.Physical, 75);
+            SetDamageType(ResistanceType.Cold, 25);
 
-            this.SetResistance(ResistanceType.Physical, 45, 55);
-            this.SetResistance(ResistanceType.Fire, 30, 40);
-            this.SetResistance(ResistanceType.Cold, 30, 40);
-            this.SetResistance(ResistanceType.Poison, 40, 50);
-            this.SetResistance(ResistanceType.Energy, 40, 50);
+            SetResistance(ResistanceType.Physical, 45, 55);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 30, 40);
+            SetResistance(ResistanceType.Poison, 40, 50);
+            SetResistance(ResistanceType.Energy, 40, 50);
 
-            this.SetSkill(SkillName.EvalInt, 100.0);
-            this.SetSkill(SkillName.Magery, 97.6, 107.5);
-            this.SetSkill(SkillName.Meditation, 100.0);
-            this.SetSkill(SkillName.MagicResist, 100.5, 150.0);
-            this.SetSkill(SkillName.Tactics, 97.6, 100.0);
-            this.SetSkill(SkillName.Wrestling, 97.6, 100.0);
+            SetSkill(SkillName.EvalInt, 100.0);
+            SetSkill(SkillName.Magery, 97.6, 107.5);
+            SetSkill(SkillName.Meditation, 100.0);
+            SetSkill(SkillName.MagicResist, 100.5, 150.0);
+            SetSkill(SkillName.Tactics, 97.6, 100.0);
+            SetSkill(SkillName.Wrestling, 97.6, 100.0);
 
-            this.Fame = 20000;
-            this.Karma = 20000;
+            Fame = 20000;
+            Karma = 20000;
 
-            this.VirtualArmor = 50;
+            VirtualArmor = 50;
         }
 
         public Silvani(Serial serial)
@@ -47,49 +47,20 @@ namespace Server.Mobiles
         {
         }
 
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override bool CanFly
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override bool Unprovokable
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Regular;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 5;
-            }
-        }
+        public override bool CanFly{ get{ return true; } }
+        public override bool Unprovokable{ get{ return true; } }
+        public override int TreasureMapLevel{ get{ return 5; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Fey; } }
+        public override Poison PoisonImmune{ get{ return Poison.Regular; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.UltraRich, 2);
+            AddLoot(LootPack.UltraRich, 2);
         }
 
         public void SpawnPixies(Mobile target)
         {
-            Map map = this.Map;
+            Map map = Map;
 
             if (map == null)
                 return;
@@ -100,20 +71,20 @@ namespace Server.Mobiles
             {
                 Pixie pixie = new Pixie();
 
-                pixie.Team = this.Team;
+                pixie.Team = Team;
                 pixie.FightMode = FightMode.Closest;
 
                 bool validLocation = false;
-                Point3D loc = this.Location;
+                Point3D loc = Location;
 
                 for (int j = 0; !validLocation && j < 10; ++j)
                 {
-                    int x = this.X + Utility.Random(3) - 1;
-                    int y = this.Y + Utility.Random(3) - 1;
+                    int x = X + Utility.Random(3) - 1;
+                    int y = Y + Utility.Random(3) - 1;
                     int z = map.GetAverageZ(x, y);
 
-                    if (validLocation = map.CanFit(x, y, this.Z, 16, false, false))
-                        loc = new Point3D(x, y, this.Z);
+                    if (validLocation = map.CanFit(x, y, Z, 16, false, false))
+                        loc = new Point3D(x, y, Z);
                     else if (validLocation = map.CanFit(x, y, z, 16, false, false))
                         loc = new Point3D(x, y, z);
                 }
@@ -126,7 +97,7 @@ namespace Server.Mobiles
         public override void AlterDamageScalarFrom(Mobile caster, ref double scalar)
         {
             if (0.1 >= Utility.RandomDouble())
-                this.SpawnPixies(caster);
+                SpawnPixies(caster);
         }
 
         public override void OnGaveMeleeAttack(Mobile defender)
@@ -143,7 +114,7 @@ namespace Server.Mobiles
             base.OnGotMeleeAttack(attacker);
 
             if (0.1 >= Utility.RandomDouble())
-                this.SpawnPixies(attacker);
+                SpawnPixies(attacker);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Named/ShadowKnight.cs
+++ b/Scripts/Mobiles/Named/ShadowKnight.cs
@@ -6,48 +6,47 @@ namespace Server.Mobiles
     [CorpseName("a shadow knight corpse")]
     public class ShadowKnight : BaseCreature
     {
-        public override bool CanStealth { get { return true; } }
-
         private Timer m_SoundTimer;
         private bool m_HasTeleportedAway;
+
         [Constructable]
         public ShadowKnight()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = NameList.RandomName("shadow knight");
-            this.Title = "the Shadow Knight";
-            this.Body = 311;
+            Name = NameList.RandomName("shadow knight");
+            Title = "the Shadow Knight";
+            Body = 311;
 
-            this.SetStr(250);
-            this.SetDex(100);
-            this.SetInt(100);
+            SetStr(250);
+            SetDex(100);
+            SetInt(100);
 
-            this.SetHits(2000);
+            SetHits(2000);
 
-            this.SetDamage(20, 30);
+            SetDamage(20, 30);
 
-            this.SetDamageType(ResistanceType.Physical, 60);
-            this.SetDamageType(ResistanceType.Cold, 40);
+            SetDamageType(ResistanceType.Physical, 60);
+            SetDamageType(ResistanceType.Cold, 40);
 
-            this.SetResistance(ResistanceType.Physical, 90);
-            this.SetResistance(ResistanceType.Fire, 65);
-            this.SetResistance(ResistanceType.Cold, 75);
-            this.SetResistance(ResistanceType.Poison, 75);
-            this.SetResistance(ResistanceType.Energy, 55);
+            SetResistance(ResistanceType.Physical, 90);
+            SetResistance(ResistanceType.Fire, 65);
+            SetResistance(ResistanceType.Cold, 75);
+            SetResistance(ResistanceType.Poison, 75);
+            SetResistance(ResistanceType.Energy, 55);
 
-            this.SetSkill(SkillName.Chivalry, 120.0);
-            this.SetSkill(SkillName.DetectHidden, 80.0);
-            this.SetSkill(SkillName.EvalInt, 100.0);
-            this.SetSkill(SkillName.Magery, 100.0);
-            this.SetSkill(SkillName.Meditation, 100.0);
-            this.SetSkill(SkillName.MagicResist, 120.0);
-            this.SetSkill(SkillName.Tactics, 100.0);
-            this.SetSkill(SkillName.Wrestling, 100.0);
+            SetSkill(SkillName.Chivalry, 120.0);
+            SetSkill(SkillName.DetectHidden, 80.0);
+            SetSkill(SkillName.EvalInt, 100.0);
+            SetSkill(SkillName.Magery, 100.0);
+            SetSkill(SkillName.Meditation, 100.0);
+            SetSkill(SkillName.MagicResist, 120.0);
+            SetSkill(SkillName.Tactics, 100.0);
+            SetSkill(SkillName.Wrestling, 100.0);
 
-            this.Fame = 25000;
-            this.Karma = -25000;
+            Fame = 25000;
+            Karma = -25000;
 
-            this.VirtualArmor = 54;
+            VirtualArmor = 54;
         }
 
         public ShadowKnight(Serial serial)
@@ -67,151 +66,94 @@ namespace Server.Mobiles
 			base.OnDamagedBySpell(from);
 		}
 
-        public override bool IgnoreYoungProtection
-        {
-            get
-            {
-                return Core.ML;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override bool BardImmune
-        {
-            get
-            {
-                return !Core.SE;
-            }
-        }
-        public override bool Unprovokable
-        {
-            get
-            {
-                return Core.SE;
-            }
-        }
-        public override bool AreaPeaceImmune
-        {
-            get
-            {
-                return Core.SE;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 1;
-            }
-        }
+        public override bool AreaPeaceImmune{ get{ return Core.SE; } }
+        public override bool BardImmune{ get{ return !Core.SE; } }
+        public override bool CanStealth{ get { return true; } }
+        public override bool IgnoreYoungProtection{ get{ return Core.ML; } }
+        public override bool Unprovokable{ get{ return Core.SE; } }
+        public override int TreasureMapLevel{ get{ return 1; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
+
         public override WeaponAbility GetWeaponAbility()
         {
             return Utility.RandomBool() ? WeaponAbility.ConcussionBlow : WeaponAbility.CrushingBlow;
         }
 
+        public override int GetIdleSound(){ return 0x2CE; }
+        public override int GetDeathSound(){ return 0x2C1; }
+        public override int GetHurtSound(){ return 0x2D1; }
+        public override int GetAttackSound(){ return 0x2C8; }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.UltraRich, 2);
-        }
-
-        
-
-        public override int GetIdleSound()
-        {
-            return 0x2CE;
-        }
-
-        public override int GetDeathSound()
-        {
-            return 0x2C1;
-        }
-
-        public override int GetHurtSound()
-        {
-            return 0x2D1;
-        }
-
-        public override int GetAttackSound()
-        {
-            return 0x2C8;
+            AddLoot(LootPack.UltraRich, 2);
         }
 
         public override void OnCombatantChange()
         {
             base.OnCombatantChange();
 
-            if (this.Hidden && this.Combatant != null)
-                this.Combatant = null;
+            if (Hidden && Combatant != null)
+                Combatant = null;
         }
 
         public virtual void SendTrackingSound()
         {
-            if (this.Hidden)
+            if (Hidden)
             {
-                Effects.PlaySound(this.Location, this.Map, 0x2C8);
-                this.Combatant = null;
+                Effects.PlaySound(Location, Map, 0x2C8);
+                Combatant = null;
             }
             else
             {
-                this.Frozen = false;
+                Frozen = false;
 
-                if (this.m_SoundTimer != null)
-                    this.m_SoundTimer.Stop();
+                if (m_SoundTimer != null)
+                    m_SoundTimer.Stop();
 
-                this.m_SoundTimer = null;
+                m_SoundTimer = null;
             }
         }
 
         public override void OnThink()
         {
-            if (!this.m_HasTeleportedAway && this.Hits < (this.HitsMax / 2))
+            if (!m_HasTeleportedAway && Hits < (HitsMax / 2))
             {
-                Map map = this.Map;
+                Map map = Map;
 
                 if (map != null)
                 {
                     // try 10 times to find a teleport spot
                     for (int i = 0; i < 10; ++i)
                     {
-                        int x = this.X + (Utility.RandomMinMax(5, 10) * (Utility.RandomBool() ? 1 : -1));
-                        int y = this.Y + (Utility.RandomMinMax(5, 10) * (Utility.RandomBool() ? 1 : -1));
-                        int z = this.Z;
+                        int x = X + (Utility.RandomMinMax(5, 10) * (Utility.RandomBool() ? 1 : -1));
+                        int y = Y + (Utility.RandomMinMax(5, 10) * (Utility.RandomBool() ? 1 : -1));
+                        int z = Z;
 
                         if (!map.CanFit(x, y, z, 16, false, false))
                             continue;
 
-                        Point3D from = this.Location;
+                        Point3D from = Location;
                         Point3D to = new Point3D(x, y, z);
 
-                        if (!this.InLOS(to))
+                        if (!InLOS(to))
                             continue;
 
-                        this.Location = to;
-                        this.ProcessDelta();
-                        this.Hidden = true;
-                        this.Combatant = null;
+                        Location = to;
+                        ProcessDelta();
+                        Hidden = true;
+                        Combatant = null;
 
                         Effects.SendLocationParticles(EffectItem.Create(from, map, EffectItem.DefaultDuration), 0x3728, 10, 10, 2023);
                         Effects.SendLocationParticles(EffectItem.Create(to, map, EffectItem.DefaultDuration), 0x3728, 10, 10, 5023);
 
                         Effects.PlaySound(to, map, 0x1FE);
 
-                        this.m_HasTeleportedAway = true;
-                        this.m_SoundTimer = Timer.DelayCall(TimeSpan.FromSeconds(5.0), TimeSpan.FromSeconds(2.5), new TimerCallback(SendTrackingSound));
+                        m_HasTeleportedAway = true;
+                        m_SoundTimer = Timer.DelayCall(TimeSpan.FromSeconds(5.0), TimeSpan.FromSeconds(2.5), new TimerCallback(SendTrackingSound));
 
-                        this.Frozen = true;
+                        Frozen = true;
 
                         break;
                     }
@@ -232,8 +174,8 @@ namespace Server.Mobiles
             base.Deserialize(reader);
             int version = reader.ReadInt();
 
-            if (this.BaseSoundID == 357)
-                this.BaseSoundID = -1;
+            if (BaseSoundID == 357)
+                BaseSoundID = -1;
         }
     }
 }

--- a/Scripts/Mobiles/Normal/AncientLich.cs
+++ b/Scripts/Mobiles/Normal/AncientLich.cs
@@ -9,43 +9,43 @@ namespace Server.Mobiles
         public AncientLich()
             : base(AIType.AI_NecroMage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = NameList.RandomName("ancient lich");
-            this.Body = 78;
-            this.BaseSoundID = 412;
+            Name = NameList.RandomName("ancient lich");
+            Body = 78;
+            BaseSoundID = 412;
 
-            this.SetStr(216, 305);
-            this.SetDex(96, 115);
-            this.SetInt(966, 1045);
+            SetStr(216, 305);
+            SetDex(96, 115);
+            SetInt(966, 1045);
 
-            this.SetHits(560, 595);
+            SetHits(560, 595);
 
-            this.SetDamage(15, 27);
+            SetDamage(15, 27);
 
-            this.SetDamageType(ResistanceType.Physical, 20);
-            this.SetDamageType(ResistanceType.Cold, 40);
-            this.SetDamageType(ResistanceType.Energy, 40);
+            SetDamageType(ResistanceType.Physical, 20);
+            SetDamageType(ResistanceType.Cold, 40);
+            SetDamageType(ResistanceType.Energy, 40);
 
-            this.SetResistance(ResistanceType.Physical, 55, 65);
-            this.SetResistance(ResistanceType.Fire, 25, 30);
-            this.SetResistance(ResistanceType.Cold, 50, 60);
-            this.SetResistance(ResistanceType.Poison, 50, 60);
-            this.SetResistance(ResistanceType.Energy, 25, 30);
+            SetResistance(ResistanceType.Physical, 55, 65);
+            SetResistance(ResistanceType.Fire, 25, 30);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 50, 60);
+            SetResistance(ResistanceType.Energy, 25, 30);
 
-            this.SetSkill(SkillName.EvalInt, 120.1, 130.0);
-            this.SetSkill(SkillName.Magery, 120.1, 130.0);
-            this.SetSkill(SkillName.Meditation, 100.1, 101.0);
-            this.SetSkill(SkillName.Poisoning, 100.1, 101.0);
-            this.SetSkill(SkillName.MagicResist, 175.2, 200.0);
-            this.SetSkill(SkillName.Tactics, 90.1, 100.0);
-            this.SetSkill(SkillName.Wrestling, 75.1, 100.0);
-            this.SetSkill(SkillName.Necromancy, 120.1, 130.0);
-            this.SetSkill(SkillName.SpiritSpeak, 120.1, 130.0);
+            SetSkill(SkillName.EvalInt, 120.1, 130.0);
+            SetSkill(SkillName.Magery, 120.1, 130.0);
+            SetSkill(SkillName.Meditation, 100.1, 101.0);
+            SetSkill(SkillName.Poisoning, 100.1, 101.0);
+            SetSkill(SkillName.MagicResist, 175.2, 200.0);
+            SetSkill(SkillName.Tactics, 90.1, 100.0);
+            SetSkill(SkillName.Wrestling, 75.1, 100.0);
+            SetSkill(SkillName.Necromancy, 120.1, 130.0);
+            SetSkill(SkillName.SpiritSpeak, 120.1, 130.0);
 
-            this.Fame = 23000;
-            this.Karma = -23000;
+            Fame = 23000;
+            Karma = -23000;
 
-            this.VirtualArmor = 60;
-            this.PackNecroReg(30, 275);
+            VirtualArmor = 60;
+            PackNecroReg(30, 275);
         }
 
         public AncientLich(Serial serial)
@@ -53,70 +53,22 @@ namespace Server.Mobiles
         {
         }
 
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override bool Unprovokable
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 5;
-            }
-        }
-        public override int GetIdleSound()
-        {
-            return 0x19D;
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override bool Unprovokable{ get{ return true; } }
+        public override int TreasureMapLevel{ get{ return 5; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
 
-        public override int GetAngerSound()
-        {
-            return 0x175;
-        }
-
-        public override int GetDeathSound()
-        {
-            return 0x108;
-        }
-
-        public override int GetAttackSound()
-        {
-            return 0xE2;
-        }
-
-        public override int GetHurtSound()
-        {
-            return 0x28B;
-        }
+        public override int GetIdleSound(){ return 0x19D; }
+        public override int GetAngerSound(){ return 0x175; }
+        public override int GetDeathSound(){ return 0x108; }
+        public override int GetAttackSound(){ return 0xE2; }
+        public override int GetHurtSound(){ return 0x28B; }
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.FilthyRich, 3);
-            this.AddLoot(LootPack.MedScrolls, 2);
+            AddLoot(LootPack.FilthyRich, 3);
+            AddLoot(LootPack.MedScrolls, 2);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -941,7 +941,7 @@ namespace Server.Mobiles
                     PlayerMobile pm = m as PlayerMobile;
                     toDrain = (int)drNO.ThieveItems.LifeShieldLotion.HandleLifeDrain(pm, toDrain);
                 }
-                //end 
+                //end
 
 
                 Hits += toDrain;
@@ -993,6 +993,147 @@ namespace Server.Mobiles
         public virtual OppositionGroup OppositionGroup { get { return null; } }
         public virtual bool IsMilitiaFighter { get { return false; } }
 
+        // Opposition List stuff
+        public virtual OppositionType OppositionList{ get{ return OppositionType.None ; } } // What opposition list am I in?
+
+        public enum OppositionType
+        {
+            None,
+            Juka,
+            Meer,
+            Terathan,
+            Ophidian,
+            Savage,
+            Orc,
+            Fey,
+            Undead,
+            BlackSolen,
+            RedSolen
+        }
+
+        public virtual bool OppositionListEnemy(Mobile m)
+        {
+            // Target must be BaseCreature
+            if (!(m is BaseCreature))
+            {
+                return false;
+            }
+
+            BaseCreature c = (BaseCreature)m;
+
+            // Target must have an OppositionType
+            if (c.OppositionList == OppositionType.None)
+            {
+                return false;
+            }
+
+            // Pick my OppositionType
+            switch (OppositionList)
+            {
+                case OppositionType.Juka: return m_JukaEnemy(c.OppositionList);
+                case OppositionType.Meer: return m_MeerEnemy(c.OppositionList);
+                case OppositionType.Terathan: return m_TerathanEnemy(c.OppositionList);
+                case OppositionType.Ophidian: return m_OphidianEnemy(c.OppositionList);
+                case OppositionType.Savage: return m_SavageEnemy(c.OppositionList);
+                case OppositionType.Orc: return m_OrcEnemy(c.OppositionList);
+                case OppositionType.Fey: return m_FeyEnemy(c.OppositionList);
+                case OppositionType.Undead: return m_UndeadEnemy(c.OppositionList);
+                case OppositionType.BlackSolen: return m_BlackSolenEnemy(c.OppositionList);
+                case OppositionType.RedSolen: return m_RedSolenEnemy(c.OppositionList);
+                default: return false;
+            }
+        }
+
+        private bool m_JukaEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Meer: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_MeerEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Juka: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_TerathanEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Ophidian: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_OphidianEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Terathan: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_SavageEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Orc: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_OrcEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Savage: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_FeyEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Undead: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_UndeadEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.Fey: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_BlackSolenEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.RedSolen: return true;
+                default: return false;
+            }
+        }
+
+        private bool m_RedSolenEnemy(OppositionType egroup)
+        {
+            switch (egroup)
+            {
+                case OppositionType.BlackSolen: return true;
+                default: return false;
+            }
+        }
+
         #region Friends
         public List<Mobile> Friends { get { return m_Friends; } }
 
@@ -1023,9 +1164,7 @@ namespace Server.Mobiles
 
 		public virtual bool IsFriend(Mobile m)
 		{
-			OppositionGroup g = OppositionGroup;
-
-			if (g != null && g.IsEnemy(this, m))
+			if (OppositionList != OppositionType.None && OppositionListEnemy(m))
 			{
 				return false;
 			}
@@ -1105,9 +1244,7 @@ namespace Server.Mobiles
 				return a.IsEnemy(m);
 			}
 
-			OppositionGroup g = OppositionGroup;
-
-			if (g != null && g.IsEnemy(this, m))
+			if (OppositionList != OppositionType.None && OppositionListEnemy(m))
 			{
 				return true;
 			}
@@ -1148,7 +1285,7 @@ namespace Server.Mobiles
 			}
 
 			BaseCreature c = (BaseCreature)m;
-            
+
 			if (c.IsMilitiaFighter)
 			{
 				return true;
@@ -1682,8 +1819,8 @@ namespace Server.Mobiles
 
         Seems this actually was removed on OSI somewhere between the original bug report and now.
         We will call it ML, until we can get better information. I suspect it was on the OSI TC when
-        originally it taken out of RunUO, and not implmented on OSIs production shards until more 
-        recently.  Either way, this is, or was, accurate OSI behavior, and just entirely 
+        originally it taken out of RunUO, and not implmented on OSIs production shards until more
+        recently.  Either way, this is, or was, accurate OSI behavior, and just entirely
         removing it was incorrect.  OSI followers were distracted by being attacked well into
         AoS, at very least.
 
@@ -4133,8 +4270,8 @@ namespace Server.Mobiles
             return true; // entered idle state
         }
 
-        /* 
-			this way, due to the huge number of locations this will have to be changed 
+        /*
+			this way, due to the huge number of locations this will have to be changed
 			Perhaps we can change this in the future when fixing game play is not the
 			major issue.
 		*/
@@ -5532,8 +5669,8 @@ namespace Server.Mobiles
         public static int[] RecipeTypes { get { return _RecipeTypes; } }
         private static int[] _RecipeTypes =
         {
-            560, 561, 562, 563, 564, 565, 566, 
-            570, 571, 572, 573, 574, 575, 576, 577, 
+            560, 561, 562, 563, 564, 565, 566,
+            570, 571, 572, 573, 574, 575, 576, 577,
             580, 581, 582, 583, 584
             //602, 603, 604,  // nutcrackers
             //800             // runic atlas
@@ -7315,7 +7452,7 @@ namespace Server.Mobiles
         private bool m_RemoveOnSave;
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public bool RemoveOnSave { get { return m_RemoveOnSave; } set { m_RemoveOnSave = value; } }    
+        public bool RemoveOnSave { get { return m_RemoveOnSave; } set { m_RemoveOnSave = value; } }
     }
 
     public class LoyaltyTimer : Timer

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -999,16 +999,12 @@ namespace Server.Mobiles
         public enum OppositionType
         {
             None,
-            Juka,
-            Meer,
             Terathan,
             Ophidian,
             Savage,
             Orc,
             Fey,
-            Undead,
-            BlackSolen,
-            RedSolen
+            Undead
         }
 
         public virtual bool OppositionListEnemy(Mobile m)
@@ -1030,34 +1026,12 @@ namespace Server.Mobiles
             // Pick my OppositionType
             switch (OppositionList)
             {
-                case OppositionType.Juka: return m_JukaEnemy(c.OppositionList);
-                case OppositionType.Meer: return m_MeerEnemy(c.OppositionList);
                 case OppositionType.Terathan: return m_TerathanEnemy(c.OppositionList);
                 case OppositionType.Ophidian: return m_OphidianEnemy(c.OppositionList);
                 case OppositionType.Savage: return m_SavageEnemy(c.OppositionList);
                 case OppositionType.Orc: return m_OrcEnemy(c.OppositionList);
                 case OppositionType.Fey: return m_FeyEnemy(c.OppositionList);
                 case OppositionType.Undead: return m_UndeadEnemy(c.OppositionList);
-                case OppositionType.BlackSolen: return m_BlackSolenEnemy(c.OppositionList);
-                case OppositionType.RedSolen: return m_RedSolenEnemy(c.OppositionList);
-                default: return false;
-            }
-        }
-
-        private bool m_JukaEnemy(OppositionType egroup)
-        {
-            switch (egroup)
-            {
-                case OppositionType.Meer: return true;
-                default: return false;
-            }
-        }
-
-        private bool m_MeerEnemy(OppositionType egroup)
-        {
-            switch (egroup)
-            {
-                case OppositionType.Juka: return true;
                 default: return false;
             }
         }
@@ -1112,24 +1086,6 @@ namespace Server.Mobiles
             switch (egroup)
             {
                 case OppositionType.Fey: return true;
-                default: return false;
-            }
-        }
-
-        private bool m_BlackSolenEnemy(OppositionType egroup)
-        {
-            switch (egroup)
-            {
-                case OppositionType.RedSolen: return true;
-                default: return false;
-            }
-        }
-
-        private bool m_RedSolenEnemy(OppositionType egroup)
-        {
-            switch (egroup)
-            {
-                case OppositionType.BlackSolen: return true;
                 default: return false;
             }
         }

--- a/Scripts/Mobiles/Normal/Bogle.cs
+++ b/Scripts/Mobiles/Normal/Bogle.cs
@@ -10,30 +10,30 @@ namespace Server.Mobiles
         public Bogle()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a bogle";
-            this.Body = 153;
-            this.BaseSoundID = 0x482;
+            Name = "a bogle";
+            Body = 153;
+            BaseSoundID = 0x482;
 
-            this.SetStr(76, 100);
-            this.SetDex(76, 95);
-            this.SetInt(36, 60);
+            SetStr(76, 100);
+            SetDex(76, 95);
+            SetInt(36, 60);
 
-            this.SetHits(46, 60);
+            SetHits(46, 60);
 
-            this.SetDamage(7, 11);
+            SetDamage(7, 11);
 
-            this.SetSkill(SkillName.EvalInt, 55.1, 70.0);
-            this.SetSkill(SkillName.Magery, 55.1, 70.0);
-            this.SetSkill(SkillName.MagicResist, 55.1, 70.0);
-            this.SetSkill(SkillName.Tactics, 45.1, 60.0);
-            this.SetSkill(SkillName.Wrestling, 45.1, 55.0);
+            SetSkill(SkillName.EvalInt, 55.1, 70.0);
+            SetSkill(SkillName.Magery, 55.1, 70.0);
+            SetSkill(SkillName.MagicResist, 55.1, 70.0);
+            SetSkill(SkillName.Tactics, 45.1, 60.0);
+            SetSkill(SkillName.Wrestling, 45.1, 55.0);
 
-            this.Fame = 4000;
-            this.Karma = -4000;
+            Fame = 4000;
+            Karma = -4000;
 
-            this.VirtualArmor = 28;
-            this.PackItem(Loot.RandomWeapon());
-            this.PackItem(new Bone());
+            VirtualArmor = 28;
+            PackItem(Loot.RandomWeapon());
+            PackItem(new Bone());
         }
 
         public Bogle(Serial serial)
@@ -41,30 +41,13 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Meager);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/BoneKnight.cs
+++ b/Scripts/Mobiles/Normal/BoneKnight.cs
@@ -10,60 +10,60 @@ namespace Server.Mobiles
         public BoneKnight()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a bone knight";
-            this.Body = 57;
-            this.BaseSoundID = 451;
+            Name = "a bone knight";
+            Body = 57;
+            BaseSoundID = 451;
 
-            this.SetStr(196, 250);
-            this.SetDex(76, 95);
-            this.SetInt(36, 60);
+            SetStr(196, 250);
+            SetDex(76, 95);
+            SetInt(36, 60);
 
-            this.SetHits(118, 150);
+            SetHits(118, 150);
 
-            this.SetDamage(8, 18);
+            SetDamage(8, 18);
 
-            this.SetDamageType(ResistanceType.Physical, 40);
-            this.SetDamageType(ResistanceType.Cold, 60);
+            SetDamageType(ResistanceType.Physical, 40);
+            SetDamageType(ResistanceType.Cold, 60);
 
-            this.SetResistance(ResistanceType.Physical, 35, 45);
-            this.SetResistance(ResistanceType.Fire, 20, 30);
-            this.SetResistance(ResistanceType.Cold, 50, 60);
-            this.SetResistance(ResistanceType.Poison, 20, 30);
-            this.SetResistance(ResistanceType.Energy, 30, 40);
+            SetResistance(ResistanceType.Physical, 35, 45);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 20, 30);
+            SetResistance(ResistanceType.Energy, 30, 40);
 
-            this.SetSkill(SkillName.MagicResist, 65.1, 80.0);
-            this.SetSkill(SkillName.Tactics, 85.1, 100.0);
-            this.SetSkill(SkillName.Wrestling, 85.1, 95.0);
+            SetSkill(SkillName.MagicResist, 65.1, 80.0);
+            SetSkill(SkillName.Tactics, 85.1, 100.0);
+            SetSkill(SkillName.Wrestling, 85.1, 95.0);
 
-            this.Fame = 3000;
-            this.Karma = -3000;
+            Fame = 3000;
+            Karma = -3000;
 
-            this.VirtualArmor = 40;
-			
+            VirtualArmor = 40;
+
             switch ( Utility.Random(6) )
             {
                 case 0:
-                    this.PackItem(new PlateArms());
+                    PackItem(new PlateArms());
                     break;
                 case 1:
-                    this.PackItem(new PlateChest());
+                    PackItem(new PlateChest());
                     break;
                 case 2:
-                    this.PackItem(new PlateGloves());
+                    PackItem(new PlateGloves());
                     break;
                 case 3:
-                    this.PackItem(new PlateGorget());
+                    PackItem(new PlateGorget());
                     break;
                 case 4:
-                    this.PackItem(new PlateLegs());
+                    PackItem(new PlateLegs());
                     break;
                 case 5:
-                    this.PackItem(new PlateHelm());
+                    PackItem(new PlateHelm());
                     break;
             }
 
-            this.PackItem(new Scimitar());
-            this.PackItem(new WoodenShield());
+            PackItem(new Scimitar());
+            PackItem(new WoodenShield());
         }
 
         public BoneKnight(Serial serial)
@@ -71,24 +71,13 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Average);
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Meager);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Centaur.cs
+++ b/Scripts/Mobiles/Normal/Centaur.cs
@@ -10,38 +10,38 @@ namespace Server.Mobiles
         public Centaur()
             : base(AIType.AI_Melee, FightMode.Aggressor, 10, 1, 0.2, 0.4)
         {
-            this.Name = NameList.RandomName("centaur");
-            this.Body = 101;
-            this.BaseSoundID = 679;
+            Name = NameList.RandomName("centaur");
+            Body = 101;
+            BaseSoundID = 679;
 
-            this.SetStr(202, 300);
-            this.SetDex(104, 260);
-            this.SetInt(91, 100);
+            SetStr(202, 300);
+            SetDex(104, 260);
+            SetInt(91, 100);
 
-            this.SetHits(130, 172);
+            SetHits(130, 172);
 
-            this.SetDamage(13, 24);
+            SetDamage(13, 24);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 45, 55);
-            this.SetResistance(ResistanceType.Fire, 35, 45);
-            this.SetResistance(ResistanceType.Cold, 25, 35);
-            this.SetResistance(ResistanceType.Poison, 45, 55);
-            this.SetResistance(ResistanceType.Energy, 35, 45);
+            SetResistance(ResistanceType.Physical, 45, 55);
+            SetResistance(ResistanceType.Fire, 35, 45);
+            SetResistance(ResistanceType.Cold, 25, 35);
+            SetResistance(ResistanceType.Poison, 45, 55);
+            SetResistance(ResistanceType.Energy, 35, 45);
 
-            this.SetSkill(SkillName.Anatomy, 95.1, 115.0);
-            this.SetSkill(SkillName.Archery, 95.1, 100.0);
-            this.SetSkill(SkillName.MagicResist, 50.3, 80.0);
-            this.SetSkill(SkillName.Tactics, 90.1, 100.0);
-            this.SetSkill(SkillName.Wrestling, 95.1, 100.0);
+            SetSkill(SkillName.Anatomy, 95.1, 115.0);
+            SetSkill(SkillName.Archery, 95.1, 100.0);
+            SetSkill(SkillName.MagicResist, 50.3, 80.0);
+            SetSkill(SkillName.Tactics, 90.1, 100.0);
+            SetSkill(SkillName.Wrestling, 95.1, 100.0);
 
-            this.Fame = 6500;
-            this.Karma = 0;
+            Fame = 6500;
+            Karma = 0;
 
-            this.VirtualArmor = 50;
-            this.AddItem(new Bow());
-            this.PackItem(new Arrow(Utility.RandomMinMax(80, 90))); // OSI it is different: in a sub backpack, this is probably just a limitation of their engine
+            VirtualArmor = 50;
+            AddItem(new Bow());
+            PackItem(new Arrow(Utility.RandomMinMax(80, 90))); // OSI it is different: in a sub backpack, this is probably just a limitation of their engine
         }
 
         public Centaur(Serial serial)
@@ -49,39 +49,16 @@ namespace Server.Mobiles
         {
         }
 
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override int Meat
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override int Hides
-        {
-            get
-            {
-                return 8;
-            }
-        }
-        public override HideType HideType
-        {
-            get
-            {
-                return HideType.Spined;
-            }
-        }
+        public override int Hides{ get{ return 8; } }
+        public override int Meat{ get{ return 1; } }
+        public override HideType HideType{ get{ return HideType.Spined; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Fey; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich);
-            this.AddLoot(LootPack.Average);
-            this.AddLoot(LootPack.Gems);
+            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Gems);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -95,8 +72,8 @@ namespace Server.Mobiles
             base.Deserialize(reader);
             int version = reader.ReadInt();
 
-            if (this.BaseSoundID == 678)
-                this.BaseSoundID = 679;
+            if (BaseSoundID == 678)
+                BaseSoundID = 679;
         }
     }
 }

--- a/Scripts/Mobiles/Normal/EtherealWarrior.cs
+++ b/Scripts/Mobiles/Normal/EtherealWarrior.cs
@@ -1,101 +1,85 @@
 using System;
 using Server.Gumps;
 
-namespace Server.Mobiles 
-{ 
-    [CorpseName("an ethereal warrior corpse")] 
-    public class EtherealWarrior : BaseCreature 
-    { 
+namespace Server.Mobiles
+{
+    [CorpseName("an ethereal warrior corpse")]
+    public class EtherealWarrior : BaseCreature
+    {
         private static readonly TimeSpan ResurrectDelay = TimeSpan.FromSeconds(2.0);
         private DateTime m_NextResurrect;
-        [Constructable] 
+
+        [Constructable]
         public EtherealWarrior()
             : base(AIType.AI_Mage, FightMode.Evil, 10, 1, 0.2, 0.4)
-        { 
-            this.Name = NameList.RandomName("ethereal warrior");
-            this.Body = 123;
+        {
+            Name = NameList.RandomName("ethereal warrior");
+            Body = 123;
 
-            this.SetStr(586, 785);
-            this.SetDex(177, 255);
-            this.SetInt(351, 450);
+            SetStr(586, 785);
+            SetDex(177, 255);
+            SetInt(351, 450);
 
-            this.SetHits(352, 471);
+            SetHits(352, 471);
 
-            this.SetDamage(13, 19);
+            SetDamage(13, 19);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 80, 90);
-            this.SetResistance(ResistanceType.Fire, 40, 50);
-            this.SetResistance(ResistanceType.Cold, 40, 50);
-            this.SetResistance(ResistanceType.Poison, 40, 50);
-            this.SetResistance(ResistanceType.Energy, 40, 50);
+            SetResistance(ResistanceType.Physical, 80, 90);
+            SetResistance(ResistanceType.Fire, 40, 50);
+            SetResistance(ResistanceType.Cold, 40, 50);
+            SetResistance(ResistanceType.Poison, 40, 50);
+            SetResistance(ResistanceType.Energy, 40, 50);
 
-            this.SetSkill(SkillName.Anatomy, 50.1, 75.0);
-            this.SetSkill(SkillName.EvalInt, 90.1, 100.0);
-            this.SetSkill(SkillName.Magery, 99.1, 100.0);
-            this.SetSkill(SkillName.Meditation, 90.1, 100.0);
-            this.SetSkill(SkillName.MagicResist, 90.1, 100.0);
-            this.SetSkill(SkillName.Tactics, 90.1, 100.0);
-            this.SetSkill(SkillName.Wrestling, 97.6, 100.0);
+            SetSkill(SkillName.Anatomy, 50.1, 75.0);
+            SetSkill(SkillName.EvalInt, 90.1, 100.0);
+            SetSkill(SkillName.Magery, 99.1, 100.0);
+            SetSkill(SkillName.Meditation, 90.1, 100.0);
+            SetSkill(SkillName.MagicResist, 90.1, 100.0);
+            SetSkill(SkillName.Tactics, 90.1, 100.0);
+            SetSkill(SkillName.Wrestling, 97.6, 100.0);
 
-            this.Fame = 7000;
-            this.Karma = 7000;
+            Fame = 7000;
+            Karma = 7000;
 
-            this.VirtualArmor = 120;
+            VirtualArmor = 120;
         }
 
         public EtherealWarrior(Serial serial)
             : base(serial)
-        { 
+        {
         }
 
-        public override bool InitialInnocent
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return Core.AOS ? 5 : 0;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override int Feathers
-        {
-            get
-            {
-                return 100;
-            }
-        }
+        public override bool InitialInnocent{ get{ return true; } }
+        public override int Feathers{ get{ return 100; } }
+        public override int TreasureMapLevel{ get{ return Core.AOS ? 5 : 0; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Fey; } }
+
+        public override int GetAngerSound(){ return 0x2F8; }
+        public override int GetIdleSound(){ return 0x2F8; }
+        public override int GetAttackSound(){ return Utility.Random(0x2F5, 2); }
+        public override int GetHurtSound(){ return 0x2F9; }
+        public override int GetDeathSound(){ return 0x2F7; }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich, 3);
-            this.AddLoot(LootPack.Gems);
+            AddLoot(LootPack.Rich, 3);
+            AddLoot(LootPack.Gems);
         }
 
         public override void OnMovement(Mobile from, Point3D oldLocation)
         {
             if (!from.Alive && (from is PlayerMobile))
             {
-                if (!from.Frozen && (DateTime.UtcNow >= this.m_NextResurrect) && this.InRange(from, 4) && !this.InRange(oldLocation, 4) && this.InLOS(from))
+                if (!from.Frozen && (DateTime.UtcNow >= m_NextResurrect) && InRange(from, 4) && !InRange(oldLocation, 4) && InLOS(from))
                 {
-                    this.m_NextResurrect = DateTime.UtcNow + ResurrectDelay;
+                    m_NextResurrect = DateTime.UtcNow + ResurrectDelay;
                     if (!from.Criminal && (from.Kills < 5) && (from.Karma > 0))
                     {
                         if (from.Map != null && from.Map.CanFit(from.Location, 16, false, false))
                         {
-                            this.Direction = this.GetDirectionTo(from);
+                            Direction = GetDirectionTo(from);
                             from.PlaySound(0x1F2);
                             from.FixedEffect(0x376A, 10, 16);
                             from.CloseGump(typeof(ResurrectGump));
@@ -104,31 +88,6 @@ namespace Server.Mobiles
                     }
                 }
             }
-        }
-
-        public override int GetAngerSound()
-        {
-            return 0x2F8;
-        }
-
-        public override int GetIdleSound()
-        {
-            return 0x2F8;
-        }
-
-        public override int GetAttackSound()
-        {
-            return Utility.Random(0x2F5, 2);
-        }
-
-        public override int GetHurtSound()
-        {
-            return 0x2F9;
-        }
-
-        public override int GetDeathSound()
-        {
-            return 0x2F7;
         }
 
         public override void OnGaveMeleeAttack(Mobile defender)
@@ -169,16 +128,16 @@ namespace Server.Mobiles
             attacker.Mana -= Utility.Random(10, 10);*/
         }
 
-        public override void Serialize(GenericWriter writer) 
-        { 
-            base.Serialize(writer); 
-            writer.Write((int)0); 
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0);
         }
 
-        public override void Deserialize(GenericReader reader) 
-        { 
-            base.Deserialize(reader); 
-            int version = reader.ReadInt(); 
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
         }
     }
 }

--- a/Scripts/Mobiles/Normal/Ghoul.cs
+++ b/Scripts/Mobiles/Normal/Ghoul.cs
@@ -9,34 +9,34 @@ namespace Server.Mobiles
         public Ghoul()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a ghoul";
-            this.Body = 153;
-            this.BaseSoundID = 0x482;
+            Name = "a ghoul";
+            Body = 153;
+            BaseSoundID = 0x482;
 
-            this.SetStr(76, 100);
-            this.SetDex(76, 95);
-            this.SetInt(36, 60);
+            SetStr(76, 100);
+            SetDex(76, 95);
+            SetInt(36, 60);
 
-            this.SetHits(46, 60);
-            this.SetMana(0);
+            SetHits(46, 60);
+            SetMana(0);
 
-            this.SetDamage(7, 9);
+            SetDamage(7, 9);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 25, 30);
-            this.SetResistance(ResistanceType.Cold, 20, 30);
-            this.SetResistance(ResistanceType.Poison, 5, 10);
-            this.SetResistance(ResistanceType.Energy, 10, 20);
+            SetResistance(ResistanceType.Physical, 25, 30);
+            SetResistance(ResistanceType.Cold, 20, 30);
+            SetResistance(ResistanceType.Poison, 5, 10);
+            SetResistance(ResistanceType.Energy, 10, 20);
 
-            this.SetSkill(SkillName.MagicResist, 45.1, 60.0);
-            this.SetSkill(SkillName.Tactics, 45.1, 60.0);
-            this.SetSkill(SkillName.Wrestling, 45.1, 55.0);
+            SetSkill(SkillName.MagicResist, 45.1, 60.0);
+            SetSkill(SkillName.Tactics, 45.1, 60.0);
+            SetSkill(SkillName.Wrestling, 45.1, 55.0);
 
-            this.Fame = 2500;
-            this.Karma = -2500;
+            Fame = 2500;
+            Karma = -2500;
 
-            this.VirtualArmor = 28;
+            VirtualArmor = 28;
         }
 
         public Ghoul(Serial serial)
@@ -44,31 +44,14 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Regular;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override Poison PoisonImmune{ get{ return Poison.Regular; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
-            this.PackItem(Loot.RandomWeapon());
+            AddLoot(LootPack.Meager);
+            PackItem(Loot.RandomWeapon());
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Kirin.cs
+++ b/Scripts/Mobiles/Normal/Kirin.cs
@@ -17,40 +17,40 @@ namespace Server.Mobiles
         public Kirin(string name)
             : base(name, 132, 0x3EAD, AIType.AI_Mage, FightMode.Evil, 10, 1, 0.2, 0.4)
         {
-            this.BaseSoundID = 0x3C5;
+            BaseSoundID = 0x3C5;
 
-            this.SetStr(296, 325);
-            this.SetDex(86, 105);
-            this.SetInt(186, 225);
+            SetStr(296, 325);
+            SetDex(86, 105);
+            SetInt(186, 225);
 
-            this.SetHits(191, 210);
+            SetHits(191, 210);
 
-            this.SetDamage(16, 22);
+            SetDamage(16, 22);
 
-            this.SetDamageType(ResistanceType.Physical, 70);
-            this.SetDamageType(ResistanceType.Fire, 10);
-            this.SetDamageType(ResistanceType.Cold, 10);
-            this.SetDamageType(ResistanceType.Energy, 10);
+            SetDamageType(ResistanceType.Physical, 70);
+            SetDamageType(ResistanceType.Fire, 10);
+            SetDamageType(ResistanceType.Cold, 10);
+            SetDamageType(ResistanceType.Energy, 10);
 
-            this.SetResistance(ResistanceType.Physical, 55, 65);
-            this.SetResistance(ResistanceType.Fire, 35, 45);
-            this.SetResistance(ResistanceType.Cold, 25, 35);
-            this.SetResistance(ResistanceType.Poison, 25, 35);
-            this.SetResistance(ResistanceType.Energy, 25, 35);
+            SetResistance(ResistanceType.Physical, 55, 65);
+            SetResistance(ResistanceType.Fire, 35, 45);
+            SetResistance(ResistanceType.Cold, 25, 35);
+            SetResistance(ResistanceType.Poison, 25, 35);
+            SetResistance(ResistanceType.Energy, 25, 35);
 
-            this.SetSkill(SkillName.EvalInt, 80.1, 90.0);
-            this.SetSkill(SkillName.Magery, 60.4, 100.0);
-            this.SetSkill(SkillName.Meditation, 90.1, 100.0);
-            this.SetSkill(SkillName.MagicResist, 85.3, 100.0);
-            this.SetSkill(SkillName.Tactics, 20.1, 22.5);
-            this.SetSkill(SkillName.Wrestling, 80.5, 92.5);
+            SetSkill(SkillName.EvalInt, 80.1, 90.0);
+            SetSkill(SkillName.Magery, 60.4, 100.0);
+            SetSkill(SkillName.Meditation, 90.1, 100.0);
+            SetSkill(SkillName.MagicResist, 85.3, 100.0);
+            SetSkill(SkillName.Tactics, 20.1, 22.5);
+            SetSkill(SkillName.Wrestling, 80.5, 92.5);
 
-            this.Fame = 9000;
-            this.Karma = 9000;
+            Fame = 9000;
+            Karma = 9000;
 
-            this.Tamable = true;
-            this.ControlSlots = 2;
-            this.MinTameSkill = 95.1;
+            Tamable = true;
+            ControlSlots = 2;
+            MinTameSkill = 95.1;
         }
 
         public Kirin(Serial serial)
@@ -58,69 +58,16 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool AllowFemaleRider
-        {
-            get
-            {
-                return false;
-            }
-        }
-        public override bool AllowFemaleTamer
-        {
-            get
-            {
-                return false;
-            }
-        }
-        public override bool InitialInnocent
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override TimeSpan MountAbilityDelay
-        {
-            get
-            {
-                return TimeSpan.FromHours(1.0);
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override int Meat
-        {
-            get
-            {
-                return 3;
-            }
-        }
-        public override int Hides
-        {
-            get
-            {
-                return 10;
-            }
-        }
-        public override HideType HideType
-        {
-            get
-            {
-                return HideType.Horned;
-            }
-        }
-        public override FoodType FavoriteFood
-        {
-            get
-            {
-                return FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
-            }
-        }
+        public override bool AllowFemaleRider{ get{ return false; } }
+        public override bool AllowFemaleTamer{ get{ return false; } }
+        public override bool InitialInnocent{ get{ return true; } }
+        public override int Hides{ get{ return 10; } }
+        public override int Meat{ get{ return 3; } }
+        public override FoodType FavoriteFood{ get{ return FoodType.FruitsAndVegies | FoodType.GrainsAndHay; } }
+        public override HideType HideType{ get{ return HideType.Horned; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Fey; } }
+        public override TimeSpan MountAbilityDelay{ get{ return TimeSpan.FromHours(1.0); } }
+
         public override void OnDisallowedRider(Mobile m)
         {
             m.SendLocalizedMessage(1042319); // The Ki-Rin refuses your attempts to mount it.
@@ -128,18 +75,18 @@ namespace Server.Mobiles
 
         public override bool DoMountAbility(int damage, Mobile attacker)
         {
-            if (this.Rider == null || attacker == null)	//sanity
+            if (Rider == null || attacker == null)	//sanity
                 return false;
 
-            if ((this.Rider.Hits - damage) < 30 && this.Rider.Map == attacker.Map && this.Rider.InRange(attacker, 18))	//Range and map checked here instead of other base fuction because of abiliites that don't need to check this
+            if ((Rider.Hits - damage) < 30 && Rider.Map == attacker.Map && Rider.InRange(attacker, 18))	//Range and map checked here instead of other base fuction because of abiliites that don't need to check this
             {
                 attacker.BoltEffect(0);
                 // 35~100 damage, unresistable, by the Ki-rin.
                 attacker.Damage(Utility.RandomMinMax(35, 100), this, false);	//Don't inform mount about this damage, Still unsure wether or not it's flagged as the mount doing damage or the player.  If changed to player, without the extra bool it'd be an infinite loop
 
-                this.Rider.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1042534);	// Your mount calls down the forces of nature on your opponent.
-                this.Rider.FixedParticles(0, 0, 0, 0x13A7, EffectLayer.Waist);
-                this.Rider.PlaySound(0xA9);	// Ki-rin's whinny.
+                Rider.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1042534);	// Your mount calls down the forces of nature on your opponent.
+                Rider.FixedParticles(0, 0, 0, 0x13A7, EffectLayer.Waist);
+                Rider.PlaySound(0xA9);	// Ki-rin's whinny.
                 return true;
             }
 
@@ -148,9 +95,9 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich);
-            this.AddLoot(LootPack.LowScrolls);
-            this.AddLoot(LootPack.Potions);
+            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.LowScrolls);
+            AddLoot(LootPack.Potions);
         }
 
 		public override void OnDeath(Container c)
@@ -175,7 +122,7 @@ namespace Server.Mobiles
             int version = reader.ReadInt();
 
             if (version == 0)
-                this.AI = AIType.AI_Mage;
+                AI = AIType.AI_Mage;
         }
     }
 }

--- a/Scripts/Mobiles/Normal/Lich.cs
+++ b/Scripts/Mobiles/Normal/Lich.cs
@@ -10,41 +10,41 @@ namespace Server.Mobiles
         public Lich()
             : base(AIType.AI_NecroMage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a lich";
-            this.Body = 24;
-            this.BaseSoundID = 0x3E9;
+            Name = "a lich";
+            Body = 24;
+            BaseSoundID = 0x3E9;
 
-            this.SetStr(171, 200);
-            this.SetDex(126, 145);
-            this.SetInt(276, 305);
+            SetStr(171, 200);
+            SetDex(126, 145);
+            SetInt(276, 305);
 
-            this.SetHits(103, 120);
+            SetHits(103, 120);
 
-            this.SetDamage(24, 26);
+            SetDamage(24, 26);
 
-            this.SetDamageType(ResistanceType.Physical, 10);
-            this.SetDamageType(ResistanceType.Cold, 40);
-            this.SetDamageType(ResistanceType.Energy, 50);
+            SetDamageType(ResistanceType.Physical, 10);
+            SetDamageType(ResistanceType.Cold, 40);
+            SetDamageType(ResistanceType.Energy, 50);
 
-            this.SetResistance(ResistanceType.Physical, 40, 60);
-            this.SetResistance(ResistanceType.Fire, 20, 30);
-            this.SetResistance(ResistanceType.Cold, 50, 60);
-            this.SetResistance(ResistanceType.Poison, 55, 65);
-            this.SetResistance(ResistanceType.Energy, 40, 50);
+            SetResistance(ResistanceType.Physical, 40, 60);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 55, 65);
+            SetResistance(ResistanceType.Energy, 40, 50);
 
-            this.SetSkill(SkillName.Necromancy, 89, 99.1);
-            this.SetSkill(SkillName.SpiritSpeak, 90.0, 99.0);
+            SetSkill(SkillName.Necromancy, 89, 99.1);
+            SetSkill(SkillName.SpiritSpeak, 90.0, 99.0);
 
-            this.SetSkill(SkillName.EvalInt, 100.0);
-            this.SetSkill(SkillName.Magery, 70.1, 80.0);
-            this.SetSkill(SkillName.Meditation, 85.1, 95.0);
-            this.SetSkill(SkillName.MagicResist, 80.1, 100.0);
-            this.SetSkill(SkillName.Tactics, 70.1, 90.0);
+            SetSkill(SkillName.EvalInt, 100.0);
+            SetSkill(SkillName.Magery, 70.1, 80.0);
+            SetSkill(SkillName.Meditation, 85.1, 95.0);
+            SetSkill(SkillName.MagicResist, 80.1, 100.0);
+            SetSkill(SkillName.Tactics, 70.1, 90.0);
 
-            this.Fame = 8000;
-            this.Karma = -8000;
+            Fame = 8000;
+            Karma = -8000;
 
-            this.VirtualArmor = 50;
+            VirtualArmor = 50;
 
 			switch (Utility.Random(25))
             {
@@ -56,8 +56,8 @@ namespace Server.Mobiles
 			}
 
 
-            this.PackItem(new GnarledStaff());
-            this.PackNecroReg(17, 24);
+            PackItem(new GnarledStaff());
+            PackNecroReg(17, 24);
         }
 
         public Lich(Serial serial)
@@ -65,45 +65,16 @@ namespace Server.Mobiles
         {
         }
 
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override bool CanRummageCorpses
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 3;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override bool CanRummageCorpses{ get{ return true; } }
+        public override int TreasureMapLevel{ get{ return 3; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich);
-            this.AddLoot(LootPack.MedScrolls, 2);
+            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.MedScrolls, 2);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/LichLord.cs
+++ b/Scripts/Mobiles/Normal/LichLord.cs
@@ -10,43 +10,43 @@ namespace Server.Mobiles
         public LichLord()
             : base(AIType.AI_NecroMage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a lich lord";
-            this.Body = 79;
-            this.BaseSoundID = 412;
+            Name = "a lich lord";
+            Body = 79;
+            BaseSoundID = 412;
 
-            this.SetStr(416, 505);
-            this.SetDex(146, 165);
-            this.SetInt(566, 655);
+            SetStr(416, 505);
+            SetDex(146, 165);
+            SetInt(566, 655);
 
-            this.SetHits(250, 303);
+            SetHits(250, 303);
 
-            this.SetDamage(11, 13);
+            SetDamage(11, 13);
 
-            this.SetDamageType(ResistanceType.Physical, 0);
-            this.SetDamageType(ResistanceType.Cold, 60);
-            this.SetDamageType(ResistanceType.Energy, 40);
+            SetDamageType(ResistanceType.Physical, 0);
+            SetDamageType(ResistanceType.Cold, 60);
+            SetDamageType(ResistanceType.Energy, 40);
 
-            this.SetResistance(ResistanceType.Physical, 40, 50);
-            this.SetResistance(ResistanceType.Fire, 30, 40);
-            this.SetResistance(ResistanceType.Cold, 50, 60);
-            this.SetResistance(ResistanceType.Poison, 50, 60);
-            this.SetResistance(ResistanceType.Energy, 40, 50);
+            SetResistance(ResistanceType.Physical, 40, 50);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 50, 60);
+            SetResistance(ResistanceType.Energy, 40, 50);
 
-            this.SetSkill(SkillName.Necromancy, 90, 110.0);
-            this.SetSkill(SkillName.SpiritSpeak, 90.0, 110.0);
+            SetSkill(SkillName.Necromancy, 90, 110.0);
+            SetSkill(SkillName.SpiritSpeak, 90.0, 110.0);
 
-            this.SetSkill(SkillName.EvalInt, 90.1, 100.0);
-            this.SetSkill(SkillName.Magery, 90.1, 100.0);
-            this.SetSkill(SkillName.MagicResist, 150.5, 200.0);
-            this.SetSkill(SkillName.Tactics, 50.1, 70.0);
-            this.SetSkill(SkillName.Wrestling, 60.1, 80.0);
+            SetSkill(SkillName.EvalInt, 90.1, 100.0);
+            SetSkill(SkillName.Magery, 90.1, 100.0);
+            SetSkill(SkillName.MagicResist, 150.5, 200.0);
+            SetSkill(SkillName.Tactics, 50.1, 70.0);
+            SetSkill(SkillName.Wrestling, 60.1, 80.0);
 
-            this.Fame = 18000;
-            this.Karma = -18000;
+            Fame = 18000;
+            Karma = -18000;
 
-            this.VirtualArmor = 50;
-            this.PackItem(new GnarledStaff());
-            this.PackNecroReg(12, 40);
+            VirtualArmor = 50;
+            PackItem(new GnarledStaff());
+            PackNecroReg(12, 40);
 
 			switch (Utility.Random(15))
             {
@@ -63,45 +63,16 @@ namespace Server.Mobiles
         {
         }
 
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override bool CanRummageCorpses
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 4;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override bool CanRummageCorpses{ get{ return true; } }
+        public override int TreasureMapLevel{ get{ return 4; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.FilthyRich);
-            this.AddLoot(LootPack.MedScrolls, 2);
+            AddLoot(LootPack.FilthyRich);
+            AddLoot(LootPack.MedScrolls, 2);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Mummy.cs
+++ b/Scripts/Mobiles/Normal/Mummy.cs
@@ -10,41 +10,41 @@ namespace Server.Mobiles
         public Mummy()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.4, 0.8)
         {
-            this.Name = "a mummy";
-            this.Body = 154;
-            this.BaseSoundID = 471;
+            Name = "a mummy";
+            Body = 154;
+            BaseSoundID = 471;
 
-            this.SetStr(346, 370);
-            this.SetDex(71, 90);
-            this.SetInt(26, 40);
+            SetStr(346, 370);
+            SetDex(71, 90);
+            SetInt(26, 40);
 
-            this.SetHits(208, 222);
+            SetHits(208, 222);
 
-            this.SetDamage(13, 23);
+            SetDamage(13, 23);
 
-            this.SetDamageType(ResistanceType.Physical, 40);
-            this.SetDamageType(ResistanceType.Cold, 60);
+            SetDamageType(ResistanceType.Physical, 40);
+            SetDamageType(ResistanceType.Cold, 60);
 
-            this.SetResistance(ResistanceType.Physical, 45, 55);
-            this.SetResistance(ResistanceType.Fire, 10, 20);
-            this.SetResistance(ResistanceType.Cold, 50, 60);
-            this.SetResistance(ResistanceType.Poison, 20, 30);
-            this.SetResistance(ResistanceType.Energy, 20, 30);
+            SetResistance(ResistanceType.Physical, 45, 55);
+            SetResistance(ResistanceType.Fire, 10, 20);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 20, 30);
+            SetResistance(ResistanceType.Energy, 20, 30);
 
-            this.SetSkill(SkillName.MagicResist, 15.1, 40.0);
-            this.SetSkill(SkillName.Tactics, 35.1, 50.0);
-            this.SetSkill(SkillName.Wrestling, 35.1, 50.0);
+            SetSkill(SkillName.MagicResist, 15.1, 40.0);
+            SetSkill(SkillName.Tactics, 35.1, 50.0);
+            SetSkill(SkillName.Wrestling, 35.1, 50.0);
 
-            this.Fame = 4000;
-            this.Karma = -4000;
+            Fame = 4000;
+            Karma = -4000;
 
-            this.VirtualArmor = 50;
+            VirtualArmor = 50;
 
             if (Core.ML && Utility.RandomDouble() < .33)
-                this.PackItem(Engines.Plants.Seed.RandomPeculiarSeed(2));
+                PackItem(Engines.Plants.Seed.RandomPeculiarSeed(2));
 
-            this.PackItem(new Garlic(5));
-            this.PackItem(new Bandage(10));
+            PackItem(new Garlic(5));
+            PackItem(new Bandage(10));
         }
 
         public Mummy(Serial serial)
@@ -52,32 +52,15 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lesser;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lesser; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich);
-            this.AddLoot(LootPack.Gems);
-            this.AddLoot(LootPack.Potions);
+            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.Gems);
+            AddLoot(LootPack.Potions);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/OphidianArchmage.cs
+++ b/Scripts/Mobiles/Normal/OphidianArchmage.cs
@@ -15,40 +15,40 @@ namespace Server.Mobiles
         public OphidianArchmage()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = m_Names[Utility.Random(m_Names.Length)];
-            this.Body = 85;
-            this.BaseSoundID = 639;
+            Name = m_Names[Utility.Random(m_Names.Length)];
+            Body = 85;
+            BaseSoundID = 639;
 
-            this.SetStr(281, 305);
-            this.SetDex(191, 215);
-            this.SetInt(226, 250);
+            SetStr(281, 305);
+            SetDex(191, 215);
+            SetInt(226, 250);
 
-            this.SetHits(169, 183);
-            this.SetStam(36, 45);
+            SetHits(169, 183);
+            SetStam(36, 45);
 
-            this.SetDamage(5, 10);
+            SetDamage(5, 10);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 40, 45);
-            this.SetResistance(ResistanceType.Fire, 20, 30);
-            this.SetResistance(ResistanceType.Cold, 25, 35);
-            this.SetResistance(ResistanceType.Poison, 35, 40);
-            this.SetResistance(ResistanceType.Energy, 25, 35);
+            SetResistance(ResistanceType.Physical, 40, 45);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 25, 35);
+            SetResistance(ResistanceType.Poison, 35, 40);
+            SetResistance(ResistanceType.Energy, 25, 35);
 
-            this.SetSkill(SkillName.EvalInt, 95.1, 100.0);
-            this.SetSkill(SkillName.Magery, 95.1, 100.0);
-            this.SetSkill(SkillName.MagicResist, 75.0, 97.5);
-            this.SetSkill(SkillName.Tactics, 65.0, 87.5);
-            this.SetSkill(SkillName.Wrestling, 20.2, 60.0);
+            SetSkill(SkillName.EvalInt, 95.1, 100.0);
+            SetSkill(SkillName.Magery, 95.1, 100.0);
+            SetSkill(SkillName.MagicResist, 75.0, 97.5);
+            SetSkill(SkillName.Tactics, 65.0, 87.5);
+            SetSkill(SkillName.Wrestling, 20.2, 60.0);
 
-            this.Fame = 11500;
-            this.Karma = -11500;
+            Fame = 11500;
+            Karma = -11500;
 
-            this.VirtualArmor = 44;
+            VirtualArmor = 44;
 
-            this.PackReg(5, 15);
-            this.PackNecroReg(5, 15);
+            PackReg(5, 15);
+            PackNecroReg(5, 15);
         }
 
         public OphidianArchmage(Serial serial)
@@ -56,24 +56,13 @@ namespace Server.Mobiles
         {
         }
 
-        public override int Meat
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+        public override int Meat{ get{ return 1; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Ophidian; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich);
-            this.AddLoot(LootPack.MedScrolls, 2);
+            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.MedScrolls, 2);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/OphidianKnight.cs
+++ b/Scripts/Mobiles/Normal/OphidianKnight.cs
@@ -16,38 +16,38 @@ namespace Server.Mobiles
         public OphidianKnight()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = m_Names[Utility.Random(m_Names.Length)];
-            this.Body = 86;
-            this.BaseSoundID = 634;
+            Name = m_Names[Utility.Random(m_Names.Length)];
+            Body = 86;
+            BaseSoundID = 634;
 
-            this.SetStr(417, 595);
-            this.SetDex(166, 175);
-            this.SetInt(46, 70);
+            SetStr(417, 595);
+            SetDex(166, 175);
+            SetInt(46, 70);
 
-            this.SetHits(266, 342);
-            this.SetMana(0);
+            SetHits(266, 342);
+            SetMana(0);
 
-            this.SetDamage(16, 19);
+            SetDamage(16, 19);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 35, 40);
-            this.SetResistance(ResistanceType.Fire, 30, 40);
-            this.SetResistance(ResistanceType.Cold, 35, 45);
-            this.SetResistance(ResistanceType.Poison, 90, 100);
-            this.SetResistance(ResistanceType.Energy, 35, 45);
+            SetResistance(ResistanceType.Physical, 35, 40);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 35, 45);
+            SetResistance(ResistanceType.Poison, 90, 100);
+            SetResistance(ResistanceType.Energy, 35, 45);
 
-            this.SetSkill(SkillName.Poisoning, 60.1, 80.0);
-            this.SetSkill(SkillName.MagicResist, 65.1, 80.0);
-            this.SetSkill(SkillName.Tactics, 90.1, 100.0);
-            this.SetSkill(SkillName.Wrestling, 90.1, 100.0);
+            SetSkill(SkillName.Poisoning, 60.1, 80.0);
+            SetSkill(SkillName.MagicResist, 65.1, 80.0);
+            SetSkill(SkillName.Tactics, 90.1, 100.0);
+            SetSkill(SkillName.Wrestling, 90.1, 100.0);
 
-            this.Fame = 10000;
-            this.Karma = -10000;
+            Fame = 10000;
+            Karma = -10000;
 
-            this.VirtualArmor = 40;
+            VirtualArmor = 40;
 
-            this.PackItem(new LesserPoisonPotion());
+            PackItem(new LesserPoisonPotion());
         }
 
         public OphidianKnight(Serial serial)
@@ -55,44 +55,15 @@ namespace Server.Mobiles
         {
         }
 
-        public override int Meat
-        {
-            get
-            {
-                return 2;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
-        public override Poison HitPoison
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 3;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+        public override int Meat{ get{ return 2; } }
+        public override int TreasureMapLevel { get { return 3; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Ophidian; } }
+        public override Poison HitPoison{ get{ return Poison.Lethal; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich, 2);
+            AddLoot(LootPack.Rich, 2);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/OphidianMage.cs
+++ b/Scripts/Mobiles/Normal/OphidianMage.cs
@@ -16,38 +16,38 @@ namespace Server.Mobiles
         public OphidianMage()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = m_Names[Utility.Random(m_Names.Length)];
-            this.Body = 85;
-            this.BaseSoundID = 639;
+            Name = m_Names[Utility.Random(m_Names.Length)];
+            Body = 85;
+            BaseSoundID = 639;
 
-            this.SetStr(181, 205);
-            this.SetDex(191, 215);
-            this.SetInt(96, 120);
+            SetStr(181, 205);
+            SetDex(191, 215);
+            SetInt(96, 120);
 
-            this.SetHits(109, 123);
+            SetHits(109, 123);
 
-            this.SetDamage(5, 10);
+            SetDamage(5, 10);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 25, 35);
-            this.SetResistance(ResistanceType.Fire, 30, 40);
-            this.SetResistance(ResistanceType.Cold, 35, 45);
-            this.SetResistance(ResistanceType.Poison, 40, 50);
-            this.SetResistance(ResistanceType.Energy, 35, 45);
+            SetResistance(ResistanceType.Physical, 25, 35);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 35, 45);
+            SetResistance(ResistanceType.Poison, 40, 50);
+            SetResistance(ResistanceType.Energy, 35, 45);
 
-            this.SetSkill(SkillName.EvalInt, 85.1, 100.0);
-            this.SetSkill(SkillName.Magery, 85.1, 100.0);
-            this.SetSkill(SkillName.MagicResist, 75.0, 97.5);
-            this.SetSkill(SkillName.Tactics, 65.0, 87.5);
-            this.SetSkill(SkillName.Wrestling, 20.2, 60.0);
+            SetSkill(SkillName.EvalInt, 85.1, 100.0);
+            SetSkill(SkillName.Magery, 85.1, 100.0);
+            SetSkill(SkillName.MagicResist, 75.0, 97.5);
+            SetSkill(SkillName.Tactics, 65.0, 87.5);
+            SetSkill(SkillName.Wrestling, 20.2, 60.0);
 
-            this.Fame = 4000;
-            this.Karma = -4000;
+            Fame = 4000;
+            Karma = -4000;
 
-            this.VirtualArmor = 30;
+            VirtualArmor = 30;
 
-            this.PackReg(10);
+            PackReg(10);
 
 			switch (Utility.Random(6))
             {
@@ -61,33 +61,16 @@ namespace Server.Mobiles
         {
         }
 
-        public override int Meat
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 2;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+        public override int Meat{ get{ return 1; } }
+        public override int TreasureMapLevel { get { return 2; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Ophidian; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Average);
-            this.AddLoot(LootPack.LowScrolls);
-            this.AddLoot(LootPack.MedScrolls);
-            this.AddLoot(LootPack.Potions);
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.LowScrolls);
+            AddLoot(LootPack.MedScrolls);
+            AddLoot(LootPack.Potions);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/OphidianMatriarch.cs
+++ b/Scripts/Mobiles/Normal/OphidianMatriarch.cs
@@ -9,37 +9,37 @@ namespace Server.Mobiles
         public OphidianMatriarch()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "an ophidian matriarch";
-            this.Body = 87;
-            this.BaseSoundID = 644;
+            Name = "an ophidian matriarch";
+            Body = 87;
+            BaseSoundID = 644;
 
-            this.SetStr(416, 505);
-            this.SetDex(96, 115);
-            this.SetInt(366, 455);
+            SetStr(416, 505);
+            SetDex(96, 115);
+            SetInt(366, 455);
 
-            this.SetHits(250, 303);
+            SetHits(250, 303);
 
-            this.SetDamage(11, 13);
+            SetDamage(11, 13);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 45, 55);
-            this.SetResistance(ResistanceType.Fire, 30, 40);
-            this.SetResistance(ResistanceType.Cold, 35, 45);
-            this.SetResistance(ResistanceType.Poison, 40, 50);
-            this.SetResistance(ResistanceType.Energy, 35, 45);
+            SetResistance(ResistanceType.Physical, 45, 55);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 35, 45);
+            SetResistance(ResistanceType.Poison, 40, 50);
+            SetResistance(ResistanceType.Energy, 35, 45);
 
-            this.SetSkill(SkillName.EvalInt, 90.1, 100.0);
-            this.SetSkill(SkillName.Magery, 90.1, 100.0);
-            this.SetSkill(SkillName.Meditation, 5.4, 25.0);
-            this.SetSkill(SkillName.MagicResist, 90.1, 100.0);
-            this.SetSkill(SkillName.Tactics, 50.1, 70.0);
-            this.SetSkill(SkillName.Wrestling, 60.1, 80.0);
+            SetSkill(SkillName.EvalInt, 90.1, 100.0);
+            SetSkill(SkillName.Magery, 90.1, 100.0);
+            SetSkill(SkillName.Meditation, 5.4, 25.0);
+            SetSkill(SkillName.MagicResist, 90.1, 100.0);
+            SetSkill(SkillName.Tactics, 50.1, 70.0);
+            SetSkill(SkillName.Wrestling, 60.1, 80.0);
 
-            this.Fame = 16000;
-            this.Karma = -16000;
+            Fame = 16000;
+            Karma = -16000;
 
-            this.VirtualArmor = 50;
+            VirtualArmor = 50;
         }
 
         public OphidianMatriarch(Serial serial)
@@ -47,32 +47,15 @@ namespace Server.Mobiles
         {
         }
 
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Greater;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 4;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+        public override int TreasureMapLevel { get { return 4; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Ophidian; } }
+        public override Poison PoisonImmune{ get{ return Poison.Greater; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich);
-            this.AddLoot(LootPack.Average, 2);
-            this.AddLoot(LootPack.MedScrolls, 2);
+            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.Average, 2);
+            AddLoot(LootPack.MedScrolls, 2);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/OphidianWarrior.cs
+++ b/Scripts/Mobiles/Normal/OphidianWarrior.cs
@@ -10,39 +10,40 @@ namespace Server.Mobiles
             "an ophidian warrior",
             "an ophidian enforcer"
         };
+
         [Constructable]
         public OphidianWarrior()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = m_Names[Utility.Random(m_Names.Length)];
-            this.Body = 86;
-            this.BaseSoundID = 634;
+            Name = m_Names[Utility.Random(m_Names.Length)];
+            Body = 86;
+            BaseSoundID = 634;
 
-            this.SetStr(150, 320);
-            this.SetDex(94, 190);
-            this.SetInt(64, 160);
+            SetStr(150, 320);
+            SetDex(94, 190);
+            SetInt(64, 160);
 
-            this.SetHits(128, 155);
-            this.SetMana(0);
+            SetHits(128, 155);
+            SetMana(0);
 
-            this.SetDamage(5, 11);
+            SetDamage(5, 11);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 35, 40);
-            this.SetResistance(ResistanceType.Fire, 20, 30);
-            this.SetResistance(ResistanceType.Cold, 25, 35);
-            this.SetResistance(ResistanceType.Poison, 30, 40);
-            this.SetResistance(ResistanceType.Energy, 25, 35);
+            SetResistance(ResistanceType.Physical, 35, 40);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 25, 35);
+            SetResistance(ResistanceType.Poison, 30, 40);
+            SetResistance(ResistanceType.Energy, 25, 35);
 
-            this.SetSkill(SkillName.MagicResist, 70.1, 85.0);
-            this.SetSkill(SkillName.Swords, 60.1, 85.0);
-            this.SetSkill(SkillName.Tactics, 75.1, 90.0);
+            SetSkill(SkillName.MagicResist, 70.1, 85.0);
+            SetSkill(SkillName.Swords, 60.1, 85.0);
+            SetSkill(SkillName.Tactics, 75.1, 90.0);
 
-            this.Fame = 4500;
-            this.Karma = -4500;
+            Fame = 4500;
+            Karma = -4500;
 
-            this.VirtualArmor = 36;
+            VirtualArmor = 36;
         }
 
         public OphidianWarrior(Serial serial)
@@ -50,32 +51,15 @@ namespace Server.Mobiles
         {
         }
 
-        public override int Meat
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+        public override int Meat{ get{ return 1; } }
+        public override int TreasureMapLevel { get { return 1; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Ophidian; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
-            this.AddLoot(LootPack.Average);
-            this.AddLoot(LootPack.Gems);
+            AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Gems);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Orc.cs
+++ b/Scripts/Mobiles/Normal/Orc.cs
@@ -11,74 +11,74 @@ namespace Server.Mobiles
         public Orc()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = NameList.RandomName("orc");
-            this.Body = 17;
-            this.BaseSoundID = 0x45A;
+            Name = NameList.RandomName("orc");
+            Body = 17;
+            BaseSoundID = 0x45A;
 
-            this.SetStr(96, 120);
-            this.SetDex(81, 105);
-            this.SetInt(36, 60);
+            SetStr(96, 120);
+            SetDex(81, 105);
+            SetInt(36, 60);
 
-            this.SetHits(58, 72);
+            SetHits(58, 72);
 
-            this.SetDamage(5, 7);
+            SetDamage(5, 7);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 25, 30);
-            this.SetResistance(ResistanceType.Fire, 20, 30);
-            this.SetResistance(ResistanceType.Cold, 10, 20);
-            this.SetResistance(ResistanceType.Poison, 10, 20);
-            this.SetResistance(ResistanceType.Energy, 20, 30);
+            SetResistance(ResistanceType.Physical, 25, 30);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 10, 20);
+            SetResistance(ResistanceType.Poison, 10, 20);
+            SetResistance(ResistanceType.Energy, 20, 30);
 
-            this.SetSkill(SkillName.MagicResist, 50.1, 75.0);
-            this.SetSkill(SkillName.Tactics, 55.1, 80.0);
-            this.SetSkill(SkillName.Wrestling, 50.1, 70.0);
+            SetSkill(SkillName.MagicResist, 50.1, 75.0);
+            SetSkill(SkillName.Tactics, 55.1, 80.0);
+            SetSkill(SkillName.Wrestling, 50.1, 70.0);
 
-            this.Fame = 1500;
-            this.Karma = -1500;
+            Fame = 1500;
+            Karma = -1500;
 
-            this.VirtualArmor = 28;
+            VirtualArmor = 28;
 
             switch ( Utility.Random(20) )
             {
                 case 0:
-                    this.PackItem(new Scimitar());
+                    PackItem(new Scimitar());
                     break;
                 case 1:
-                    this.PackItem(new Katana());
+                    PackItem(new Katana());
                     break;
                 case 2:
-                    this.PackItem(new WarMace());
+                    PackItem(new WarMace());
                     break;
                 case 3:
-                    this.PackItem(new WarHammer());
+                    PackItem(new WarHammer());
                     break;
                 case 4:
-                    this.PackItem(new Kryss());
+                    PackItem(new Kryss());
                     break;
                 case 5:
-                    this.PackItem(new Pitchfork());
+                    PackItem(new Pitchfork());
                     break;
             }
 
-            this.PackItem(new ThighBoots());
+            PackItem(new ThighBoots());
 
             switch ( Utility.Random(3) )
             {
                 case 0:
-                    this.PackItem(new Ribs());
+                    PackItem(new Ribs());
                     break;
                 case 1:
-                    this.PackItem(new Shaft());
+                    PackItem(new Shaft());
                     break;
                 case 2:
-                    this.PackItem(new Candle());
+                    PackItem(new Candle());
                     break;
             }
 
             if (0.2 > Utility.RandomDouble())
-                this.PackItem(new BolaBall());
+                PackItem(new BolaBall());
 
             if (0.5 > Utility.RandomDouble())
                 PackItem(new Yeast());
@@ -89,44 +89,15 @@ namespace Server.Mobiles
         {
         }
 
-        public override InhumanSpeech SpeechType
-        {
-            get
-            {
-                return InhumanSpeech.Orc;
-            }
-        }
-        public override bool CanRummageCorpses
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override int Meat
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+        public override bool CanRummageCorpses{ get{ return true; } }
+        public override int Meat{ get{ return 1; } }
+        public override int TreasureMapLevel{ get{ return 1; } }
+        public override InhumanSpeech SpeechType{ get{ return InhumanSpeech.Orc; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Orc; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Meager);
         }
 
         public override bool IsEnemy(Mobile m)

--- a/Scripts/Mobiles/Normal/OrcBomber.cs
+++ b/Scripts/Mobiles/Normal/OrcBomber.cs
@@ -13,46 +13,46 @@ namespace Server.Mobiles
         public OrcBomber()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Body = 182;
+            Body = 182;
 
-            this.Name = "an orc bomber";
-            this.BaseSoundID = 0x45A;
+            Name = "an orc bomber";
+            BaseSoundID = 0x45A;
 
-            this.SetStr(147, 215);
-            this.SetDex(91, 115);
-            this.SetInt(61, 85);
+            SetStr(147, 215);
+            SetDex(91, 115);
+            SetInt(61, 85);
 
-            this.SetHits(95, 123);
+            SetHits(95, 123);
 
-            this.SetDamage(1, 8);
+            SetDamage(1, 8);
 
-            this.SetDamageType(ResistanceType.Physical, 75);
-            this.SetDamageType(ResistanceType.Fire, 25);
+            SetDamageType(ResistanceType.Physical, 75);
+            SetDamageType(ResistanceType.Fire, 25);
 
-            this.SetResistance(ResistanceType.Physical, 25, 35);
-            this.SetResistance(ResistanceType.Fire, 30, 40);
-            this.SetResistance(ResistanceType.Cold, 15, 25);
-            this.SetResistance(ResistanceType.Poison, 15, 20);
-            this.SetResistance(ResistanceType.Energy, 25, 30);
+            SetResistance(ResistanceType.Physical, 25, 35);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 15, 25);
+            SetResistance(ResistanceType.Poison, 15, 20);
+            SetResistance(ResistanceType.Energy, 25, 30);
 
-            this.SetSkill(SkillName.MagicResist, 70.1, 85.0);
-            this.SetSkill(SkillName.Swords, 60.1, 85.0);
-            this.SetSkill(SkillName.Tactics, 75.1, 90.0);
-            this.SetSkill(SkillName.Wrestling, 60.1, 85.0);
+            SetSkill(SkillName.MagicResist, 70.1, 85.0);
+            SetSkill(SkillName.Swords, 60.1, 85.0);
+            SetSkill(SkillName.Tactics, 75.1, 90.0);
+            SetSkill(SkillName.Wrestling, 60.1, 85.0);
 
-            this.Fame = 2500;
-            this.Karma = -2500;
+            Fame = 2500;
+            Karma = -2500;
 
-            this.VirtualArmor = 30;
+            VirtualArmor = 30;
 
-            this.PackItem(new SulfurousAsh(Utility.RandomMinMax(6, 10)));
-            this.PackItem(new MandrakeRoot(Utility.RandomMinMax(6, 10)));
-            this.PackItem(new BlackPearl(Utility.RandomMinMax(6, 10)));
-            this.PackItem(new MortarPestle());
-            this.PackItem(new LesserExplosionPotion());
+            PackItem(new SulfurousAsh(Utility.RandomMinMax(6, 10)));
+            PackItem(new MandrakeRoot(Utility.RandomMinMax(6, 10)));
+            PackItem(new BlackPearl(Utility.RandomMinMax(6, 10)));
+            PackItem(new MortarPestle());
+            PackItem(new LesserExplosionPotion());
 
             if (0.2 > Utility.RandomDouble())
-                this.PackItem(new BolaBall());
+                PackItem(new BolaBall());
 
             if (0.5 > Utility.RandomDouble())
                 PackItem(new Yeast());
@@ -63,31 +63,14 @@ namespace Server.Mobiles
         {
         }
 
-        public override InhumanSpeech SpeechType
-        {
-            get
-            {
-                return InhumanSpeech.Orc;
-            }
-        }
-        public override bool CanRummageCorpses
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+        public override bool CanRummageCorpses{ get{ return true; } }
+        public override InhumanSpeech SpeechType{ get{ return InhumanSpeech.Orc; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Orc; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Average);
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Meager);
         }
 
         public override bool IsEnemy(Mobile m)
@@ -115,29 +98,29 @@ namespace Server.Mobiles
 
         public override void OnActionCombat()
         {
-            Mobile combatant = this.Combatant as Mobile;
+            Mobile combatant = Combatant as Mobile;
 
-            if (combatant == null || combatant.Deleted || combatant.Map != this.Map || !this.InRange(combatant, 12) || !this.CanBeHarmful(combatant) || !this.InLOS(combatant))
+            if (combatant == null || combatant.Deleted || combatant.Map != Map || !InRange(combatant, 12) || !CanBeHarmful(combatant) || !InLOS(combatant))
                 return;
 
-            if (DateTime.UtcNow >= this.m_NextBomb)
+            if (DateTime.UtcNow >= m_NextBomb)
             {
-                this.ThrowBomb(combatant);
+                ThrowBomb(combatant);
 
-                this.m_Thrown++;
+                m_Thrown++;
 
-                if (0.75 >= Utility.RandomDouble() && (this.m_Thrown % 2) == 1) // 75% chance to quickly throw another bomb
-                    this.m_NextBomb = DateTime.UtcNow + TimeSpan.FromSeconds(3.0);
+                if (0.75 >= Utility.RandomDouble() && (m_Thrown % 2) == 1) // 75% chance to quickly throw another bomb
+                    m_NextBomb = DateTime.UtcNow + TimeSpan.FromSeconds(3.0);
                 else
-                    this.m_NextBomb = DateTime.UtcNow + TimeSpan.FromSeconds(5.0 + (10.0 * Utility.RandomDouble())); // 5-15 seconds
+                    m_NextBomb = DateTime.UtcNow + TimeSpan.FromSeconds(5.0 + (10.0 * Utility.RandomDouble())); // 5-15 seconds
             }
         }
 
         public void ThrowBomb(Mobile m)
         {
-            this.DoHarmful(m);
+            DoHarmful(m);
 
-            this.MovingParticles(m, 0x1C19, 1, 0, false, true, 0, 0, 9502, 6014, 0x11D, EffectLayer.Waist, 0);
+            MovingParticles(m, 0x1C19, 1, 0, false, true, 0, 0, 9502, 6014, 0x11D, EffectLayer.Waist, 0);
 
             new InternalTimer(m, this).Start();
         }
@@ -161,15 +144,15 @@ namespace Server.Mobiles
             public InternalTimer(Mobile m, Mobile from)
                 : base(TimeSpan.FromSeconds(1.0))
             {
-                this.m_Mobile = m;
-                this.m_From = from;
-                this.Priority = TimerPriority.TwoFiftyMS;
+                m_Mobile = m;
+                m_From = from;
+                Priority = TimerPriority.TwoFiftyMS;
             }
 
             protected override void OnTick()
             {
-                this.m_Mobile.PlaySound(0x11D);
-                AOS.Damage(this.m_Mobile, this.m_From, Utility.RandomMinMax(10, 20), 0, 100, 0, 0, 0);
+                m_Mobile.PlaySound(0x11D);
+                AOS.Damage(m_Mobile, m_From, Utility.RandomMinMax(10, 20), 0, 100, 0, 0, 0);
             }
         }
     }

--- a/Scripts/Mobiles/Normal/OrcBrute.cs
+++ b/Scripts/Mobiles/Normal/OrcBrute.cs
@@ -10,47 +10,47 @@ namespace Server.Mobiles
         public OrcBrute()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Body = 189;
+            Body = 189;
 
-            this.Name = "an orc brute";
-            this.BaseSoundID = 0x45A;
+            Name = "an orc brute";
+            BaseSoundID = 0x45A;
 
-            this.SetStr(767, 945);
-            this.SetDex(66, 75);
-            this.SetInt(46, 70);
+            SetStr(767, 945);
+            SetDex(66, 75);
+            SetInt(46, 70);
 
-            this.SetHits(476, 552);
+            SetHits(476, 552);
 
-            this.SetDamage(20, 25);
+            SetDamage(20, 25);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 45, 55);
-            this.SetResistance(ResistanceType.Fire, 40, 50);
-            this.SetResistance(ResistanceType.Cold, 25, 35);
-            this.SetResistance(ResistanceType.Poison, 25, 35);
-            this.SetResistance(ResistanceType.Energy, 25, 35);
+            SetResistance(ResistanceType.Physical, 45, 55);
+            SetResistance(ResistanceType.Fire, 40, 50);
+            SetResistance(ResistanceType.Cold, 25, 35);
+            SetResistance(ResistanceType.Poison, 25, 35);
+            SetResistance(ResistanceType.Energy, 25, 35);
 
-            this.SetSkill(SkillName.Macing, 90.1, 100.0);
-            this.SetSkill(SkillName.MagicResist, 125.1, 140.0);
-            this.SetSkill(SkillName.Tactics, 90.1, 100.0);
-            this.SetSkill(SkillName.Wrestling, 90.1, 100.0);
+            SetSkill(SkillName.Macing, 90.1, 100.0);
+            SetSkill(SkillName.MagicResist, 125.1, 140.0);
+            SetSkill(SkillName.Tactics, 90.1, 100.0);
+            SetSkill(SkillName.Wrestling, 90.1, 100.0);
 
-            this.Fame = 15000;
-            this.Karma = -15000;
+            Fame = 15000;
+            Karma = -15000;
 
-            this.VirtualArmor = 50;
+            VirtualArmor = 50;
 
             Item ore = new ShadowIronOre(25);
             ore.ItemID = 0x19B9;
-            this.PackItem(ore);
-            this.PackItem(new IronIngot(10));
+            PackItem(ore);
+            PackItem(new IronIngot(10));
 
             if (0.05 > Utility.RandomDouble())
-                this.PackItem(new OrcishKinMask());
+                PackItem(new OrcishKinMask());
 
             if (0.2 > Utility.RandomDouble())
-                this.PackItem(new BolaBall());
+                PackItem(new BolaBall());
 
             PackItem(new Yeast());
         }
@@ -60,52 +60,17 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BardImmune
-        {
-            get
-            {
-                return !Core.AOS;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
-        public override int Meat
-        {
-            get
-            {
-                return 2;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
-        public override bool CanRummageCorpses
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override bool AutoDispel
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool AutoDispel{ get{ return true; } }
+        public override bool BardImmune{ get{ return !Core.AOS; } }
+        public override bool CanRummageCorpses{ get{ return true; } }
+        public override int Meat{ get{ return 2; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Orc; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.FilthyRich);
-            this.AddLoot(LootPack.Rich);
+            AddLoot(LootPack.FilthyRich);
+            AddLoot(LootPack.Rich);
         }
 
         public override bool IsEnemy(Mobile m)
@@ -136,7 +101,7 @@ namespace Server.Mobiles
             if (caster == this)
                 return;
 
-            this.SpawnOrcLord(caster);
+            SpawnOrcLord(caster);
         }
 
         public void SpawnOrcLord(Mobile target)
@@ -148,7 +113,7 @@ namespace Server.Mobiles
 
             int orcs = 0;
 
-            foreach (Mobile m in this.GetMobilesInRange(10))
+            foreach (Mobile m in GetMobilesInRange(10))
             {
                 if (m is OrcishLord)
                     ++orcs;
@@ -158,7 +123,7 @@ namespace Server.Mobiles
             {
                 BaseCreature orc = new SpawnedOrcishLord();
 
-                orc.Team = this.Team;
+                orc.Team = Team;
 
                 Point3D loc = target.Location;
                 bool validLocation = false;
@@ -169,8 +134,8 @@ namespace Server.Mobiles
                     int y = target.Y + Utility.Random(3) - 1;
                     int z = map.GetAverageZ(x, y);
 
-                    if (validLocation = map.CanFit(x, y, this.Z, 16, false, false))
-                        loc = new Point3D(x, y, this.Z);
+                    if (validLocation = map.CanFit(x, y, Z, 16, false, false))
+                        loc = new Point3D(x, y, Z);
                     else if (validLocation = map.CanFit(x, y, z, 16, false, false))
                         loc = new Point3D(x, y, z);
                 }

--- a/Scripts/Mobiles/Normal/OrcCaptain.cs
+++ b/Scripts/Mobiles/Normal/OrcCaptain.cs
@@ -78,34 +78,11 @@ namespace Server.Mobiles
         {
         }
 
-        public override InhumanSpeech SpeechType
-        {
-            get
-            {
-                return InhumanSpeech.Orc;
-            }
-        }
-        public override bool CanRummageCorpses
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override int Meat
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+        public override bool CanRummageCorpses{ get{ return true; } }
+        public override int Meat{ get{ return 1; } }
+        public override InhumanSpeech SpeechType{ get{ return InhumanSpeech.Orc; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Orc; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager, 2);

--- a/Scripts/Mobiles/Normal/OrcishLord.cs
+++ b/Scripts/Mobiles/Normal/OrcishLord.cs
@@ -11,60 +11,60 @@ namespace Server.Mobiles
         public OrcishLord()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "an orcish lord";
-            this.Body = 138;
-            this.BaseSoundID = 0x45A;
+            Name = "an orcish lord";
+            Body = 138;
+            BaseSoundID = 0x45A;
 
-            this.SetStr(147, 215);
-            this.SetDex(91, 115);
-            this.SetInt(61, 85);
+            SetStr(147, 215);
+            SetDex(91, 115);
+            SetInt(61, 85);
 
-            this.SetHits(95, 123);
+            SetHits(95, 123);
 
-            this.SetDamage(4, 14);
+            SetDamage(4, 14);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 25, 35);
-            this.SetResistance(ResistanceType.Fire, 30, 40);
-            this.SetResistance(ResistanceType.Cold, 20, 30);
-            this.SetResistance(ResistanceType.Poison, 30, 40);
-            this.SetResistance(ResistanceType.Energy, 30, 40);
+            SetResistance(ResistanceType.Physical, 25, 35);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 20, 30);
+            SetResistance(ResistanceType.Poison, 30, 40);
+            SetResistance(ResistanceType.Energy, 30, 40);
 
-            this.SetSkill(SkillName.MagicResist, 70.1, 85.0);
-            this.SetSkill(SkillName.Swords, 60.1, 85.0);
-            this.SetSkill(SkillName.Tactics, 75.1, 90.0);
-            this.SetSkill(SkillName.Wrestling, 60.1, 85.0);
+            SetSkill(SkillName.MagicResist, 70.1, 85.0);
+            SetSkill(SkillName.Swords, 60.1, 85.0);
+            SetSkill(SkillName.Tactics, 75.1, 90.0);
+            SetSkill(SkillName.Wrestling, 60.1, 85.0);
 
-            this.Fame = 2500;
-            this.Karma = -2500;
+            Fame = 2500;
+            Karma = -2500;
 
             switch ( Utility.Random(5) )
             {
                 case 0:
-                    this.PackItem(new Lockpick());
+                    PackItem(new Lockpick());
                     break;
                 case 1:
-                    this.PackItem(new MortarPestle());
+                    PackItem(new MortarPestle());
                     break;
                 case 2:
-                    this.PackItem(new Bottle());
+                    PackItem(new Bottle());
                     break;
                 case 3:
-                    this.PackItem(new RawRibs());
+                    PackItem(new RawRibs());
                     break;
                 case 4:
-                    this.PackItem(new Shovel());
+                    PackItem(new Shovel());
                     break;
             }
 
-            this.PackItem(new RingmailChest());
+            PackItem(new RingmailChest());
 
             if (0.3 > Utility.RandomDouble())
-                this.PackItem(Loot.RandomPossibleReagent());
+                PackItem(Loot.RandomPossibleReagent());
 
             if (0.2 > Utility.RandomDouble())
-                this.PackItem(new BolaBall());
+                PackItem(new BolaBall());
 
             if (0.5 > Utility.RandomDouble())
                 PackItem(new Yeast());
@@ -75,45 +75,16 @@ namespace Server.Mobiles
         {
         }
 
-        public override InhumanSpeech SpeechType
-        {
-            get
-            {
-                return InhumanSpeech.Orc;
-            }
-        }
-        public override bool CanRummageCorpses
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override int Meat
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+        public override bool CanRummageCorpses{ get{ return true; } }
+        public override int Meat{ get{ return 1; } }
+        public override int TreasureMapLevel{ get{ return 1; } }
+        public override InhumanSpeech SpeechType{ get{ return InhumanSpeech.Orc; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Orc; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
-            this.AddLoot(LootPack.Average);
+            AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Average);
             // TODO: evil orc helm
         }
 

--- a/Scripts/Mobiles/Normal/OrcishMage.cs
+++ b/Scripts/Mobiles/Normal/OrcishMage.cs
@@ -11,38 +11,38 @@ namespace Server.Mobiles
         public OrcishMage()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "an orcish mage";
-            this.Body = 140;
-            this.BaseSoundID = 0x45A;
+            Name = "an orcish mage";
+            Body = 140;
+            BaseSoundID = 0x45A;
 
-            this.SetStr(116, 150);
-            this.SetDex(91, 115);
-            this.SetInt(161, 185);
+            SetStr(116, 150);
+            SetDex(91, 115);
+            SetInt(161, 185);
 
-            this.SetHits(70, 90);
+            SetHits(70, 90);
 
-            this.SetDamage(4, 14);
+            SetDamage(4, 14);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 25, 35);
-            this.SetResistance(ResistanceType.Fire, 30, 40);
-            this.SetResistance(ResistanceType.Cold, 20, 30);
-            this.SetResistance(ResistanceType.Poison, 30, 40);
-            this.SetResistance(ResistanceType.Energy, 30, 40);
+            SetResistance(ResistanceType.Physical, 25, 35);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 20, 30);
+            SetResistance(ResistanceType.Poison, 30, 40);
+            SetResistance(ResistanceType.Energy, 30, 40);
 
-            this.SetSkill(SkillName.EvalInt, 60.1, 72.5);
-            this.SetSkill(SkillName.Magery, 60.1, 72.5);
-            this.SetSkill(SkillName.MagicResist, 60.1, 75.0);
-            this.SetSkill(SkillName.Tactics, 50.1, 65.0);
-            this.SetSkill(SkillName.Wrestling, 40.1, 50.0);
+            SetSkill(SkillName.EvalInt, 60.1, 72.5);
+            SetSkill(SkillName.Magery, 60.1, 72.5);
+            SetSkill(SkillName.MagicResist, 60.1, 75.0);
+            SetSkill(SkillName.Tactics, 50.1, 65.0);
+            SetSkill(SkillName.Wrestling, 40.1, 50.0);
 
-            this.Fame = 3000;
-            this.Karma = -3000;
+            Fame = 3000;
+            Karma = -3000;
 
-            this.VirtualArmor = 30;
+            VirtualArmor = 30;
 
-            this.PackReg(6);
+            PackReg(6);
 
 			switch (Utility.Random(8))
             {
@@ -50,7 +50,7 @@ namespace Server.Mobiles
 			}
 
             if (0.05 > Utility.RandomDouble())
-                this.PackItem(new OrcishKinMask());
+                PackItem(new OrcishKinMask());
 
             if (0.5 > Utility.RandomDouble())
                 PackItem(new Yeast());
@@ -61,45 +61,16 @@ namespace Server.Mobiles
         {
         }
 
-        public override InhumanSpeech SpeechType
-        {
-            get
-            {
-                return InhumanSpeech.Orc;
-            }
-        }
-        public override bool CanRummageCorpses
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override int Meat
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+        public override bool CanRummageCorpses{ get{ return true; } }
+        public override int Meat{ get{ return 1; } }
+        public override int TreasureMapLevel{ get{ return 1; } }
+        public override InhumanSpeech SpeechType{ get{ return InhumanSpeech.Orc; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Orc; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Average);
-            this.AddLoot(LootPack.LowScrolls);
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.LowScrolls);
         }
 
         public override bool IsEnemy(Mobile m)

--- a/Scripts/Mobiles/Normal/Pixie.cs
+++ b/Scripts/Mobiles/Normal/Pixie.cs
@@ -10,39 +10,39 @@ namespace Server.Mobiles
         public Pixie()
             : base(AIType.AI_Mage, FightMode.Evil, 10, 1, 0.2, 0.4)
         {
-            this.Name = NameList.RandomName("pixie");
-            this.Body = 128;
-            this.BaseSoundID = 0x467;
+            Name = NameList.RandomName("pixie");
+            Body = 128;
+            BaseSoundID = 0x467;
 
-            this.SetStr(21, 30);
-            this.SetDex(301, 400);
-            this.SetInt(201, 250);
+            SetStr(21, 30);
+            SetDex(301, 400);
+            SetInt(201, 250);
 
-            this.SetHits(13, 18);
+            SetHits(13, 18);
 
-            this.SetDamage(9, 15);
+            SetDamage(9, 15);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 80, 90);
-            this.SetResistance(ResistanceType.Fire, 40, 50);
-            this.SetResistance(ResistanceType.Cold, 40, 50);
-            this.SetResistance(ResistanceType.Poison, 40, 50);
-            this.SetResistance(ResistanceType.Energy, 40, 50);
+            SetResistance(ResistanceType.Physical, 80, 90);
+            SetResistance(ResistanceType.Fire, 40, 50);
+            SetResistance(ResistanceType.Cold, 40, 50);
+            SetResistance(ResistanceType.Poison, 40, 50);
+            SetResistance(ResistanceType.Energy, 40, 50);
 
-            this.SetSkill(SkillName.EvalInt, 90.1, 100.0);
-            this.SetSkill(SkillName.Magery, 90.1, 100.0);
-            this.SetSkill(SkillName.Meditation, 90.1, 100.0);
-            this.SetSkill(SkillName.MagicResist, 100.5, 150.0);
-            this.SetSkill(SkillName.Tactics, 10.1, 20.0);
-            this.SetSkill(SkillName.Wrestling, 10.1, 12.5);
+            SetSkill(SkillName.EvalInt, 90.1, 100.0);
+            SetSkill(SkillName.Magery, 90.1, 100.0);
+            SetSkill(SkillName.Meditation, 90.1, 100.0);
+            SetSkill(SkillName.MagicResist, 100.5, 150.0);
+            SetSkill(SkillName.Tactics, 10.1, 20.0);
+            SetSkill(SkillName.Wrestling, 10.1, 12.5);
 
-            this.Fame = 7000;
-            this.Karma = 7000;
+            Fame = 7000;
+            Karma = 7000;
 
-            this.VirtualArmor = 100;
+            VirtualArmor = 100;
             if (0.02 > Utility.RandomDouble())
-                this.PackStatue();
+                PackStatue();
         }
 
         public Pixie(Serial serial)
@@ -50,45 +50,16 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool InitialInnocent
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override HideType HideType
-        {
-            get
-            {
-                return HideType.Spined;
-            }
-        }
-        public override int Hides
-        {
-            get
-            {
-                return 5;
-            }
-        }
-        public override int Meat
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+        public override bool InitialInnocent{ get{ return true; } }
+        public override int Hides{ get{ return 5; } }
+        public override int Meat{ get{ return 1; } }
+        public override HideType HideType{ get{ return HideType.Spined; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Fey; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.LowScrolls);
-            this.AddLoot(LootPack.Gems, 2);
+            AddLoot(LootPack.LowScrolls);
+            AddLoot(LootPack.Gems, 2);
         }
 
 		public override void OnDeath(Container c)

--- a/Scripts/Mobiles/Normal/RottingCorpse.cs
+++ b/Scripts/Mobiles/Normal/RottingCorpse.cs
@@ -10,39 +10,39 @@ namespace Server.Mobiles
         public RottingCorpse()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a rotting corpse";
-            this.Body = 155;
-            this.BaseSoundID = 471;
+            Name = "a rotting corpse";
+            Body = 155;
+            BaseSoundID = 471;
 
-            this.SetStr(301, 350);
-            this.SetDex(75);
-            this.SetInt(151, 200);
+            SetStr(301, 350);
+            SetDex(75);
+            SetInt(151, 200);
 
-            this.SetHits(1200);
-            this.SetStam(150);
-            this.SetMana(0);
+            SetHits(1200);
+            SetStam(150);
+            SetMana(0);
 
-            this.SetDamage(8, 10);
+            SetDamage(8, 10);
 
-            this.SetDamageType(ResistanceType.Physical, 0);
-            this.SetDamageType(ResistanceType.Cold, 50);
-            this.SetDamageType(ResistanceType.Poison, 50);
+            SetDamageType(ResistanceType.Physical, 0);
+            SetDamageType(ResistanceType.Cold, 50);
+            SetDamageType(ResistanceType.Poison, 50);
 
-            this.SetResistance(ResistanceType.Physical, 35, 45);
-            this.SetResistance(ResistanceType.Fire, 20, 30);
-            this.SetResistance(ResistanceType.Cold, 50, 70);
-            this.SetResistance(ResistanceType.Poison, 40, 50);
-            this.SetResistance(ResistanceType.Energy, 20, 30);
+            SetResistance(ResistanceType.Physical, 35, 45);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 50, 70);
+            SetResistance(ResistanceType.Poison, 40, 50);
+            SetResistance(ResistanceType.Energy, 20, 30);
 
-            this.SetSkill(SkillName.Poisoning, 120.0);
-            this.SetSkill(SkillName.MagicResist, 250.0);
-            this.SetSkill(SkillName.Tactics, 100.0);
-            this.SetSkill(SkillName.Wrestling, 90.1, 100.0);
+            SetSkill(SkillName.Poisoning, 120.0);
+            SetSkill(SkillName.MagicResist, 250.0);
+            SetSkill(SkillName.Tactics, 100.0);
+            SetSkill(SkillName.Wrestling, 90.1, 100.0);
 
-            this.Fame = 6000;
-            this.Karma = -6000;
+            Fame = 6000;
+            Karma = -6000;
 
-            this.VirtualArmor = 40;
+            VirtualArmor = 40;
         }
 
         public RottingCorpse(Serial serial)
@@ -50,44 +50,15 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
-        public override Poison HitPoison
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 5;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override int TreasureMapLevel { get { return 5; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+        public override Poison HitPoison{ get{ return Poison.Lethal; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.FilthyRich, 2);
+            AddLoot(LootPack.FilthyRich, 2);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Satyr.cs
+++ b/Scripts/Mobiles/Normal/Satyr.cs
@@ -11,74 +11,59 @@ namespace Server.Mobiles
         public Satyr()
             : base(AIType.AI_Animal, FightMode.Aggressor, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a satyr";
-            this.Body = 271;
-            this.BaseSoundID = 0x586;
+            Name = "a satyr";
+            Body = 271;
+            BaseSoundID = 0x586;
 
-            this.SetStr(177, 195);
-            this.SetDex(251, 269);
-            this.SetInt(153, 170);
+            SetStr(177, 195);
+            SetDex(251, 269);
+            SetInt(153, 170);
 
-            this.SetHits(350, 400);
+            SetHits(350, 400);
 
-            this.SetDamage(13, 24);
+            SetDamage(13, 24);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 55, 60);
-            this.SetResistance(ResistanceType.Fire, 25, 35);
-            this.SetResistance(ResistanceType.Cold, 30, 40);
-            this.SetResistance(ResistanceType.Poison, 30, 40);
-            this.SetResistance(ResistanceType.Energy, 30, 40);
+            SetResistance(ResistanceType.Physical, 55, 60);
+            SetResistance(ResistanceType.Fire, 25, 35);
+            SetResistance(ResistanceType.Cold, 30, 40);
+            SetResistance(ResistanceType.Poison, 30, 40);
+            SetResistance(ResistanceType.Energy, 30, 40);
 
-            this.SetSkill(SkillName.MagicResist, 55.0, 65.0);
-            this.SetSkill(SkillName.Tactics, 80.0, 100.0);
-            this.SetSkill(SkillName.Wrestling, 80.0, 100.0);
+            SetSkill(SkillName.MagicResist, 55.0, 65.0);
+            SetSkill(SkillName.Tactics, 80.0, 100.0);
+            SetSkill(SkillName.Wrestling, 80.0, 100.0);
 
-            this.SetSkill(SkillName.Musicianship, 100);
-            this.SetSkill(SkillName.Discordance, 100);
-            this.SetSkill(SkillName.Provocation, 100);
-            this.SetSkill(SkillName.Peacemaking, 100);
+            SetSkill(SkillName.Musicianship, 100);
+            SetSkill(SkillName.Discordance, 100);
+            SetSkill(SkillName.Provocation, 100);
+            SetSkill(SkillName.Peacemaking, 100);
 
-            this.Fame = 5000;
-            this.Karma = 0;
+            Fame = 5000;
+            Karma = 0;
 
-            this.VirtualArmor = 28; // Don't know what it should be
+            VirtualArmor = 28; // Don't know what it should be
 
             for (int i = 0; i < Utility.RandomMinMax(0, 1); i++)
             {
-                this.PackItem(Loot.RandomScroll(0, Loot.ArcanistScrollTypes.Length, SpellbookType.Arcanist));
+                PackItem(Loot.RandomScroll(0, Loot.ArcanistScrollTypes.Length, SpellbookType.Arcanist));
             }
-        }
-
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-
-        public override void GenerateLoot()
-        {
-            this.AddLoot(LootPack.MlRich);
-            this.AddLoot(LootPack.MedScrolls);
         }
 
         public override bool CanDiscord { get { return true; } }
         public override bool CanPeace { get { return true; } }
         public override bool CanProvoke { get { return true; } }
-
+        public override int Meat{ get{ return 1; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Fey; } }
         public override TimeSpan DiscordInterval { get { return TimeSpan.FromSeconds(Utility.RandomMinMax(30, 60)); } }
         public override TimeSpan PeaceInterval { get { return TimeSpan.FromSeconds(Utility.RandomMinMax(30, 60)); } }
         public override TimeSpan ProvokeInterval { get { return TimeSpan.FromSeconds(Utility.RandomMinMax(30, 60)); } }
 
-        public override int Meat
+        public override void GenerateLoot()
         {
-            get
-            {
-                return 1;
-            }
+            AddLoot(LootPack.MlRich);
+            AddLoot(LootPack.MedScrolls);
         }
 
         public Satyr(Serial serial)

--- a/Scripts/Mobiles/Normal/Savage.cs
+++ b/Scripts/Mobiles/Normal/Savage.cs
@@ -10,46 +10,46 @@ namespace Server.Mobiles
         public Savage()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = NameList.RandomName("savage");
+            Name = NameList.RandomName("savage");
 
-            if (this.Female = Utility.RandomBool())
-                this.Body = 184;
+            if (Female = Utility.RandomBool())
+                Body = 184;
             else
-                this.Body = 183;
+                Body = 183;
 
-            this.SetStr(96, 115);
-            this.SetDex(86, 105);
-            this.SetInt(51, 65);
+            SetStr(96, 115);
+            SetDex(86, 105);
+            SetInt(51, 65);
 
-            this.SetDamage(23, 27);
+            SetDamage(23, 27);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetSkill(SkillName.Fencing, 60.0, 82.5);
-            this.SetSkill(SkillName.Macing, 60.0, 82.5);
-            this.SetSkill(SkillName.Poisoning, 60.0, 82.5);
-            this.SetSkill(SkillName.MagicResist, 57.5, 80.0);
-            this.SetSkill(SkillName.Swords, 60.0, 82.5);
-            this.SetSkill(SkillName.Tactics, 60.0, 82.5);
+            SetSkill(SkillName.Fencing, 60.0, 82.5);
+            SetSkill(SkillName.Macing, 60.0, 82.5);
+            SetSkill(SkillName.Poisoning, 60.0, 82.5);
+            SetSkill(SkillName.MagicResist, 57.5, 80.0);
+            SetSkill(SkillName.Swords, 60.0, 82.5);
+            SetSkill(SkillName.Tactics, 60.0, 82.5);
 
-            this.Fame = 1000;
-            this.Karma = -1000;
+            Fame = 1000;
+            Karma = -1000;
 
-            this.PackItem(new Bandage(Utility.RandomMinMax(1, 15)));
+            PackItem(new Bandage(Utility.RandomMinMax(1, 15)));
 
-            if (this.Female && 0.1 > Utility.RandomDouble())
-                this.PackItem(new TribalBerry());
-            else if (!this.Female && 0.1 > Utility.RandomDouble())
-                this.PackItem(new BolaBall());
+            if (Female && 0.1 > Utility.RandomDouble())
+                PackItem(new TribalBerry());
+            else if (!Female && 0.1 > Utility.RandomDouble())
+                PackItem(new BolaBall());
 
-            this.AddItem(new Spear());
-            this.AddItem(new BoneArms());
-            this.AddItem(new BoneLegs());
+            AddItem(new Spear());
+            AddItem(new BoneArms());
+            AddItem(new BoneLegs());
 
             if (0.5 > Utility.RandomDouble())
-                this.AddItem(new SavageMask());
+                AddItem(new SavageMask());
             else if (0.1 > Utility.RandomDouble())
-                this.AddItem(new OrcishKinMask());
+                AddItem(new OrcishKinMask());
         }
 
         public Savage(Serial serial)
@@ -57,37 +57,14 @@ namespace Server.Mobiles
         {
         }
 
-        public override int Meat
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override bool AlwaysMurderer
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override bool ShowFameTitle
-        {
-            get
-            {
-                return false;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+        public override bool AlwaysMurderer { get { return true; } }
+        public override bool ShowFameTitle { get { return false; } }
+        public override int Meat { get { return 1; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Savage; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Meager);
         }
 
         public override bool IsEnemy(Mobile m)

--- a/Scripts/Mobiles/Normal/SavageRider.cs
+++ b/Scripts/Mobiles/Normal/SavageRider.cs
@@ -10,41 +10,37 @@ namespace Server.Mobiles
         public SavageRider()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.15, 0.4)
         {
-            this.Name = NameList.RandomName("savage rider");
+            Name = NameList.RandomName("savage rider");
+            Body = 185;
 
-            if (this.Female = Utility.RandomBool())
-                this.Body = 186;
-            else
-                this.Body = 185;
+            SetStr(151, 170);
+            SetDex(92, 130);
+            SetInt(51, 65);
 
-            this.SetStr(151, 170);
-            this.SetDex(92, 130);
-            this.SetInt(51, 65);
+            SetDamage(29, 34);
 
-            this.SetDamage(29, 34);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetSkill(SkillName.Fencing, 72.5, 95.0);
+            SetSkill(SkillName.Healing, 60.3, 90.0);
+            SetSkill(SkillName.Macing, 72.5, 95.0);
+            SetSkill(SkillName.Poisoning, 60.0, 82.5);
+            SetSkill(SkillName.MagicResist, 72.5, 95.0);
+            SetSkill(SkillName.Swords, 72.5, 95.0);
+            SetSkill(SkillName.Tactics, 72.5, 95.0);
 
-            this.SetSkill(SkillName.Fencing, 72.5, 95.0);
-            this.SetSkill(SkillName.Healing, 60.3, 90.0);
-            this.SetSkill(SkillName.Macing, 72.5, 95.0);
-            this.SetSkill(SkillName.Poisoning, 60.0, 82.5);
-            this.SetSkill(SkillName.MagicResist, 72.5, 95.0);
-            this.SetSkill(SkillName.Swords, 72.5, 95.0);
-            this.SetSkill(SkillName.Tactics, 72.5, 95.0);
+            Fame = 1000;
+            Karma = -1000;
 
-            this.Fame = 1000;
-            this.Karma = -1000;
-
-            this.PackItem(new Bandage(Utility.RandomMinMax(1, 15)));
+            PackItem(new Bandage(Utility.RandomMinMax(1, 15)));
 
             if (0.1 > Utility.RandomDouble())
-                this.PackItem(new BolaBall());
+                PackItem(new BolaBall());
 
-            this.AddItem(new TribalSpear());
-            this.AddItem(new BoneArms());
-            this.AddItem(new BoneLegs());
-            this.AddItem(new BearMask());
+            AddItem(new TribalSpear());
+            AddItem(new BoneArms());
+            AddItem(new BoneLegs());
+            AddItem(new BearMask());
 
             new SavageRidgeback().Rider = this;
         }
@@ -54,42 +50,19 @@ namespace Server.Mobiles
         {
         }
 
-        public override int Meat
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override bool AlwaysMurderer
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override bool ShowFameTitle
-        {
-            get
-            {
-                return false;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+        public override bool AlwaysMurderer { get { return true; } }
+        public override bool ShowFameTitle { get { return false; } }
+        public override int Meat { get { return 1; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Savage; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Average);
+            AddLoot(LootPack.Average);
         }
 
         public override bool OnBeforeDeath()
         {
-            IMount mount = this.Mount;
+            IMount mount = Mount;
 
             if (mount != null)
                 mount.Rider = null;

--- a/Scripts/Mobiles/Normal/SavageShaman.cs
+++ b/Scripts/Mobiles/Normal/SavageShaman.cs
@@ -14,331 +14,325 @@ using Server.Spells;
 
 namespace Server.Mobiles
 {
-	[CorpseName("a savage corpse")]
-	public class SavageShaman : BaseCreature
-	{
-		[Constructable]
-		public SavageShaman()
-			: base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
-		{
-			Name = NameList.RandomName("savage shaman");
-
-			if (Utility.RandomBool())
-			{
-				Body = 184;
-			}
-			else
-			{
-				Body = 183;
-			}
-
-			SetStr(126, 145);
-			SetDex(91, 110);
-			SetInt(161, 185);
-
-			SetDamage(4, 10);
-
-			SetDamageType(ResistanceType.Physical, 100);
-
-			SetResistance(ResistanceType.Physical, 30, 40);
-			SetResistance(ResistanceType.Fire, 20, 30);
-			SetResistance(ResistanceType.Cold, 20, 30);
-			SetResistance(ResistanceType.Poison, 20, 30);
-			SetResistance(ResistanceType.Energy, 40, 50);
-
-			SetSkill(SkillName.EvalInt, 77.5, 100.0);
-			SetSkill(SkillName.Fencing, 62.5, 85.0);
-			SetSkill(SkillName.Macing, 62.5, 85.0);
-			SetSkill(SkillName.Magery, 72.5, 95.0);
-			SetSkill(SkillName.Meditation, 77.5, 100.0);
-			SetSkill(SkillName.MagicResist, 77.5, 100.0);
-			SetSkill(SkillName.Swords, 62.5, 85.0);
-			SetSkill(SkillName.Tactics, 62.5, 85.0);
-			SetSkill(SkillName.Wrestling, 62.5, 85.0);
-
-			Fame = 1000;
-			Karma = -1000;
-
-			PackReg(10, 15);
-			PackItem(new Bandage(Utility.RandomMinMax(1, 15)));
-
-			if (0.1 > Utility.RandomDouble())
-			{
-				PackItem(new TribalBerry());
-			}
-
-			AddItem(new BoneArms());
-			AddItem(new BoneLegs());
-			AddItem(new DeerMask());
-		}
-
-		public SavageShaman(Serial serial)
-			: base(serial)
-		{ }
-
-		public override int Meat { get { return 1; } }
-		public override bool AlwaysMurderer { get { return true; } }
-		public override bool ShowFameTitle { get { return false; } }
-		public override OppositionGroup OppositionGroup { get { return OppositionGroup.SavagesAndOrcs; } }
-
-		public override void GenerateLoot()
-		{
-			AddLoot(LootPack.Average);
-		}
-
-		public override bool IsEnemy(Mobile m)
-		{
-			if (m.BodyMod == 183 || m.BodyMod == 184)
-			{
-				return false;
-			}
-
-			return base.IsEnemy(m);
-		}
-
-		public override void AggressiveAction(Mobile aggressor, bool criminal)
-		{
-			base.AggressiveAction(aggressor, criminal);
-
-			if (aggressor.BodyMod == 183 || aggressor.BodyMod == 184)
-			{
-				AOS.Damage(aggressor, 50, 0, 100, 0, 0, 0);
-				aggressor.BodyMod = 0;
-				aggressor.HueMod = -1;
-				aggressor.FixedParticles(0x36BD, 20, 10, 5044, EffectLayer.Head);
-				aggressor.PlaySound(0x307);
-				aggressor.SendLocalizedMessage(1040008); // Your skin is scorched as the tribal paint burns away!
-
-				if (aggressor is PlayerMobile)
-				{
-					((PlayerMobile)aggressor).SavagePaintExpiration = TimeSpan.Zero;
-				}
-			}
-		}
-
-		public override void AlterMeleeDamageTo(Mobile to, ref int damage)
-		{
-			if (to is Dragon || to is WhiteWyrm || to is SwampDragon || to is Drake || to is Nightmare || to is Hiryu ||
-				to is LesserHiryu || to is Daemon)
-			{
-				damage *= 3;
-			}
-		}
-
-		public override void OnGotMeleeAttack(Mobile attacker)
-		{
-			base.OnGotMeleeAttack(attacker);
-
-			if (0.1 > Utility.RandomDouble())
-			{
-				BeginSavageDance();
-			}
-		}
-
-		public void BeginSavageDance()
-		{
-			if (Map == null)
-			{
-				return;
-			}
-
-			ArrayList list = new ArrayList();
-
-			foreach (Mobile m in GetMobilesInRange(8))
-			{
-				if (m != this && m is SavageShaman)
-				{
-					list.Add(m);
-				}
-			}
-
-			Animate(111, 5, 1, true, false, 0); // Do a little dance...
-
-			if (AIObject != null)
-			{
-				AIObject.NextMove = Core.TickCount + 1000;
-			}
-
-			if (list.Count >= 3)
-			{
-				for (int i = 0; i < list.Count; ++i)
-				{
-					SavageShaman dancer = (SavageShaman)list[i];
-
-					dancer.Animate(111, 5, 1, true, false, 0); // Get down tonight...
-
-					if (dancer.AIObject != null)
-					{
-						dancer.AIObject.NextMove = Core.TickCount + 1000;
-					}
-				}
-
-				Timer.DelayCall(TimeSpan.FromSeconds(1.0), EndSavageDance);
-			}
-		}
-
-		public void EndSavageDance()
-		{
-			if (Deleted)
-			{
-				return;
-			}
-
-			ArrayList list = new ArrayList();
-
-			foreach (Mobile m in GetMobilesInRange(8))
-			{
-				list.Add(m);
-			}
-
-			if (list.Count > 0)
-			{
-				switch (Utility.Random(3))
-				{
-					case 0: /* greater heal */
-						{
-							foreach (Mobile m in list)
-							{
-								bool isFriendly = (m is Savage || m is SavageRider || m is SavageShaman || m is SavageRidgeback);
-
-								if (!isFriendly)
-								{
-									continue;
-								}
-
-								if (m.Poisoned || MortalStrike.IsWounded(m) || !CanBeBeneficial(m))
-								{
-									continue;
-								}
-
-								DoBeneficial(m);
-
-								// Algorithm: (40% of magery) + (1-10)
-
-								int toHeal = (int)(Skills[SkillName.Magery].Value * 0.4);
-								toHeal += Utility.Random(1, 10);
-
-								m.Heal(toHeal, this);
-
-								m.FixedParticles(0x376A, 9, 32, 5030, EffectLayer.Waist);
-								m.PlaySound(0x202);
-							}
-
-							break;
-						}
-					case 1: /* lightning */
-						{
-							foreach (Mobile m in list)
-							{
-								bool isFriendly = (m is Savage || m is SavageRider || m is SavageShaman || m is SavageRidgeback);
-
-								if (isFriendly)
-								{
-									continue;
-								}
-
-								if (!CanBeHarmful(m))
-								{
-									continue;
-								}
-
-								DoHarmful(m);
-
-								double damage;
-
-								if (Core.AOS)
-								{
-									int baseDamage = 6 + (int)(Skills[SkillName.EvalInt].Value / 5.0);
-
-									damage = Utility.RandomMinMax(baseDamage, baseDamage + 3);
-								}
-								else
-								{
-									damage = Utility.Random(12, 9);
-								}
-
-								m.BoltEffect(0);
-
-								SpellHelper.Damage(TimeSpan.FromSeconds(0.25), m, this, damage, 0, 0, 0, 0, 100);
-							}
-
-							break;
-						}
-					case 2: /* poison */
-						{
-							foreach (Mobile m in list)
-							{
-								bool isFriendly = (m is Savage || m is SavageRider || m is SavageShaman || m is SavageRidgeback);
-
-								if (isFriendly)
-								{
-									continue;
-								}
-
-								if (!CanBeHarmful(m))
-								{
-									continue;
-								}
-
-								DoHarmful(m);
-
-								if (m.Spell != null)
-								{
-									m.Spell.OnCasterHurt();
-								}
-
-								m.Paralyzed = false;
-
-								double total = Skills[SkillName.Magery].Value + Skills[SkillName.Poisoning].Value;
-
-								double dist = GetDistanceToSqrt(m);
-
-								if (dist >= 3.0)
-								{
-									total -= (dist - 3.0) * 10.0;
-								}
-
-								int level;
-
-								if (total >= 200.0 && Utility.Random(1, 100) <= 10)
-								{
-									level = 3;
-								}
-								else if (total > 170.0)
-								{
-									level = 2;
-								}
-								else if (total > 130.0)
-								{
-									level = 1;
-								}
-								else
-								{
-									level = 0;
-								}
-
-								m.ApplyPoison(this, Poison.GetPoison(level));
-
-								m.FixedParticles(0x374A, 10, 15, 5021, EffectLayer.Waist);
-								m.PlaySound(0x474);
-							}
-
-							break;
-						}
-				}
-			}
-		}
-
-		public override void Serialize(GenericWriter writer)
-		{
-			base.Serialize(writer);
-			writer.Write(0);
-		}
-
-		public override void Deserialize(GenericReader reader)
-		{
-			base.Deserialize(reader);
-			int version = reader.ReadInt();
-		}
-	}
+    [CorpseName("a savage corpse")]
+    public class SavageShaman : BaseCreature
+    {
+        [Constructable]
+        public SavageShaman()
+            : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
+        {
+            Name = NameList.RandomName("savage shaman");
+
+            Female = true;
+            Body = 186;
+
+            SetStr(126, 145);
+            SetDex(91, 110);
+            SetInt(161, 185);
+
+            SetDamage(4, 10);
+
+            SetDamageType(ResistanceType.Physical, 100);
+
+            SetResistance(ResistanceType.Physical, 30, 40);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 20, 30);
+            SetResistance(ResistanceType.Poison, 20, 30);
+            SetResistance(ResistanceType.Energy, 40, 50);
+
+            SetSkill(SkillName.EvalInt, 77.5, 100.0);
+            SetSkill(SkillName.Fencing, 62.5, 85.0);
+            SetSkill(SkillName.Macing, 62.5, 85.0);
+            SetSkill(SkillName.Magery, 72.5, 95.0);
+            SetSkill(SkillName.Meditation, 77.5, 100.0);
+            SetSkill(SkillName.MagicResist, 77.5, 100.0);
+            SetSkill(SkillName.Swords, 62.5, 85.0);
+            SetSkill(SkillName.Tactics, 62.5, 85.0);
+            SetSkill(SkillName.Wrestling, 62.5, 85.0);
+
+            Fame = 1000;
+            Karma = -1000;
+
+            PackReg(10, 15);
+            PackItem(new Bandage(Utility.RandomMinMax(1, 15)));
+
+            if (0.1 > Utility.RandomDouble())
+            {
+                PackItem(new TribalBerry());
+            }
+
+            AddItem(new BoneArms());
+            AddItem(new BoneLegs());
+            AddItem(new DeerMask());
+        }
+
+        public SavageShaman(Serial serial)
+            : base(serial)
+        { }
+
+        public override bool AlwaysMurderer { get { return true; } }
+        public override bool ShowFameTitle { get { return false; } }
+        public override int Meat { get { return 1; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Savage; } }
+
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.Average);
+        }
+
+        public override bool IsEnemy(Mobile m)
+        {
+            if (m.BodyMod == 183 || m.BodyMod == 184)
+            {
+                return false;
+            }
+
+            return base.IsEnemy(m);
+        }
+
+        public override void AggressiveAction(Mobile aggressor, bool criminal)
+        {
+            base.AggressiveAction(aggressor, criminal);
+
+            if (aggressor.BodyMod == 183 || aggressor.BodyMod == 184)
+            {
+                AOS.Damage(aggressor, 50, 0, 100, 0, 0, 0);
+                aggressor.BodyMod = 0;
+                aggressor.HueMod = -1;
+                aggressor.FixedParticles(0x36BD, 20, 10, 5044, EffectLayer.Head);
+                aggressor.PlaySound(0x307);
+                aggressor.SendLocalizedMessage(1040008); // Your skin is scorched as the tribal paint burns away!
+
+                if (aggressor is PlayerMobile)
+                {
+                    ((PlayerMobile)aggressor).SavagePaintExpiration = TimeSpan.Zero;
+                }
+            }
+        }
+
+        public override void AlterMeleeDamageTo(Mobile to, ref int damage)
+        {
+            if (to is Dragon || to is WhiteWyrm || to is SwampDragon || to is Drake || to is Nightmare || to is Hiryu ||
+                to is LesserHiryu || to is Daemon)
+            {
+                damage *= 3;
+            }
+        }
+
+        public override void OnGotMeleeAttack(Mobile attacker)
+        {
+            base.OnGotMeleeAttack(attacker);
+
+            if (0.1 > Utility.RandomDouble())
+            {
+                BeginSavageDance();
+            }
+        }
+
+        public void BeginSavageDance()
+        {
+            if (Map == null)
+            {
+                return;
+            }
+
+            ArrayList list = new ArrayList();
+
+            foreach (Mobile m in GetMobilesInRange(8))
+            {
+                if (m != this && m is SavageShaman)
+                {
+                    list.Add(m);
+                }
+            }
+
+            Animate(111, 5, 1, true, false, 0); // Do a little dance...
+
+            if (AIObject != null)
+            {
+                AIObject.NextMove = Core.TickCount + 1000;
+            }
+
+            if (list.Count >= 3)
+            {
+                for (int i = 0; i < list.Count; ++i)
+                {
+                    SavageShaman dancer = (SavageShaman)list[i];
+
+                    dancer.Animate(111, 5, 1, true, false, 0); // Get down tonight...
+
+                    if (dancer.AIObject != null)
+                    {
+                        dancer.AIObject.NextMove = Core.TickCount + 1000;
+                    }
+                }
+
+                Timer.DelayCall(TimeSpan.FromSeconds(1.0), EndSavageDance);
+            }
+        }
+
+        public void EndSavageDance()
+        {
+            if (Deleted)
+            {
+                return;
+            }
+
+            ArrayList list = new ArrayList();
+
+            foreach (Mobile m in GetMobilesInRange(8))
+            {
+                list.Add(m);
+            }
+
+            if (list.Count > 0)
+            {
+                switch (Utility.Random(3))
+                {
+                    case 0: /* greater heal */
+                        {
+                            foreach (Mobile m in list)
+                            {
+                                bool isFriendly = (m is Savage || m is SavageRider || m is SavageShaman || m is SavageRidgeback);
+
+                                if (!isFriendly)
+                                {
+                                    continue;
+                                }
+
+                                if (m.Poisoned || MortalStrike.IsWounded(m) || !CanBeBeneficial(m))
+                                {
+                                    continue;
+                                }
+
+                                DoBeneficial(m);
+
+                                // Algorithm: (40% of magery) + (1-10)
+
+                                int toHeal = (int)(Skills[SkillName.Magery].Value * 0.4);
+                                toHeal += Utility.Random(1, 10);
+
+                                m.Heal(toHeal, this);
+
+                                m.FixedParticles(0x376A, 9, 32, 5030, EffectLayer.Waist);
+                                m.PlaySound(0x202);
+                            }
+
+                            break;
+                        }
+                    case 1: /* lightning */
+                        {
+                            foreach (Mobile m in list)
+                            {
+                                bool isFriendly = (m is Savage || m is SavageRider || m is SavageShaman || m is SavageRidgeback);
+
+                                if (isFriendly)
+                                {
+                                    continue;
+                                }
+
+                                if (!CanBeHarmful(m))
+                                {
+                                    continue;
+                                }
+
+                                DoHarmful(m);
+
+                                double damage;
+
+                                if (Core.AOS)
+                                {
+                                    int baseDamage = 6 + (int)(Skills[SkillName.EvalInt].Value / 5.0);
+
+                                    damage = Utility.RandomMinMax(baseDamage, baseDamage + 3);
+                                }
+                                else
+                                {
+                                    damage = Utility.Random(12, 9);
+                                }
+
+                                m.BoltEffect(0);
+
+                                SpellHelper.Damage(TimeSpan.FromSeconds(0.25), m, this, damage, 0, 0, 0, 0, 100);
+                            }
+
+                            break;
+                        }
+                    case 2: /* poison */
+                        {
+                            foreach (Mobile m in list)
+                            {
+                                bool isFriendly = (m is Savage || m is SavageRider || m is SavageShaman || m is SavageRidgeback);
+
+                                if (isFriendly)
+                                {
+                                    continue;
+                                }
+
+                                if (!CanBeHarmful(m))
+                                {
+                                    continue;
+                                }
+
+                                DoHarmful(m);
+
+                                if (m.Spell != null)
+                                {
+                                    m.Spell.OnCasterHurt();
+                                }
+
+                                m.Paralyzed = false;
+
+                                double total = Skills[SkillName.Magery].Value + Skills[SkillName.Poisoning].Value;
+
+                                double dist = GetDistanceToSqrt(m);
+
+                                if (dist >= 3.0)
+                                {
+                                    total -= (dist - 3.0) * 10.0;
+                                }
+
+                                int level;
+
+                                if (total >= 200.0 && Utility.Random(1, 100) <= 10)
+                                {
+                                    level = 3;
+                                }
+                                else if (total > 170.0)
+                                {
+                                    level = 2;
+                                }
+                                else if (total > 130.0)
+                                {
+                                    level = 1;
+                                }
+                                else
+                                {
+                                    level = 0;
+                                }
+
+                                m.ApplyPoison(this, Poison.GetPoison(level));
+
+                                m.FixedParticles(0x374A, 10, 15, 5021, EffectLayer.Waist);
+                                m.PlaySound(0x474);
+                            }
+
+                            break;
+                        }
+                }
+            }
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+        }
+    }
 }

--- a/Scripts/Mobiles/Normal/Shade.cs
+++ b/Scripts/Mobiles/Normal/Shade.cs
@@ -10,38 +10,38 @@ namespace Server.Mobiles
         public Shade()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a shade";
-            this.Body = 26;
-            this.Hue = 0x4001;
-            this.BaseSoundID = 0x482;
+            Name = "a shade";
+            Body = 26;
+            Hue = 0x4001;
+            BaseSoundID = 0x482;
 
-            this.SetStr(76, 100);
-            this.SetDex(76, 95);
-            this.SetInt(36, 60);
+            SetStr(76, 100);
+            SetDex(76, 95);
+            SetInt(36, 60);
 
-            this.SetHits(46, 60);
+            SetHits(46, 60);
 
-            this.SetDamage(7, 11);
+            SetDamage(7, 11);
 
-            this.SetDamageType(ResistanceType.Physical, 50);
-            this.SetDamageType(ResistanceType.Cold, 50);
+            SetDamageType(ResistanceType.Physical, 50);
+            SetDamageType(ResistanceType.Cold, 50);
 
-            this.SetResistance(ResistanceType.Physical, 25, 30);
-            this.SetResistance(ResistanceType.Cold, 15, 25);
-            this.SetResistance(ResistanceType.Poison, 10, 20);
+            SetResistance(ResistanceType.Physical, 25, 30);
+            SetResistance(ResistanceType.Cold, 15, 25);
+            SetResistance(ResistanceType.Poison, 10, 20);
 
-            this.SetSkill(SkillName.EvalInt, 55.1, 70.0);
-            this.SetSkill(SkillName.Magery, 55.1, 70.0);
-            this.SetSkill(SkillName.MagicResist, 55.1, 70.0);
-            this.SetSkill(SkillName.Tactics, 45.1, 60.0);
-            this.SetSkill(SkillName.Wrestling, 45.1, 55.0);
+            SetSkill(SkillName.EvalInt, 55.1, 70.0);
+            SetSkill(SkillName.Magery, 55.1, 70.0);
+            SetSkill(SkillName.MagicResist, 55.1, 70.0);
+            SetSkill(SkillName.Tactics, 45.1, 60.0);
+            SetSkill(SkillName.Wrestling, 45.1, 55.0);
 
-            this.Fame = 4000;
-            this.Karma = -4000;
+            Fame = 4000;
+            Karma = -4000;
 
-            this.VirtualArmor = 28;
+            VirtualArmor = 28;
 
-            this.PackReg(10);
+            PackReg(10);
         }
 
         public Shade(Serial serial)
@@ -49,30 +49,13 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Meager);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/SkeletalKnight.cs
+++ b/Scripts/Mobiles/Normal/SkeletalKnight.cs
@@ -10,60 +10,60 @@ namespace Server.Mobiles
         public SkeletalKnight()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a skeletal knight";
-            this.Body = 147;
-            this.BaseSoundID = 451;
+            Name = "a skeletal knight";
+            Body = 147;
+            BaseSoundID = 451;
 
-            this.SetStr(196, 250);
-            this.SetDex(76, 95);
-            this.SetInt(36, 60);
+            SetStr(196, 250);
+            SetDex(76, 95);
+            SetInt(36, 60);
 
-            this.SetHits(118, 150);
+            SetHits(118, 150);
 
-            this.SetDamage(8, 18);
+            SetDamage(8, 18);
 
-            this.SetDamageType(ResistanceType.Physical, 40);
-            this.SetDamageType(ResistanceType.Cold, 60);
+            SetDamageType(ResistanceType.Physical, 40);
+            SetDamageType(ResistanceType.Cold, 60);
 
-            this.SetResistance(ResistanceType.Physical, 35, 45);
-            this.SetResistance(ResistanceType.Fire, 20, 30);
-            this.SetResistance(ResistanceType.Cold, 50, 60);
-            this.SetResistance(ResistanceType.Poison, 20, 30);
-            this.SetResistance(ResistanceType.Energy, 30, 40);
+            SetResistance(ResistanceType.Physical, 35, 45);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 20, 30);
+            SetResistance(ResistanceType.Energy, 30, 40);
 
-            this.SetSkill(SkillName.MagicResist, 65.1, 80.0);
-            this.SetSkill(SkillName.Tactics, 85.1, 100.0);
-            this.SetSkill(SkillName.Wrestling, 85.1, 95.0);
+            SetSkill(SkillName.MagicResist, 65.1, 80.0);
+            SetSkill(SkillName.Tactics, 85.1, 100.0);
+            SetSkill(SkillName.Wrestling, 85.1, 95.0);
 
-            this.Fame = 3000;
-            this.Karma = -3000;
+            Fame = 3000;
+            Karma = -3000;
 
-            this.VirtualArmor = 40;
+            VirtualArmor = 40;
 
             switch ( Utility.Random(6) )
             {
                 case 0:
-                    this.PackItem(new PlateArms());
+                    PackItem(new PlateArms());
                     break;
                 case 1:
-                    this.PackItem(new PlateChest());
+                    PackItem(new PlateChest());
                     break;
                 case 2:
-                    this.PackItem(new PlateGloves());
+                    PackItem(new PlateGloves());
                     break;
                 case 3:
-                    this.PackItem(new PlateGorget());
+                    PackItem(new PlateGorget());
                     break;
                 case 4:
-                    this.PackItem(new PlateLegs());
+                    PackItem(new PlateLegs());
                     break;
                 case 5:
-                    this.PackItem(new PlateHelm());
+                    PackItem(new PlateHelm());
                     break;
             }
 
-            this.PackItem(new Scimitar());
-            this.PackItem(new WoodenShield());
+            PackItem(new Scimitar());
+            PackItem(new WoodenShield());
         }
 
         public SkeletalKnight(Serial serial)
@@ -71,24 +71,13 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Average);
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Meager);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Skeleton.cs
+++ b/Scripts/Mobiles/Normal/Skeleton.cs
@@ -10,51 +10,51 @@ namespace Server.Mobiles
         public Skeleton()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a skeleton";
-            this.Body = Utility.RandomList(50, 56);
-            this.BaseSoundID = 0x48D;
+            Name = "a skeleton";
+            Body = Utility.RandomList(50, 56);
+            BaseSoundID = 0x48D;
 
-            this.SetStr(56, 80);
-            this.SetDex(56, 75);
-            this.SetInt(16, 40);
+            SetStr(56, 80);
+            SetDex(56, 75);
+            SetInt(16, 40);
 
-            this.SetHits(34, 48);
+            SetHits(34, 48);
 
-            this.SetDamage(3, 7);
+            SetDamage(3, 7);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 15, 20);
-            this.SetResistance(ResistanceType.Fire, 5, 10);
-            this.SetResistance(ResistanceType.Cold, 25, 40);
-            this.SetResistance(ResistanceType.Poison, 25, 35);
-            this.SetResistance(ResistanceType.Energy, 5, 15);
+            SetResistance(ResistanceType.Physical, 15, 20);
+            SetResistance(ResistanceType.Fire, 5, 10);
+            SetResistance(ResistanceType.Cold, 25, 40);
+            SetResistance(ResistanceType.Poison, 25, 35);
+            SetResistance(ResistanceType.Energy, 5, 15);
 
-            this.SetSkill(SkillName.MagicResist, 45.1, 60.0);
-            this.SetSkill(SkillName.Tactics, 45.1, 60.0);
-            this.SetSkill(SkillName.Wrestling, 45.1, 55.0);
+            SetSkill(SkillName.MagicResist, 45.1, 60.0);
+            SetSkill(SkillName.Tactics, 45.1, 60.0);
+            SetSkill(SkillName.Wrestling, 45.1, 55.0);
 
-            this.Fame = 450;
-            this.Karma = -450;
+            Fame = 450;
+            Karma = -450;
 
-            this.VirtualArmor = 16;
+            VirtualArmor = 16;
 
             switch ( Utility.Random(5))
             {
                 case 0:
-                    this.PackItem(new BoneArms());
+                    PackItem(new BoneArms());
                     break;
                 case 1:
-                    this.PackItem(new BoneChest());
+                    PackItem(new BoneChest());
                     break;
                 case 2:
-                    this.PackItem(new BoneGloves());
+                    PackItem(new BoneGloves());
                     break;
                 case 3:
-                    this.PackItem(new BoneLegs());
+                    PackItem(new BoneLegs());
                     break;
                 case 4:
-                    this.PackItem(new BoneHelm());
+                    PackItem(new BoneHelm());
                     break;
             }
         }
@@ -64,30 +64,13 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lesser;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lesser; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Poor);
+            AddLoot(LootPack.Poor);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Spectre.cs
+++ b/Scripts/Mobiles/Normal/Spectre.cs
@@ -10,38 +10,38 @@ namespace Server.Mobiles
         public Spectre()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a spectre";
-            this.Body = 26;
-            this.Hue = 0x4001;
-            this.BaseSoundID = 0x482;
+            Name = "a spectre";
+            Body = 26;
+            Hue = 0x4001;
+            BaseSoundID = 0x482;
 
-            this.SetStr(76, 100);
-            this.SetDex(76, 95);
-            this.SetInt(36, 60);
+            SetStr(76, 100);
+            SetDex(76, 95);
+            SetInt(36, 60);
 
-            this.SetHits(46, 60);
+            SetHits(46, 60);
 
-            this.SetDamage(7, 11);
+            SetDamage(7, 11);
 
-            this.SetDamageType(ResistanceType.Physical, 50);
-            this.SetDamageType(ResistanceType.Cold, 50);
+            SetDamageType(ResistanceType.Physical, 50);
+            SetDamageType(ResistanceType.Cold, 50);
 
-            this.SetResistance(ResistanceType.Physical, 25, 30);
-            this.SetResistance(ResistanceType.Cold, 15, 25);
-            this.SetResistance(ResistanceType.Poison, 10, 20);
+            SetResistance(ResistanceType.Physical, 25, 30);
+            SetResistance(ResistanceType.Cold, 15, 25);
+            SetResistance(ResistanceType.Poison, 10, 20);
 
-            this.SetSkill(SkillName.EvalInt, 55.1, 70.0);
-            this.SetSkill(SkillName.Magery, 55.1, 70.0);
-            this.SetSkill(SkillName.MagicResist, 55.1, 70.0);
-            this.SetSkill(SkillName.Tactics, 45.1, 60.0);
-            this.SetSkill(SkillName.Wrestling, 45.1, 55.0);
+            SetSkill(SkillName.EvalInt, 55.1, 70.0);
+            SetSkill(SkillName.Magery, 55.1, 70.0);
+            SetSkill(SkillName.MagicResist, 55.1, 70.0);
+            SetSkill(SkillName.Tactics, 45.1, 60.0);
+            SetSkill(SkillName.Wrestling, 45.1, 55.0);
 
-            this.Fame = 4000;
-            this.Karma = -4000;
+            Fame = 4000;
+            Karma = -4000;
 
-            this.VirtualArmor = 28;
+            VirtualArmor = 28;
 
-            this.PackReg(10);
+            PackReg(10);
         }
 
         public Spectre(Serial serial)
@@ -49,30 +49,13 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Meager);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/TerathanAvenger.cs
+++ b/Scripts/Mobiles/Normal/TerathanAvenger.cs
@@ -9,39 +9,39 @@ namespace Server.Mobiles
         public TerathanAvenger()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a terathan avenger";
-            this.Body = 152;
-            this.BaseSoundID = 0x24D;
+            Name = "a terathan avenger";
+            Body = 152;
+            BaseSoundID = 0x24D;
 
-            this.SetStr(467, 645);
-            this.SetDex(77, 95);
-            this.SetInt(126, 150);
+            SetStr(467, 645);
+            SetDex(77, 95);
+            SetInt(126, 150);
 
-            this.SetHits(296, 372);
-            this.SetMana(46, 70);
+            SetHits(296, 372);
+            SetMana(46, 70);
 
-            this.SetDamage(18, 22);
+            SetDamage(18, 22);
 
-            this.SetDamageType(ResistanceType.Physical, 50);
-            this.SetDamageType(ResistanceType.Poison, 50);
+            SetDamageType(ResistanceType.Physical, 50);
+            SetDamageType(ResistanceType.Poison, 50);
 
-            this.SetResistance(ResistanceType.Physical, 40, 50);
-            this.SetResistance(ResistanceType.Fire, 30, 40);
-            this.SetResistance(ResistanceType.Cold, 35, 45);
-            this.SetResistance(ResistanceType.Poison, 90, 100);
-            this.SetResistance(ResistanceType.Energy, 35, 45);
+            SetResistance(ResistanceType.Physical, 40, 50);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 35, 45);
+            SetResistance(ResistanceType.Poison, 90, 100);
+            SetResistance(ResistanceType.Energy, 35, 45);
 
-            this.SetSkill(SkillName.EvalInt, 70.3, 100.0);
-            this.SetSkill(SkillName.Magery, 70.3, 100.0);
-            this.SetSkill(SkillName.Poisoning, 60.1, 80.0);
-            this.SetSkill(SkillName.MagicResist, 65.1, 80.0);
-            this.SetSkill(SkillName.Tactics, 90.1, 100.0);
-            this.SetSkill(SkillName.Wrestling, 90.1, 100.0);
+            SetSkill(SkillName.EvalInt, 70.3, 100.0);
+            SetSkill(SkillName.Magery, 70.3, 100.0);
+            SetSkill(SkillName.Poisoning, 60.1, 80.0);
+            SetSkill(SkillName.MagicResist, 65.1, 80.0);
+            SetSkill(SkillName.Tactics, 90.1, 100.0);
+            SetSkill(SkillName.Wrestling, 90.1, 100.0);
 
-            this.Fame = 15000;
-            this.Karma = -15000;
+            Fame = 15000;
+            Karma = -15000;
 
-            this.VirtualArmor = 50;
+            VirtualArmor = 50;
         }
 
         public TerathanAvenger(Serial serial)
@@ -49,44 +49,15 @@ namespace Server.Mobiles
         {
         }
 
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Deadly;
-            }
-        }
-        public override Poison HitPoison
-        {
-            get
-            {
-                return Poison.Deadly;
-            }
-        }
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 3;
-            }
-        }
-        public override int Meat
-        {
-            get
-            {
-                return 2;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+        public override int Meat{ get{ return 2; } }
+        public override int TreasureMapLevel { get { return 3; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Terathan; } }
+        public override Poison HitPoison{ get{ return Poison.Deadly; } }
+        public override Poison PoisonImmune{ get{ return Poison.Deadly; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich, 2);
+            AddLoot(LootPack.Rich, 2);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -100,8 +71,8 @@ namespace Server.Mobiles
             base.Deserialize(reader);
             int version = reader.ReadInt();
 
-            if (this.BaseSoundID == 263)
-                this.BaseSoundID = 0x24D;
+            if (BaseSoundID == 263)
+                BaseSoundID = 0x24D;
         }
     }
 }

--- a/Scripts/Mobiles/Normal/TerathanDrone.cs
+++ b/Scripts/Mobiles/Normal/TerathanDrone.cs
@@ -10,38 +10,38 @@ namespace Server.Mobiles
         public TerathanDrone()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a terathan drone";
-            this.Body = 71;
-            this.BaseSoundID = 594;
+            Name = "a terathan drone";
+            Body = 71;
+            BaseSoundID = 594;
 
-            this.SetStr(36, 65);
-            this.SetDex(96, 145);
-            this.SetInt(21, 45);
+            SetStr(36, 65);
+            SetDex(96, 145);
+            SetInt(21, 45);
 
-            this.SetHits(22, 39);
-            this.SetMana(0);
+            SetHits(22, 39);
+            SetMana(0);
 
-            this.SetDamage(6, 12);
+            SetDamage(6, 12);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 20, 25);
-            this.SetResistance(ResistanceType.Fire, 10, 20);
-            this.SetResistance(ResistanceType.Cold, 15, 25);
-            this.SetResistance(ResistanceType.Poison, 30, 40);
-            this.SetResistance(ResistanceType.Energy, 15, 25);
+            SetResistance(ResistanceType.Physical, 20, 25);
+            SetResistance(ResistanceType.Fire, 10, 20);
+            SetResistance(ResistanceType.Cold, 15, 25);
+            SetResistance(ResistanceType.Poison, 30, 40);
+            SetResistance(ResistanceType.Energy, 15, 25);
 
-            this.SetSkill(SkillName.Poisoning, 40.1, 60.0);
-            this.SetSkill(SkillName.MagicResist, 30.1, 45.0);
-            this.SetSkill(SkillName.Tactics, 30.1, 50.0);
-            this.SetSkill(SkillName.Wrestling, 40.1, 50.0);
+            SetSkill(SkillName.Poisoning, 40.1, 60.0);
+            SetSkill(SkillName.MagicResist, 30.1, 45.0);
+            SetSkill(SkillName.Tactics, 30.1, 50.0);
+            SetSkill(SkillName.Wrestling, 40.1, 50.0);
 
-            this.Fame = 2000;
-            this.Karma = -2000;
+            Fame = 2000;
+            Karma = -2000;
 
-            this.VirtualArmor = 24;
-			
-            this.PackItem(new SpidersSilk(2));
+            VirtualArmor = 24;
+
+            PackItem(new SpidersSilk(2));
         }
 
         public TerathanDrone(Serial serial)
@@ -49,23 +49,12 @@ namespace Server.Mobiles
         {
         }
 
-        public override int Meat
-        {
-            get
-            {
-                return 4;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+        public override int Meat{ get{ return 4; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Terathan; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Meager);
             // TODO: weapon?
         }
 
@@ -80,8 +69,8 @@ namespace Server.Mobiles
             base.Deserialize(reader);
             int version = reader.ReadInt();
 
-            if (this.BaseSoundID == 589)
-                this.BaseSoundID = 594;
+            if (BaseSoundID == 589)
+                BaseSoundID = 594;
         }
     }
 }

--- a/Scripts/Mobiles/Normal/TerathanMatriarch.cs
+++ b/Scripts/Mobiles/Normal/TerathanMatriarch.cs
@@ -10,37 +10,37 @@ namespace Server.Mobiles
         public TerathanMatriarch()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a terathan matriarch";
-            this.Body = 72;
-            this.BaseSoundID = 599;
+            Name = "a terathan matriarch";
+            Body = 72;
+            BaseSoundID = 599;
 
-            this.SetStr(316, 405);
-            this.SetDex(96, 115);
-            this.SetInt(366, 455);
+            SetStr(316, 405);
+            SetDex(96, 115);
+            SetInt(366, 455);
 
-            this.SetHits(190, 243);
+            SetHits(190, 243);
 
-            this.SetDamage(11, 14);
+            SetDamage(11, 14);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 45, 55);
-            this.SetResistance(ResistanceType.Fire, 30, 40);
-            this.SetResistance(ResistanceType.Cold, 35, 45);
-            this.SetResistance(ResistanceType.Poison, 40, 50);
-            this.SetResistance(ResistanceType.Energy, 35, 45);
+            SetResistance(ResistanceType.Physical, 45, 55);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 35, 45);
+            SetResistance(ResistanceType.Poison, 40, 50);
+            SetResistance(ResistanceType.Energy, 35, 45);
 
-            this.SetSkill(SkillName.EvalInt, 90.1, 100.0);
-            this.SetSkill(SkillName.Magery, 90.1, 100.0);
-            this.SetSkill(SkillName.MagicResist, 90.1, 100.0);
-            this.SetSkill(SkillName.Tactics, 50.1, 70.0);
-            this.SetSkill(SkillName.Wrestling, 60.1, 80.0);
+            SetSkill(SkillName.EvalInt, 90.1, 100.0);
+            SetSkill(SkillName.Magery, 90.1, 100.0);
+            SetSkill(SkillName.MagicResist, 90.1, 100.0);
+            SetSkill(SkillName.Tactics, 50.1, 70.0);
+            SetSkill(SkillName.Wrestling, 60.1, 80.0);
 
-            this.Fame = 10000;
-            this.Karma = -10000;
+            Fame = 10000;
+            Karma = -10000;
 
-            this.PackItem(new SpidersSilk(5));
-            this.PackNecroReg(Utility.RandomMinMax(4, 10));
+            PackItem(new SpidersSilk(5));
+            PackNecroReg(Utility.RandomMinMax(4, 10));
         }
 
         public TerathanMatriarch(Serial serial)
@@ -48,26 +48,15 @@ namespace Server.Mobiles
         {
         }
 
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 4;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+        public override int TreasureMapLevel { get { return 4; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Terathan; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich);
-            this.AddLoot(LootPack.Average, 2);
-            this.AddLoot(LootPack.MedScrolls, 2);
-            this.AddLoot(LootPack.Potions);
+            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.Average, 2);
+            AddLoot(LootPack.MedScrolls, 2);
+            AddLoot(LootPack.Potions);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/TerathanWarrior.cs
+++ b/Scripts/Mobiles/Normal/TerathanWarrior.cs
@@ -9,39 +9,39 @@ namespace Server.Mobiles
         public TerathanWarrior()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a terathan warrior";
-            this.Body = 70;
-            this.BaseSoundID = 589;
+            Name = "a terathan warrior";
+            Body = 70;
+            BaseSoundID = 589;
 
-            this.SetStr(166, 215);
-            this.SetDex(96, 145);
-            this.SetInt(41, 65);
+            SetStr(166, 215);
+            SetDex(96, 145);
+            SetInt(41, 65);
 
-            this.SetHits(100, 129);
-            this.SetMana(0);
+            SetHits(100, 129);
+            SetMana(0);
 
-            this.SetDamage(7, 17);
+            SetDamage(7, 17);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 30, 35);
-            this.SetResistance(ResistanceType.Fire, 20, 30);
-            this.SetResistance(ResistanceType.Cold, 25, 35);
-            this.SetResistance(ResistanceType.Poison, 30, 40);
-            this.SetResistance(ResistanceType.Energy, 25, 35);
+            SetResistance(ResistanceType.Physical, 30, 35);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 25, 35);
+            SetResistance(ResistanceType.Poison, 30, 40);
+            SetResistance(ResistanceType.Energy, 25, 35);
 
-            this.SetSkill(SkillName.Poisoning, 60.1, 80.0);
-            this.SetSkill(SkillName.MagicResist, 60.1, 75.0);
-            this.SetSkill(SkillName.Tactics, 80.1, 100.0);
-            this.SetSkill(SkillName.Wrestling, 80.1, 90.0);
+            SetSkill(SkillName.Poisoning, 60.1, 80.0);
+            SetSkill(SkillName.MagicResist, 60.1, 75.0);
+            SetSkill(SkillName.Tactics, 80.1, 100.0);
+            SetSkill(SkillName.Wrestling, 80.1, 90.0);
 
-            this.Fame = 4000;
-            this.Karma = -4000;
+            Fame = 4000;
+            Karma = -4000;
 
-            this.VirtualArmor = 30;
+            VirtualArmor = 30;
 
             if (Core.ML && Utility.RandomDouble() < .33)
-                this.PackItem(Engines.Plants.Seed.RandomPeculiarSeed(3));
+                PackItem(Engines.Plants.Seed.RandomPeculiarSeed(3));
         }
 
         public TerathanWarrior(Serial serial)
@@ -49,30 +49,13 @@ namespace Server.Mobiles
         {
         }
 
-        public override int TreasureMapLevel
-        {
-            get
-            {
-                return 1;
-            }
-        }
-        public override int Meat
-        {
-            get
-            {
-                return 4;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+        public override int Meat{ get{ return 4; } }
+        public override int TreasureMapLevel{ get{ return 1; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Terathan; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Average);
+            AddLoot(LootPack.Average);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Treefellow.cs
+++ b/Scripts/Mobiles/Normal/Treefellow.cs
@@ -10,33 +10,33 @@ namespace Server.Mobiles
         public Treefellow()
             : base(AIType.AI_Melee, FightMode.Evil, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a treefellow";
-            this.Body = 301;
+            Name = "a treefellow";
+            Body = 301;
 
-            this.SetStr(196, 220);
-            this.SetDex(31, 55);
-            this.SetInt(66, 90);
+            SetStr(196, 220);
+            SetDex(31, 55);
+            SetInt(66, 90);
 
-            this.SetHits(118, 132);
+            SetHits(118, 132);
 
-            this.SetDamage(12, 16);
+            SetDamage(12, 16);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 20, 25);
-            this.SetResistance(ResistanceType.Cold, 50, 60);
-            this.SetResistance(ResistanceType.Poison, 30, 35);
-            this.SetResistance(ResistanceType.Energy, 20, 30);
+            SetResistance(ResistanceType.Physical, 20, 25);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 30, 35);
+            SetResistance(ResistanceType.Energy, 20, 30);
 
-            this.SetSkill(SkillName.MagicResist, 40.1, 55.0);
-            this.SetSkill(SkillName.Tactics, 65.1, 90.0);
-            this.SetSkill(SkillName.Wrestling, 65.1, 85.0);
+            SetSkill(SkillName.MagicResist, 40.1, 55.0);
+            SetSkill(SkillName.Tactics, 65.1, 90.0);
+            SetSkill(SkillName.Wrestling, 65.1, 85.0);
 
-            this.Fame = 500;
-            this.Karma = 1500;
+            Fame = 500;
+            Karma = 1500;
 
-            this.VirtualArmor = 24;
-            this.PackItem(new Log(Utility.RandomMinMax(23, 34)));
+            VirtualArmor = 24;
+            PackItem(new Log(Utility.RandomMinMax(23, 34)));
         }
 
         public Treefellow(Serial serial)
@@ -44,43 +44,17 @@ namespace Server.Mobiles
         {
         }
 
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override WeaponAbility GetWeaponAbility()
-        {
-            return WeaponAbility.Dismount;
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Fey; } }
+        public override WeaponAbility GetWeaponAbility(){ return WeaponAbility.Dismount; }
 
-        public override int GetIdleSound()
-        {
-            return 443;
-        }
-
-        public override int GetDeathSound()
-        {
-            return 31;
-        }
-
-        public override int GetAttackSound()
-        {
-            return 672;
-        }
+        public override int GetIdleSound(){ return 443; }
+        public override int GetDeathSound(){ return 31; }
+        public override int GetAttackSound(){ return 672; }
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Average);
+            AddLoot(LootPack.Average);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -94,8 +68,8 @@ namespace Server.Mobiles
             base.Deserialize(reader);
             int version = reader.ReadInt();
 
-            if (this.BaseSoundID == 442)
-                this.BaseSoundID = -1;
+            if (BaseSoundID == 442)
+                BaseSoundID = -1;
         }
     }
 }

--- a/Scripts/Mobiles/Normal/Unicorn.cs
+++ b/Scripts/Mobiles/Normal/Unicorn.cs
@@ -16,38 +16,38 @@ namespace Server.Mobiles
         public Unicorn(string name)
             : base(name, 0x7A, 0x3EB4, AIType.AI_Mage, FightMode.Evil, 10, 1, 0.2, 0.4)
         {
-            this.BaseSoundID = 0x4BC;
+            BaseSoundID = 0x4BC;
 
-            this.SetStr(296, 325);
-            this.SetDex(96, 115);
-            this.SetInt(186, 225);
+            SetStr(296, 325);
+            SetDex(96, 115);
+            SetInt(186, 225);
 
-            this.SetHits(191, 210);
+            SetHits(191, 210);
 
-            this.SetDamage(16, 22);
+            SetDamage(16, 22);
 
-            this.SetDamageType(ResistanceType.Physical, 75);
-            this.SetDamageType(ResistanceType.Energy, 25);
+            SetDamageType(ResistanceType.Physical, 75);
+            SetDamageType(ResistanceType.Energy, 25);
 
-            this.SetResistance(ResistanceType.Physical, 55, 65);
-            this.SetResistance(ResistanceType.Fire, 25, 40);
-            this.SetResistance(ResistanceType.Cold, 25, 40);
-            this.SetResistance(ResistanceType.Poison, 55, 65);
-            this.SetResistance(ResistanceType.Energy, 25, 40);
+            SetResistance(ResistanceType.Physical, 55, 65);
+            SetResistance(ResistanceType.Fire, 25, 40);
+            SetResistance(ResistanceType.Cold, 25, 40);
+            SetResistance(ResistanceType.Poison, 55, 65);
+            SetResistance(ResistanceType.Energy, 25, 40);
 
-            this.SetSkill(SkillName.EvalInt, 80.1, 90.0);
-            this.SetSkill(SkillName.Magery, 60.2, 80.0);
-            this.SetSkill(SkillName.Meditation, 50.1, 60.0);
-            this.SetSkill(SkillName.MagicResist, 75.3, 90.0);
-            this.SetSkill(SkillName.Tactics, 20.1, 22.5);
-            this.SetSkill(SkillName.Wrestling, 80.5, 92.5);
+            SetSkill(SkillName.EvalInt, 80.1, 90.0);
+            SetSkill(SkillName.Magery, 60.2, 80.0);
+            SetSkill(SkillName.Meditation, 50.1, 60.0);
+            SetSkill(SkillName.MagicResist, 75.3, 90.0);
+            SetSkill(SkillName.Tactics, 20.1, 22.5);
+            SetSkill(SkillName.Wrestling, 80.5, 92.5);
 
-            this.Fame = 9000;
-            this.Karma = 9000;
+            Fame = 9000;
+            Karma = 9000;
 
-            this.Tamable = true;
-            this.ControlSlots = 2;
-            this.MinTameSkill = 95.1;
+            Tamable = true;
+            ControlSlots = 2;
+            MinTameSkill = 95.1;
         }
 
         public Unicorn(Serial serial)
@@ -55,76 +55,17 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool AllowMaleRider
-        {
-            get
-            {
-                return false;
-            }
-        }
-        public override bool AllowMaleTamer
-        {
-            get
-            {
-                return false;
-            }
-        }
-        public override bool InitialInnocent
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override TimeSpan MountAbilityDelay
-        {
-            get
-            {
-                return TimeSpan.FromHours(1.0);
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
-        public override int Meat
-        {
-            get
-            {
-                return 3;
-            }
-        }
-        public override int Hides
-        {
-            get
-            {
-                return 10;
-            }
-        }
-        public override HideType HideType
-        {
-            get
-            {
-                return HideType.Horned;
-            }
-        }
-        public override FoodType FavoriteFood
-        {
-            get
-            {
-                return FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
-            }
-        }
+        public override bool AllowMaleRider{ get{ return false; } }
+        public override bool AllowMaleTamer{ get{ return false; } }
+        public override bool InitialInnocent{ get{ return true; } }
+        public override int Hides{ get{ return 10; } }
+        public override int Meat{ get{ return 3; } }
+        public override FoodType FavoriteFood{ get{ return FoodType.FruitsAndVegies | FoodType.GrainsAndHay; } }
+        public override HideType HideType{ get{ return HideType.Horned; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Fey; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
+        public override TimeSpan MountAbilityDelay{ get{ return TimeSpan.FromHours(1.0); } }
+
         public override void OnDisallowedRider(Mobile m)
         {
             m.SendLocalizedMessage(1042318); // The unicorn refuses to allow you to ride it.
@@ -132,26 +73,26 @@ namespace Server.Mobiles
 
         public override bool DoMountAbility(int damage, Mobile attacker)
         {
-            if (this.Rider == null || attacker == null)	//sanity
+            if (Rider == null || attacker == null)	//sanity
                 return false;
 
-            if (this.Rider.Poisoned && ((this.Rider.Hits - damage) < 40))
+            if (Rider.Poisoned && ((Rider.Hits - damage) < 40))
             {
-                Poison p = this.Rider.Poison;
+                Poison p = Rider.Poison;
 
                 if (p != null)
                 {
-                    int chanceToCure = 10000 + (int)(this.Skills[SkillName.Magery].Value * 75) - ((p.RealLevel + 1) * (Core.AOS ? (p.RealLevel < 4 ? 3300 : 3100) : 1750));
+                    int chanceToCure = 10000 + (int)(Skills[SkillName.Magery].Value * 75) - ((p.RealLevel + 1) * (Core.AOS ? (p.RealLevel < 4 ? 3300 : 3100) : 1750));
                     chanceToCure /= 100;
 
                     if (chanceToCure > Utility.Random(100))
                     {
-                        if (this.Rider.CurePoison(this))	//TODO: Confirm if mount is the one flagged for curing it or the rider is
+                        if (Rider.CurePoison(this))	//TODO: Confirm if mount is the one flagged for curing it or the rider is
                         {
-                            this.Rider.LocalOverheadMessage(Server.Network.MessageType.Regular, 0x3B2, true, "Your mount senses you are in danger and aids you with magic.");
-                            this.Rider.FixedParticles(0x373A, 10, 15, 5012, EffectLayer.Waist);
-                            this.Rider.PlaySound(0x1E0);	// Cure spell effect.
-                            this.Rider.PlaySound(0xA9);		// Unicorn's whinny.
+                            Rider.LocalOverheadMessage(Server.Network.MessageType.Regular, 0x3B2, true, "Your mount senses you are in danger and aids you with magic.");
+                            Rider.FixedParticles(0x373A, 10, 15, 5012, EffectLayer.Waist);
+                            Rider.PlaySound(0x1E0);	// Cure spell effect.
+                            Rider.PlaySound(0xA9);		// Unicorn's whinny.
 
                             return true;
                         }
@@ -164,9 +105,9 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich);
-            this.AddLoot(LootPack.LowScrolls);
-            this.AddLoot(LootPack.Potions);
+            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.LowScrolls);
+            AddLoot(LootPack.Potions);
         }
 
 		public override void OnDeath(Container c)

--- a/Scripts/Mobiles/Normal/Wisp.cs
+++ b/Scripts/Mobiles/Normal/Wisp.cs
@@ -12,42 +12,42 @@ namespace Server.Mobiles
         public Wisp()
             : base(AIType.AI_Mage, FightMode.Aggressor, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a wisp";
-            this.Body = 58;
-            this.BaseSoundID = 466;
+            Name = "a wisp";
+            Body = 58;
+            BaseSoundID = 466;
 
-            this.SetStr(196, 225);
-            this.SetDex(196, 225);
-            this.SetInt(196, 225);
+            SetStr(196, 225);
+            SetDex(196, 225);
+            SetInt(196, 225);
 
-            this.SetHits(118, 135);
+            SetHits(118, 135);
 
-            this.SetDamage(17, 18);
+            SetDamage(17, 18);
 
-            this.SetDamageType(ResistanceType.Physical, 50);
-            this.SetDamageType(ResistanceType.Energy, 50);
+            SetDamageType(ResistanceType.Physical, 50);
+            SetDamageType(ResistanceType.Energy, 50);
 
-            this.SetResistance(ResistanceType.Physical, 35, 45);
-            this.SetResistance(ResistanceType.Fire, 20, 40);
-            this.SetResistance(ResistanceType.Cold, 10, 30);
-            this.SetResistance(ResistanceType.Poison, 5, 10);
-            this.SetResistance(ResistanceType.Energy, 50, 70);
+            SetResistance(ResistanceType.Physical, 35, 45);
+            SetResistance(ResistanceType.Fire, 20, 40);
+            SetResistance(ResistanceType.Cold, 10, 30);
+            SetResistance(ResistanceType.Poison, 5, 10);
+            SetResistance(ResistanceType.Energy, 50, 70);
 
-            this.SetSkill(SkillName.EvalInt, 80.0);
-            this.SetSkill(SkillName.Magery, 80.0);
-            this.SetSkill(SkillName.MagicResist, 80.0);
-            this.SetSkill(SkillName.Tactics, 80.0);
-            this.SetSkill(SkillName.Wrestling, 80.0);
+            SetSkill(SkillName.EvalInt, 80.0);
+            SetSkill(SkillName.Magery, 80.0);
+            SetSkill(SkillName.MagicResist, 80.0);
+            SetSkill(SkillName.Tactics, 80.0);
+            SetSkill(SkillName.Wrestling, 80.0);
 
-            this.Fame = 4000;
-            this.Karma = 0;
+            Fame = 4000;
+            Karma = 0;
 
-            this.VirtualArmor = 40;
+            VirtualArmor = 40;
 
             if (Core.ML && Utility.RandomDouble() < .33)
-                this.PackItem(Engines.Plants.Seed.RandomPeculiarSeed(3));
+                PackItem(Engines.Plants.Seed.RandomPeculiarSeed(3));
 
-            this.AddItem(new LightSource());
+            AddItem(new LightSource());
         }
 
         public Wisp(Serial serial)
@@ -55,45 +55,16 @@ namespace Server.Mobiles
         {
         }
 
-        public override InhumanSpeech SpeechType
-        {
-            get
-            {
-                return InhumanSpeech.Wisp;
-            }
-        }
-        public override Faction FactionAllegiance
-        {
-            get
-            {
-                return CouncilOfMages.Instance;
-            }
-        }
-        public override Ethics.Ethic EthicAllegiance
-        {
-            get
-            {
-                return Ethics.Ethic.Hero;
-            }
-        }
-        public override TimeSpan ReacquireDelay
-        {
-            get
-            {
-                return TimeSpan.FromSeconds(1.0);
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+        public override InhumanSpeech SpeechType{ get{ return InhumanSpeech.Wisp; } }
+        public override Faction FactionAllegiance{ get{ return CouncilOfMages.Instance; } }
+        public override Ethics.Ethic EthicAllegiance{ get{ return Ethics.Ethic.Hero; } }
+        public override TimeSpan ReacquireDelay{ get{ return TimeSpan.FromSeconds(1.0); } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Fey; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich);
-            this.AddLoot(LootPack.Average);
+            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.Average);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Wraith.cs
+++ b/Scripts/Mobiles/Normal/Wraith.cs
@@ -10,38 +10,38 @@ namespace Server.Mobiles
         public Wraith()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a wraith";
-            this.Body = 26;
-            this.Hue = 0x4001;
-            this.BaseSoundID = 0x482;
+            Name = "a wraith";
+            Body = 26;
+            Hue = 0x4001;
+            BaseSoundID = 0x482;
 
-            this.SetStr(76, 100);
-            this.SetDex(76, 95);
-            this.SetInt(36, 60);
+            SetStr(76, 100);
+            SetDex(76, 95);
+            SetInt(36, 60);
 
-            this.SetHits(46, 60);
+            SetHits(46, 60);
 
-            this.SetDamage(7, 11);
+            SetDamage(7, 11);
 
-            this.SetDamageType(ResistanceType.Physical, 50);
-            this.SetDamageType(ResistanceType.Cold, 50);
+            SetDamageType(ResistanceType.Physical, 50);
+            SetDamageType(ResistanceType.Cold, 50);
 
-            this.SetResistance(ResistanceType.Physical, 25, 30);
-            this.SetResistance(ResistanceType.Cold, 15, 25);
-            this.SetResistance(ResistanceType.Poison, 10, 20);
+            SetResistance(ResistanceType.Physical, 25, 30);
+            SetResistance(ResistanceType.Cold, 15, 25);
+            SetResistance(ResistanceType.Poison, 10, 20);
 
-            this.SetSkill(SkillName.EvalInt, 55.1, 70.0);
-            this.SetSkill(SkillName.Magery, 55.1, 70.0);
-            this.SetSkill(SkillName.MagicResist, 55.1, 70.0);
-            this.SetSkill(SkillName.Tactics, 45.1, 60.0);
-            this.SetSkill(SkillName.Wrestling, 45.1, 55.0);
+            SetSkill(SkillName.EvalInt, 55.1, 70.0);
+            SetSkill(SkillName.Magery, 55.1, 70.0);
+            SetSkill(SkillName.MagicResist, 55.1, 70.0);
+            SetSkill(SkillName.Tactics, 45.1, 60.0);
+            SetSkill(SkillName.Wrestling, 45.1, 55.0);
 
-            this.Fame = 4000;
-            this.Karma = -4000;
+            Fame = 4000;
+            Karma = -4000;
 
-            this.VirtualArmor = 28;
+            VirtualArmor = 28;
 
-            this.PackReg(10);
+            PackReg(10);
         }
 
         public Wraith(Serial serial)
@@ -49,30 +49,13 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Lethal;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override Poison PoisonImmune{ get{ return Poison.Lethal; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Meager);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Zombie.cs
+++ b/Scripts/Mobiles/Normal/Zombie.cs
@@ -10,64 +10,64 @@ namespace Server.Mobiles
         public Zombie()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a zombie";
-            this.Body = 3;
-            this.BaseSoundID = 471;
+            Name = "a zombie";
+            Body = 3;
+            BaseSoundID = 471;
 
-            this.SetStr(46, 70);
-            this.SetDex(31, 50);
-            this.SetInt(26, 40);
+            SetStr(46, 70);
+            SetDex(31, 50);
+            SetInt(26, 40);
 
-            this.SetHits(28, 42);
+            SetHits(28, 42);
 
-            this.SetDamage(3, 7);
+            SetDamage(3, 7);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 15, 20);
-            this.SetResistance(ResistanceType.Cold, 20, 30);
-            this.SetResistance(ResistanceType.Poison, 5, 10);
+            SetResistance(ResistanceType.Physical, 15, 20);
+            SetResistance(ResistanceType.Cold, 20, 30);
+            SetResistance(ResistanceType.Poison, 5, 10);
 
-            this.SetSkill(SkillName.MagicResist, 15.1, 40.0);
-            this.SetSkill(SkillName.Tactics, 35.1, 50.0);
-            this.SetSkill(SkillName.Wrestling, 35.1, 50.0);
+            SetSkill(SkillName.MagicResist, 15.1, 40.0);
+            SetSkill(SkillName.Tactics, 35.1, 50.0);
+            SetSkill(SkillName.Wrestling, 35.1, 50.0);
 
-            this.Fame = 600;
-            this.Karma = -600;
+            Fame = 600;
+            Karma = -600;
 
-            this.VirtualArmor = 18;
-			
+            VirtualArmor = 18;
+
             switch ( Utility.Random(10))
             {
                 case 0:
-                    this.PackItem(new LeftArm());
+                    PackItem(new LeftArm());
                     break;
                 case 1:
-                    this.PackItem(new RightArm());
+                    PackItem(new RightArm());
                     break;
                 case 2:
-                    this.PackItem(new Torso());
+                    PackItem(new Torso());
                     break;
                 case 3:
-                    this.PackItem(new Bone());
+                    PackItem(new Bone());
                     break;
                 case 4:
-                    this.PackItem(new RibCage());
+                    PackItem(new RibCage());
                     break;
                 case 5:
-                    this.PackItem(new RibCage());
+                    PackItem(new RibCage());
                     break;
                 case 6:
-                    this.PackItem(new BonePile());
+                    PackItem(new BonePile());
                     break;
                 case 7:
-                    this.PackItem(new BonePile());
+                    PackItem(new BonePile());
                     break;
                 case 8:
-                    this.PackItem(new BonePile());
+                    PackItem(new BonePile());
                     break;
                 case 9:
-                    this.PackItem(new BonePile());
+                    PackItem(new BonePile());
                     break;
             }
         }
@@ -77,30 +77,13 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool BleedImmune
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override Poison PoisonImmune
-        {
-            get
-            {
-                return Poison.Regular;
-            }
-        }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+        public override bool BleedImmune{ get{ return true; } }
+        public override OppositionType OppositionList{ get{ return OppositionType.Undead; } }
+        public override Poison PoisonImmune{ get{ return Poison.Regular; } }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Meager);
         }
 
         public override void Serialize(GenericWriter writer)


### PR DESCRIPTION
Alright guys, this is ready, and should work better. However, it's replacing stable, if clunky, code, so please test and review for a while to make sure nothing unexpected becomes a problem.

-Simpler, more dynamic, more elegant than OppositionGroup.
-OppositionGroup has an XvsY-group virtual enum, along with two lists of types, each of which are checked until it finds the type in the list.
-OppositionList has an X-group virtual enum, which has two switch(), first for its own OppositionType to pick the correct function, then a second for the target's OppositionType which determines if it has an enemy OppositionType.
-The first few checks are nearly identical to OppositionGroup(modified for OppositionType), making sure 'this' has an OppositionType, then checking if the target is a mobile, then checking if the target has an OppositionType. (A creature having a ControlMaster is ignored, just as in OppositionGroup)
-entirely handled within BaseCreature.cs (with the OppositionType set within the creature's type file)
--No need to update a clunky list for each new member of the Opposition, simply add the enum into its creature file
-OppositionGroup hasn't been completely excised for compatibility reasons
-Easily expandable, including the ability to add more than a single enemy group
-All mobiles with currently functioning OppositionGroup converted to OppositionList
-Savage Shaman is Female-Only
-Savage Rider is Male-Only