### PR TITLE
Familiar AI Fix/Revamp v4

### DIFF
--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -1179,6 +1179,15 @@ namespace Server.Mobiles
 				case OrderType.Transfer:
 					return DoOrderTransfer();
 
+				case OrderType.Aggro:
+					return CheckFamiliar();
+
+				case OrderType.Heel:
+					return CheckFamiliar();
+
+				case OrderType.Fetch:
+					return DoOrderFetch();
+
 				default:
 					return false;
 			}
@@ -1233,7 +1242,6 @@ namespace Server.Mobiles
 					m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
-
 					m_Mobile.Warmode = true;
 					m_Mobile.Combatant = null;
 					break;
@@ -1270,7 +1278,6 @@ namespace Server.Mobiles
 					m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
-
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
@@ -1278,7 +1285,27 @@ namespace Server.Mobiles
 					m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
-
+					m_Mobile.Warmode = false;
+					m_Mobile.Combatant = null;
+					break;
+				case OrderType.Aggro:
+					m_Mobile.DebugSay("I aggro for my master");
+					m_Mobile.CurrentSpeed = 0.1;
+					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
+					m_Mobile.Warmode = true;
+					m_Mobile.Combatant = null;
+					break;
+				case OrderType.Heel:
+					m_Mobile.DebugSay("I heel to my master");
+					m_Mobile.CurrentSpeed = 0.01;
+					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
+					m_Mobile.Warmode = false;
+					m_Mobile.Combatant = null;
+					break;
+				case OrderType.Fetch:
+					m_Mobile.DebugSay("I fetch for my master");
+					m_Mobile.CurrentSpeed = 0.3;
+					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
@@ -1399,27 +1426,6 @@ namespace Server.Mobiles
 
 			if (distance < 1 || distance > 15)
 			{
-				if (distance < 1 && target.X == 1076 && target.Y == 450 && (m_Mobile is HordeMinionFamiliar))
-				{
-					PlayerMobile pm = m_Mobile.ControlMaster as PlayerMobile;
-
-					if (pm != null)
-					{
-						QuestSystem qs = pm.Quest;
-
-						if (qs is DarkTidesQuest)
-						{
-							QuestObjective obj = qs.FindObjective(typeof(FetchAbraxusScrollObjective));
-
-							if (obj != null && !obj.Completed)
-							{
-								m_Mobile.AddToBackpack(new ScrollOfAbraxus());
-								obj.Complete();
-							}
-						}
-					}
-				}
-
 				m_Mobile.TargetLocation = null;
 				return false; // At the target or too far away
 			}
@@ -2070,6 +2076,196 @@ namespace Server.Mobiles
 
 			return true;
 		}
