### PR TITLE
Replacing OppositionGroup with Opposition Tribe v1.0

### DIFF
--- a/Scripts/Mobiles/Bosses/LordOaks.cs
+++ b/Scripts/Mobiles/Bosses/LordOaks.cs
@@ -138,6 +138,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Fey; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override Poison PoisonImmune
         {
             get

--- a/Scripts/Mobiles/Bosses/Silvani.cs
+++ b/Scripts/Mobiles/Bosses/Silvani.cs
@@ -49,6 +49,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Fey; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override bool CanFly
         {
             get

--- a/Scripts/Mobiles/Named/ShadowKnight.cs
+++ b/Scripts/Mobiles/Named/ShadowKnight.cs
@@ -77,6 +77,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override bool BardImmune
         {
             get
@@ -121,8 +128,6 @@ namespace Server.Mobiles
         {
             this.AddLoot(LootPack.UltraRich, 2);
         }
-
-        
 
         public override int GetIdleSound()
         {

--- a/Scripts/Mobiles/Normal/AncientLich.cs
+++ b/Scripts/Mobiles/Normal/AncientLich.cs
@@ -55,6 +55,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override bool Unprovokable
         {
             get

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -1009,7 +1009,7 @@ namespace Server.Mobiles
         // Tribe Opposition stuff
         public virtual TribeType Tribe{ get{ return TribeType.None ; } } // What opposition list am I in?
 
-        private bool IsTribeEnemy(Mobile m)
+        public virtual bool IsTribeEnemy(Mobile m)
         {
             // Target must be BaseCreature
             if (!(m is BaseCreature))
@@ -1063,9 +1063,21 @@ namespace Server.Mobiles
 
 		public virtual bool IsFriend(Mobile m)
 		{
-			if (Tribe != TribeType.None && IsTribeEnemy(m))
+			if (Core.TOL)
 			{
-				return false;
+				if (Tribe != TribeType.None && IsTribeEnemy(m))
+				{
+					return false;
+				}
+			}
+			else
+			{
+				OppositionGroup g = OppositionGroup;
+
+				if (g != null && g.IsEnemy(this, m))
+				{
+					return false;
+				}
 			}
 
 			if (!(m is BaseCreature))
@@ -1143,9 +1155,21 @@ namespace Server.Mobiles
 				return a.IsEnemy(m);
 			}
 
-			if (Tribe != TribeType.None && IsTribeEnemy(m))
+			if (Core.TOL)
 			{
-				return true;
+				if (Tribe != TribeType.None && IsTribeEnemy(m))
+				{
+					return true;
+				}
+			}
+			else
+			{
+				OppositionGroup g = OppositionGroup;
+
+				if (g != null && g.IsEnemy(this, m))
+				{
+					return true;
+				}
 			}
 
 			if (m is BaseGuard)

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -1021,14 +1021,14 @@ namespace Server.Mobiles
 
             switch(Tribe)
             {
-                case TribeType.Terathan: return (c.TribeType == TribeType.Ophidian);
-                case TribeType.Ophidian: return (c.TribeType == TribeType.Terathan);
-                case TribeType.Savage: return (c.TribeType == TribeType.Orc);
-                case TribeType.Orc: return (c.TribeType == TribeType.Savage);
-                case TribeType.Fey: return (c.TribeType == TribeType.Undead);
-                case TribeType.Undead: return (c.TribeType == TribeType.Fey);
-                case TribeType.GrayGoblin: return (c.TribeType == TribeType.GreenGoblin);
-                case TribeType.GreenGoblin: return (c.TribeType == TribeType.GrayGoblin);
+                case TribeType.Terathan: return (c.Tribe == TribeType.Ophidian);
+                case TribeType.Ophidian: return (c.Tribe == TribeType.Terathan);
+                case TribeType.Savage: return (c.Tribe == TribeType.Orc);
+                case TribeType.Orc: return (c.Tribe == TribeType.Savage);
+                case TribeType.Fey: return (c.Tribe == TribeType.Undead);
+                case TribeType.Undead: return (c.Tribe == TribeType.Fey);
+                case TribeType.GrayGoblin: return (c.Tribe == TribeType.GreenGoblin);
+                case TribeType.GreenGoblin: return (c.Tribe == TribeType.GrayGoblin);
                 default: return false;
             }
         }

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -1008,90 +1008,29 @@ namespace Server.Mobiles
 
         // Tribe Opposition stuff
         public virtual TribeType Tribe{ get{ return TribeType.None ; } } // What opposition list am I in?
-/*      Stupid-OSI behavior
-        private bool m_HasFoughtPlayer;
-
-        [CommandProperty(AccessLevel.GameMaster)]
-        public bool HasFoughtPlayer
-        {
-            get { return m_HasFoughtPlayer; }
-            set
-            {
-                m_HasFoughtPlayer = value;
-                InvalidateProperties();
-            }
-        }
-*/
-        private static readonly Tuple<TribeType, TribeType>[] TribeConflicts =
-            new Tuple<TribeType, TribeType>[]
-        {
-            Tuple.Create(TribeType.Terathan, TribeType.Ophidian),
-            Tuple.Create(TribeType.Savage, TribeType.Orc),
-            Tuple.Create(TribeType.Fey, TribeType.Undead),
-            Tuple.Create(TribeType.GrayGoblin, TribeType.GreenGoblin)
-        };
-
-        private Dictionary<TribeType, ISet<TribeType>> m_TribeTable;
-
-        public Dictionary<TribeType, ISet<TribeType>> TribeTable
-        {
-            get
-            {
-                if (m_TribeTable == null)
-                {
-                    m_TribeTable = new Dictionary<TribeType, ISet<TribeType>>();
-
-                    foreach (var tribeConflict in TribeConflicts)
-                    {
-                        ISet<TribeType> conflicts;
-                        if (m_TribeTable.ContainsKey(tribeConflict.Item1))
-                        {
-                            conflicts = m_TribeTable[tribeConflict.Item1];
-                        }
-                        else
-                        {
-                            conflicts = m_TribeTable[tribeConflict.Item1] = new HashSet<TribeType>();
-                        }
-                        conflicts.Add(tribeConflict.Item2);
-
-                        ISet<TribeType> conflicts2;
-                        if (m_TribeTable.ContainsKey(tribeConflict.Item2))
-                        {
-                            conflicts2 = m_TribeTable[tribeConflict.Item2];
-                        }
-                        else
-                        {
-                            conflicts2 = m_TribeTable[tribeConflict.Item2] = new HashSet<TribeType>();
-                        }
-                        conflicts2.Add(tribeConflict.Item1);
-                    }
-                }
-                return m_TribeTable;
-            }
-        }
 
         private bool IsTribeEnemy(Mobile m)
         {
-/*          Stupid-OSI behavior
-            // Don't fight monsters after fighting players, until sector deactivate/server restart
-            if (HasFoughtPlayer)
-            {
-                return false;
-            }
-*/
             // Target must be BaseCreature
             if (!(m is BaseCreature))
             {
                 return false;
             }
-/*
-            // Sanity check. Only necessary if you have a non-None creature with no enemy TribeType.
-            if (!TribeTable.ContainsKey(Tribe))
+
+            BaseCreature c = (BaseCreature)m;
+
+            switch(Tribe)
             {
-                return false;
+                case TribeType.Terathan: return (c.TribeType == TribeType.Ophidian);
+                case TribeType.Ophidian: return (c.TribeType == TribeType.Terathan);
+                case TribeType.Savage: return (c.TribeType == TribeType.Orc);
+                case TribeType.Orc: return (c.TribeType == TribeType.Savage);
+                case TribeType.Fey: return (c.TribeType == TribeType.Undead);
+                case TribeType.Undead: return (c.TribeType == TribeType.Fey);
+                case TribeType.GrayGoblin: return (c.TribeType == TribeType.GreenGoblin);
+                case TribeType.GreenGoblin: return (c.TribeType == TribeType.GrayGoblin);
+                default: return false;
             }
-*/
-            return TribeTable[Tribe].Contains(((BaseCreature)m).Tribe);
         }
 
         #region Friends
@@ -3927,13 +3866,7 @@ namespace Server.Mobiles
                     aggressor.Aggressors.Add(AggressorInfo.Create(this, aggressor, true));
                 }
             }
-/*          Stupid-OSI behavior
-            else if (!HasFoughtPlayer && (aggressor.Player ||
-                (aggressor is BaseCreature && ((BaseCreature)aggressor).GetMaster() is PlayerMobile)))
-            {
-                HasFoughtPlayer = true;
-            }
-*/
+
             OrderType ct = m_ControlOrder;
 
             if (m_AI != null)
@@ -4270,19 +4203,10 @@ namespace Server.Mobiles
             base.OnCombatantChange();
 
             Warmode = (Combatant != null && !Combatant.Deleted && Combatant.Alive);
-            if (Warmode)
+
+            if (CanFly && Warmode)
             {
-/*              Stupid-OSI behavior
-                if (!HasFoughtPlayer && (Combatant is PlayerMobile ||
-                    (Combatant is BaseCreature && ((BaseCreature)Combatant).GetMaster() is PlayerMobile)))
-                {
-                    HasFoughtPlayer = true;
-                }
-*/
-                if (CanFly)
-                {
-                    Flying = false;
-                }
+                Flying = false;
             }
         }
 
@@ -7380,9 +7304,7 @@ namespace Server.Mobiles
             {
                 m_AI.Deactivate();
             }
-/*          Stupid-OSI behavior
-            HasFoughtPlayer = false;
-*/
+
             base.OnSectorDeactivate();
         }
 

--- a/Scripts/Mobiles/Normal/Bogle.cs
+++ b/Scripts/Mobiles/Normal/Bogle.cs
@@ -58,6 +58,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/BoneKnight.cs
+++ b/Scripts/Mobiles/Normal/BoneKnight.cs
@@ -81,6 +81,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Average);

