### PR TITLE
New AddSignGump/Expanded AddDoorGump

### DIFF
--- a/Scripts/Gumps/AddDoorGump.cs
+++ b/Scripts/Gumps/AddDoorGump.cs
@@ -13,7 +13,38 @@ namespace Server.Gumps
             new DoorInfo(typeof(RattanDoor), 0x695),
             new DoorInfo(typeof(DarkWoodDoor), 0x6A5),
             new DoorInfo(typeof(LightWoodDoor), 0x6D5),
-            new DoorInfo(typeof(StrongWoodDoor), 0x6E5)
+            new DoorInfo(typeof(StrongWoodDoor), 0x6E5),
+            new DoorInfo(typeof(BarredMetalDoor2), 0x1FED),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(BarredMetalDoor), 0x685),
+            new DoorInfo(typeof(MediumWoodDoor), 0x6B5),
+            new DoorInfo(typeof(MetalDoor2), 0x6C5),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(IronGate), 0x824),
+            new DoorInfo(typeof(IronGateShort), 0x84C),
+            new DoorInfo(typeof(LightWoodGate), 0x839),
+            new DoorInfo(typeof(DarkWoodGate), 0x866),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(MetalDoor), -1),
+            new DoorInfo(typeof(SecretStoneDoor1), 0xE8),
+            new DoorInfo(typeof(SecretDungeonDoor), 0x314),
+            new DoorInfo(typeof(SecretStoneDoor2), 0x324),
+            new DoorInfo(typeof(SecretWoodenDoor), 0x334),
+            new DoorInfo(typeof(SecretLightWoodDoor), 0x344),
+            new DoorInfo(typeof(SecretStoneDoor3), 0x354)
         };
         private readonly int m_Type;
         public AddDoorGump()
@@ -24,38 +55,65 @@ namespace Server.Gumps
         public AddDoorGump(int type)
             : base(50, 40)
         {
-            this.m_Type = type;
+            m_Type = type;
 
-            this.AddPage(0);
+            AddPage(0);
 
-            if (this.m_Type >= 0 && this.m_Type < m_Types.Length)
+            if (m_Type >= 0 && m_Type < m_Types.Length)
             {
-                this.AddBlueBack(155, 174);
+                AddBlueBack(155, 174);
 
-                int baseID = m_Types[this.m_Type].m_BaseID;
+                int baseID = m_Types[m_Type].m_BaseID;
 
-                this.AddItem(25, 24, baseID);
-                this.AddButton(26, 37, 0x5782, 0x5782, 1, GumpButtonType.Reply, 0);
+                AddItem(25, 24, baseID);
+                AddButton(26, 37, 0x5782, 0x5782, 1, GumpButtonType.Reply, 0);
 
-                this.AddItem(47, 45, baseID + 2);
-                this.AddButton(43, 57, 0x5783, 0x5783, 2, GumpButtonType.Reply, 0);
+                AddItem(47, 45, baseID + 2);
+                AddButton(43, 57, 0x5783, 0x5783, 2, GumpButtonType.Reply, 0);
 
-                this.AddItem(87, 22, baseID + 10);
-                this.AddButton(116, 35, 0x5785, 0x5785, 6, GumpButtonType.Reply, 0);
+                AddItem(87, 22, baseID + 10);
+                AddButton(116, 35, 0x5785, 0x5785, 6, GumpButtonType.Reply, 0);
 
-                this.AddItem(65, 45, baseID + 8);
-                this.AddButton(96, 55, 0x5784, 0x5784, 5, GumpButtonType.Reply, 0);
+                AddItem(65, 45, baseID + 8);
+                AddButton(96, 55, 0x5784, 0x5784, 5, GumpButtonType.Reply, 0);
 
-                this.AddButton(73, 36, 0x2716, 0x2716, 9, GumpButtonType.Reply, 0);
+                AddButton(73, 36, 0x2716, 0x2716, 9, GumpButtonType.Reply, 0);
             }
             else
             {
-                this.AddBlueBack(265, 145);
+                AddBlueBack(570, 165);
 
+                int pages = m_Types.Length / 10 + 1;
                 for (int i = 0; i < m_Types.Length; ++i)
                 {
-                    this.AddButton(30 + (i * 49), 13, 0x2624, 0x2625, i + 1, GumpButtonType.Reply, 0);
-                    this.AddItem(22 + (i * 49), 20, m_Types[i].m_BaseID);
+                    int page = i / 10 + 1;
+                    int pos = i % 10;
+
+                    if (pos == 0)
+                    {
+                        AddPage(page);
+                        AddHtmlLocalized(30, 20, 60, 20, 1042971, String.Format("{0}",page), 0x7FFF, false, false); // #
+
+                        AddHtmlLocalized(30, 45, 60, 20, 1043353, 0x7FFF, false, false); // Next
+                        if (page < pages)
+                            AddButton(30, 60, 0xFA5, 0xFA7, 0, GumpButtonType.Page, page + 1);
+                        else
+                            AddButton(30, 60, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 1);
+
+                        AddHtmlLocalized(30, 85, 60, 20, 1011393, 0x7FFF, false, false); // Back
+                        if (page > 1)
+                            AddButton(30, 100, 0xFAE, 0xFB0, 0, GumpButtonType.Page, page - 1);
+                        else
+                            AddButton(30, 100, 0xFAE, 0xFB0, 0, GumpButtonType.Page, pages);
+                    }
+
+                    if (m_Types[i].m_BaseID < 0)
+                        continue;
+
+                    int x = (pos + 1) * 50;
+
+                    AddButton(30 + x, 20, 0x2624, 0x2625, i + 1, GumpButtonType.Reply, 0);
+                    AddItem(15 + x, 30, m_Types[i].m_BaseID);
                 }
             }
         }
