### PR TITLE
Removed Wood Tools from tinkering bod list

### DIFF
--- a/Data/Bulk Orders/Tinkering/smalls.cfg
+++ b/Data/Bulk Orders/Tinkering/smalls.cfg
@@ -30,9 +30,9 @@ SledgeHammer,0xFB5
 Saw,0x1034
 Froe,0x10E5
 FlourSifter,0x103E
-JointingPlane,0x1030
-MouldingPlane,0x102C
-SmoothingPlane,0x1032
+# JointingPlane,0x1030
+# MouldingPlane,0x102C
+# SmoothingPlane,0x1032
 
 Nunchaku,0x27AE
 Hatchet,0xF43


### PR DESCRIPTION
- Removed wooden tools from tinkering bod list. I found no support for tinker bods with wood resources on EA, only metal resources.