### PR TITLE
Generalize IsBlackSolen/IsRedSolen

### DIFF
--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -331,27 +331,28 @@ namespace Server.Mobiles
 
 			if (order == OrderType.Attack)
 			{
-				if (target is BaseCreature && ((BaseCreature)target).IsScaryToPets && m_Mobile.IsScaredOfScaryThings)
+				if (target is BaseCreature)
 				{
-					m_Mobile.SayTo(from, "Your pet refuses to attack this creature!");
-					return;
-				}
+					BaseCreature bc = (BaseCreature)target;
 
-				if ((SolenHelper.CheckRedFriendship(from) &&
-					 (target is RedSolenInfiltratorQueen || target is RedSolenInfiltratorWarrior || target is RedSolenQueen ||
-					  target is RedSolenWarrior || target is RedSolenWorker)) ||
-					(SolenHelper.CheckBlackFriendship(from) &&
-					 (target is BlackSolenInfiltratorQueen || target is BlackSolenInfiltratorWarrior || target is BlackSolenQueen ||
-					  target is BlackSolenWarrior || target is BlackSolenWorker)))
-				{
-					from.SendAsciiMessage("You can not force your pet to attack a creature you are protected from.");
-					return;
-				}
+					if (bc.IsScaryToPets && m_Mobile.IsScaredOfScaryThings)
+					{
+						m_Mobile.SayTo(from, "Your pet refuses to attack this creature!");
+						return;
+					}
 
-				if (target is BaseFactionGuard)
-				{
-					m_Mobile.SayTo(from, "Your pet refuses to attack the guard.");
-					return;
+					if ((bc.IsBlackSolen && SolenHelper.CheckBlackFriendship(from)) ||
+						(bc.IsRedSolen && SolenHelper.CheckRedFriendship(from)))
+					{
+						from.SendAsciiMessage("You can not force your pet to attack a creature you are protected from.");
+						return;
+					}
+
+					if (bc is BaseFactionGuard)
+					{
+						m_Mobile.SayTo(from, "Your pet refuses to attack the guard.");
+						return;
+					}
 				}
 			}
 

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -992,6 +992,8 @@ namespace Server.Mobiles
 
         public virtual OppositionGroup OppositionGroup { get { return null; } }
         public virtual bool IsMilitiaFighter { get { return false; } }
+        public virtual bool IsBlackSolen { get { return false; } }
+        public virtual bool IsRedSolen { get { return false; } }
 
         #region Friends
         public List<Mobile> Friends { get { return m_Friends; } }

--- a/Scripts/Mobiles/Normal/BlackSolenInfiltratorQueen.cs
+++ b/Scripts/Mobiles/Normal/BlackSolenInfiltratorQueen.cs
@@ -51,6 +51,8 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool IsBlackSolen { get { return true; } }
+
         public override int GetAngerSound()
         {
             return 0x259;

--- a/Scripts/Mobiles/Normal/BlackSolenInfiltratorWarrior.cs
+++ b/Scripts/Mobiles/Normal/BlackSolenInfiltratorWarrior.cs
@@ -51,6 +51,8 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool IsBlackSolen { get { return true; } }
+
         public override int GetAngerSound()
         {
             return 0xB5;

--- a/Scripts/Mobiles/Normal/BlackSolenQueen.cs
+++ b/Scripts/Mobiles/Normal/BlackSolenQueen.cs
@@ -61,6 +61,8 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool IsBlackSolen { get { return true; } }
+
         public bool BurstSac
         {
             get

--- a/Scripts/Mobiles/Normal/BlackSolenWarrior.cs
+++ b/Scripts/Mobiles/Normal/BlackSolenWarrior.cs
@@ -56,6 +56,8 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool IsBlackSolen { get { return true; } }
+
         public override void OnGotMeleeAttack(Mobile attacker)
         {
             if (attacker.Weapon is BaseRanged)

--- a/Scripts/Mobiles/Normal/BlackSolenWorker.cs
+++ b/Scripts/Mobiles/Normal/BlackSolenWorker.cs
@@ -52,6 +52,8 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool IsBlackSolen { get { return true; } }
+
         public override int GetAngerSound()
         {
             return 0x269;

--- a/Scripts/Mobiles/Normal/RedSolenInfiltratorQueen.cs
+++ b/Scripts/Mobiles/Normal/RedSolenInfiltratorQueen.cs
@@ -50,6 +50,8 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool IsRedSolen { get { return true; } }
+
         public override int GetAngerSound()
         {
             return 0x259;

--- a/Scripts/Mobiles/Normal/RedSolenInfiltratorWarrior.cs
+++ b/Scripts/Mobiles/Normal/RedSolenInfiltratorWarrior.cs
@@ -50,6 +50,8 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool IsRedSolen { get { return true; } }
+
         public override int GetAngerSound()
         {
             return 0xB5;

--- a/Scripts/Mobiles/Normal/RedSolenQueen.cs
+++ b/Scripts/Mobiles/Normal/RedSolenQueen.cs
@@ -67,6 +67,9 @@ namespace Server.Mobiles
                 return this.m_BurstSac;
             }
         }
+
+        public override bool IsRedSolen { get { return true; } }
+
         public override int GetAngerSound()
         {
             return 0x259;

--- a/Scripts/Mobiles/Normal/RedSolenWarrior.cs
+++ b/Scripts/Mobiles/Normal/RedSolenWarrior.cs
@@ -54,6 +54,9 @@ namespace Server.Mobiles
         {
         }
 
+
+        public override bool IsRedSolen { get { return true; } }
+
         public override void OnGotMeleeAttack(Mobile attacker)
         {
 

--- a/Scripts/Mobiles/Normal/RedSolenWorker.cs
+++ b/Scripts/Mobiles/Normal/RedSolenWorker.cs
@@ -51,6 +51,8 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool IsRedSolen { get { return true; } }
+
         public override int GetAngerSound()
         {
             return 0x269;

--- a/Scripts/Mobiles/Normal/SolenHelper.cs
+++ b/Scripts/Mobiles/Normal/SolenHelper.cs
@@ -4,6 +4,14 @@ using Server.Network;
 
 namespace Server.Mobiles
 {
+    interface IBlackSolen
+    {
+    }
+
+    interface IRedSolen
+    {
+    }
+
     public class SolenHelper
     {
         public static void PackPicnicBasket(BaseCreature solen)


### PR DESCRIPTION
EDITING: DO NOT MERGE.

The purpose of this pull is to generalize black and red solen groups so that when they are checked in BaseAI, it does not check a type list of them.

-Added virtual bool IsBlackSolen (default false)
--Add override true in Black Solen creatures
-Added virtual bool IsRedSolen (default false)
--Add override true in Red Solen creatures
-Changed Cleaned up EndPickTarget().if (order == OrderType.Attack) checks
-Changed Solen checks to check IsBlackSolen and IsRedSolen bools instead of a list of types.