--- a/Scripts/Mobiles/Normal/Centaur.cs
+++ b/Scripts/Mobiles/Normal/Centaur.cs
@@ -51,6 +51,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Fey; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override int Meat
         {
             get

--- a/Scripts/Mobiles/Normal/EtherealWarrior.cs
+++ b/Scripts/Mobiles/Normal/EtherealWarrior.cs
@@ -67,6 +67,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Fey; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override int Feathers
         {
             get

--- a/Scripts/Mobiles/Normal/Ghoul.cs
+++ b/Scripts/Mobiles/Normal/Ghoul.cs
@@ -61,6 +61,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/GrayGoblin.cs
+++ b/Scripts/Mobiles/Normal/GrayGoblin.cs
@@ -10,7 +10,7 @@ namespace Server.Mobiles
         public GrayGoblin()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "Gray Goblin";
+            this.Name = "a gray goblin";
             this.Body = 334;
             this.BaseSoundID = 0x45A;
 
@@ -110,13 +110,9 @@ namespace Server.Mobiles
                 return 1;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.GrayGoblin; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/GrayGoblinKeeper.cs
+++ b/Scripts/Mobiles/Normal/GrayGoblinKeeper.cs
@@ -110,13 +110,9 @@ namespace Server.Mobiles
                 return 1;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.GrayGoblin; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/GrayGoblinKeeper.cs
+++ b/Scripts/Mobiles/Normal/GrayGoblinKeeper.cs
@@ -10,7 +10,7 @@ namespace Server.Mobiles
         public GrayGoblinKeeper()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a Gray goblin keeper";
+            this.Name = "a gray goblin keeper";
             this.Body = 334;
             this.BaseSoundID = 0x45A;
 

--- a/Scripts/Mobiles/Normal/GrayGoblinMage.cs
+++ b/Scripts/Mobiles/Normal/GrayGoblinMage.cs
@@ -10,7 +10,7 @@ namespace Server.Mobiles
         public GrayGoblinMage()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "Gray Goblin Mage";
+            this.Name = "a gray goblin mage";
             this.Body = 334;
             this.BaseSoundID = 0x45A;
 
@@ -112,13 +112,9 @@ namespace Server.Mobiles
                 return 1;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.GrayGoblin; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/GreenGoblin.cs
+++ b/Scripts/Mobiles/Normal/GreenGoblin.cs
@@ -11,7 +11,7 @@ namespace Server.Mobiles
         public GreenGoblin()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            Name = "Green Goblin";
+            Name = "a green goblin";
             Body = 723;
             BaseSoundID = 0x45A;
 
@@ -122,13 +122,9 @@ namespace Server.Mobiles
                 return 1;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.GreenGoblin; } }
