### PR TITLE
Add generic method Region.IsPartOf<T> and convert usages

### DIFF
--- a/Scripts/Items/Consumables/Kindling.cs
+++ b/Scripts/Items/Consumables/Kindling.cs
@@ -75,7 +75,7 @@ namespace Server.Items
 
         private Point3D GetFireLocation(Mobile from)
         {
-            if (from.Region.IsPartOf(typeof(DungeonRegion)))
+            if (from.Region.IsPartOf<DungeonRegion>())
                 return Point3D.Zero;
 
             if (this.Parent == null)

--- a/Scripts/Items/Consumables/RepairDeed.cs
+++ b/Scripts/Items/Consumables/RepairDeed.cs
@@ -163,7 +163,7 @@ namespace Server.Items
         public bool VerifyRegion(Mobile m)
         {
             //TODO: When the entire region system data is in, convert to that instead of a proximity thing.
-            if (!m.Region.IsPartOf(typeof(TownRegion)))
+            if (!m.Region.IsPartOf<TownRegion>())
                 return false;
 
             return Server.Factions.Faction.IsNearType(m, RepairSkillInfo.GetInfo(this.m_Skill).NearbyTypes, 6);

--- a/Scripts/Items/Decorative/DecorativeCarpet.cs
+++ b/Scripts/Items/Decorative/DecorativeCarpet.cs
@@ -73,7 +73,7 @@ namespace Server.Items
 
         public bool IsInsideHouse()
         {
-            return Region.Find(Location, Map).IsPartOf(typeof(HouseRegion));
+            return Region.Find(Location, Map).IsPartOf<HouseRegion>();
         }
 
         public DecorativeCarpet(Serial serial)

--- a/Scripts/Items/Decorative/PileOfGlacialSnow.cs
+++ b/Scripts/Items/Decorative/PileOfGlacialSnow.cs
@@ -117,7 +117,7 @@ namespace Server.Items
                     Mobile targ = (Mobile)target;
                     Container pack = targ.Backpack;
 
-                    if (from.Region.IsPartOf(typeof(Engines.ConPVP.SafeZone)) || targ.Region.IsPartOf(typeof(Engines.ConPVP.SafeZone)))
+                    if (from.Region.IsPartOf<Engines.ConPVP.SafeZone>() || targ.Region.IsPartOf<Engines.ConPVP.SafeZone>())
                     {
                         from.SendMessage("You may not throw snow here.");
                     }

--- a/Scripts/Items/Decorative/SnowPile.cs
+++ b/Scripts/Items/Decorative/SnowPile.cs
@@ -103,7 +103,7 @@ namespace Server.Items
                     Mobile targ = (Mobile)target;
                     Container pack = targ.Backpack;
 
-                    if (from.Region.IsPartOf(typeof(Engines.ConPVP.SafeZone)) || targ.Region.IsPartOf(typeof(Engines.ConPVP.SafeZone)))
+                    if (from.Region.IsPartOf<Engines.ConPVP.SafeZone>() || targ.Region.IsPartOf<Engines.ConPVP.SafeZone>())
                     {
                         from.SendMessage("You may not throw snow here.");
                     }

--- a/Scripts/Items/Functional/MushroomTrap.cs
+++ b/Scripts/Items/Functional/MushroomTrap.cs
@@ -59,7 +59,7 @@ namespace Server.Items
 
         public virtual void OnMushroomReset()
         {
-            if (Region.Find(this.Location, this.Map).IsPartOf(typeof(DungeonRegion)))
+            if (Region.Find(this.Location, this.Map).IsPartOf<DungeonRegion>())
                 this.ItemID = 0x1125; // reset
             else
                 this.Delete();

--- a/Scripts/Items/Tools/BagOfSending.cs
+++ b/Scripts/Items/Tools/BagOfSending.cs
@@ -170,7 +170,7 @@ namespace Server.Items
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (from.Region.IsPartOf(typeof(Regions.Jail)))
+            if (from.Region.IsPartOf<Regions.Jail>())
             {
                 from.SendMessage("You may not do that in jail.");
             }
@@ -260,7 +260,7 @@ namespace Server.Items
                 if (this.m_Bag.Deleted)
                     return;
 
-                if (from.Region.IsPartOf(typeof(Regions.Jail)))
+                if (from.Region.IsPartOf<Regions.Jail>())
                 {
                     from.SendMessage("You may not do that in jail.");
                 }

--- a/Scripts/Items/Tools/BallOfSummoning.cs
+++ b/Scripts/Items/Tools/BallOfSummoning.cs
@@ -215,7 +215,7 @@ namespace Server.Items
             {
                 MessageHelper.SendLocalizedMessageTo(this, from, 1054127, 0x22); // The Crystal Ball fills with a red mist. You appear to have let your bond to your pet deteriorate.
             }
-            else if (from.Map == Map.Ilshenar || from.Region.IsPartOf(typeof(DungeonRegion)) || from.Region.IsPartOf(typeof(Jail)) || from.Region.IsPartOf(typeof(Server.Engines.ConPVP.SafeZone)))
+            else if (from.Map == Map.Ilshenar || from.Region.IsPartOf<DungeonRegion>() || from.Region.IsPartOf<Jail>() || from.Region.IsPartOf<Server.Engines.ConPVP.SafeZone>())
             {
                 from.Send(new AsciiMessage(this.Serial, this.ItemID, MessageType.Regular, 0x22, 3, "", "You cannot summon your pet to this location."));
             }

--- a/Scripts/Items/Tools/BraceletOfBinding.cs
+++ b/Scripts/Items/Tools/BraceletOfBinding.cs
@@ -339,12 +339,12 @@ namespace Server.Items
                 from.SendLocalizedMessage(502359, "", 0x22); // Thou art too encumbered to move.
                 return false;
             }
-            else if (from.Region.IsPartOf(typeof(Server.Regions.Jail)))
+            else if (from.Region.IsPartOf<Server.Regions.Jail>())
             {
                 from.SendLocalizedMessage(1114345, "", 0x35); // You'll need a better jailbreak plan than that!
                 return false;
             }
-            else if (boundRoot.Region.IsPartOf(typeof(Server.Regions.Jail)))
+            else if (boundRoot.Region.IsPartOf<Server.Regions.Jail>())
             {
                 from.SendLocalizedMessage(1019004); // You are not allowed to travel there.
                 return false;

--- a/Scripts/Items/Tools/ChestOfSending.cs
+++ b/Scripts/Items/Tools/ChestOfSending.cs
@@ -60,7 +60,7 @@ namespace Server.Items
         {
             if (!from.InRange(GetWorldLocation(), 2))
                 from.LocalOverheadMessage(Network.MessageType.Regular, 0x3B2, 1019045); // I can't reach that.
-            else if (!from.Region.IsPartOf(typeof(HouseRegion)))
+            else if (!from.Region.IsPartOf<HouseRegion>())
                 from.SendLocalizedMessage(502092); // You must be in your house to do this.
             else if (!IsLockedDown && !IsSecure)
                 from.SendLocalizedMessage(1112573); // This must be locked down or secured in order to use it.
@@ -119,7 +119,7 @@ namespace Server.Items
                 if (item == null || from.Backpack == null)
                     return;
 
-                if (!from.Region.IsPartOf(typeof(HouseRegion)))
+                if (!from.Region.IsPartOf<HouseRegion>())
                 {
                     from.SendLocalizedMessage(502092); // You must be in your house to do this.
                 }

--- a/Scripts/Misc/SkillCheck.cs
+++ b/Scripts/Misc/SkillCheck.cs
@@ -260,7 +260,7 @@ namespace Server.Misc
 
         public static void Gain(Mobile from, Skill skill)
         {
-            if (from.Region.IsPartOf(typeof(Regions.Jail)))
+            if (from.Region.IsPartOf<Regions.Jail>())
                 return;
 
             if (from is BaseCreature && ((BaseCreature)from).IsDeadPet)

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -2527,7 +2527,7 @@ namespace Server.Mobiles
 
         public virtual bool IsHumanInTown()
         {
-            return (Body.IsHuman && Region.IsPartOf(typeof(GuardedRegion)));
+            return (Body.IsHuman && Region.IsPartOf<GuardedRegion>());
         }
 
         public virtual bool CheckGold(Mobile from, Item dropped)
@@ -5868,7 +5868,7 @@ namespace Server.Mobiles
         {
             bool ret = base.CanBeRenamedBy(from);
 
-            if (Controlled && from == ControlMaster && !from.Region.IsPartOf(typeof(Jail)))
+            if (Controlled && from == ControlMaster && !from.Region.IsPartOf<Jail>())
             {
                 ret = true;
             }
@@ -7412,7 +7412,7 @@ namespace Server.Mobiles
 
                         // added lines to check if a wild creature in a house region has to be removed or not
                         if (!c.Controlled && !c.IsStabled &&
-                            ((c.Region.IsPartOf(typeof(HouseRegion)) && c.CanBeDamaged()) || (c.RemoveIfUntamed && c.Spawner == null)))
+                            ((c.Region.IsPartOf<HouseRegion>() && c.CanBeDamaged()) || (c.RemoveIfUntamed && c.Spawner == null)))
                         {
                             c.RemoveStep++;
 

--- a/Scripts/Mobiles/Normal/DemonKnight.cs
+++ b/Scripts/Mobiles/Normal/DemonKnight.cs
@@ -154,7 +154,7 @@ namespace Server.Mobiles
         {
             Region r = m.Region;
 
-            if (r.IsPartOf(typeof(Server.Regions.HouseRegion)) || Server.Multis.BaseBoat.FindBoatAt(m, m.Map) != null)
+            if (r.IsPartOf<Server.Regions.HouseRegion>() || Server.Multis.BaseBoat.FindBoatAt(m, m.Map) != null)
                 return false;
             //TODO: a CanReach of something check as opposed to above?
 

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -2138,7 +2138,7 @@ namespace Server.Mobiles
 						list.Add(new CallbackEntry(6204, GetVendor));
 					}
 
-					if (house.IsAosRules && !Region.IsPartOf(typeof(SafeZone))) // Dueling
+					if (house.IsAosRules && !Region.IsPartOf<SafeZone>()) // Dueling
 					{
 						list.Add(new CallbackEntry(6207, LeaveHouse));
 					}
@@ -3055,7 +3055,7 @@ namespace Server.Mobiles
 			}
 
 			#region Dueling
-			if (Region.IsPartOf(typeof(SafeZone)) && m is PlayerMobile)
+			if (Region.IsPartOf<SafeZone>() && m is PlayerMobile)
 			{
 				PlayerMobile pm = (PlayerMobile)m;
 
@@ -5907,7 +5907,7 @@ namespace Server.Mobiles
 
 		public bool YoungDeathTeleport()
 		{
-			if (Region.IsPartOf(typeof(Jail)) || Region.IsPartOf("Samurai start location") ||
+			if (Region.IsPartOf<Jail>() || Region.IsPartOf("Samurai start location") ||
 				Region.IsPartOf("Ninja start location") || Region.IsPartOf("Ninja cave"))
 			{
 				return false;

--- a/Scripts/Multis/Deeds.cs
+++ b/Scripts/Multis/Deeds.cs
@@ -29,11 +29,11 @@ namespace Server.Multis.Deeds
 
                 if (from.AccessLevel >= AccessLevel.GameMaster || reg.AllowHousing(from, p))
                     this.m_Deed.OnPlacement(from, p);
-                else if (reg.IsPartOf(typeof(TempNoHousingRegion)))
+                else if (reg.IsPartOf<TempNoHousingRegion>())
                     from.SendLocalizedMessage(501270); // Lord British has decreed a 'no build' period, thus you cannot build this house at this time.
-                else if (reg.IsPartOf(typeof(TreasureRegion)) || reg.IsPartOf(typeof(HouseRegion)))
+                else if (reg.IsPartOf<TreasureRegion>() || reg.IsPartOf<HouseRegion>())
                     from.SendLocalizedMessage(1043287); // The house could not be created here.  Either something is blocking the house, or the house would not be on valid terrain.
-                else if (reg.IsPartOf(typeof(HouseRaffleRegion)))
+                else if (reg.IsPartOf<HouseRaffleRegion>())
                     from.SendLocalizedMessage(1150493); // You must have a deed for this plot of land in order to build here.
                 else
                     from.SendLocalizedMessage(501265); // Housing can not be created in this area.

--- a/Scripts/Multis/HousePlacement.cs
+++ b/Scripts/Multis/HousePlacement.cs
@@ -113,13 +113,13 @@ namespace Server.Multis
 
                     if (!reg.AllowHousing(from, testPoint)) // Cannot place houses in dungeons, towns, treasure map areas etc
                     {
-                        if (reg.IsPartOf(typeof(TempNoHousingRegion)))
+                        if (reg.IsPartOf<TempNoHousingRegion>())
                             return HousePlacementResult.BadRegionTemp;
 
-                        if (reg.IsPartOf(typeof(TreasureRegion)) || reg.IsPartOf(typeof(HouseRegion)))
+                        if (reg.IsPartOf<TreasureRegion>() || reg.IsPartOf<HouseRegion>())
                             return HousePlacementResult.BadRegionHidden;
 
-                        if (reg.IsPartOf(typeof(HouseRaffleRegion)))
+                        if (reg.IsPartOf<HouseRaffleRegion>())
                             return HousePlacementResult.BadRegionRaffle;
 
                         return HousePlacementResult.BadRegion;

--- a/Scripts/Multis/HousePlacementTool.cs
+++ b/Scripts/Multis/HousePlacementTool.cs
@@ -251,11 +251,11 @@ namespace Server.Items
 
                 if (from.AccessLevel >= AccessLevel.GameMaster || reg.AllowHousing(from, p))
                     this.m_Placed = this.m_Entry.OnPlacement(from, p);
-                else if (reg.IsPartOf(typeof(TempNoHousingRegion)))
+                else if (reg.IsPartOf<TempNoHousingRegion>())
                     from.SendLocalizedMessage(501270); // Lord British has decreed a 'no build' period, thus you cannot build this house at this time.
-                else if (reg.IsPartOf(typeof(TreasureRegion)) || reg.IsPartOf(typeof(HouseRegion)))
+                else if (reg.IsPartOf<TreasureRegion>() || reg.IsPartOf<HouseRegion>())
                     from.SendLocalizedMessage(1043287); // The house could not be created here.  Either something is blocking the house, or the house would not be on valid terrain.
-                else if (reg.IsPartOf(typeof(HouseRaffleRegion)))
+                else if (reg.IsPartOf<HouseRaffleRegion>())
                     from.SendLocalizedMessage(1150493); // You must have a deed for this plot of land in order to build here.
                 else
                     from.SendLocalizedMessage(501265); // Housing can not be created in this area.

--- a/Scripts/Regions/TwistedWealdDesert.cs
+++ b/Scripts/Regions/TwistedWealdDesert.cs
@@ -36,7 +36,7 @@ namespace Server.Regions
         private static void Desert_OnLogin(LoginEventArgs e) 
         {
             Mobile m = e.Mobile;
-            if (m.Region.IsPartOf(typeof(TwistedWealdDesert)) && m.AccessLevel < AccessLevel.GameMaster)
+            if (m.Region.IsPartOf<TwistedWealdDesert>() && m.AccessLevel < AccessLevel.GameMaster)
                 m.Send(SpeedControl.WalkSpeed);
         }
     }

--- a/Scripts/Services/City Loyalty System/Trading/TradeSystem.cs
+++ b/Scripts/Services/City Loyalty System/Trading/TradeSystem.cs
@@ -368,7 +368,7 @@ namespace Server.Engines.CityLoyalty
             if (crate == null || crate.Deleted || crate.Entry == null || crate.Expired || crate.Entry.LastAmbush + TimeSpan.FromMinutes(AmbushWaitDuration) > DateTime.UtcNow)
                 return;
 
-            if (crate.RootParentEntity is Mobile && !((Mobile)crate.RootParentEntity).Region.IsPartOf(typeof(GuardedRegion)))
+            if (crate.RootParentEntity is Mobile && !((Mobile)crate.RootParentEntity).Region.IsPartOf<GuardedRegion>())
             {
                 Mobile m = crate.RootParentEntity as Mobile;
 

--- a/Scripts/Services/ConPVP/DuelContext.cs
+++ b/Scripts/Services/ConPVP/DuelContext.cs
@@ -1719,7 +1719,7 @@ namespace Server.Engines.ConPVP
                     if (dp == null)
                         return "a slot is empty";
 
-                    if (dp.Mobile.Region.IsPartOf(typeof(Regions.Jail)))
+                    if (dp.Mobile.Region.IsPartOf<Regions.Jail>())
                         return String.Format("{0} is in jail", dp.Mobile.Name);
 
                     if (Sigil.ExistsOn(dp.Mobile))
@@ -2044,7 +2044,7 @@ namespace Server.Engines.ConPVP
                 if (!pm.CheckAlive())
                 {
                 }
-                else if (pm.Region.IsPartOf(typeof(Regions.Jail)))
+                else if (pm.Region.IsPartOf<Regions.Jail>())
                 {
                 }
                 else if (CheckCombat(pm))

--- a/Scripts/Services/ConPVP/Tournament.cs
+++ b/Scripts/Services/ConPVP/Tournament.cs
@@ -2157,7 +2157,7 @@ namespace Server.Engines.ConPVP
                         {
                             Mobile check = (Mobile)part.Players[j];
 
-                            if (check.Deleted || check.Map == null || check.Map == Map.Internal || !check.Alive || Factions.Sigil.ExistsOn(check) || check.Region.IsPartOf(typeof(Regions.Jail)))
+                            if (check.Deleted || check.Map == null || check.Map == Map.Internal || !check.Alive || Factions.Sigil.ExistsOn(check) || check.Region.IsPartOf<Regions.Jail>())
                             {
                                 bad = true;
                                 break;
@@ -2277,7 +2277,7 @@ namespace Server.Engines.ConPVP
                             {
                                 Mobile check = (Mobile)part.Players[j];
 
-                                if (check.Deleted || check.Map == null || check.Map == Map.Internal || !check.Alive || Factions.Sigil.ExistsOn(check) || check.Region.IsPartOf(typeof(Regions.Jail)))
+                                if (check.Deleted || check.Map == null || check.Map == Map.Internal || !check.Alive || Factions.Sigil.ExistsOn(check) || check.Region.IsPartOf<Regions.Jail>())
                                 {
                                     bad = true;
                                     break;

--- a/Scripts/Services/Expansions/High Seas/Gumps/ShipPlacementGump.cs
+++ b/Scripts/Services/Expansions/High Seas/Gumps/ShipPlacementGump.cs
@@ -99,9 +99,9 @@ namespace Server.Gumps
 
                     Region region = Region.Find(p, from.Map);
 
-                    if (region.IsPartOf(typeof(DungeonRegion)))
+                    if (region.IsPartOf<DungeonRegion>())
                         from.SendLocalizedMessage(502488); // You can not place a ship inside a dungeon.
-                    else if (region.IsPartOf(typeof(HouseRegion)) || region.IsPartOf(typeof(Server.Engines.CannedEvil.ChampionSpawnRegion)))
+                    else if (region.IsPartOf<HouseRegion>() || region.IsPartOf<Server.Engines.CannedEvil.ChampionSpawnRegion>())
                         from.SendLocalizedMessage(1042549); // A boat may not be placed in this area.
                     else
                     {

--- a/Scripts/Services/Expansions/High Seas/Items/Fish/FishInfo.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Fish/FishInfo.cs
@@ -401,7 +401,7 @@ namespace Server.Items
 
         public static bool IsDungeon(Point3D pnt, Map map, Region region)
         {
-            return region.IsPartOf(typeof(DungeonRegion)) || IsMondainDungeon(region) || Server.Spells.SpellHelper.IsTrammelWind(map, pnt) || Server.Spells.SpellHelper.IsFeluccaWind(map, pnt);
+            return region.IsPartOf<DungeonRegion>() || IsMondainDungeon(region) || Server.Spells.SpellHelper.IsTrammelWind(map, pnt) || Server.Spells.SpellHelper.IsFeluccaWind(map, pnt);
         }
 
         public static bool IsMondainDungeon(Region region)

--- a/Scripts/Services/Expansions/High Seas/Mobiles/Corgul/CorgulTheSoulbinder.cs
+++ b/Scripts/Services/Expansions/High Seas/Mobiles/Corgul/CorgulTheSoulbinder.cs
@@ -209,7 +209,7 @@ namespace Server.Mobiles
             {
                 Point3D p = CorgulAltar.SpawnLoc;
 
-                if (this.Region.IsPartOf(typeof(CorgulRegion)) && !Utility.InRange(this.Location, p, 15))
+                if (this.Region.IsPartOf<CorgulRegion>() && !Utility.InRange(this.Location, p, 15))
                 {
                     PlaySound(0x1FE);
                     FixedParticles(0x376A, 9, 32, 0x13AF, EffectLayer.Waist);

--- a/Scripts/Services/Expansions/High Seas/Multis/MooringLine.cs
+++ b/Scripts/Services/Expansions/High Seas/Multis/MooringLine.cs
@@ -192,7 +192,7 @@ namespace Server.Items
 
             Map map = from.Map;
 
-            if (Server.Spells.SpellHelper.CheckMulti(p, map) || Region.Find(p, map).IsPartOf(typeof(Factions.StrongholdRegion)))
+            if (Server.Spells.SpellHelper.CheckMulti(p, map) || Region.Find(p, map).IsPartOf<Factions.StrongholdRegion>())
                 return false;
 
             StaticTile[] staticTiles = map.Tiles.GetStaticTiles(x, y, true);

--- a/Scripts/Services/Expansions/Time Of Legends/Mobiles/BritannianInfantry.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Mobiles/BritannianInfantry.cs
@@ -64,7 +64,7 @@ namespace Server.Mobiles
         {
             get
             {
-                if (this.Region != null && this.Region.IsPartOf(typeof(BattleRegion)))
+                if (this.Region != null && this.Region.IsPartOf<BattleRegion>())
                 {
                     if (((BattleRegion)this.Region).Spawner != null)
                         return !((BattleRegion)this.Region).Spawner.HasPlayers();
@@ -91,7 +91,7 @@ namespace Server.Mobiles
             return base.IsEnemy(m);
         }
 
-        public override bool AlwaysAttackable { get { return this.Region.IsPartOf(typeof(BattleRegion)); } }
+        public override bool AlwaysAttackable { get { return this.Region.IsPartOf<BattleRegion>(); } }
         public override bool ShowFameTitle { get { return false; } }
         public override bool ClickTitle { get { return false; } }
         public override bool AutoRearms { get { return true; } }

--- a/Scripts/Services/Expansions/Time Of Legends/Mobiles/EodonTribesman.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Mobiles/EodonTribesman.cs
@@ -61,7 +61,7 @@ namespace Server.Mobiles
         {
             get
             {
-                if (this.Region != null && this.Region.IsPartOf(typeof(BattleRegion)))
+                if (this.Region != null && this.Region.IsPartOf<BattleRegion>())
                 {
                     if (((BattleRegion)this.Region).Spawner != null)
                         return !((BattleRegion)this.Region).Spawner.HasPlayers();
@@ -420,7 +420,7 @@ namespace Server.Mobiles
             }
 		}
 
-        public override bool AlwaysAttackable { get { return this.Region.IsPartOf(typeof(BattleRegion)); } }
+        public override bool AlwaysAttackable { get { return this.Region.IsPartOf<BattleRegion>(); } }
         public override bool ShowFameTitle { get { return false; } }
 
         public override void GenerateLoot()
@@ -639,7 +639,7 @@ namespace Server.Mobiles
             }
 		}
 
-        public override bool AlwaysAttackable { get { return this.Region.IsPartOf(typeof(BattleRegion)); } }
+        public override bool AlwaysAttackable { get { return this.Region.IsPartOf<BattleRegion>(); } }
         public override bool ShowFameTitle { get { return false; } }
 
         public TribeShaman(Serial serial) : base(serial)

--- a/Scripts/Services/Expansions/Time Of Legends/Mobiles/MyrmidexDrone.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Mobiles/MyrmidexDrone.cs
@@ -62,7 +62,7 @@ namespace Server.Mobiles
         {
             get
             {
-                if (this.Region != null && this.Region.IsPartOf(typeof(BattleRegion)))
+                if (this.Region != null && this.Region.IsPartOf<BattleRegion>())
                 {
                     if (((BattleRegion)this.Region).Spawner != null)
                         return !((BattleRegion)this.Region).Spawner.HasPlayers();

--- a/Scripts/Services/Expansions/Time Of Legends/Mobiles/MyrmidexWarrior.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Mobiles/MyrmidexWarrior.cs
@@ -67,7 +67,7 @@ namespace Server.Mobiles
         {
             get
             {
-                if (this.Region != null && this.Region.IsPartOf(typeof(BattleRegion)))
+                if (this.Region != null && this.Region.IsPartOf<BattleRegion>())
                 {
                     if (((BattleRegion)this.Region).Spawner != null)
                         return !((BattleRegion)this.Region).Spawner.HasPlayers();

--- a/Scripts/Services/Expansions/Time Of Legends/Myrmidex Invasion/AllegianceIdol.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Myrmidex Invasion/AllegianceIdol.cs
@@ -67,7 +67,7 @@ namespace Server.Engines.MyrmidexInvasion
                             entry,
                             confirm: (m, state) =>
                                 {
-                                    if (m.Region.IsPartOf(typeof(BattleRegion)))
+                                    if (m.Region.IsPartOf<BattleRegion>())
                                     {
                                         m.SendLocalizedMessage(1156632); // You cannot switch allegiance in the midst of the battle field!
                                     }

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Encounters.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Encounters.cs
@@ -1390,7 +1390,7 @@ namespace Server.Engines.Shadowguard
             {
                 foreach (PartyMemberInfo info in p.Members)
                 {
-                    if (info.Mobile is PlayerMobile && info.Mobile.Region.IsPartOf(typeof(ShadowguardRegion)))
+                    if (info.Mobile is PlayerMobile && info.Mobile.Region.IsPartOf<ShadowguardRegion>())
                         ((PlayerMobile)info.Mobile).AddCollectionTitle(1156318); // Destroyer of the Time Rift
                 }
             }

--- a/Scripts/Services/Factions/Core/Faction.cs
+++ b/Scripts/Services/Factions/Core/Faction.cs
@@ -1196,7 +1196,7 @@ namespace Server.Factions
                 return;
 
             #region Dueling
-            if (victim.Region.IsPartOf(typeof(Engines.ConPVP.SafeZone)))
+            if (victim.Region.IsPartOf<Engines.ConPVP.SafeZone>())
                 return;
             #endregion
 

--- a/Scripts/Services/Help/HelpGump.cs
+++ b/Scripts/Services/Help/HelpGump.cs
@@ -200,11 +200,11 @@ namespace Server.Engines.Help
                     {
                         BaseHouse house = BaseHouse.FindHouseAt(from);
 
-                        if (house != null && house.IsAosRules && !from.Region.IsPartOf(typeof(Engines.ConPVP.SafeZone))) // Dueling
+                        if (house != null && house.IsAosRules && !from.Region.IsPartOf<Engines.ConPVP.SafeZone>()) // Dueling
                         {
                             from.Location = house.BanLocation;
                         }
-                        else if (from.Region.IsPartOf(typeof(Server.Regions.Jail)))
+                        else if (from.Region.IsPartOf<Server.Regions.Jail>())
                         {
                             from.SendLocalizedMessage(1114345, "", 0x35); // You'll need a better jailbreak plan than that!
                         }
@@ -261,7 +261,7 @@ namespace Server.Engines.Help
                     {
                         if (IsYoung(from))
                         {
-                            if (from.Region.IsPartOf(typeof(Regions.Jail)))
+                            if (from.Region.IsPartOf<Regions.Jail>())
                             {
                                 from.SendLocalizedMessage(1114345, "", 0x35); // You'll need a better jailbreak plan than that!
                             }

--- a/Scripts/Services/Quests/Items/HornOfRetreat.cs
+++ b/Scripts/Services/Quests/Items/HornOfRetreat.cs
@@ -198,7 +198,7 @@ namespace Server.Engines.Quests
 
         public override void UseGate(Mobile m)
         {
-            if (m.Region.IsPartOf(typeof(Regions.Jail)))
+            if (m.Region.IsPartOf<Regions.Jail>())
             {
                 m.SendLocalizedMessage(1114345); // You'll need a better jailbreak plan than that!
             }

--- a/Scripts/Services/Revamped Dungeons/DespiseRevamped/DespiseController.cs
+++ b/Scripts/Services/Revamped Dungeons/DespiseRevamped/DespiseController.cs
@@ -463,7 +463,7 @@ namespace Server.Engines.Despise
             foreach (Mobile m in list)
             {
                 WispOrb orb = GetWispOrb(m);
-                if (orb == null || orb.Deleted || !orb.Conscripted || m.Region == null || !m.Region.IsPartOf(typeof(DespiseRegion)))
+                if (orb == null || orb.Deleted || !orb.Conscripted || m.Region == null || !m.Region.IsPartOf<DespiseRegion>())
                     m_ToTransport.Remove(m);
             }
 
@@ -476,7 +476,7 @@ namespace Server.Engines.Despise
             {
                 foreach (Mobile m in m_ToTransport)
                 {
-                    if (m != null && m.Region != null && m.Region.IsPartOf(typeof(DespiseRegion)))
+                    if (m != null && m.Region != null && m.Region.IsPartOf<DespiseRegion>())
                     {
                         WispOrb orb = GetWispOrb(m);
 
@@ -595,7 +595,7 @@ namespace Server.Engines.Despise
         {
             WispOrb orb = GetWispOrb(e.From);
 
-            if (orb != null && !Region.Find(e.From.Location, e.From.Map).IsPartOf(typeof(DespiseRegion)))
+            if (orb != null && !Region.Find(e.From.Location, e.From.Map).IsPartOf<DespiseRegion>())
             {
                 Timer.DelayCall(() =>
                     {

--- a/Scripts/Services/RunicReforging/ReadMe.txt
+++ b/Scripts/Services/RunicReforging/ReadMe.txt
@@ -20,7 +20,7 @@ GenerateRandomItem(Item item, Mobile killer, BaseCreature victim)
    if(victim != null && victim.Map == Map.Felucca && .10 > Utility.RandomDouble())
      return RunicReforging.GenerateRandomItem(item, killer, victim);
 
-   if(victim.Region != null && victim.Region.IsPartOf(typeof(DespiseRegion)))
+   if(victim.Region != null && victim.Region.IsPartOf<DespiseRegion>())
       return RunicReforging.GenerateRandomItem(item, killer, victim);
 }
 

--- a/Scripts/Services/TreasuresOfTokuno/TreasuresOfTokuno.cs
+++ b/Scripts/Services/TreasuresOfTokuno/TreasuresOfTokuno.cs
@@ -135,7 +135,7 @@ namespace Server.Misc
         {
             Region r = m.Region;
 
-            if (r.IsPartOf(typeof(Server.Regions.HouseRegion)) || Server.Multis.BaseBoat.FindBoatAt(m, m.Map) != null)
+            if (r.IsPartOf<Server.Regions.HouseRegion>() || Server.Multis.BaseBoat.FindBoatAt(m, m.Map) != null)
                 return false;
             //TODO: a CanReach of something check as opposed to above?
 

--- a/Scripts/Services/Underworld/Maze of Death/GoldenCompass.cs
+++ b/Scripts/Services/Underworld/Maze of Death/GoldenCompass.cs
@@ -24,7 +24,7 @@ namespace Server.Items
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (IsChildOf(from.Backpack) && from.Region != null && from.Region.IsPartOf(typeof(MazeOfDeathRegion)))
+            if (IsChildOf(from.Backpack) && from.Region != null && from.Region.IsPartOf<MazeOfDeathRegion>())
             {
                 from.CloseGump(typeof(CompassDirectionGump));
                 from.SendGump(new CompassDirectionGump(from));

--- a/Scripts/Services/Virtue Artifacts/VirtueArtifactsSystem.cs
+++ b/Scripts/Services/Virtue Artifacts/VirtueArtifactsSystem.cs
@@ -32,7 +32,7 @@ namespace Server.Misc
 	        if (m is BaseCreature && ((BaseCreature)m).IsChampionSpawn)
 		        return false;
 	        
-	        if (r.IsPartOf(typeof(Server.Regions.HouseRegion)) || Server.Multis.BaseBoat.FindBoatAt(m, m.Map) != null)
+	        if (r.IsPartOf<Server.Regions.HouseRegion>() || Server.Multis.BaseBoat.FindBoatAt(m, m.Map) != null)
                 return false;
 
             return (r.IsPartOf("Covetous") || r.IsPartOf("Deceit") || r.IsPartOf("Despise") || r.IsPartOf("Destard") ||

--- a/Scripts/Services/XmlSpawner/XMLSpawner Extras/XmlPoints/Attachments/XmlPoints.cs
+++ b/Scripts/Services/XmlSpawner/XMLSpawner Extras/XmlPoints/Attachments/XmlPoints.cs
@@ -1346,14 +1346,14 @@ namespace Server.Engines.XmlSpawner2
 
 			// uncomment the code below if you want to restrict challenges to towns only
 			/*
-			if (!from.Region.IsPartOf(typeof(Regions.TownRegion)) || !target.Region.IsPartOf(typeof(Regions.TownRegion)))
+			if (!from.Region.IsPartOf<Regions.TownRegion>() || !target.Region.IsPartOf<Regions.TownRegion>())
 			{
 				from.SendMessage("You must be in a town to issue a challenge"); 
 				return false;
 			}
 			*/
 
-			if (from.Region.IsPartOf(typeof(Regions.Jail)) || target.Region.IsPartOf(typeof(Regions.Jail)))
+			if (from.Region.IsPartOf<Regions.Jail>() || target.Region.IsPartOf<Regions.Jail>())
 			{
 				from.SendLocalizedMessage(1042632); // You'll need a better jailbreak plan then that!
 				return false;

--- a/Scripts/Skills/Mining.cs
+++ b/Scripts/Skills/Mining.cs
@@ -456,7 +456,7 @@ namespace Server.Engines.Harvest
             if ((map == Map.Felucca || map == Map.Trammel) && bounds.Contains(new Point2D(from.X, from.Y)))
                 return false;
 
-            return reg != null && (reg.IsPartOf(typeof(Server.Regions.DungeonRegion)) || map == Map.Ilshenar);
+            return reg != null && (reg.IsPartOf<Server.Regions.DungeonRegion>() || map == Map.Ilshenar);
         }
         #endregion
 

--- a/Scripts/Skills/Peacemaking.cs
+++ b/Scripts/Skills/Peacemaking.cs
@@ -68,11 +68,11 @@ namespace Server.SkillHandlers
 				{
 					from.SendLocalizedMessage(1049528); // You cannot calm that!
 				}
-				else if (from.Region.IsPartOf(typeof(SafeZone)))
+				else if (from.Region.IsPartOf<SafeZone>())
 				{
 					from.SendMessage("You may not peacemake in this area.");
 				}
-				else if (((Mobile)targeted).Region.IsPartOf(typeof(SafeZone)))
+				else if (((Mobile)targeted).Region.IsPartOf<SafeZone>())
 				{
 					from.SendMessage("You may not peacemake there.");
 				}

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -750,7 +750,7 @@ namespace Server.Spells
             if (caster != null && caster.IsPlayer())
             {
 				// Jail region
-				if (caster.Region.IsPartOf(typeof(Regions.Jail)))
+				if (caster.Region.IsPartOf<Regions.Jail>())
 				{
 					caster.SendLocalizedMessage(1114345); // You'll need a better jailbreak plan than that!
 					return false;
@@ -864,7 +864,7 @@ namespace Server.Spells
         public static bool IsFeluccaDungeon(Map map, Point3D loc)
         {
             Region region = Region.Find(loc, map);
-            return (region.IsPartOf(typeof(DungeonRegion)) && region.Map == Map.Felucca);
+            return (region.IsPartOf<DungeonRegion>() && region.Map == Map.Felucca);
         }
 
         public static bool IsKhaldun(Map map, Point3D loc)
@@ -888,7 +888,7 @@ namespace Server.Spells
         public static bool IsSafeZone(Map map, Point3D loc)
         {
             #region Duels
-            if (Region.Find(loc, map).IsPartOf(typeof(Engines.ConPVP.SafeZone)))
+            if (Region.Find(loc, map).IsPartOf<Engines.ConPVP.SafeZone>())
             {
                 if (m_TravelType == TravelCheckType.TeleportTo || m_TravelType == TravelCheckType.TeleportFrom)
                 {
@@ -913,12 +913,12 @@ namespace Server.Spells
             if ( Factions.Faction.Find( m_TravelCaster, true, true ) != null )
             return false;
             }*/
-            return (Region.Find(loc, map).IsPartOf(typeof(Factions.StrongholdRegion)));
+            return (Region.Find(loc, map).IsPartOf<Factions.StrongholdRegion>());
         }
 
         public static bool IsChampionSpawn(Map map, Point3D loc)
         {
-            return (Region.Find(loc, map).IsPartOf(typeof(Engines.CannedEvil.ChampionSpawnRegion)));
+            return (Region.Find(loc, map).IsPartOf<Engines.CannedEvil.ChampionSpawnRegion>());
         }
 
         public static bool IsDoomFerry(Map map, Point3D loc)

--- a/Scripts/Spells/Necromancy/Exorcism.cs
+++ b/Scripts/Spells/Necromancy/Exorcism.cs
@@ -181,7 +181,7 @@ namespace Server.Spells.Necromancy
                 if (SpellHelper.IsAnyT2A(map, c.Location) && SpellHelper.IsAnyT2A(map, m.Location))
                     return false;	//Same Map, both in T2A, ie, same 'sub server'.
 
-                if (m.Region.IsPartOf(typeof(DungeonRegion)) == Region.Find(c.Location, map).IsPartOf(typeof(DungeonRegion)))
+                if (m.Region.IsPartOf<DungeonRegion>() == Region.Find(c.Location, map).IsPartOf<DungeonRegion>())
                     return false; //Same Map, both in Dungeon region OR They're both NOT in a dungeon region.
                 //Just an approximation cause RunUO doens't divide up the world the same way OSI does ;p
             }

--- a/Server/Region.cs
+++ b/Server/Region.cs
@@ -436,6 +436,11 @@ namespace Server
 			return (GetRegion(regionType) != null);
 		}
 
+		public bool IsPartOf<T>() where T : Region
+		{
+			return IsPartOf(typeof(T));
+		}
+
 		public bool IsPartOf(string regionName)
 		{
 			return (GetRegion(regionName) != null);


### PR DESCRIPTION
This pull requests adds the following method in the `Region` class:

```
public bool IsPartOf<T>() where T : Region
```

which is a shortcut for the region type checking. So now, instead of writing:

```
from.Region.IsPartOf(typeof(DungeonRegion))
```

you can just write:

```
from.Region.IsPartOf<DungeonRegion>()
```

Most usages of the previous version in scripts have been converted to the later.