### PR TITLE
Generalize IBlackSolen & IRedSolen

### DIFF
--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -331,27 +331,28 @@ namespace Server.Mobiles
 
 			if (order == OrderType.Attack)
 			{
-				if (target is BaseCreature && ((BaseCreature)target).IsScaryToPets && m_Mobile.IsScaredOfScaryThings)
+				if (target is BaseCreature)
 				{
-					m_Mobile.SayTo(from, "Your pet refuses to attack this creature!");
-					return;
-				}
+					BaseCreature bc = (BaseCreature)target;
 
-				if ((SolenHelper.CheckRedFriendship(from) &&
-					 (target is RedSolenInfiltratorQueen || target is RedSolenInfiltratorWarrior || target is RedSolenQueen ||
-					  target is RedSolenWarrior || target is RedSolenWorker)) ||
-					(SolenHelper.CheckBlackFriendship(from) &&
-					 (target is BlackSolenInfiltratorQueen || target is BlackSolenInfiltratorWarrior || target is BlackSolenQueen ||
-					  target is BlackSolenWarrior || target is BlackSolenWorker)))
-				{
-					from.SendAsciiMessage("You can not force your pet to attack a creature you are protected from.");
-					return;
-				}
+					if (bc.IsScaryToPets && m_Mobile.IsScaredOfScaryThings)
+					{
+						m_Mobile.SayTo(from, "Your pet refuses to attack this creature!");
+						return;
+					}
 
-				if (target is BaseFactionGuard)
-				{
-					m_Mobile.SayTo(from, "Your pet refuses to attack the guard.");
-					return;
+					if ((bc is IBlackSolen && SolenHelper.CheckBlackFriendship(from)) ||
+						(bc is IRedSolen && SolenHelper.CheckRedFriendship(from)))
+					{
+						from.SendAsciiMessage("You can not force your pet to attack a creature you are protected from.");
+						return;
+					}
+
+					if (bc is BaseFactionGuard)
+					{
+						m_Mobile.SayTo(from, "Your pet refuses to attack the guard.");
+						return;
+					}
 				}
 			}
 