+
         //public override bool IsEnemy( Mobile m )
         //{
         //	if ( m.Player && m.FindItemOnLayer( Layer.Helm ) is OrcishKinMask )

--- a/Scripts/Mobiles/Normal/GreenGoblin.cs
+++ b/Scripts/Mobiles/Normal/GreenGoblin.cs
@@ -3,7 +3,7 @@ using Server.Items;
 
 namespace Server.Mobiles
 {
-    [CorpseName("an goblin corpse")]
+    [CorpseName("a goblin corpse")]
     public class GreenGoblin : BaseCreature
     {
         //public override InhumanSpeech SpeechType{ get{ return InhumanSpeech.Orc; } }

--- a/Scripts/Mobiles/Normal/GreenGoblinAlchemist.cs
+++ b/Scripts/Mobiles/Normal/GreenGoblinAlchemist.cs
@@ -3,7 +3,7 @@ using Server.Items;
 
 namespace Server.Mobiles
 {
-    [CorpseName("an goblin corpse")]
+    [CorpseName("a goblin corpse")]
     public class GreenGoblinAlchemist : BaseCreature
     {
         //public override InhumanSpeech SpeechType{ get{ return InhumanSpeech.Orc; } }
@@ -11,7 +11,7 @@ namespace Server.Mobiles
         public GreenGoblinAlchemist()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            Name = "Green Goblin Alchemist";
+            Name = "a green goblin alchemist";
             Body = 723;
             BaseSoundID = 0x45A;
 
@@ -123,13 +123,9 @@ namespace Server.Mobiles
                 return 1;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.SavagesAndOrcs;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.GreenGoblin; } }
+
         //public override bool IsEnemy( Mobile m )
         //{
         //	if ( m.Player && m.FindItemOnLayer( Layer.Helm ) is OrcishKinMask )

--- a/Scripts/Mobiles/Normal/GreenGoblinScout.cs
+++ b/Scripts/Mobiles/Normal/GreenGoblinScout.cs
@@ -11,7 +11,7 @@ using Server.Items;
 
 namespace Server.Mobiles
 {
-	[CorpseName("an goblin corpse")]
+	[CorpseName("a goblin corpse")]
 	public class GreenGoblinScout : BaseCreature
 	{
 		//public override InhumanSpeech SpeechType { get { return InhumanSpeech.Orc; } }
@@ -19,7 +19,7 @@ namespace Server.Mobiles
 		public GreenGoblinScout()
 			: base(AIType.AI_OrcScout, FightMode.Closest, 10, 7, 0.2, 0.4)
 		{
-			Name = "an green goblin scout";
+			Name = "a green goblin scout";
 			Body = 723;
 			BaseSoundID = 0x45A;
 
@@ -56,7 +56,9 @@ namespace Server.Mobiles
 			: base(serial)
 		{ }
 
-		public override OppositionGroup OppositionGroup { get { return OppositionGroup.SavagesAndOrcs; } }
+
+        public override TribeType Tribe { get { return TribeType.GreenGoblin; } }
+
 		public override bool CanRummageCorpses { get { return true; } }
 		public override int Meat { get { return 1; } }
 

--- a/Scripts/Mobiles/Normal/Kirin.cs
+++ b/Scripts/Mobiles/Normal/Kirin.cs
@@ -89,6 +89,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Fey; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override int Meat
         {
             get

--- a/Scripts/Mobiles/Normal/Lich.cs
+++ b/Scripts/Mobiles/Normal/Lich.cs
@@ -67,6 +67,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override bool CanRummageCorpses
         {
             get

--- a/Scripts/Mobiles/Normal/LichLord.cs
+++ b/Scripts/Mobiles/Normal/LichLord.cs
@@ -65,6 +65,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override bool CanRummageCorpses
         {
             get

--- a/Scripts/Mobiles/Normal/Mummy.cs
+++ b/Scripts/Mobiles/Normal/Mummy.cs
@@ -69,6 +69,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Rich);

--- a/Scripts/Mobiles/Normal/OphidianArchmage.cs
+++ b/Scripts/Mobiles/Normal/OphidianArchmage.cs
@@ -66,6 +66,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Ophidian; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.TerathansAndOphidians;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Rich);

--- a/Scripts/Mobiles/Normal/OphidianKnight.cs
+++ b/Scripts/Mobiles/Normal/OphidianKnight.cs
@@ -86,6 +86,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Ophidian; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.TerathansAndOphidians;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Rich, 2);

--- a/Scripts/Mobiles/Normal/OphidianMage.cs
+++ b/Scripts/Mobiles/Normal/OphidianMage.cs
@@ -78,6 +78,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Ophidian; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.TerathansAndOphidians;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Average);

--- a/Scripts/Mobiles/Normal/OphidianMatriarch.cs
+++ b/Scripts/Mobiles/Normal/OphidianMatriarch.cs
@@ -64,6 +64,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Ophidian; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.TerathansAndOphidians;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Rich);

--- a/Scripts/Mobiles/Normal/OphidianWarrior.cs
+++ b/Scripts/Mobiles/Normal/OphidianWarrior.cs
@@ -67,6 +67,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Ophidian; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.TerathansAndOphidians;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/Orc.cs
+++ b/Scripts/Mobiles/Normal/Orc.cs
@@ -120,6 +120,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Orc; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.SavagesAndOrcs;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/OrcBomber.cs
+++ b/Scripts/Mobiles/Normal/OrcBomber.cs
@@ -80,6 +80,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Orc; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.SavagesAndOrcs;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Average);

--- a/Scripts/Mobiles/Normal/OrcBrute.cs
+++ b/Scripts/Mobiles/Normal/OrcBrute.cs
@@ -84,6 +84,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Orc; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.SavagesAndOrcs;
+            }
+        }
         public override bool CanRummageCorpses
         {
             get

--- a/Scripts/Mobiles/Normal/OrcCaptain.cs
+++ b/Scripts/Mobiles/Normal/OrcCaptain.cs
@@ -102,6 +102,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Orc; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.SavagesAndOrcs;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager, 2);

