### PR TITLE
Goblin Opposition

### DIFF
--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -994,6 +994,7 @@ namespace Server.Mobiles
         public virtual bool IsMilitiaFighter { get { return false; } }
 
         // Opposition List stuff
+/*
         private bool m_HasFoughtPlayer;
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -1006,7 +1007,7 @@ namespace Server.Mobiles
                 InvalidateProperties();
             }
         }
-
+*/
         public virtual OppositionType OppositionList{ get{ return OppositionType.None ; } } // What opposition list am I in?
 
         public enum OppositionType
@@ -1055,12 +1056,13 @@ namespace Server.Mobiles
 
         private bool m_TerathanEnemy(OppositionType egroup)
         {
+/*
             // Don't fight monsters after fighting players, until sector deactivate/server restart
             if (HasFoughtPlayer)
             {
                 return false;
             }
-
+*/
             switch (egroup)
             {
                 case OppositionType.Ophidian: return true;
@@ -1070,12 +1072,13 @@ namespace Server.Mobiles
 
         private bool m_OphidianEnemy(OppositionType egroup)
         {
+/*
             // Don't fight monsters after fighting players, until sector deactivate/server restart
             if (HasFoughtPlayer)
             {
                 return false;
             }
-
+*/
             switch (egroup)
             {
                 case OppositionType.Terathan: return true;
@@ -1121,12 +1124,13 @@ namespace Server.Mobiles
 
         private bool m_GrayGoblinEnemy(OppositionType egroup)
         {
+/*
             // Don't fight monsters after fighting players, until sector deactivate/server restart
             if (HasFoughtPlayer)
             {
                 return false;
             }
-
+*/
             switch (egroup)
             {
                 case OppositionType.GreenGoblin: return true;
@@ -1136,12 +1140,13 @@ namespace Server.Mobiles
 
         private bool m_GreenGoblinEnemy(OppositionType egroup)
         {
+/*
             // Don't fight monsters after fighting players, until sector deactivate/server restart
             if (HasFoughtPlayer)
             {
                 return false;
             }
-
+*/
             switch (egroup)
             {
                 case OppositionType.GrayGoblin: return true;
@@ -3982,12 +3987,13 @@ namespace Server.Mobiles
                     aggressor.Aggressors.Add(AggressorInfo.Create(this, aggressor, true));
                 }
             }
+/*
             else if (!HasFoughtPlayer && (aggressor.Player ||
                 (aggressor is BaseCreature && ((BaseCreature)aggressor).GetMaster() is PlayerMobile)))
             {
                 HasFoughtPlayer = true;
             }
-
+*/
             OrderType ct = m_ControlOrder;
 
             if (m_AI != null)
@@ -4327,12 +4333,13 @@ namespace Server.Mobiles
 
             if (Warmode)
             {
+/*
                 if (!HasFoughtPlayer && (Combatant is PlayerMobile ||
                     (Combatant is BaseCreature && ((BaseCreature)Combatant).GetMaster() is PlayerMobile)))
                 {
                     HasFoughtPlayer = true;
                 }
-
+*/
                 if (CanFly)
                 {
                     Flying = false;
@@ -7434,9 +7441,9 @@ namespace Server.Mobiles
             {
                 m_AI.Deactivate();
             }
-
+/*
             HasFoughtPlayer = false;
-
+*/
             base.OnSectorDeactivate();
         }
 

--- a/Scripts/Mobiles/Normal/GrayGoblin.cs
+++ b/Scripts/Mobiles/Normal/GrayGoblin.cs
@@ -110,13 +110,9 @@ namespace Server.Mobiles
                 return 1;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+
+        public override OppositionType OppositionList{ get{ return OppositionType.GrayGoblin; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/GrayGoblinKeeper.cs
+++ b/Scripts/Mobiles/Normal/GrayGoblinKeeper.cs
@@ -110,13 +110,9 @@ namespace Server.Mobiles
                 return 1;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+
+        public override OppositionType OppositionList{ get{ return OppositionType.GrayGoblin; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/GrayGoblinMage.cs
+++ b/Scripts/Mobiles/Normal/GrayGoblinMage.cs
@@ -112,13 +112,9 @@ namespace Server.Mobiles
                 return 1;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+
+        public override OppositionType OppositionList{ get{ return OppositionType.GrayGoblin; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/GreenGoblin.cs
+++ b/Scripts/Mobiles/Normal/GreenGoblin.cs
@@ -122,24 +122,9 @@ namespace Server.Mobiles
                 return 1;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
-        //public override bool IsEnemy( Mobile m )
-        //{
-        //	if ( m.Player && m.FindItemOnLayer( Layer.Helm ) is OrcishKinMask )
-        //		return false;
 
-        //	return base.IsEnemy( m );
-        //}
+        public override OppositionType OppositionList{ get{ return OppositionType.GreenGoblin; } }
 
-        //public override void AggressiveAction( Mobile aggressor, bool criminal )
-        //{
-        //base.AggressiveAction( aggressor, criminal );
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/GreenGoblinAlchemist.cs
+++ b/Scripts/Mobiles/Normal/GreenGoblinAlchemist.cs
@@ -87,16 +87,6 @@ namespace Server.Mobiles
                 PackItem(new BolaBall());
         }
 
-        //Item item = aggressor.FindItemOnLayer( Layer.Helm );
-
-        //if ( item is OrcishKinMask )
-        //{
-        //	AOS.Damage( aggressor, 50, 0, 100, 0, 0, 0 );
-        //	item.Delete();
-        //	aggressor.FixedParticles( 0x36BD, 20, 10, 5044, EffectLayer.Head );
-        //	aggressor.PlaySound( 0x307 );
-        //}
-        //}
         public GreenGoblinAlchemist(Serial serial)
             : base(serial)
         {
@@ -123,24 +113,9 @@ namespace Server.Mobiles
                 return 1;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
-        //public override bool IsEnemy( Mobile m )
-        //{
-        //	if ( m.Player && m.FindItemOnLayer( Layer.Helm ) is OrcishKinMask )
-        //		return false;
 
-        //	return base.IsEnemy( m );
-        //}
+        public override OppositionType OppositionList{ get{ return OppositionType.GreenGoblin; } }
 
-        //public override void AggressiveAction( Mobile aggressor, bool criminal )
-        //{
-        //base.AggressiveAction( aggressor, criminal );
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/GreenGoblinScout.cs
+++ b/Scripts/Mobiles/Normal/GreenGoblinScout.cs
@@ -56,7 +56,8 @@ namespace Server.Mobiles
 			: base(serial)
 		{ }
 
-		public override OppositionGroup OppositionGroup { get { return OppositionGroup.SavagesAndOrcs; } }
+
+        public override OppositionType OppositionList{ get{ return OppositionType.GreenGoblin; } }
 		public override bool CanRummageCorpses { get { return true; } }
 		public override int Meat { get { return 1; } }
 


### PR DESCRIPTION
Associated Thread: [https://www.servuo.com/threads/opposition-green-goblin-vs-grey-goblin.6992](url)
-Added HasFoughtPlayer property.
--Available in props
--Defaults to false
--Set True in OnCombatantChanged() when Combatant is player or player pet
--Set True in AggressiveAction() when ControlMaster is null and aggressor is player or player pet
--Is not saved
--Reverts to false on sector deactivation
-Added GreenGoblin and GrayGoblin Opposition Types with HasFoughtPlayer check.
-Added HasFoughtPlayer check in Terathan and Ophidian Opposition checks.

-Added OppositionType.GrayGoblin to GrayGoblin, GrayGoblinKeeper, and GrayGoblinMage
-Added OppositionType.GreenGoblin to GreenGoblin, GreenGoblinAlchemist, and GreenGoblinScout

v2
-Deprecated Commented out HasFoughtPlayer functionality.