### PR TITLE
Consecrate Weapon and Enemy of One damage modifier changes

### DIFF
--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -2230,11 +2230,15 @@ namespace Server.Items
 
             if (m_Consecrated)
             {
-                if (Utility.RandomDouble() <= ConsecrateProcChance / 100)
-                {
-                    if (ConsecrateDamageBonus > 0)
-                        damageBonus *= 1 + ConsecrateDamageBonus / 100;
-                }
+                //if (Utility.RandomDouble() <= ConsecrateProcChance / 100)
+                //{
+                //    if (ConsecrateDamageBonus > 0)
+                //        damageBonus *= 1 + ConsecrateDamageBonus / 100;
+                //}
+                
+                // Based on chiv skill will give 1-15 damage modifier bonus when skill value >= 92 as OSI Test Center
+                double chivSkill = attacker.Skills[SkillName.Chivalry].Value;
+                percentageBonus += chivSkill < 92.0 ? 0 : Convert.ToInt32(Math.Floor((chivSkill - 92) / 2) + 1);
             }
 
             percentageBonus += (int)(damageBonus * 100) - 100;
@@ -2306,9 +2310,11 @@ namespace Server.Items
 
 					if (pm.EnemyOfOneType == defender.GetType())
 					{
-						defender.FixedEffect(0x37B9, 10, 5, 1160, 0);
+					    defender.FixedEffect(0x37B9, 10, 5, 1160, 0);
 
-						percentageBonus += 50;
+						//percentageBonus += 50;
+                        //Based on chiv skill will give damage modifier bonus up to 64. Karma is not considered yet
+                        percentageBonus += Convert.ToInt32(Math.Floor((attacker.Skills[SkillName.Chivalry].Base - 30) / 7 * 5));
 					}
 				}
 			}

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -2231,12 +2231,6 @@ namespace Server.Items
 
             if (m_Consecrated)
             {
-                //if (Utility.RandomDouble() <= ConsecrateProcChance / 100)
-                //{
-                //    if (ConsecrateDamageBonus > 0)
-                //        damageBonus *= 1 + ConsecrateDamageBonus / 100;
-                //}
-                
                 // Based on chiv skill will give 1-15 damage modifier bonus when skill value >= 92 as OSI Test Center
                 percentageBonus += attackerChivSkill < 92.0 ? 0 : Convert.ToInt32(Math.Floor((attackerChivSkill - 92) / 2) + 1);
             }
@@ -2312,7 +2306,6 @@ namespace Server.Items
 					{
 					    defender.FixedEffect(0x37B9, 10, 5, 1160, 0);
 
-						//percentageBonus += 50;
                         //Based on chiv skill will give damage modifier bonus up to 64. Karma is not considered yet
                         percentageBonus += Convert.ToInt32(Math.Floor((attackerChivSkill - 30) / 7 * 5));
 					}

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -2217,7 +2217,8 @@ namespace Server.Items
             * Capped at x3 (300%).
             */
 			int percentageBonus = 0;
-
+            double attackerChivSkill = attacker.Skills[SkillName.Chivalry].Value;
+            
 			if (a != null)
 			{
 				percentageBonus += (int)(a.DamageScalar * 100) - 100;
@@ -2237,8 +2238,7 @@ namespace Server.Items
                 //}
                 
                 // Based on chiv skill will give 1-15 damage modifier bonus when skill value >= 92 as OSI Test Center
-                double chivSkill = attacker.Skills[SkillName.Chivalry].Value;
-                percentageBonus += chivSkill < 92.0 ? 0 : Convert.ToInt32(Math.Floor((chivSkill - 92) / 2) + 1);
+                percentageBonus += attackerChivSkill < 92.0 ? 0 : Convert.ToInt32(Math.Floor((attackerChivSkill - 92) / 2) + 1);
             }
 
             percentageBonus += (int)(damageBonus * 100) - 100;
@@ -2314,7 +2314,7 @@ namespace Server.Items
 
 						//percentageBonus += 50;
                         //Based on chiv skill will give damage modifier bonus up to 64. Karma is not considered yet
-                        percentageBonus += Convert.ToInt32(Math.Floor((attacker.Skills[SkillName.Chivalry].Value - 30) / 7 * 5));
+                        percentageBonus += Convert.ToInt32(Math.Floor((attackerChivSkill - 30) / 7 * 5));
 					}
 				}
 			}

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -2314,7 +2314,7 @@ namespace Server.Items
 
 						//percentageBonus += 50;
                         //Based on chiv skill will give damage modifier bonus up to 64. Karma is not considered yet
-                        percentageBonus += Convert.ToInt32(Math.Floor((attacker.Skills[SkillName.Chivalry].Base - 30) / 7 * 5));
+                        percentageBonus += Convert.ToInt32(Math.Floor((attacker.Skills[SkillName.Chivalry].Value - 30) / 7 * 5));
 					}
 				}
 			}

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -2217,7 +2217,6 @@ namespace Server.Items
             * Capped at x3 (300%).
             */
 			int percentageBonus = 0;
-            double attackerChivSkill = attacker.Skills[SkillName.Chivalry].Value;
             
 			if (a != null)
 			{
@@ -2232,7 +2231,7 @@ namespace Server.Items
             if (m_Consecrated)
             {
                 // Based on chiv skill will give 1-15 damage modifier bonus when skill value >= 92 as OSI Test Center
-                percentageBonus += attackerChivSkill < 92.0 ? 0 : Convert.ToInt32(Math.Floor((attackerChivSkill - 92) / 2) + 1);
+                percentageBonus += attacker.Skills[SkillName.Chivalry].Value < 92.0 ? 0 : Convert.ToInt32(Math.Floor((attacker.Skills[SkillName.Chivalry].Value - 92) / 2) + 1);
             }
 
             percentageBonus += (int)(damageBonus * 100) - 100;
@@ -2307,7 +2306,7 @@ namespace Server.Items
 					    defender.FixedEffect(0x37B9, 10, 5, 1160, 0);
 
                         //Based on chiv skill will give damage modifier bonus up to 64. Karma is not considered yet
-                        percentageBonus += Convert.ToInt32(Math.Floor((attackerChivSkill - 30) / 7 * 5));
+                        percentageBonus += Convert.ToInt32(Math.Floor((attacker.Skills[SkillName.Chivalry].Value - 30) / 7 * 5));
 					}
 				}
 			}


### PR DESCRIPTION
Consecrate Weapon: Based on chiv skill will give damage bonus 1-15 when skill value >= 92 as OSI Test Center
Enemy of One: Based on chiv skill will give damage modifier bonus up to 64. Karma is not considered yet. Formula taken from http://stratics.com/threads/chivalry-changes.245029/#post-1977380