--- a/Scripts/Mobiles/Normal/OrcishLord.cs
+++ b/Scripts/Mobiles/Normal/OrcishLord.cs
@@ -106,6 +106,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Orc; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.SavagesAndOrcs;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/OrcishMage.cs
+++ b/Scripts/Mobiles/Normal/OrcishMage.cs
@@ -92,6 +92,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Orc; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.SavagesAndOrcs;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Average);

--- a/Scripts/Mobiles/Normal/Pixie.cs
+++ b/Scripts/Mobiles/Normal/Pixie.cs
@@ -81,6 +81,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Fey; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.LowScrolls);

--- a/Scripts/Mobiles/Normal/RottingCorpse.cs
+++ b/Scripts/Mobiles/Normal/RottingCorpse.cs
@@ -81,6 +81,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.FilthyRich, 2);

--- a/Scripts/Mobiles/Normal/Satyr.cs
+++ b/Scripts/Mobiles/Normal/Satyr.cs
@@ -53,6 +53,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Fey; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.MlRich);

--- a/Scripts/Mobiles/Normal/Savage.cs
+++ b/Scripts/Mobiles/Normal/Savage.cs
@@ -81,6 +81,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Savage; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.SavagesAndOrcs;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/SavageRider.cs
+++ b/Scripts/Mobiles/Normal/SavageRider.cs
@@ -75,6 +75,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Savage; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.SavagesAndOrcs;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Average);

