### PR TITLE
Nether Bolt Stack Damage Fix

### DIFF
--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -843,7 +843,12 @@ namespace Server.Spells
         #endregion
 
         public virtual void OnBeginCast()
-		{ }
+		{
+            SendCastEffect();
+        }
+
+        public virtual void SendCastEffect()
+        { }
 
 		public virtual void GetCastSkills(out double min, out double max)
 		{
@@ -986,7 +991,7 @@ namespace Server.Spells
 				fc = fcMax;
 			}
 
-            if (ProtectionSpell.Registry.ContainsKey(m_Caster) /*|| EodonianPotion.IsUnderEffects(m, PotionEffect.Urali)*/)
+            if (ProtectionSpell.Registry.ContainsKey(m_Caster) || EodonianPotion.IsUnderEffects(m_Caster, PotionEffect.Urali))
             {
                 fc = Math.Min(fcMax - 2, fc - 2);
             }
@@ -1246,10 +1251,13 @@ namespace Server.Spells
 						// Spell.NextSpellDelay;
 
 					Target originalTarget = m_Spell.m_Caster.Target;
-               
-                    if (m_Spell.InstantTarget != null) {
+
+                    if (m_Spell.InstantTarget != null)
+                    {
                         m_Spell.OnCastInstantTarget();
-                    } else {
+                    }
+                    else
+                    {
                         m_Spell.OnCast();
                     }
 

--- a/Scripts/Spells/Chivalry/PaladinSpell.cs
+++ b/Scripts/Spells/Chivalry/PaladinSpell.cs
@@ -123,14 +123,7 @@ namespace Server.Spells.Chivalry
 			return false;
 		}
 
-		public override void OnBeginCast()
-		{
-			base.OnBeginCast();
-
-			SendCastEffect();
-		}
-
-		public virtual void SendCastEffect()
+		public override void SendCastEffect()
 		{
 			Caster.FixedEffect(0x37C4, 10, (int)(GetCastDelay().TotalSeconds * 28), 4, 3);
 		}

--- a/Scripts/Spells/Mysticism/MysticSpell.cs
+++ b/Scripts/Spells/Mysticism/MysticSpell.cs
@@ -52,6 +52,11 @@ namespace Server.Spells.Mysticism
             }
         }
 
+        public override void SendCastEffect()
+        {
+            Caster.FixedEffect(0x37C4, 5, (int)(GetCastDelay().TotalSeconds * 28), 0x484, 4);
+        }
+
         public override int GetMana()
         {
             if (Core.TOL && this is HailStormSpell)

--- a/Scripts/Spells/Mysticism/SpellDefinitions/HealingStoneSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/HealingStoneSpell.cs
@@ -11,6 +11,11 @@ namespace Server.Spells.Mysticism
 	{
         public override SpellCircle Circle { get { return SpellCircle.First; } }
 
+        public override TimeSpan GetCastDelay()
+        {
+            return TimeSpan.FromTicks(base.GetCastDelay().Ticks * 5);
+        }
+
 		private static SpellInfo m_Info = new SpellInfo(
 				"Healing Stone", "Kal In Mani",
 				230,
@@ -38,6 +43,8 @@ namespace Server.Spells.Mysticism
                 int maxHeal = (int)((Caster.Skills[CastSkill].Value + Caster.Skills[DamageSkill].Value) / 5);
 
 				Caster.PlaySound( 0x650 );
+                Caster.FixedParticles(0x3779, 1, 15, 0x251E, 0, 0, EffectLayer.Waist);
+
 				Caster.Backpack.DropItem( new HealingStone( Caster, amount, maxHeal ) );
 				Caster.SendLocalizedMessage( 1080115 ); // A Healing Stone appears in your backpack.
 			}

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
@@ -20,13 +20,14 @@ namespace Server.Spells.Mysticism
 		}
 
 		public override bool DelayedDamage{ get{ return true; } }
+        public override bool DelayedDamageStacking { get { return false; } }
 
 		public override void OnCast()
 		{
 			Caster.Target = new MysticSpellTarget( this, TargetFlags.Harmful );
 		}
 
-		public override void OnTarget( Object o )
+		public override void OnTarget( object o )
 		{
 			Mobile target = o as Mobile;
 
@@ -37,12 +38,11 @@ namespace Server.Spells.Mysticism
 			else if ( CheckHSequence( target ) )
 			{
 				double damage = GetNewAosDamage( 10, 1, 4, target );
-				int hue = 0;
 
                 SpellHelper.Damage(this, target, damage, 0, 0, 0, 0, 0, 100, 0);
 
-				Effects.SendBoltEffect( target, false, hue );
-				Caster.PlaySound( 0x653 );
+                target.FixedParticles(0x36CB, 1, 9, 9911, 1455, 5, EffectLayer.Head);
+                target.PlaySound(0x211);
 			}
 
 			FinishSequence();

--- a/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
+++ b/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
@@ -116,17 +116,10 @@ namespace Server.Spells.SkillMasteries
             }
         }
 
-        public virtual void SendCastEffect()
+        public override void SendCastEffect()
         {
-            Caster.FixedEffect(0x37C4, 10, (int)(GetCastDelay().TotalSeconds * 28), 4, 3);
+            Caster.FixedEffect(0x37C4, 5, (int)(GetCastDelay().TotalSeconds * 28), 4, 2);
         }
-
-		public override void OnBeginCast()
-		{
-			base.OnBeginCast();
-
-			SendCastEffect();
-		}
 
 		public override void GetCastSkills( out double min, out double max )
 		{

--- a/Scripts/Spells/Spellweaving/ArcanistSpell.cs
+++ b/Scripts/Spells/Spellweaving/ArcanistSpell.cs
@@ -152,11 +152,10 @@ namespace Server.Spells.Spellweaving
 		{
 			base.OnBeginCast();
 
-			SendCastEffect();
 			m_CastTimeFocusLevel = GetFocusLevel(Caster);
 		}
 
-		public virtual void SendCastEffect()
+		public override void SendCastEffect()
 		{
 			Caster.FixedEffect(0x37C4, 10, (int)(GetCastDelay().TotalSeconds * 28), 4, 3);
 		}


### PR DESCRIPTION
- Updated spell effects on HealingStone and NetherBolt
- Nether Bolt will no longer stack damage, like magic arrow. Confirmed on EA.
- TODO: Rest of mystic Spells and pre-cast effects need to be moved to spell timer. this is for chiv, mystic and skill mastery Spells