+
+        private bool m_LastHidden;
+
+        public virtual bool CheckFamiliar()
+        {
+            // Part 1: Delete Familiar check
+            BaseCreature m = m_Mobile;
+            Mobile master = m.ControlMaster;
+            Map map = m.Map;
+
+            if (master == null || master.Deleted)
+            {
+
+                if (map != null && map != Map.Internal)
+                {
+                    Container pack = m.Backpack;
+
+                    if (pack != null)
+                    {
+                        var list = new List<Item>(pack.Items);
+
+                        for (int i = 0; i < list.Count; ++i)
+                        {
+                            list[i].MoveToWorld(m.Location, map);
+                        }
+
+                    }
+                    Effects.SendLocationParticles(
+                        EffectItem.Create(m.Location, map, EffectItem.DefaultDuration), 0x3728, 1, 13, 2100, 3, 5042, 0);
+                    m.PlaySound(0x201);
+                }
+                m.Delete();
+                return false;
+            }
+
+            // Part 2: Teleport to master check
+            Point3D m_Loc = Point3D.Zero;
+
+            if (map != master.Map)
+            {
+                m.Map = master.Map;
+                m.SetLocation(master.Location, true);
+            }
+            else if (!m.InRange(master.Location, m.RangePerception))
+            {
+                int range = (int)(m.RangeHome / 2 + 1);
+                int x = (m.X > master.X) ? (master.X + range) : (master.X - range);
+                int y = (m.Y > master.Y) ? (master.Y + range) : (master.Y - range);
+
+                for (int i = 0; i < 10; i++)
+                {
+                    m_Loc.X = x + Utility.RandomMinMax(-1, 1);
+                    m_Loc.Y = y + Utility.RandomMinMax(-1, 1);
+
+                    m_Loc.Z = map.GetAverageZ(m_Loc.X, m_Loc.Y);
+
+                    if (map.CanSpawnMobile(m_Loc))
+                    {
+                        break;
+                    }
+
+                    m_Loc = master.Location;
+                }
+
+                m.SetLocation(m_Loc, true);
+            }
+
+            //Part 3: Attack master's target check
+
+            // Don't attack your familiar!
+            if (master.Combatant == m)
+            {
+                master.Combatant = null;
+            }
+
+            // Don't attack my master!
+            if (m.Combatant == master)
+            {
+                m.Combatant = null;
+            }
+
+            // Only attack my master's combatant, and only if he's in range
+            m.Combatant = GetFamiliarCombatant(master.Combatant, master);
+
+            int delay = (int)(TransformMoveDelay(m.CurrentSpeed) * 1000);
+            bool mounted = m.Mounted || m.Flying;
+            bool bRun = (mounted && delay < Mobile.WalkMount) || (!mounted && delay < Mobile.WalkFoot);
+
+            // Do I lack a combatant?
+            if (m.Combatant == null)
+            {
+                m.ControlTarget = master;
+
+                if (WalkMobileRange(master, 1, bRun, 0, 1) &&
+                    m.Direction != m.GetDirectionTo(master) &&
+                    (m.LastMoveTime + 500) < Core.TickCount)
+                {
+                    m.Direction = m.GetDirectionTo(master);
+                }
+
+                if (m_LastHidden != master.Hidden)
+                {
+                    m.Hidden = m_LastHidden = master.Hidden;
+                }
+
+                if (m.ControlOrder != OrderType.Heel)
+                {
+                    m.ControlOrder = OrderType.Heel;
+                }
+
+                return true;
+            }
+
+            m.ControlTarget = m.Combatant;
+
+            if (MoveTo(m.Combatant, bRun, m.RangeFight) &&
+                m.Direction != m.GetDirectionTo(m.Combatant) &&
+                (m.LastMoveTime + 1000) < Core.TickCount)
+            {
+                m.Direction = m.GetDirectionTo(m.Combatant);
+            }
+
+            if (m.ControlOrder != OrderType.Aggro)
+            {
+                m.ControlOrder = OrderType.Aggro;
+            }
+
+            return true;
+        }
+
+        private IDamageable GetFamiliarCombatant(IDamageable mc, Mobile master)
+        {
+            if (mc == null)
+            {
+                return null;
+            }
+
+            if (((BaseFamiliar)m_Mobile).AttacksMastersTarget && master.InRange(mc.Location, m_Mobile.RangeHome))
+            {
+                return mc;
+            }
+
+            if (m_Mobile.InRange(master, 1) && (master.InRange(mc.Location, 1) || m_Mobile.InRange(mc.Location, 1)))
+            {
+                return mc;
+            }
+
+            return null;
+        }
+
+        public virtual bool DoOrderFetch()
+        {
+            BaseCreature m = m_Mobile;
+            IPoint2D target = m.TargetLocation;
+
+            if (target == null)
+            {
+                m.ControlOrder = OrderType.Heel;
+                return false; // Creature is not being herded
+            }
+
+            double distance = m.GetDistanceToSqrt(target);
+
+            if (distance < 1 && target.X == 1076 && target.Y == 450 && (m is HordeMinionFamiliar))
+            {
+                PlayerMobile pm = m.ControlMaster as PlayerMobile;
+
+                if (pm != null)
+                {
+                    QuestSystem qs = pm.Quest;
+
+                    if (qs is DarkTidesQuest)
+                    {
+                        QuestObjective obj = qs.FindObjective(typeof(FetchAbraxusScrollObjective));
+
+                        if (obj != null && !obj.Completed)
+                        {
+                            m.AddToBackpack(new ScrollOfAbraxus());
+                            obj.Complete();
+                            m.TargetLocation = null;
+                            m.ControlTarget = pm;
+                            m.ControlOrder = OrderType.Heel;
+                        }
+                    }
+                }
+            }
+
+            DoMove(m.GetDirectionTo(target));
+            return true;
+        }
 
 		public virtual bool DoBardPacified()
 		{

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -69,7 +69,10 @@ namespace Server.Mobiles
         Release, //"(Name) release"  Releases pet back into the wild (removes "tame" status).
         Stay, //"(All/Name) stay" All or the specified pet(s) will stop and stay in current spot.
         Stop, //"(All/Name) stop Cancels any current orders to attack, guard or follow.
-        Transfer //"(Name) transfer" Transfers complete ownership to targeted player.
+        Transfer, //"(Name) transfer" Transfers complete ownership to targeted player.
+        Aggro, // Familiar fight mode
+        Heel, // Familiar follow mode
+        Fetch // Familiar quest herding mode
     }
 
     [Flags]