--- a/Scripts/Mobiles/Normal/SavageShaman.cs
+++ b/Scripts/Mobiles/Normal/SavageShaman.cs
@@ -75,6 +75,13 @@ namespace Server.Mobiles
 		public override bool ShowFameTitle { get { return false; } }
         public override TribeType Tribe { get { return TribeType.Savage; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.SavagesAndOrcs;
+            }
+        }
 
 		public override void GenerateLoot()
 		{

--- a/Scripts/Mobiles/Normal/Shade.cs
+++ b/Scripts/Mobiles/Normal/Shade.cs
@@ -56,13 +56,9 @@ namespace Server.Mobiles
                 return true;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.Undead; } }
+
         public override Poison PoisonImmune
         {
             get

--- a/Scripts/Mobiles/Normal/Shade.cs
+++ b/Scripts/Mobiles/Normal/Shade.cs
@@ -59,6 +59,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override Poison PoisonImmune
         {
             get

--- a/Scripts/Mobiles/Normal/SkeletalKnight.cs
+++ b/Scripts/Mobiles/Normal/SkeletalKnight.cs
@@ -81,6 +81,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Average);

--- a/Scripts/Mobiles/Normal/Skeleton.cs
+++ b/Scripts/Mobiles/Normal/Skeleton.cs
@@ -81,7 +81,14 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
-        public override void GenerateLoot()
+         public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
+       public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Poor);
         }

