### PR TITLE
Non-hostility against non-familiar summons fix

### DIFF
--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -2996,7 +2996,7 @@ namespace Server.Mobiles
 			return (m_Mobile.FocusMob != null);
 		}
 
-		private bool IsHostile(Mobile from)
+		public virtual bool IsHostile(Mobile from)
 		{
 			int count = Math.Max(m_Mobile.Aggressors.Count, m_Mobile.Aggressed.Count);
 


### PR DESCRIPTION
This fix removes special non-hostility against summons in AcquireFocusMob(), which is not present on OSI. 

While behavior towards standard content in this pull is correct, where summons only ever appear with player masters, there are some erroneous behaviors if non-standard setups are encountered:

1) IsEnemy() and IsFriend() erroneously assume that summons/controls without a master have player masters and attack them if they're wild, or do not attack them if they're pets.
2) IsEnemy() and IsFriend() only check creature and target master settings for Team and pet status comparison checks. Oppositions, notably, do not check masters. (The masters check is toward the end of the methods)

-Moved InLOS check from bottom to near top
-Added CanBeBeneficial check when choosing a friendly unit
-Moved Familiar Target and Special Summon checks into enemy selection nest
-Fixed Removed special non-hostility against summons for OSI behavior, confirmed on OSI (only Familiars are ignored, and they have their own check)
-Removed redundant combatant check from players with activated honor
-Cleaned Moved BaseCreature c setting into the nest it's used in
-Changed Replaced c.Controlled && c.ControlMaster != null checks with c.GetMaster() != null checks
-Changed Replaced c.ControlMaster.Karma (>/<) 0 checks with c.GetMaster().Karma (>/<) 0 checks