@@ -3889,6 +3892,12 @@ namespace Server.Mobiles
                 {
                     aggressor.Aggressors.Add(AggressorInfo.Create(this, aggressor, true));
                 }
+
+                if (this is BaseFamiliar)
+                {
+                    DebugSay("Familiars only attack what their masters do.");
+                    return;
+                }
             }
 
             OrderType ct = m_ControlOrder;
@@ -5970,8 +5979,16 @@ namespace Server.Mobiles
                 ControlMaster = m;
                 Controlled = true;
                 ControlTarget = null;
-                ControlOrder = OrderType.Come;
                 Guild = null;
+
+                if (this is BaseFamiliar)
+                {
+                    ControlOrder = OrderType.Heel;
+                }
+                else
+                {
+                    ControlOrder = OrderType.Come;
+                }
 
                 if (m_DeleteTimer != null)
                 {
@@ -7216,7 +7233,7 @@ namespace Server.Mobiles
                         if (!onlyBonded || pet.IsBonded)
                         {
                             if (pet.ControlOrder == OrderType.Guard || pet.ControlOrder == OrderType.Follow ||
-                                pet.ControlOrder == OrderType.Come)
+                                pet.ControlOrder == OrderType.Come || (pet is BaseFamiliar))
                             {
                                 move.Add(pet);
                             }

--- a/Scripts/Mobiles/Summons/BaseFamiliar.cs
+++ b/Scripts/Mobiles/Summons/BaseFamiliar.cs
@@ -15,8 +15,6 @@ namespace Server.Mobiles
 {
 	public abstract class BaseFamiliar : BaseCreature
 	{
-		private bool m_LastHidden;
-
 		public BaseFamiliar()
 			: base(AIType.AI_Melee, FightMode.Closest, 10, 1, -1, -1)
 		{ }
@@ -29,127 +27,11 @@ namespace Server.Mobiles
 		public override Poison PoisonImmune { get { return Poison.Lethal; } }
 		public override bool Commandable { get { return false; } }
 		public override bool PlayerRangeSensitive { get { return false; } }
-
-        public virtual bool AttacksMastersTarget { get { return true; } }
-
-		public virtual void RangeCheck()
-		{
-			if (!Deleted && ControlMaster != null && !ControlMaster.Deleted)
-			{
-				int range = (RangeHome - 2);
-
-				if (!InRange(ControlMaster.Location, RangeHome))
-				{
-					Mobile master = ControlMaster;
-
-					Point3D m_Loc = Point3D.Zero;
-
-					if (Map == master.Map)
-					{
-						int x = (X > master.X) ? (master.X + range) : (master.X - range);
-						int y = (Y > master.Y) ? (master.Y + range) : (master.Y - range);
-
-						for (int i = 0; i < 10; i++)
-						{
-							m_Loc.X = x + Utility.RandomMinMax(-1, 1);
-							m_Loc.Y = y + Utility.RandomMinMax(-1, 1);
-
-							m_Loc.Z = Map.GetAverageZ(m_Loc.X, m_Loc.Y);
-
-							if (Map.CanSpawnMobile(m_Loc))
-							{
-								break;
-							}
-
-							m_Loc = master.Location;
-						}
-
-						if (!Deleted)
-						{
-							SetLocation(m_Loc, true);
-						}
-					}
-				}
-			}
-		}
+		public virtual bool AttacksMastersTarget { get { return false; } }
 
 		public override void OnThink()
 		{
-			Mobile master = ControlMaster;
-
-			if (Deleted)
-			{
-				return;
-			}
-
-			if (master == null || master.Deleted)
-			{
-				DropPackContents();
-				EndRelease(null);
-				return;
-			}
-
-            if (AttacksMastersTarget)
-            {
-                if (Combatant == null)
-                {
-                    if (master.Combatant != null)
-                    {
-                        Combatant = master.Combatant;
-                    }
-                }
-                else
-                {
-                    if (Combatant.Deleted)
-                    {
-                        Combatant = null;
-                    }
-
-                    return;
-                }
-            }
-
-			RangeCheck();
-
-			if (m_LastHidden != master.Hidden)
-			{
-				Hidden = m_LastHidden = master.Hidden;
-			}
-
-			if (AIObject != null && AIObject.WalkMobileRange(master, 5, true, 1, 1))
-			{
-                if ((master.Combatant !=null) && (InRange(master.Combatant, 1)))
-                {
-		            Warmode = master.Warmode;
-		            Combatant = master.Combatant;
-
-		            CurrentSpeed = 0.10;
-			    }
-
-                if ((master.Combatant !=null) && (!InRange(master.Combatant, 1)))
-                {
-                    Warmode = false;
-                    FocusMob = null;
-                    Combatant = null;
-                    CurrentSpeed = 0.01;
-                }
-
-                if (master.Combatant == null)
-                {
-                    Warmode = false;
-                    FocusMob = null;
-                    Combatant = null;
-                    CurrentSpeed = 0.01;
-                }
-            }
-			else
-			{
-				Warmode = false;
-				FocusMob = null;
-                Combatant = null;
-
-				CurrentSpeed = .01;
-			}
+			return;
 		}
 
 		public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)

--- a/Scripts/Quests/DarkTides/Objectives.cs
+++ b/Scripts/Quests/DarkTides/Objectives.cs
@@ -230,6 +230,7 @@ namespace Server.Engines.Quests.Necro
                 {
                     this.System.From.SendLocalizedMessage(1060113); // You instinctively will your familiar to fetch the scroll for you.
                     hmf.TargetLocation = new Point2D(1076, 450);
+                    hmf.ControlOrder = OrderType.Fetch;
                 }
             }
         }