--- a/Scripts/Mobiles/Normal/Spectre.cs
+++ b/Scripts/Mobiles/Normal/Spectre.cs
@@ -56,13 +56,9 @@ namespace Server.Mobiles
                 return true;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.Undead; } }
+
         public override Poison PoisonImmune
         {
             get

--- a/Scripts/Mobiles/Normal/Spectre.cs
+++ b/Scripts/Mobiles/Normal/Spectre.cs
@@ -59,6 +59,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override Poison PoisonImmune
         {
             get

--- a/Scripts/Mobiles/Normal/TerathanAvenger.cs
+++ b/Scripts/Mobiles/Normal/TerathanAvenger.cs
@@ -77,13 +77,9 @@ namespace Server.Mobiles
                 return 2;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.Terathan; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Rich, 2);

--- a/Scripts/Mobiles/Normal/TerathanAvenger.cs
+++ b/Scripts/Mobiles/Normal/TerathanAvenger.cs
@@ -80,6 +80,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Terathan; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.TerathansAndOphidians;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Rich, 2);

--- a/Scripts/Mobiles/Normal/TerathanDrone.cs
+++ b/Scripts/Mobiles/Normal/TerathanDrone.cs
@@ -59,6 +59,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Terathan; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.TerathansAndOphidians;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/TerathanDrone.cs
+++ b/Scripts/Mobiles/Normal/TerathanDrone.cs
@@ -56,13 +56,9 @@ namespace Server.Mobiles
                 return 4;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.Terathan; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/TerathanMatriarch.cs
+++ b/Scripts/Mobiles/Normal/TerathanMatriarch.cs
@@ -55,13 +55,9 @@ namespace Server.Mobiles
                 return 4;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.Terathan; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Rich);

--- a/Scripts/Mobiles/Normal/TerathanMatriarch.cs
+++ b/Scripts/Mobiles/Normal/TerathanMatriarch.cs
@@ -58,6 +58,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Terathan; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.TerathansAndOphidians;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Rich);

--- a/Scripts/Mobiles/Normal/TerathanWarrior.cs
+++ b/Scripts/Mobiles/Normal/TerathanWarrior.cs
@@ -63,13 +63,9 @@ namespace Server.Mobiles
                 return 4;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.TerathansAndOphidians;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.Terathan; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Average);

--- a/Scripts/Mobiles/Normal/TerathanWarrior.cs
+++ b/Scripts/Mobiles/Normal/TerathanWarrior.cs
@@ -66,6 +66,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Terathan; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.TerathansAndOphidians;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Average);