--- a/Scripts/Mobiles/Normal/BlackSolenInfiltratorQueen.cs
+++ b/Scripts/Mobiles/Normal/BlackSolenInfiltratorQueen.cs
@@ -4,7 +4,7 @@ using Server.Items;
 namespace Server.Mobiles
 {
     [CorpseName("a solen infiltrator corpse")] // TODO: Corpse name?
-    public class BlackSolenInfiltratorQueen : BaseCreature
+    public class BlackSolenInfiltratorQueen : BaseCreature, IBlackSolen
     {
         [Constructable]
         public BlackSolenInfiltratorQueen()

--- a/Scripts/Mobiles/Normal/BlackSolenInfiltratorWarrior.cs
+++ b/Scripts/Mobiles/Normal/BlackSolenInfiltratorWarrior.cs
@@ -4,7 +4,7 @@ using Server.Items;
 namespace Server.Mobiles
 {
     [CorpseName("a solen infiltrator corpse")]
-    public class BlackSolenInfiltratorWarrior : BaseCreature
+    public class BlackSolenInfiltratorWarrior : BaseCreature, IBlackSolen
     {
         [Constructable]
         public BlackSolenInfiltratorWarrior()

--- a/Scripts/Mobiles/Normal/BlackSolenQueen.cs
+++ b/Scripts/Mobiles/Normal/BlackSolenQueen.cs
@@ -6,7 +6,7 @@ using Server.Network;
 namespace Server.Mobiles
 {
     [CorpseName("a solen queen corpse")]
-    public class BlackSolenQueen : BaseCreature
+    public class BlackSolenQueen : BaseCreature, IBlackSolen
     {
         private bool m_BurstSac;
 

--- a/Scripts/Mobiles/Normal/BlackSolenWarrior.cs
+++ b/Scripts/Mobiles/Normal/BlackSolenWarrior.cs
@@ -5,7 +5,7 @@ using Server.Network;
 namespace Server.Mobiles
 {
     [CorpseName("a solen warrior corpse")]
-    public class BlackSolenWarrior : BaseCreature
+    public class BlackSolenWarrior : BaseCreature, IBlackSolen
     {
         private bool m_BurstSac;
         [Constructable]

--- a/Scripts/Mobiles/Normal/BlackSolenWorker.cs
+++ b/Scripts/Mobiles/Normal/BlackSolenWorker.cs
@@ -4,7 +4,7 @@ using Server.Items;
 namespace Server.Mobiles
 {
     [CorpseName("a solen worker corpse")]
-    public class BlackSolenWorker : BaseCreature
+    public class BlackSolenWorker : BaseCreature, IBlackSolen
     {
         [Constructable]
         public BlackSolenWorker()

--- a/Scripts/Mobiles/Normal/RedSolenInfiltratorQueen.cs
+++ b/Scripts/Mobiles/Normal/RedSolenInfiltratorQueen.cs
@@ -4,7 +4,7 @@ using Server.Items;
 namespace Server.Mobiles
 {
     [CorpseName("a solen infiltrator corpse")] // TODO: Corpse name?
-    public class RedSolenInfiltratorQueen : BaseCreature
+    public class RedSolenInfiltratorQueen : BaseCreature, IRedSolen
     {
         [Constructable]
         public RedSolenInfiltratorQueen()

--- a/Scripts/Mobiles/Normal/RedSolenInfiltratorWarrior.cs
+++ b/Scripts/Mobiles/Normal/RedSolenInfiltratorWarrior.cs
@@ -4,7 +4,7 @@ using Server.Items;
 namespace Server.Mobiles
 {
     [CorpseName("a solen infiltrator corpse")]
-    public class RedSolenInfiltratorWarrior : BaseCreature
+    public class RedSolenInfiltratorWarrior : BaseCreature, IRedSolen
     {
         [Constructable]
         public RedSolenInfiltratorWarrior()

--- a/Scripts/Mobiles/Normal/RedSolenQueen.cs
+++ b/Scripts/Mobiles/Normal/RedSolenQueen.cs
@@ -6,7 +6,7 @@ using Server.Network;
 namespace Server.Mobiles
 {
     [CorpseName("a solen queen corpse")]
-    public class RedSolenQueen : BaseCreature
+    public class RedSolenQueen : BaseCreature, IRedSolen
     {
         private bool m_BurstSac;
 

--- a/Scripts/Mobiles/Normal/RedSolenWarrior.cs
+++ b/Scripts/Mobiles/Normal/RedSolenWarrior.cs
@@ -5,7 +5,7 @@ using Server.Network;
 namespace Server.Mobiles
 {
     [CorpseName("a solen warrior corpse")]
-    public class RedSolenWarrior : BaseCreature
+    public class RedSolenWarrior : BaseCreature, IRedSolen
     {
         private bool m_BurstSac;
         [Constructable]

--- a/Scripts/Mobiles/Normal/RedSolenWorker.cs
+++ b/Scripts/Mobiles/Normal/RedSolenWorker.cs
@@ -4,7 +4,7 @@ using Server.Items;
 namespace Server.Mobiles
 {
     [CorpseName("a solen worker corpse")]
-    public class RedSolenWorker : BaseCreature
+    public class RedSolenWorker : BaseCreature, IRedSolen
     {
         [Constructable]
         public RedSolenWorker()

--- a/Scripts/Mobiles/Normal/SolenHelper.cs
+++ b/Scripts/Mobiles/Normal/SolenHelper.cs
@@ -4,6 +4,14 @@ using Server.Network;
 
 namespace Server.Mobiles
 {
+    interface IBlackSolen
+    {
+    }
+
+    interface IRedSolen
+    {
+    }
+
     public class SolenHelper
     {
         public static void PackPicnicBasket(BaseCreature solen)


### PR DESCRIPTION
The purpose of this pull is to generalize black and red solen groups so that when they are checked in BaseAI, it does not check a type list of them.

-Added interface IBlackSolen
--Added IBlackSolen to Black Solen creatures
-Added interface IRedSolen
--Added IRedSolen to Red Solen creatures
-Changed Cleaned up EndPickTarget().if (order == OrderType.Attack) checks
-Changed Solen checks to check is IBlackSolen and is IRedSolen types instead of a list of types.