@@ -74,10 +132,10 @@ namespace Server.Gumps
 
         public void AddBlueBack(int width, int height)
         {
-            this.AddBackground(0, 0, width - 00, height - 00, 0xE10);
-            this.AddBackground(8, 5, width - 16, height - 11, 0x053);
-            this.AddImageTiled(15, 14, width - 29, height - 29, 0xE14);
-            this.AddAlphaRegion(15, 14, width - 29, height - 29);
+            AddBackground(0, 0, width - 00, height - 00, 0xE10);
+            AddBackground(8, 5, width - 16, height - 11, 0x053);
+            AddImageTiled(15, 14, width - 29, height - 29, 0xE14);
+            AddAlphaRegion(15, 14, width - 29, height - 29);
         }
 
         public override void OnResponse(NetState sender, RelayInfo info)
@@ -85,7 +143,7 @@ namespace Server.Gumps
             Mobile from = sender.Mobile;
             int button = info.ButtonID - 1;
 
-            if (this.m_Type == -1)
+            if (m_Type == -1)
             {
                 if (button >= 0 && button < m_Types.Length)
                     from.SendGump(new AddDoorGump(button));
@@ -94,12 +152,12 @@ namespace Server.Gumps
             {
                 if (button >= 0 && button < 8)
                 {
-                    from.SendGump(new AddDoorGump(this.m_Type));
-                    CommandSystem.Handle(from, String.Format("{0}Add {1} {2}", CommandSystem.Prefix, m_Types[this.m_Type].m_Type.Name, (DoorFacing)button));
+                    from.SendGump(new AddDoorGump(m_Type));
+                    CommandSystem.Handle(from, String.Format("{0}Add {1} {2}", CommandSystem.Prefix, m_Types[m_Type].m_Type.Name, (DoorFacing)button));
                 }
                 else if (button == 8)
                 {
-                    from.SendGump(new AddDoorGump(this.m_Type));
+                    from.SendGump(new AddDoorGump(m_Type));
                     CommandSystem.Handle(from, String.Format("{0}Link", CommandSystem.Prefix));
                 }
                 else
@@ -116,8 +174,8 @@ namespace Server.Gumps
         public int m_BaseID;
         public DoorInfo(Type type, int baseID)
         {
-            this.m_Type = type;
-            this.m_BaseID = baseID;
+            m_Type = type;
+            m_BaseID = baseID;
         }
     }
 }