--- a/Scripts/Mobiles/Normal/Treefellow.cs
+++ b/Scripts/Mobiles/Normal/Treefellow.cs
@@ -46,6 +46,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Fey; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override bool BleedImmune
         {
             get

--- a/Scripts/Mobiles/Normal/Treefellow.cs
+++ b/Scripts/Mobiles/Normal/Treefellow.cs
@@ -44,13 +44,8 @@ namespace Server.Mobiles
         {
         }
 
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+        public override TribeType Tribe { get { return TribeType.Fey; } }
+
         public override bool BleedImmune
         {
             get

--- a/Scripts/Mobiles/Normal/Unicorn.cs
+++ b/Scripts/Mobiles/Normal/Unicorn.cs
@@ -86,6 +86,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Fey; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override Poison PoisonImmune
         {
             get

--- a/Scripts/Mobiles/Normal/Unicorn.cs
+++ b/Scripts/Mobiles/Normal/Unicorn.cs
@@ -83,13 +83,9 @@ namespace Server.Mobiles
                 return TimeSpan.FromHours(1.0);
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.Fey; } }
+
         public override Poison PoisonImmune
         {
             get

--- a/Scripts/Mobiles/Normal/Wisp.cs
+++ b/Scripts/Mobiles/Normal/Wisp.cs
@@ -86,6 +86,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Fey; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Rich);

--- a/Scripts/Mobiles/Normal/Wisp.cs
+++ b/Scripts/Mobiles/Normal/Wisp.cs
@@ -83,13 +83,9 @@ namespace Server.Mobiles
                 return TimeSpan.FromSeconds(1.0);
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.Fey; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Rich);

--- a/Scripts/Mobiles/Normal/Wraith.cs
+++ b/Scripts/Mobiles/Normal/Wraith.cs
@@ -56,13 +56,9 @@ namespace Server.Mobiles
                 return true;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.Undead; } }
+
         public override Poison PoisonImmune
         {
             get

--- a/Scripts/Mobiles/Normal/Wraith.cs
+++ b/Scripts/Mobiles/Normal/Wraith.cs
@@ -59,6 +59,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override Poison PoisonImmune
         {
             get

--- a/Scripts/Mobiles/Normal/Zombie.cs
+++ b/Scripts/Mobiles/Normal/Zombie.cs
@@ -91,13 +91,9 @@ namespace Server.Mobiles
                 return Poison.Regular;
             }
         }
-        public override OppositionGroup OppositionGroup
-        {
-            get
-            {
-                return OppositionGroup.FeyAndUndead;
-            }
-        }
+
+        public override TribeType Tribe { get { return TribeType.Undead; } }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/Zombie.cs
+++ b/Scripts/Mobiles/Normal/Zombie.cs
@@ -94,6 +94,13 @@ namespace Server.Mobiles
 
         public override TribeType Tribe { get { return TribeType.Undead; } }
 
+        public override OppositionGroup OppositionGroup
+        {
+            get
+            {
+                return OppositionGroup.FeyAndUndead;
+            }
+        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.Meager);


### PR DESCRIPTION
Please test and give feedback.
[Associated Thread: Replacing OppositionGroup with Opposition Tribes](https://www.servuo.com/threads/replacing-oppositiongroup-with-opposition-tribes.7002/)
[Source Branch](https://github.com/GriffonSpade/ServUO/tree/OppositionTribe-1.0)
Opposition Tribes V1.02 replaces OppositionGroup's systemic functionality.
Uses a simple TribeType switch and target's TribeType check.

BaseCreature:
-Changed Replaced functioning OppositionGroup with Opposition Tribes in Core.TOL check:
--Added enum TribeType
---Added GrayGoblin, GreenGoblin TribeTypes
--Added public virtual bool Tribe
--Added public virtual bool IsTribeEnemy()
--Added IsTribeEnemy() check in IsFriend() and IsEnemy()
-Deprecated OppositionGroup usage in !Core.TOL check in IsFriend() and IsEnemy()

Other:
-Added Tribe to Goblins 
-Removed Erroneous OppositionGroup from Goblins
-Fixed Savage Riders are always male
-Fixed Savage Shamans are always female
-Fixed Goblin names uncapitalized and articled, corpse name articles fixed
