### PR TITLE
Exclude resharper user settings from control version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ reportHistory.xml
 *.csproj.user
 *.suo
 /.idea
+*.DotSettings.user
 *.log
 *.bin


### PR DESCRIPTION
This pull request excludes [ReSharper](https://www.jetbrains.com/resharper/) user settings file (*.DotSettings.user) from version control, to prevent concrete user IDE settings to leak into the repository.