### PR DESCRIPTION
[Associated Thread](https://www.servuo.com/threads/familiar-ai-fix-revamp.6961/)
[Associated Branch](https://github.com/GriffonSpade/ServUO/tree/Familiar-AI-Fix/Revamp)
This pull is designed to clear out and streamline the kludge that is Familiar AI.

This version 4 should have full OSI fidelity.

-Fixes bug that usually cause familiar to be unable to work properly for the Dark Tides quest. (Though the AI rarely takes a bit to get around the wall)
-Familiars ONLY attack their master's current combatant.
-Familiars with AttacksMastersTarget ONLY attack creatures within RangeHome (default 10) of master.
--Sanity Check: If master is attacking familiar, or vise-versa, set attacker's combatant to null. (Masters don't attack their familiars, familiars don't attack their masters)
-No support for Archer/Mage familiars. (all familiars are Melee)
-While not attacking, familiars follow their master.
-Familiars teleport to their master if they're on another map.
-Familiars teleport nearer to their master if they're more than RangePerception (default 16) apart.

v2:
-Brought code into line with Master.
-Fixed a a bug causing familiar to not attack anything not attacking itself
--Reduced setting of OrderType to only when necessary
-Changed AggressiveAction() familiar behavior to abort early on
-Various incidental Trims

v3:
-Brought code into line with Master.
-Fixed Familiar Powersliding issues.
-Fixed AttacksMastersTarget default to false in BaseFamiliar

v4:
-Brought code into line with Master.
-Added Familiars without AttacksMastersTarget now have melee-range combat as per OSI. (Both require familiar to be within 1 range of master, and target can be within 1 range of either the familiar or the master)