### PR TITLE
Configuarable Primary Stat Caps

### DIFF
--- a/Config/PlayerCaps.cfg
+++ b/Config/PlayerCaps.cfg
@@ -15,11 +15,29 @@ TotalSkillCap=7000
 # The total stat cap
 TotalStatCap=225
 
+# The individual str cap
+StrCap=125
+
+# The individual dex cap
+DexCap=125
+
+# The individual int cap
+IntCap=125
+
+# The individual enhanced str cap for players
+StrMaxCap=150
+
+# The individual enhanced dex cap for players
+DexMaxCap=150
+
+# The individual enhanced int cap for players
+IntMaxCap=150
+
 #------------
 # Exisitng chars too
 #-----------------------
 
-# The individual stat cap
+# Deprecated: The individual stat cap
 StatCap=125
 
 # If true, limit the player's ability to gain stats within a certain time
@@ -35,7 +53,7 @@ PlayerStatTimeDelay=00:00:15:00
 # I think this was disabled by OSI Publish 45 as well, but no certain.
 EnablePetStatTimeDelay=false
 
-# Time delay between player stat gains
+# Time delay between pet stat gains
 # Default: 5 minutes
 # Format: dd:hh:mm:ss 
 PetStatTimeDelay=00:00:05:00

--- a/Scripts/Misc/SkillCheck.cs
+++ b/Scripts/Misc/SkillCheck.cs
@@ -9,7 +9,6 @@ namespace Server.Misc
 {
     public class SkillCheck
     {
-        private static int StatCap;
         private static bool m_StatGainDelayEnabled;
         private static TimeSpan m_StatGainDelay;
         private static bool m_PetStatGainDelayEnabled;
@@ -20,7 +19,6 @@ namespace Server.Misc
 
         public static void Configure()
         {
-            StatCap = Config.Get("PlayerCaps.StatCap", 125);
             m_StatGainDelayEnabled = Config.Get("PlayerCaps.EnablePlayerStatTimeDelay", false);
             m_StatGainDelay = Config.Get("PlayerCaps.PlayerStatTimeDelay", TimeSpan.FromMinutes(15.0));
             m_PetStatGainDelayEnabled = Config.Get("PlayerCaps.EnablePetStatTimeDelay", false);
@@ -289,7 +287,7 @@ namespace Server.Misc
                 if (from is PlayerMobile)
                 {
                     PlayerMobile pm = from as PlayerMobile;
-                    
+
                     if (pm != null && skill.SkillName == pm.AcceleratedSkill && pm.AcceleratedStart > DateTime.UtcNow)
                     {
                         pm.SendLocalizedMessage(1077956); // You are infused with intense energy. You are under the effects of an accelerated skillgain scroll.
@@ -340,7 +338,7 @@ namespace Server.Misc
                 Server.Engines.Quests.QuestHelper.CheckSkill((PlayerMobile)from, skill);
             #endregion
 
-			
+
             if (skill.Lock == SkillLock.Up)
             {
                 SkillInfo info = skill.Info;
@@ -435,11 +433,11 @@ namespace Server.Misc
             switch ( stat )
             {
                 case Stat.Str:
-                    return (from.StrLock == StatLockType.Up && from.RawStr < StatCap);
+                    return (from.StrLock == StatLockType.Up && from.RawStr < from.StrCap);
                 case Stat.Dex:
-                    return (from.DexLock == StatLockType.Up && from.RawDex < StatCap);
+                    return (from.DexLock == StatLockType.Up && from.RawDex < from.DexCap);
                 case Stat.Int:
-                    return (from.IntLock == StatLockType.Up && from.RawInt < StatCap);
+                    return (from.IntLock == StatLockType.Up && from.RawInt < from.IntCap);
             }
 
             return false;

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -1788,7 +1788,7 @@ namespace Server.Mobiles
 			{
 				if (Core.ML && IsPlayer())
 				{
-					return Math.Min(base.Str, 150);
+					return Math.Min(base.Str, StrMaxCap);
 				}
 
 				return base.Str;
@@ -1803,7 +1803,7 @@ namespace Server.Mobiles
 			{
 				if (Core.ML && IsPlayer())
 				{
-					return Math.Min(base.Int, 150);
+					return Math.Min(base.Int, IntMaxCap);
 				}
 
 				return base.Int;
@@ -1818,7 +1818,7 @@ namespace Server.Mobiles
 			{
 				if (Core.ML && IsPlayer())
 				{
-					return Math.Min(base.Dex, 150);
+					return Math.Min(base.Dex, DexMaxCap);
 				}
 
 				return base.Dex;

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -6020,12 +6020,12 @@ namespace Server
 					{
 						if (version < 34)
 						{
-							m_StrCap = 125;
-							m_DexCap = 125;
-							m_IntCap = 125;
-							m_StrMaxCap = 150;
-							m_DexMaxCap = 150;
-							m_IntMaxCap = 150;
+                            m_StrCap = Config.Get("PlayerCaps.StrCap", 125);
+                            m_DexCap = Config.Get("PlayerCaps.DexCap", 125);
+                            m_IntCap = Config.Get("PlayerCaps.IntCap", 125);
+                            m_StrMaxCap = Config.Get("PlayerCaps.StrMaxCap", 150);
+                            m_DexMaxCap = Config.Get("PlayerCaps.DexMaxCap", 150);
+                            m_IntMaxCap = Config.Get("PlayerCaps.IntMaxCap", 150);
 						}
 
 						if (version < 21)
@@ -6045,7 +6045,7 @@ namespace Server
 
 						if (version < 3)
 						{
-							m_StatCap = 225;
+                            m_StatCap = Config.Get("PlayerCaps.TotalStatCap", 225);
 						}
 
 						if (version < 15)
@@ -10870,13 +10870,13 @@ namespace Server
 
 		public void DefaultMobileInit()
 		{
-            m_StatCap = Config.Get("PlayerCaps.TotalStatCap", 225); ;
-            m_StrCap = Config.Get("PlayerCaps.StrCap", 125); ;
-            m_DexCap = Config.Get("PlayerCaps.DexCap", 125); ;
-            m_IntCap = Config.Get("PlayerCaps.IntCap", 125); ;
-            m_StrMaxCap = Config.Get("PlayerCaps.StrMaxCap", 150); ;
-            m_DexMaxCap = Config.Get("PlayerCaps.DexMaxCap", 150); ;
-            m_IntMaxCap = Config.Get("PlayerCaps.IntMaxCap", 150); ;
+            m_StatCap = Config.Get("PlayerCaps.TotalStatCap", 225);
+            m_StrCap = Config.Get("PlayerCaps.StrCap", 125);
+            m_DexCap = Config.Get("PlayerCaps.DexCap", 125);
+            m_IntCap = Config.Get("PlayerCaps.IntCap", 125);
+            m_StrMaxCap = Config.Get("PlayerCaps.StrMaxCap", 150);
+            m_DexMaxCap = Config.Get("PlayerCaps.DexMaxCap", 150);
+            m_IntMaxCap = Config.Get("PlayerCaps.IntMaxCap", 150);
 			m_FollowersMax = 5;
 			m_Skills = new Skills(this);
 			m_Items = new List<Item>();

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -728,6 +728,12 @@ namespace Server
 		private NetState m_NetState;
 		private bool m_Female, m_Warmode, m_Hidden, m_Blessed, m_Flying;
 		private int m_StatCap;
+		private int m_StrCap;
+		private int m_DexCap;
+		private int m_IntCap;
+		private int m_StrMaxCap;
+		private int m_DexMaxCap;
+		private int m_IntMaxCap;
 		private int m_Str, m_Dex, m_Int;
 		private int m_Hits, m_Stam, m_Mana;
 		private int m_Fame, m_Karma;
@@ -5771,6 +5777,17 @@ namespace Server
 
 			switch (version)
 			{
+                case 34:
+                    {
+						m_StrCap = reader.ReadInt();
+						m_DexCap = reader.ReadInt();
+						m_IntCap = reader.ReadInt();
+						m_StrMaxCap = reader.ReadInt();
+						m_DexMaxCap = reader.ReadInt();
+						m_IntMaxCap = reader.ReadInt();
+
+                        goto case 33;
+                    }
                 case 33:
                     {
                         m_SpecialSlayerMechanics = reader.ReadBool();
@@ -6001,6 +6018,16 @@ namespace Server
 					}
 				case 0:
 					{
+						if (version < 34)
+						{
+							m_StrCap = 125;
+							m_DexCap = 125;
+							m_IntCap = 125;
+							m_StrMaxCap = 150;
+							m_DexMaxCap = 150;
+							m_IntMaxCap = 150;
+						}
+
 						if (version < 21)
 						{
 							m_Stabled = new List<Mobile>();
@@ -6259,7 +6286,14 @@ namespace Server
 
 		public virtual void Serialize(GenericWriter writer)
 		{
-			writer.Write(33); // version
+			writer.Write(34); // version
+
+			writer.Write(m_StrCap);
+			writer.Write(m_DexCap);
+			writer.Write(m_IntCap);
+			writer.Write(m_StrMaxCap);
+			writer.Write(m_DexMaxCap);
+			writer.Write(m_IntMaxCap);
 
             writer.Write(m_SpecialSlayerMechanics);
 
@@ -10837,6 +10871,12 @@ namespace Server
 		public void DefaultMobileInit()
 		{
             m_StatCap = Config.Get("PlayerCaps.TotalStatCap", 225); ;
+            m_StrCap = Config.Get("PlayerCaps.StrCap", 125); ;
+            m_DexCap = Config.Get("PlayerCaps.DexCap", 125); ;
+            m_IntCap = Config.Get("PlayerCaps.IntCap", 125); ;
+            m_StrMaxCap = Config.Get("PlayerCaps.StrMaxCap", 150); ;
+            m_DexMaxCap = Config.Get("PlayerCaps.DexMaxCap", 150); ;
+            m_IntMaxCap = Config.Get("PlayerCaps.IntMaxCap", 150); ;
 			m_FollowersMax = 5;
 			m_Skills = new Skills(this);
 			m_Items = new List<Item>();
@@ -12417,6 +12457,48 @@ namespace Server
 		}
 
 		[CommandProperty(AccessLevel.GameMaster)]
+		public int StrCap
+		{
+			get { return m_StrCap; }
+			set { m_StrCap = value; }
+		}
+
+		[CommandProperty(AccessLevel.GameMaster)]
+		public int DexCap
+		{
+			get { return m_DexCap; }
+			set { m_DexCap = value; }
+		}
+
+		[CommandProperty(AccessLevel.GameMaster)]
+		public int IntCap
+		{
+			get { return m_IntCap; }
+			set { m_IntCap = value; }
+		}
+
+		[CommandProperty(AccessLevel.GameMaster)]
+		public int StrMaxCap
+		{
+			get { return m_StrMaxCap; }
+			set { m_StrMaxCap = value; }
+		}
+
+		[CommandProperty(AccessLevel.GameMaster)]
+		public int DexMaxCap
+		{
+			get { return m_DexMaxCap; }
+			set { m_DexMaxCap = value; }
+		}
+
+		[CommandProperty(AccessLevel.GameMaster)]
+		public int IntMaxCap
+		{
+			get { return m_IntMaxCap; }
+			set { IntMaxCap = value; }
+		}
+
+		[CommandProperty(AccessLevel.GameMaster)]
 		public virtual bool Meditating { get; set; }
 
 		[CommandProperty(AccessLevel.Decorator)]
@@ -12446,3 +12528,4 @@ namespace Server
 		{ }
 	}
 }
+    


### PR DESCRIPTION
[Associated Thread](https://www.servuo.com/threads/configurable-stat-caps.7111/)
[Associated Branch](https://github.com/GriffonSpade/ServUO/tree/Configuarable-Statcaps)
The purpose of this pull is to make primary stat caps, both base and enhanced, configurable.

-Added StrCap, DexCap, IntCap, StrMaxCap, DexMaxCap, and IntMaxCap and related fields in PlayerCaps.cfg and Mobile.cs (Updated to serialization v34)
-Changed replaced old hardcoded 150 stat checks with StrMaxCap, DexMaxCap, and IntMaxCap checks in PlayerMobile.cs
-Changed replaced old hardcoded (generic individual) StatCap checks with checks based on the individual creature's individual StrCap, DexCap, and IntCap.

v1.01:
-Added When loading older save versions, deserialize now reads config settings for stat caps rather than using a default value.