--- a/Scripts/Gumps/AddSignGump.cs
+++ b/Scripts/Gumps/AddSignGump.cs
@@ -1,0 +1,235 @@
+using System;
+using Server.Commands;
+using Server.Items;
+using Server.Network;
+
+namespace Server.Gumps
+{
+    public class AddSignGump : Gump
+    {
+        public static SignInfo[] m_Types = new SignInfo[]
+        {
+            new SignInfo(0xB95),
+            new SignInfo(0xB96),
+            new SignInfo(0xBA3),
+            new SignInfo(0xBA4),
+            new SignInfo(0xBA5),
+            new SignInfo(0xBA6),
+            new SignInfo(0xBA7),
+            new SignInfo(0xBA8),
+            new SignInfo(0xBA9),
+            new SignInfo(0xBAA),
+            new SignInfo(0xBAB),
+            new SignInfo(0xBAC),
+            new SignInfo(0xBAD),
+            new SignInfo(0xBAE),
+            new SignInfo(0xBAF),
+            new SignInfo(0xBB0),
+            new SignInfo(0xBB1),
+            new SignInfo(0xBB2),
+            new SignInfo(0xBB3),
+            new SignInfo(0xBB4),
+            new SignInfo(0xBB5),
+            new SignInfo(0xBB6),
+            new SignInfo(0xBB7),
+            new SignInfo(0xBB8),
+            new SignInfo(0xBB9),
+            new SignInfo(0xBBA),
+            new SignInfo(0xBBB),
+            new SignInfo(0xBBC),
+            new SignInfo(0xBBD),
+            new SignInfo(0xBBE),
+            new SignInfo(0xBBF),
+            new SignInfo(0xBC0),
+            new SignInfo(0xBC1),
+            new SignInfo(0xBC2),
+            new SignInfo(0xBC3),
+            new SignInfo(0xBC4),
+            new SignInfo(0xBC5),
+            new SignInfo(0xBC6),
+            new SignInfo(0xBC7),
+            new SignInfo(0xBC8),
+            new SignInfo(0xBC9),
+            new SignInfo(0xBCA),
+            new SignInfo(0xBCB),
+            new SignInfo(0xBCC),
+            new SignInfo(0xBCD),
+            new SignInfo(0xBCE),
+            new SignInfo(0xBCF),
+            new SignInfo(0xBD0),
+            new SignInfo(0xBD1),
+            new SignInfo(0xBD2),
+            new SignInfo(0xBD3),
+            new SignInfo(0xBD4),
+            new SignInfo(0xBD5),
+            new SignInfo(0xBD6),
+            new SignInfo(0xBD7),
+            new SignInfo(0xBD8),
+            new SignInfo(0xBD9),
+            new SignInfo(0xBDA),
+            new SignInfo(0xBDB),
+            new SignInfo(0xBDC),
+            new SignInfo(0xBDD),
+            new SignInfo(0xBDE),
+            new SignInfo(0xBDF),
+            new SignInfo(0xBE0),
+            new SignInfo(0xBE1),
+            new SignInfo(0xBE2),
+            new SignInfo(0xBE3),
+            new SignInfo(0xBE4),
+            new SignInfo(0xBE5),
+            new SignInfo(0xBE6),
+            new SignInfo(0xBE7),
+            new SignInfo(0xBE8),
+            new SignInfo(0xBE9),
+            new SignInfo(0xBEA),
+            new SignInfo(0xBEB),
+            new SignInfo(0xBEC),
+            new SignInfo(0xBED),
+            new SignInfo(0xBEE),
+            new SignInfo(0xBEF),
+            new SignInfo(0xBF0),
+            new SignInfo(0xBF1),
+            new SignInfo(0xBF2),
+            new SignInfo(0xBF3),
+            new SignInfo(0xBF4),
+            new SignInfo(0xBF5),
+            new SignInfo(0xBF6),
+            new SignInfo(0xBF7),
+            new SignInfo(0xBF8),
+            new SignInfo(0xBF9),
+            new SignInfo(0xBFA),
+            new SignInfo(0xBFB),
+            new SignInfo(0xBFC),
+            new SignInfo(0xBFD),
+            new SignInfo(0xBFE),
+            new SignInfo(0xBFF),
+            new SignInfo(0xC00),
+            new SignInfo(0xC01),
+            new SignInfo(0xC02),
+            new SignInfo(0xC03),
+            new SignInfo(0xC04),
+            new SignInfo(0xC05),
+            new SignInfo(0xC06),
+            new SignInfo(0xC07),
+            new SignInfo(0xC08),
+            new SignInfo(0xC09),
+            new SignInfo(0xC0A),
+            new SignInfo(0xC0B),
+            new SignInfo(0xC0C),
+            new SignInfo(0xC0D),
+            new SignInfo(0xC0E),
+            new SignInfo(0x1297),
+            new SignInfo(0x1298),
+            new SignInfo(0x1299),
+            new SignInfo(0x129A),
+            new SignInfo(0x129B),
+            new SignInfo(0x129C),
+            new SignInfo(0x129D),
+            new SignInfo(0x129E),
+            new SignInfo(0x1F28),
+            new SignInfo(0x1F29),
+            new SignInfo(0x4B20),
+            new SignInfo(0x4B21),
+            new SignInfo(0x9A0C),
+            new SignInfo(0x9A0D),
+            new SignInfo(0x9A0E),
+            new SignInfo(0x9A0F),
+            new SignInfo(0x9A10),
+            new SignInfo(0x9A11),
+            new SignInfo(0x9A12),
+            new SignInfo(0x9A13)
+        };
+
+        private readonly int m_Type;
+        public AddSignGump()
+            : this(-1)
+        {
+        }
+
+        public AddSignGump(int type)
+            : base(50, 40)
+        {
+            m_Type = type;
+
+            AddPage(0);
+
+            AddBlueBack(570, 175);
+
+            int pages = m_Types.Length / 20 + 1;
+            for (int i = 0; i < m_Types.Length; ++i)
+            {
+                int page = i / 20 + 1;
+                int xpos = (i / 2) % 10 ;
+                int ypos = i % 2;
+
+                if (xpos == 0 && ypos == 0)
+                {
+                    AddPage(page);
+                    AddHtmlLocalized(30, 20, 60, 20, 1042971, String.Format("{0}",page), 0x7FFF, false, false); // #
+
+                    AddHtmlLocalized(30, 45, 60, 20, 1043353, 0x7FFF, false, false); // Next
+                    if (page < pages)
+                        AddButton(30, 60, 0xFA5, 0xFA7, 0, GumpButtonType.Page, page + 1);
+                    else
+                        AddButton(30, 60, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 1);
+
+                    AddHtmlLocalized(30, 85, 60, 20, 1011393, 0x7FFF, false, false); // Back
+                    if (page > 1)
+                        AddButton(30, 100, 0xFAE, 0xFB0, 0, GumpButtonType.Page, page - 1);
+                    else
+                        AddButton(30, 100, 0xFAE, 0xFB0, 0, GumpButtonType.Page, pages);
+                }
+
+                if (m_Types[i].m_BaseID == 0)
+                    continue;
+
+                int x = (xpos + 1) * 50;
+                int y = (ypos * 75);
+                AddButton(30 + x, 20 + y, 0x2624, 0x2625, i + 1, GumpButtonType.Reply, m_Types[i].m_BaseID);
+                AddItem(15 + x, 40 + y, m_Types[i].m_BaseID);
+            }
+        }
+
+        public static void Initialize()
+        {
+            CommandSystem.Register("AddSign", AccessLevel.GameMaster, new CommandEventHandler(AddSign_OnCommand));
+        }
+
+        [Usage("AddSign")]
+        [Description("Displays a menu from which you can interactively add signs.")]
+        public static void AddSign_OnCommand(CommandEventArgs e)
+        {
+            e.Mobile.SendGump(new AddSignGump());
+        }
+
+        public void AddBlueBack(int width, int height)
+        {
+            AddBackground(0, 0, width - 00, height - 00, 0xE10);
+            AddBackground(8, 5, width - 16, height - 11, 0x053);
+            AddImageTiled(15, 14, width - 29, height - 29, 0xE14);
+            AddAlphaRegion(15, 14, width - 29, height - 29);
+        }
+
+        public override void OnResponse(NetState sender, RelayInfo info)
+        {
+            Mobile from = sender.Mobile;
+            int button = info.ButtonID - 1;
+
+            if (button < 0)
+                return;
+
+            CommandSystem.Handle(from, String.Format("{0}Add {1} {2}", CommandSystem.Prefix, " Sign ", m_Types[button].m_BaseID));
+            from.SendGump(new AddSignGump());
+        }
+    }
+
+    public class SignInfo
+    {
+        public int m_BaseID;
+        public SignInfo(int baseID)
+        {
+            m_BaseID = baseID;
+        }
+    }
+}

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -298,6 +298,9 @@
     <Compile Include="Gumps\AddGump.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Gumps\AddSignGump.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Gumps\AdminGump.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
[Associated Branch](https://github.com/GriffonSpade/ServUO/tree/New-AddSignGump-Expand-AddDoorGump)
Both work, and I've been unable to find any bugs with them. AddDoorGump might have room for improvement in the way it handles pages: It uses dummy entries.

-Added AddSignGump.cs
--Contains varied sign types, including shop signs, warning signs, arrow signs, wall signs, and bar signs

-Improved Expanded AddDoorGump.cs
--Contains multiple pages with regular doors, tall doors, gates, and secret doors.
--TODO: SE+ doors, portcullis