### PR TITLE
BaseCreature.cs: Idle Anim Fix

### DIFF
--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -4166,16 +4166,23 @@ namespace Server.Mobiles
 
             m_IdleReleaseTime = DateTime.UtcNow + TimeSpan.FromSeconds(Utility.RandomMinMax(15, 25));
 
-            if (Body.IsHuman && !Mounted && !Flying)
+            if (Body.IsHuman && !Mounted)
             {
-                switch (Utility.Random(2))
+                if (Flying)
                 {
-                    case 0:
-                        Animate(5, 5, 1, true, true, 1);
-                        break;
-                    case 1:
-                        Animate(6, 5, 1, true, false, 1);
-                        break;
+                    Animate(66, 10, 1, true, false, 1);
+                }
+                else
+                {
+                    switch (Utility.Random(2))
+                    {
+                        case 0:
+                            Animate(5, 5, 1, true, true, 1);
+                            break;
+                        case 1:
+                            Animate(6, 5, 1, true, false, 1);
+                            break;
+                    }
                 }
             }
             else if (Body.IsAnimal)

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -4166,7 +4166,7 @@ namespace Server.Mobiles
 
             m_IdleReleaseTime = DateTime.UtcNow + TimeSpan.FromSeconds(Utility.RandomMinMax(15, 25));
 
-            if (Body.IsHuman)
+            if (Body.IsHuman && !Mounted && !Flying)
             {
                 switch (Utility.Random(2))
                 {
@@ -4208,20 +4208,6 @@ namespace Server.Mobiles
 
             PlaySound(GetIdleSound());
             return true; // entered idle state
-        }
-
-        /*
-			this way, due to the huge number of locations this will have to be changed
-			Perhaps we can change this in the future when fixing game play is not the
-			major issue.
-		*/
-
-        public virtual void CheckedAnimate(int action, int frameCount, int repeatCount, bool forward, bool repeat, int delay)
-        {
-            if (!Mounted)
-            {
-                base.Animate(action, frameCount, repeatCount, forward, repeat, delay);
-            }
         }
 
         public override void Animate(int action, int frameCount, int repeatCount, bool forward, bool repeat, int delay)


### PR DESCRIPTION
-Fixed blocked inappropriate idle anim for Body.IsHuman creatures while mounted/flying
-Removed unused CheckedAnimate method, Body.IsHuman mobiles that are Mounted or Flying need only Idle anim blocked as far as is known.
-Not covered here, but flying player gargoyles appear to use midair somersault animation 66 at 10 frames, 1 repetition, forward true, repeat false, delay 1. It may be preferred to set flying Body.IsHuman (Which I do believe includes elves and player gargoyles) to use this animation instead of none.

-Added the flying gargoyle idle animation. human and elf response to trying to use this anim is no stranger than when they're set to flying in the first place.