### PR TITLE
MageAI: Fleeing Bugfix

### DIFF
--- a/Scripts/Mobiles/AI/AnimalAI.cs
+++ b/Scripts/Mobiles/AI/AnimalAI.cs
@@ -6,8 +6,8 @@ using System;
 // More your close, the more it can panic
 /*
 * AnimalHunterAI, AnimalHidingAI, AnimalDomesticAI...
-* 
-*/ 
+*
+*/
 
 namespace Server.Mobiles
 {
@@ -29,7 +29,7 @@ namespace Server.Mobiles
 			}
 			else if ( m_Mobile.IsHurt() || m_Mobile.Combatant != null )
 			{
-				m_Mobile.DebugSay( "I am hurt or being attacked, I flee" );						
+				m_Mobile.DebugSay( "I am hurt or being attacked, I flee" );
 				Action = ActionType.Flee;
 			}
 			else
@@ -39,20 +39,19 @@ namespace Server.Mobiles
 			return true;
             #endif
             // New, only flee @ 10%
-            double hitPercent = (double)this.m_Mobile.Hits / this.m_Mobile.HitsMax;
+            double hitPercent = (double)m_Mobile.Hits / m_Mobile.HitsMax;
 
-            if (!this.m_Mobile.Summoned && !this.m_Mobile.Controlled && hitPercent < 0.1 && this.m_Mobile.CanFlee) // Less than 10% health
+            if (!m_Mobile.Summoned && !m_Mobile.Controlled && hitPercent < 0.1 && m_Mobile.CanFlee) // Less than 10% health
             {
-                this.m_Mobile.DebugSay("I am low on health!");
-                this.Action = ActionType.Flee;
+                m_Mobile.DebugSay("I am low on health!");
+                Action = ActionType.Flee;
             }
-            else if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+            else if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I have detected {0}, attacking", this.m_Mobile.FocusMob.Name);
+                m_Mobile.DebugSay("I have detected {0}, attacking", m_Mobile.FocusMob.Name);
 
-                this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                this.Action = ActionType.Combat;
+                m_Mobile.Combatant = m_Mobile.FocusMob;
+                Action = ActionType.Combat;
             }
             else
             {
@@ -64,47 +63,45 @@ namespace Server.Mobiles
 
         public override bool DoActionCombat()
         {
-            IDamageable combatant = this.m_Mobile.Combatant;
+            IDamageable combatant = m_Mobile.Combatant;
 
-            if (combatant == null || combatant.Deleted || combatant.Map != this.m_Mobile.Map)
+            if (combatant == null || combatant.Deleted || combatant.Map != m_Mobile.Map)
             {
-                this.m_Mobile.DebugSay("My combatant is gone..");
+                m_Mobile.DebugSay("My combatant is gone..");
 
-                this.Action = ActionType.Wander;
+                Action = ActionType.Wander;
 
                 return true;
             }
 
-            if (this.WalkMobileRange(combatant, 1, true, this.m_Mobile.RangeFight, this.m_Mobile.RangeFight))
+            if (WalkMobileRange(combatant, 1, true, m_Mobile.RangeFight, m_Mobile.RangeFight))
             {
-                this.m_Mobile.Direction = this.m_Mobile.GetDirectionTo(combatant);
+                m_Mobile.Direction = m_Mobile.GetDirectionTo(combatant);
             }
             else
             {
-                if (this.m_Mobile.GetDistanceToSqrt(combatant) > this.m_Mobile.RangePerception + 1)
+                if (m_Mobile.GetDistanceToSqrt(combatant) > m_Mobile.RangePerception + 1)
                 {
-                    if (this.m_Mobile.Debug)
-                        this.m_Mobile.DebugSay("I cannot find {0}", combatant.Name);
+                    m_Mobile.DebugSay("I cannot find {0}", combatant.Name);
 
-                    this.Action = ActionType.Wander;
+                    Action = ActionType.Wander;
 
                     return true;
                 }
                 else
                 {
-                    if (this.m_Mobile.Debug)
-                        this.m_Mobile.DebugSay("I should be closer to {0}", combatant.Name);
+                    m_Mobile.DebugSay("I should be closer to {0}", combatant.Name);
                 }
             }
 
-            if (!this.m_Mobile.Controlled && !this.m_Mobile.Summoned && this.m_Mobile.CanFlee)
+            if (!m_Mobile.Controlled && !m_Mobile.Summoned && m_Mobile.CanFlee)
             {
-                double hitPercent = (double)this.m_Mobile.Hits / this.m_Mobile.HitsMax;
+                double hitPercent = (double)m_Mobile.Hits / m_Mobile.HitsMax;
 
                 if (hitPercent < 0.1)
                 {
-                    this.m_Mobile.DebugSay("I am low on health!");
-                    this.Action = ActionType.Flee;
+                    m_Mobile.DebugSay("I am low on health!");
+                    Action = ActionType.Flee;
                 }
             }
 
@@ -113,40 +110,30 @@ namespace Server.Mobiles
 
         public override bool DoActionBackoff()
         {
-            double hitPercent = (double)this.m_Mobile.Hits / this.m_Mobile.HitsMax;
+            double hitPercent = (double)m_Mobile.Hits / m_Mobile.HitsMax;
 
-            if (!this.m_Mobile.Summoned && !this.m_Mobile.Controlled && hitPercent < 0.1 && this.m_Mobile.CanFlee) // Less than 10% health
+            if (!m_Mobile.Summoned && !m_Mobile.Controlled && hitPercent < 0.1 && m_Mobile.CanFlee) // Less than 10% health
             {
-                this.Action = ActionType.Flee;
+                Action = ActionType.Flee;
             }
             else
             {
-                if (this.AcquireFocusMob(this.m_Mobile.RangePerception * 2, FightMode.Closest, true, false, true))
+                if (AcquireFocusMob(m_Mobile.RangePerception * 2, FightMode.Closest, true, false, true))
                 {
-                    if (this.WalkMobileRange(this.m_Mobile.FocusMob, 1, false, this.m_Mobile.RangePerception, this.m_Mobile.RangePerception * 2))
+                    if (WalkMobileRange(m_Mobile.FocusMob, 1, false, m_Mobile.RangePerception, m_Mobile.RangePerception * 2))
                     {
-                        this.m_Mobile.DebugSay("Well, here I am safe");
-                        this.Action = ActionType.Wander;
+                        m_Mobile.DebugSay("Well, here I am safe");
+                        Action = ActionType.Wander;
                     }
                 }
                 else
                 {
-                    this.m_Mobile.DebugSay("I have lost my focus, lets relax");
-                    this.Action = ActionType.Wander;
+                    m_Mobile.DebugSay("I have lost my focus, lets relax");
+                    Action = ActionType.Wander;
                 }
             }
 
             return true;
-        }
-
-        public override bool DoActionFlee()
-        {
-            this.AcquireFocusMob(this.m_Mobile.RangePerception * 2, this.m_Mobile.FightMode, true, false, true);
-
-            if (this.m_Mobile.FocusMob == null)
-                this.m_Mobile.FocusMob = this.m_Mobile.Combatant as Mobile;
-
-            return base.DoActionFlee();
         }
     }
 }

--- a/Scripts/Mobiles/AI/ArcherAI.cs
+++ b/Scripts/Mobiles/AI/ArcherAI.cs
@@ -126,7 +126,7 @@ namespace Server.Mobiles
             if (/*hasAmmo && */m_Mobile.Hits > (m_Mobile.HitsMax / 2))
             {
                 // If I have a target, go back and fight them
-                if (c != null)
+                if (c != null && m_Mobile.GetDistanceToSqrt(c) <= m_Mobile.RangePerception * 2)
                 {
                     m_Mobile.DebugSay("I am stronger now, reengaging {0}", c.Name);
                     Action = ActionType.Combat;

--- a/Scripts/Mobiles/AI/ArcherAI.cs
+++ b/Scripts/Mobiles/AI/ArcherAI.cs
@@ -5,6 +5,7 @@
 #endregion
 
 #region References
+using System;
 using Server.Items;
 #endregion
 
@@ -22,10 +23,7 @@ namespace Server.Mobiles
 
 			if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
 			{
-				if (m_Mobile.Debug)
-				{
-					m_Mobile.DebugSay("I have detected {0} and I will attack", m_Mobile.FocusMob.Name);
-				}
+				m_Mobile.DebugSay("I have detected {0} and I will attack", m_Mobile.FocusMob.Name);
 
 				m_Mobile.Combatant = m_Mobile.FocusMob;
 				Action = ActionType.Combat;
@@ -40,8 +38,10 @@ namespace Server.Mobiles
 
 		public override bool DoActionCombat()
 		{
-			if (m_Mobile.Combatant == null || m_Mobile.Combatant.Deleted || 
-                !m_Mobile.Combatant.Alive || (m_Mobile.Combatant is Mobile && ((Mobile)m_Mobile.Combatant).IsDeadBondedPet))
+            IDamageable c = m_Mobile.Combatant;
+
+			if (c == null || c.Deleted ||
+                !c.Alive || (c is Mobile && ((Mobile)c).IsDeadBondedPet))
 			{
 				m_Mobile.DebugSay("My combatant is deleted");
 				Action = ActionType.Guard;
@@ -50,28 +50,21 @@ namespace Server.Mobiles
 
 			if (Core.TickCount - m_Mobile.LastMoveTime > 1000)
 			{
-				if (WalkMobileRange(m_Mobile.Combatant, 1, true, m_Mobile.RangeFight, m_Mobile.Weapon.MaxRange))
+				if (WalkMobileRange(c, 1, true, m_Mobile.RangeFight, m_Mobile.Weapon.MaxRange))
 				{
 					// Be sure to face the combatant
-					m_Mobile.Direction = m_Mobile.GetDirectionTo(m_Mobile.Combatant.Location);
+					m_Mobile.Direction = m_Mobile.GetDirectionTo(c.Location);
 				}
 				else
 				{
-					if (m_Mobile.Combatant != null)
+					if (c != null)
 					{
-						if (m_Mobile.Debug)
-						{
-							m_Mobile.DebugSay("I am still not in range of {0}", m_Mobile.Combatant.Name);
-						}
+						m_Mobile.DebugSay("I am still not in range of {0}", c.Name);
 
-						if ((int)m_Mobile.GetDistanceToSqrt(m_Mobile.Combatant) > m_Mobile.RangePerception + 1)
+						if ((int)m_Mobile.GetDistanceToSqrt(c) > m_Mobile.RangePerception + 1)
 						{
-							if (m_Mobile.Debug)
-							{
-								m_Mobile.DebugSay("I have lost {0}", m_Mobile.Combatant.Name);
-							}
+							m_Mobile.DebugSay("I have lost {0}", c.Name);
 
-							m_Mobile.Combatant = null;
 							Action = ActionType.Guard;
 							return true;
 						}
@@ -79,42 +72,27 @@ namespace Server.Mobiles
 				}
 			}
 
-			// When we have no ammo, we flee
-			Container pack = m_Mobile.Backpack;
+            if (!m_Mobile.Controlled && !m_Mobile.Summoned && m_Mobile.CanFlee)
+            {
+/*                // When we have no ammo, we flee
+                Container pack = m_Mobile.Backpack;
 
-			if (pack == null || pack.FindItemByType(typeof(Arrow)) == null)
-			{
-				Action = ActionType.Flee;
-				return true;
-			}
-
-			// At 20% we should check if we must leave
-			if (m_Mobile.Hits < m_Mobile.HitsMax * 20 / 100 && m_Mobile.CanFlee)
-			{
-				bool bFlee = false;
-				// if my current hits are more than my opponent, i don't care
-				if (m_Mobile.Combatant != null && m_Mobile.Hits < m_Mobile.Combatant.Hits)
-				{
-					int iDiff = m_Mobile.Combatant.Hits - m_Mobile.Hits;
-
-					if (Utility.Random(0, 100) > 10 + iDiff) // 10% to flee + the diff of hits
-					{
-						bFlee = true;
-					}
-				}
-				else if (m_Mobile.Combatant != null && m_Mobile.Hits >= m_Mobile.Combatant.Hits)
-				{
-					if (Utility.Random(0, 100) > 10) // 10% to flee
-					{
-						bFlee = true;
-					}
-				}
-
-				if (bFlee)
-				{
-					Action = ActionType.Flee;
-				}
-			}
+                if (pack == null || pack.FindItemByType(typeof(Arrow)) == null)
+                {
+                    Action = ActionType.Flee;
+                    return true;
+                }
+*/
+                if (m_Mobile.Hits < m_Mobile.HitsMax * 20 / 100)
+                {
+                    // We are low on health, should we flee?
+                    if (Utility.Random(100) <= Math.Max(10, 10 + c.Hits - m_Mobile.Hits))
+                    {
+                        m_Mobile.DebugSay("I am going to flee from {0}", c.Name);
+                        Action = ActionType.Flee;
+                    }
+                }
+            }
 
 			return true;
 		}
@@ -123,10 +101,7 @@ namespace Server.Mobiles
 		{
 			if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
 			{
-				if (m_Mobile.Debug)
-				{
-					m_Mobile.DebugSay("I have detected {0}, attacking", m_Mobile.FocusMob.Name);
-				}
+				m_Mobile.DebugSay("I have detected {0}, attacking", m_Mobile.FocusMob.Name);
 
 				m_Mobile.Combatant = m_Mobile.FocusMob;
 				Action = ActionType.Combat;
@@ -138,5 +113,36 @@ namespace Server.Mobiles
 
 			return true;
 		}
-	}
+
+        public override bool DoActionFlee()
+        {
+            Mobile c = m_Mobile.Combatant as Mobile;
+
+            // When we have no ammo, we flee
+//            Container pack = m_Mobile.Backpack;
+//            bool hasAmmo = !(pack == null || pack.FindItemByType(typeof(Arrow)) == null);
+// They can shoot even with no ammo!
+
+            if (/*hasAmmo && */m_Mobile.Hits > (m_Mobile.HitsMax / 2))
+            {
+                // If I have a target, go back and fight them
+                if (c != null)
+                {
+                    m_Mobile.DebugSay("I am stronger now, reengaging {0}", c.Name);
+                    Action = ActionType.Combat;
+                }
+                else
+                {
+                    m_Mobile.DebugSay("I am stronger now, my guard is up");
+                    Action = ActionType.Guard;
+                }
+            }
+            else
+            {
+                base.DoActionFlee();
+            }
+
+            return true;
+        }
+    }
 }

--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -1120,7 +1120,7 @@ namespace Server.Mobiles
                     return true;
                 }
 
-                if (WalkMobileRange(c, 1, ShouldRun, m_Mobile.RangePerception * 2, m_Mobile.RangePerception * 3))
+                if (WalkMobileRange(c, 1, true, m_Mobile.RangePerception * 2, m_Mobile.RangePerception * 3))
                 {
                     m_Mobile.DebugSay("I have fled");
                     Action = ActionType.Guard;
@@ -1139,8 +1139,6 @@ namespace Server.Mobiles
 
 			return true;
 		}
-
-		public virtual bool ShouldRun { get { return m_Mobile.AllowedStealthSteps <= 0 ; } }
 
 		public virtual bool DoActionInteract()
 		{
@@ -2337,13 +2335,13 @@ namespace Server.Mobiles
 
 			int delay = (int)(TransformMoveDelay(m_Mobile.CurrentSpeed) * 1000);
 
-			var mounted = m_Mobile.Mounted || m_Mobile.Flying;
-			var running = (mounted && delay <= Mobile.RunMount) || (!mounted && delay <= Mobile.RunFoot);
+            bool mounted = (m_Mobile.Mounted || m_Mobile.Flying);
+            bool running = mounted ? (delay < Mobile.WalkMount) : (delay < Mobile.WalkFoot);
 
-			if (running)
-			{
-				d |= Direction.Running;
-			}
+            if (running)
+            {
+                d |= Direction.Running;
+            }
 
 			// This makes them always move one step, never any direction changes
 			m_Mobile.Direction = d;

--- a/Scripts/Mobiles/AI/MageAI.cs
+++ b/Scripts/Mobiles/AI/MageAI.cs
@@ -75,10 +75,10 @@ namespace Server.Mobiles
 
         public override bool Think()
         {
-            if (this.m_Mobile.Deleted)
+            if (m_Mobile.Deleted)
                 return false;
 
-            if (this.ProcessTarget())
+            if (ProcessTarget())
                 return true;
             else
                 return base.Think();
@@ -91,36 +91,36 @@ namespace Server.Mobiles
 
         public virtual double ScaleBySkill(double v, SkillName skill)
         {
-            return v * this.m_Mobile.Skills[skill].Value / 100;
+            return v * m_Mobile.Skills[skill].Value / 100;
         }
 
         public override bool DoActionWander()
         {
-            if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+            if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
             {
-                this.m_Mobile.DebugSay("I am going to attack {0}", this.m_Mobile.FocusMob.Name);
+                m_Mobile.DebugSay("I am going to attack {0}", m_Mobile.FocusMob.Name);
 
-                this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                this.Action = ActionType.Combat;
-                this.m_NextCastTime = DateTime.UtcNow;
+                m_Mobile.Combatant = m_Mobile.FocusMob;
+                Action = ActionType.Combat;
+                m_NextCastTime = DateTime.UtcNow;
             }
-            else if (this.SmartAI && this.m_Mobile.Mana < this.m_Mobile.ManaMax && !this.m_Mobile.Meditating)
+            else if (SmartAI && m_Mobile.Mana < m_Mobile.ManaMax && !m_Mobile.Meditating)
             {
-                this.m_Mobile.DebugSay("I am going to meditate");
+                m_Mobile.DebugSay("I am going to meditate");
 
-                this.m_Mobile.UseSkill(SkillName.Meditation);
+                m_Mobile.UseSkill(SkillName.Meditation);
             }
             else
             {
-                this.m_Mobile.DebugSay("I am wandering");
+                m_Mobile.DebugSay("I am wandering");
 
-                this.m_Mobile.Warmode = false;
+                m_Mobile.Warmode = false;
 
                 base.DoActionWander();
 
                 if (Utility.RandomDouble() < 0.05)
                 {
-                    Spell spell = this.CheckCastHealingSpell();
+                    Spell spell = CheckCastHealingSpell();
 
                     if (spell != null)
                         spell.Cast();
@@ -132,73 +132,73 @@ namespace Server.Mobiles
 
         public void RunTo(IDamageable d)
         {
-            if (!this.SmartAI)
+            if (!SmartAI)
             {
-                if (!this.MoveTo(d, true, this.m_Mobile.RangeFight))
-                    this.OnFailedMove();
+                if (!MoveTo(d, true, m_Mobile.RangeFight))
+                    OnFailedMove();
 
                 return;
             }
 
             if (d is Mobile && (((Mobile)d).Paralyzed || ((Mobile)d).Frozen))
             {
-                if (this.m_Mobile.InRange(d, 1))
-                    this.RunFrom(d);
-                else if (!this.m_Mobile.InRange(d, this.m_Mobile.RangeFight > 2 ? this.m_Mobile.RangeFight : 2) && !this.MoveTo(d, true, 1))
-                    this.OnFailedMove();
+                if (m_Mobile.InRange(d, 1))
+                    RunFrom(d);
+                else if (!m_Mobile.InRange(d, m_Mobile.RangeFight > 2 ? m_Mobile.RangeFight : 2) && !MoveTo(d, true, 1))
+                    OnFailedMove();
             }
             else
             {
-                if (!this.m_Mobile.InRange(d, this.m_Mobile.RangeFight))
+                if (!m_Mobile.InRange(d, m_Mobile.RangeFight))
                 {
-                    if (!this.MoveTo(d, true, 1))
-                        this.OnFailedMove();
+                    if (!MoveTo(d, true, 1))
+                        OnFailedMove();
                 }
-                else if (this.m_Mobile.InRange(d, this.m_Mobile.RangeFight - 1))
+                else if (m_Mobile.InRange(d, m_Mobile.RangeFight - 1))
                 {
-                    this.RunFrom(d);
+                    RunFrom(d);
                 }
             }
         }
 
         public void RunFrom(IDamageable d)
         {
-            this.Run((Direction)((int)this.m_Mobile.GetDirectionTo(d) - 4) & Direction.Mask);
+            Run((Direction)((int)m_Mobile.GetDirectionTo(d) - 4) & Direction.Mask);
         }
 
         public void OnFailedMove()
         {
             if (!m_Mobile.DisallowAllMoves && (SmartAI ? Utility.Random(10) == 0 : ScaleByMagery(TeleportChance) > Utility.RandomDouble()))
             {
-                if (this.m_Mobile.Target != null)
-                    this.m_Mobile.Target.Cancel(this.m_Mobile, TargetCancelType.Canceled);
+                if (m_Mobile.Target != null)
+                    m_Mobile.Target.Cancel(m_Mobile, TargetCancelType.Canceled);
 
-                new TeleportSpell(this.m_Mobile, null).Cast();
+                new TeleportSpell(m_Mobile, null).Cast();
 
-                this.m_Mobile.DebugSay("I am stuck, I'm going to try teleporting away");
+                m_Mobile.DebugSay("I am stuck, I'm going to try teleporting away");
             }
-            else if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+            else if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
             {
-                this.m_Mobile.DebugSay("My move is blocked, so I am going to attack {0}", this.m_Mobile.FocusMob.Name);
+                m_Mobile.DebugSay("My move is blocked, so I am going to attack {0}", m_Mobile.FocusMob.Name);
 
-                this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                this.Action = ActionType.Combat;
+                m_Mobile.Combatant = m_Mobile.FocusMob;
+                Action = ActionType.Combat;
             }
             else
             {
-                this.m_Mobile.DebugSay("I am stuck");
+                m_Mobile.DebugSay("I am stuck");
             }
         }
 
         public void Run(Direction d)
         {
-            if ((this.m_Mobile.Spell != null && this.m_Mobile.Spell.IsCasting) || this.m_Mobile.Paralyzed || this.m_Mobile.Frozen || this.m_Mobile.DisallowAllMoves)
+            if ((m_Mobile.Spell != null && m_Mobile.Spell.IsCasting) || m_Mobile.Paralyzed || m_Mobile.Frozen || m_Mobile.DisallowAllMoves)
                 return;
 
-            this.m_Mobile.Direction = d | Direction.Running;
+            m_Mobile.Direction = d | Direction.Running;
 
-            if (!this.DoMove(this.m_Mobile.Direction, true))
-                this.OnFailedMove();
+            if (!DoMove(m_Mobile.Direction, true))
+                OnFailedMove();
         }
 
         public virtual int GetMaxCircle()
@@ -289,24 +289,24 @@ namespace Server.Mobiles
 
         public virtual Spell DoDispel(Mobile toDispel)
         {
-            if (!this.SmartAI)
+            if (!SmartAI)
             {
                 if (ScaleByMagery(DispelChance) > Utility.RandomDouble())
                     return new DispelSpell(m_Mobile, null);
 
-                return this.ChooseSpell(toDispel);
+                return ChooseSpell(toDispel);
             }
 
-            Spell spell = this.CheckCastHealingSpell();
+            Spell spell = CheckCastHealingSpell();
 
             if (spell == null)
             {
-                if (!this.m_Mobile.DisallowAllMoves && Utility.Random((int)this.m_Mobile.GetDistanceToSqrt(toDispel)) == 0)
-                    spell = new TeleportSpell(this.m_Mobile, null);
-                else if (Utility.Random(3) == 0 && !this.m_Mobile.InRange(toDispel, 3) && !toDispel.Paralyzed && !toDispel.Frozen)
-                    spell = new ParalyzeSpell(this.m_Mobile, null);
+                if (!m_Mobile.DisallowAllMoves && Utility.Random((int)m_Mobile.GetDistanceToSqrt(toDispel)) == 0)
+                    spell = new TeleportSpell(m_Mobile, null);
+                else if (Utility.Random(3) == 0 && !m_Mobile.InRange(toDispel, 3) && !toDispel.Paralyzed && !toDispel.Frozen)
+                    spell = new ParalyzeSpell(m_Mobile, null);
                 else
-                    spell = new DispelSpell(this.m_Mobile, null);
+                    spell = new DispelSpell(m_Mobile, null);
             }
 
             return spell;
@@ -323,9 +323,9 @@ namespace Server.Mobiles
             Mobile c = d as Mobile;
             Spell spell = null;
 
-            if (!this.SmartAI)
+            if (!SmartAI)
             {
-                spell = this.CheckCastHealingSpell();
+                spell = CheckCastHealingSpell();
 
                 if (spell == null && m_Mobile.RawInt >= 80)
                     spell = CheckCastDispelField();
@@ -343,29 +343,29 @@ namespace Server.Mobiles
                             if (c.Poisoned)
                                 goto default;
 
-                            this.m_Mobile.DebugSay("Attempting to poison");
+                            m_Mobile.DebugSay("Attempting to poison");
 
-                            spell = new PoisonSpell(this.m_Mobile, null);
+                            spell = new PoisonSpell(m_Mobile, null);
                             break;
                         }
                     case 2:	// Bless ourselves
                         {
-                            this.m_Mobile.DebugSay("Blessing myself");
+                            m_Mobile.DebugSay("Blessing myself");
 
-                            spell = GetRandomBuffSpell();//new BlessSpell(this.m_Mobile, null);
+                            spell = GetRandomBuffSpell();//new BlessSpell(m_Mobile, null);
                             break;
                         }
                     case 3:
                     case 4: // Curse them
                         {
-                            this.m_Mobile.DebugSay("Attempting to curse");
+                            m_Mobile.DebugSay("Attempting to curse");
 
-                            spell = this.GetRandomCurseSpell();
+                            spell = GetRandomCurseSpell();
                             break;
                         }
                     case 5:	// Paralyze them
                         {
-                            this.m_Mobile.DebugSay("Attempting to paralyze");
+                            m_Mobile.DebugSay("Attempting to paralyze");
 
                             if (maxCircle >= 5)
                                 spell = new ParalyzeSpell(m_Mobile, null);
@@ -375,16 +375,16 @@ namespace Server.Mobiles
                         }
                     case 6: // Drain mana
                         {
-                            this.m_Mobile.DebugSay("Attempting to drain mana");
+                            m_Mobile.DebugSay("Attempting to drain mana");
 
-                            spell = this.GetRandomManaDrainSpell();
+                            spell = GetRandomManaDrainSpell();
                             break;
                         }
                     default: // Damage them
                         {
-                            this.m_Mobile.DebugSay("Just doing damage");
+                            m_Mobile.DebugSay("Just doing damage");
 
-                            spell = this.GetRandomDamageSpell();
+                            spell = GetRandomDamageSpell();
                             break;
                         }
                 }
@@ -422,41 +422,41 @@ namespace Server.Mobiles
                         if (c.Poisoned)
                             goto case 1;
 
-                        spell = new PoisonSpell(this.m_Mobile, null);
+                        spell = new PoisonSpell(m_Mobile, null);
                         break;
                     }
                 case 1: // Deal some damage
                     {
-                        spell = this.GetRandomDamageSpell();
+                        spell = GetRandomDamageSpell();
 
                         break;
                     }
                 default: // Set up a combo
                     {
-                        if (this.m_Mobile.Mana > 15 && this.m_Mobile.Mana < 40)
+                        if (m_Mobile.Mana > 15 && m_Mobile.Mana < 40)
                         {
-                            if (c.Paralyzed && !c.Poisoned && !this.m_Mobile.Meditating)
+                            if (c.Paralyzed && !c.Poisoned && !m_Mobile.Meditating)
                             {
-                                this.m_Mobile.DebugSay("I am going to meditate");
+                                m_Mobile.DebugSay("I am going to meditate");
 
-                                this.m_Mobile.UseSkill(SkillName.Meditation);
+                                m_Mobile.UseSkill(SkillName.Meditation);
                             }
                             else if (!c.Poisoned)
                             {
-                                spell = new ParalyzeSpell(this.m_Mobile, null);
+                                spell = new ParalyzeSpell(m_Mobile, null);
                             }
                         }
-                        else if (this.m_Mobile.Mana > 60)
+                        else if (m_Mobile.Mana > 60)
                         {
                             if (Utility.RandomBool() && !c.Paralyzed && !c.Frozen && !c.Poisoned)
                             {
-                                this.m_Combo = 0;
-                                spell = new ParalyzeSpell(this.m_Mobile, null);
+                                m_Combo = 0;
+                                spell = new ParalyzeSpell(m_Mobile, null);
                             }
                             else
                             {
-                                this.m_Combo = 1;
-                                spell = new ExplosionSpell(this.m_Mobile, null);
+                                m_Combo = 1;
+                                spell = new ExplosionSpell(m_Mobile, null);
                             }
                         }
 
@@ -591,128 +591,113 @@ namespace Server.Mobiles
 
         public override bool DoActionCombat()
         {
-            IDamageable c = this.m_Mobile.Combatant;
+            IDamageable c = m_Mobile.Combatant;
             m_Mobile.Warmode = true;
 
             if (m_Mobile.Target != null)
                 ProcessTarget();
 
-            if (c == null || c.Deleted || !c.Alive || (c is Mobile && ((Mobile)c).IsDeadBondedPet) || !this.m_Mobile.CanSee(c) || !this.m_Mobile.CanBeHarmful(c, false) || c.Map != this.m_Mobile.Map)
+            if (c == null || c.Deleted || !c.Alive || (c is Mobile && ((Mobile)c).IsDeadBondedPet) || !m_Mobile.CanSee(c) || !m_Mobile.CanBeHarmful(c, false) || c.Map != m_Mobile.Map)
             {
                 // Our combatant is deleted, dead, hidden, or we cannot hurt them
                 // Try to find another combatant
-                if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+                if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
                 {
-                    this.m_Mobile.DebugSay("Something happened to my combatant, so I am going to fight {0}", this.m_Mobile.FocusMob.Name);
+                    m_Mobile.DebugSay("Something happened to my combatant, so I am going to fight {0}", m_Mobile.FocusMob.Name);
 
-                    this.m_Mobile.Combatant = c = this.m_Mobile.FocusMob;
-                    this.m_Mobile.FocusMob = null;
+                    m_Mobile.Combatant = c = m_Mobile.FocusMob;
+                    m_Mobile.FocusMob = null;
                 }
                 else
                 {
-                    this.m_Mobile.DebugSay("Something happened to my combatant, and nothing is around. I am on guard.");
-                    this.Action = ActionType.Guard;
+                    m_Mobile.DebugSay("Something happened to my combatant, and nothing is around. I am on guard.");
+                    Action = ActionType.Guard;
                     return true;
                 }
             }
 
-            if (!this.m_Mobile.InLOS(c))
+            if (!m_Mobile.InLOS(c))
             {
-                this.m_Mobile.DebugSay("I can't see my target");
+                m_Mobile.DebugSay("I can't see my target");
 
-                if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+                if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
                 {
-                    this.m_Mobile.DebugSay("I will switch to {0}", this.m_Mobile.FocusMob.Name);
-                    this.m_Mobile.Combatant = c = this.m_Mobile.FocusMob;
-                    this.m_Mobile.FocusMob = null;
+                    m_Mobile.DebugSay("I will switch to {0}", m_Mobile.FocusMob.Name);
+                    m_Mobile.Combatant = c = m_Mobile.FocusMob;
+                    m_Mobile.FocusMob = null;
                 }
             }
 
-            if (!Core.AOS && this.SmartAI && !this.m_Mobile.StunReady && this.m_Mobile.Skills[SkillName.Wrestling].Value >= 80.0 && this.m_Mobile.Skills[SkillName.Anatomy].Value >= 80.0)
-                EventSink.InvokeStunRequest(new StunRequestEventArgs(this.m_Mobile));
+            if (!Core.AOS && SmartAI && !m_Mobile.StunReady && m_Mobile.Skills[SkillName.Wrestling].Value >= 80.0 && m_Mobile.Skills[SkillName.Anatomy].Value >= 80.0)
+                EventSink.InvokeStunRequest(new StunRequestEventArgs(m_Mobile));
 
-            if (!this.m_Mobile.InRange(c, this.m_Mobile.RangePerception))
+            if (!m_Mobile.InRange(c, m_Mobile.RangePerception))
             {
                 // They are somewhat far away, can we find something else?
-                if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+                if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
                 {
-                    this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                    this.m_Mobile.FocusMob = null;
+                    m_Mobile.Combatant = m_Mobile.FocusMob;
+                    m_Mobile.FocusMob = null;
                 }
-                else if (!this.m_Mobile.InRange(c, this.m_Mobile.RangePerception * 3))
+                else if (!m_Mobile.InRange(c, m_Mobile.RangePerception * 3))
                 {
-                    this.m_Mobile.Combatant = null;
+                    m_Mobile.Combatant = null;
                 }
 
-                c = this.m_Mobile.Combatant as Mobile;
+                c = m_Mobile.Combatant as Mobile;
 
                 if (c == null)
                 {
-                    this.m_Mobile.DebugSay("My combatant has fled, so I am on guard");
-                    this.Action = ActionType.Guard;
+                    m_Mobile.DebugSay("My combatant has fled, so I am on guard");
+                    Action = ActionType.Guard;
 
                     return true;
                 }
             }
 
-            if (!this.m_Mobile.Controlled && !this.m_Mobile.Summoned && this.m_Mobile.CanFlee)
+            if (!m_Mobile.Controlled && !m_Mobile.Summoned && m_Mobile.CanFlee)
             {
-                if (this.m_Mobile.Hits < this.m_Mobile.HitsMax * 20 / 100)
+                if (m_Mobile.Hits < m_Mobile.HitsMax * 20 / 100)
                 {
                     // We are low on health, should we flee?
-                    bool flee = false;
-
-                    if (this.m_Mobile.Hits < c.Hits)
+                    if (Utility.Random(100) <= Math.Max(10, 10 + c.Hits - m_Mobile.Hits))
                     {
-                        // We are more hurt than them
-                        int diff = c.Hits - this.m_Mobile.Hits;
-
-                        flee = (Utility.Random(0, 100) > (10 + diff)); // (10 + diff)% chance to flee
-                    }
-                    else
-                    {
-                        flee = Utility.Random(0, 100) > 10; // 10% chance to flee
-                    }
-
-                    if (flee)
-                    {
-                        this.m_Mobile.DebugSay("I am going to flee from {0}", c.Name);
-
-                        this.Action = ActionType.Flee;
+                        m_Mobile.DebugSay("I am going to flee from {0}", c.Name);
+                        Action = ActionType.Flee;
                         return true;
                     }
                 }
             }
 
-            if (this.m_Mobile.Spell == null && DateTime.UtcNow > this.m_NextCastTime && this.m_Mobile.InRange(c, Core.ML ? 10 : 12))
+            if (m_Mobile.Spell == null && DateTime.UtcNow > m_NextCastTime && m_Mobile.InRange(c, Core.ML ? 10 : 12))
             {
                 // We are ready to cast a spell
                 Spell spell = null;
-                Mobile toDispel = this.FindDispelTarget(true);
+                Mobile toDispel = FindDispelTarget(true);
 
-                if (this.m_Mobile.Poisoned) // Top cast priority is cure
+                if (m_Mobile.Poisoned) // Top cast priority is cure
                 {
-                    this.m_Mobile.DebugSay("I am going to cure myself");
+                    m_Mobile.DebugSay("I am going to cure myself");
 
-                    spell = new CureSpell(this.m_Mobile, null);
+                    spell = new CureSpell(m_Mobile, null);
                 }
                 else if (toDispel != null) // Something dispellable is attacking us
                 {
-                    this.m_Mobile.DebugSay("I am going to dispel {0}", toDispel);
+                    m_Mobile.DebugSay("I am going to dispel {0}", toDispel);
 
-                    spell = this.DoDispel(toDispel);
+                    spell = DoDispel(toDispel);
                 }
-                else if (c is Mobile && this.SmartAI && this.m_Combo != -1) // We are doing a spell combo
+                else if (c is Mobile && SmartAI && m_Combo != -1) // We are doing a spell combo
                 {
-                    spell = this.DoCombo((Mobile)c);
+                    spell = DoCombo((Mobile)c);
                 }
-                else if (c is Mobile && this.SmartAI && (((Mobile)c).Spell is HealSpell || ((Mobile)c).Spell is GreaterHealSpell) && !((Mobile)c).Poisoned) // They have a heal spell out
+                else if (c is Mobile && SmartAI && (((Mobile)c).Spell is HealSpell || ((Mobile)c).Spell is GreaterHealSpell) && !((Mobile)c).Poisoned) // They have a heal spell out
                 {
-                    spell = new PoisonSpell(this.m_Mobile, null);
+                    spell = new PoisonSpell(m_Mobile, null);
                 }
                 else
                 {
-                    spell = this.ChooseSpell(c);
+                    spell = ChooseSpell(c);
                 }
 
                 // Now we have a spell picked
@@ -726,57 +711,57 @@ namespace Server.Mobiles
                 if (spell != null)
                     spell.Cast();
 
-                this.m_NextCastTime = DateTime.UtcNow + delay;
+                m_NextCastTime = DateTime.UtcNow + delay;
             }
-            else/* if (this.m_Mobile.Spell == null || !this.m_Mobile.Spell.IsCasting)*/
+            else/* if (m_Mobile.Spell == null || !m_Mobile.Spell.IsCasting)*/
             {
-                this.RunTo(c);
+                RunTo(c);
             }
 
-            this.m_LastTarget = c as Mobile;
-            this.m_LastTargetLoc = c.Location;
+            m_LastTarget = c as Mobile;
+            m_LastTargetLoc = c.Location;
 
             return true;
         }
 
         public override bool DoActionGuard()
         {
-            if (this.m_LastTarget != null && this.m_LastTarget.Hidden)
+            if (m_LastTarget != null && m_LastTarget.Hidden)
             {
-                Map map = this.m_Mobile.Map;
+                Map map = m_Mobile.Map;
 
-                if (map == null || !this.m_Mobile.InRange(this.m_LastTargetLoc, Core.ML ? 10 : 12))
+                if (map == null || !m_Mobile.InRange(m_LastTargetLoc, Core.ML ? 10 : 12))
                 {
-                    this.m_LastTarget = null;
+                    m_LastTarget = null;
                 }
-                else if (this.m_Mobile.Spell == null && DateTime.UtcNow > this.m_NextCastTime)
+                else if (m_Mobile.Spell == null && DateTime.UtcNow > m_NextCastTime)
                 {
-                    this.m_Mobile.DebugSay("I am going to reveal my last target");
+                    m_Mobile.DebugSay("I am going to reveal my last target");
 
-                    this.m_RevealTarget = new LandTarget(this.m_LastTargetLoc, map);
-                    Spell spell = new RevealSpell(this.m_Mobile, null);
+                    m_RevealTarget = new LandTarget(m_LastTargetLoc, map);
+                    Spell spell = new RevealSpell(m_Mobile, null);
 
                     if (spell.Cast())
-                        this.m_LastTarget = null; // only do it once
+                        m_LastTarget = null; // only do it once
 
-                    this.m_NextCastTime = DateTime.UtcNow + this.GetDelay(spell);
+                    m_NextCastTime = DateTime.UtcNow + GetDelay(spell);
                 }
             }
 
-            if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+            if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
             {
-                this.m_Mobile.DebugSay("I am going to attack {0}", this.m_Mobile.FocusMob.Name);
+                m_Mobile.DebugSay("I am going to attack {0}", m_Mobile.FocusMob.Name);
 
-                this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                this.Action = ActionType.Combat;
+                m_Mobile.Combatant = m_Mobile.FocusMob;
+                Action = ActionType.Combat;
             }
             else
             {
-                if (!this.m_Mobile.Controlled)
+                if (!m_Mobile.Controlled)
                 {
-                    this.ProcessTarget();
+                    ProcessTarget();
 
-                    Spell spell = this.CheckCastHealingSpell();
+                    Spell spell = CheckCastHealingSpell();
 
                     if (spell != null)
                         spell.Cast();
@@ -790,29 +775,53 @@ namespace Server.Mobiles
 
         public override bool DoActionFlee()
         {
-            Mobile c = this.m_Mobile.Combatant as Mobile;
+            Mobile c = m_Mobile.Combatant as Mobile;
 
-            if ((this.m_Mobile.Mana > 20 || this.m_Mobile.Mana == this.m_Mobile.ManaMax) && this.m_Mobile.Hits > (this.m_Mobile.HitsMax / 2))
+            if ((m_Mobile.Mana > 20 || m_Mobile.Mana == m_Mobile.ManaMax) && m_Mobile.Hits > (m_Mobile.HitsMax / 2))
             {
-                this.m_Mobile.DebugSay("I am stronger now, my guard is up");
-                this.Action = ActionType.Guard;
+                // If I have a target, go back and fight them
+                if (c != null)
+                {
+                    m_Mobile.DebugSay("I am stronger now, reengaging {0}", c.Name);
+                    Action = ActionType.Combat;
+                }
+                else
+                {
+                    m_Mobile.DebugSay("I am stronger now, my guard is up");
+                    Action = ActionType.Guard;
+                }
             }
-            else if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+            // We only want enemies we know want to attack us, not those we want to attack
+            else if (AcquireFocusMob(m_Mobile.RangePerception, FightMode.Aggressor, false, false, true) || c != null)
             {
-                this.m_Mobile.DebugSay("I am scared of {0}", this.m_Mobile.FocusMob.Name);
+                // If I found a new target, set it as my combatant
+                if (m_Mobile.FocusMob != null)
+                {
+                    m_Mobile.Combatant = m_Mobile.FocusMob;
+                    c = m_Mobile.Combatant as Mobile;
+                    m_Mobile.FocusMob = null;
+                }
 
-                this.RunFrom(this.m_Mobile.FocusMob);
-                this.m_Mobile.FocusMob = null;
+                // If my combatant is bad, guard
+                if (c == null || c.Deleted || c.Map != m_Mobile.Map ||
+                    m_Mobile.GetDistanceToSqrt(c) > m_Mobile.RangePerception * 2)
+                {
+                    m_Mobile.DebugSay("I have lost him");
+                    m_Mobile.Combatant = null;
+                    Action = ActionType.Guard;
+                    return true;
+                }
 
-                if (this.m_Mobile.Poisoned && Utility.Random(0, 5) == 0)
-                    new CureSpell(this.m_Mobile, null).Cast();
+                m_Mobile.DebugSay("I am scared of {0}", c.Name);
+                RunFrom(c);
+
+                if (m_Mobile.Poisoned && Utility.Random(0, 5) == 0)
+                    new CureSpell(m_Mobile, null).Cast();
             }
             else
             {
-                this.m_Mobile.DebugSay("Area seems clear, but my guard is up");
-
-                this.Action = ActionType.Guard;
-                this.m_Mobile.Warmode = true;
+                m_Mobile.DebugSay("Area seems clear, but my guard is up");
+                Action = ActionType.Guard;
             }
 
             return true;
@@ -820,23 +829,23 @@ namespace Server.Mobiles
 
         public Mobile FindDispelTarget(bool activeOnly)
         {
-            if (this.m_Mobile.Deleted || this.m_Mobile.Int < 95 || this.CanDispel(this.m_Mobile) || this.m_Mobile.AutoDispel)
+            if (m_Mobile.Deleted || m_Mobile.Int < 95 || CanDispel(m_Mobile) || m_Mobile.AutoDispel)
                 return null;
 
             if (activeOnly)
             {
-                List<AggressorInfo> aggressed = this.m_Mobile.Aggressed;
-                List<AggressorInfo> aggressors = this.m_Mobile.Aggressors;
+                List<AggressorInfo> aggressed = m_Mobile.Aggressed;
+                List<AggressorInfo> aggressors = m_Mobile.Aggressors;
 
                 Mobile active = null;
                 double activePrio = 0.0;
 
-                Mobile comb = this.m_Mobile.Combatant as Mobile;
+                Mobile comb = m_Mobile.Combatant as Mobile;
 
-                if (comb != null && !comb.Deleted && comb.Alive && !comb.IsDeadBondedPet && this.m_Mobile.InRange(comb, Core.ML ? 10 : 12) && this.CanDispel(comb))
+                if (comb != null && !comb.Deleted && comb.Alive && !comb.IsDeadBondedPet && m_Mobile.InRange(comb, Core.ML ? 10 : 12) && CanDispel(comb))
                 {
                     active = comb;
-                    activePrio = this.m_Mobile.GetDistanceToSqrt(comb);
+                    activePrio = m_Mobile.GetDistanceToSqrt(comb);
 
                     if (activePrio <= 2)
                         return active;
@@ -847,9 +856,9 @@ namespace Server.Mobiles
                     AggressorInfo info = aggressed[i];
                     Mobile m = info.Defender;
 
-                    if (m != comb && m.Combatant == this.m_Mobile && this.m_Mobile.InRange(m, Core.ML ? 10 : 12) && this.CanDispel(m))
+                    if (m != comb && m.Combatant == m_Mobile && m_Mobile.InRange(m, Core.ML ? 10 : 12) && CanDispel(m))
                     {
-                        double prio = this.m_Mobile.GetDistanceToSqrt(m);
+                        double prio = m_Mobile.GetDistanceToSqrt(m);
 
                         if (active == null || prio < activePrio)
                         {
@@ -867,9 +876,9 @@ namespace Server.Mobiles
                     AggressorInfo info = aggressors[i];
                     Mobile m = info.Attacker;
 
-                    if (m != comb && m.Combatant == this.m_Mobile && this.m_Mobile.InRange(m, Core.ML ? 10 : 12) && this.CanDispel(m))
+                    if (m != comb && m.Combatant == m_Mobile && m_Mobile.InRange(m, Core.ML ? 10 : 12) && CanDispel(m))
                     {
-                        double prio = this.m_Mobile.GetDistanceToSqrt(m);
+                        double prio = m_Mobile.GetDistanceToSqrt(m);
 
                         if (active == null || prio < activePrio)
                         {
@@ -886,26 +895,26 @@ namespace Server.Mobiles
             }
             else
             {
-                Map map = this.m_Mobile.Map;
+                Map map = m_Mobile.Map;
 
                 if (map != null)
                 {
                     Mobile active = null, inactive = null;
                     double actPrio = 0.0, inactPrio = 0.0;
 
-                    Mobile comb = this.m_Mobile.Combatant as Mobile;
+                    Mobile comb = m_Mobile.Combatant as Mobile;
 
-                    if (comb != null && !comb.Deleted && comb.Alive && !comb.IsDeadBondedPet && this.CanDispel(comb))
+                    if (comb != null && !comb.Deleted && comb.Alive && !comb.IsDeadBondedPet && CanDispel(comb))
                     {
                         active = inactive = comb;
-                        actPrio = inactPrio = this.m_Mobile.GetDistanceToSqrt(comb);
+                        actPrio = inactPrio = m_Mobile.GetDistanceToSqrt(comb);
                     }
 
-                    foreach (Mobile m in this.m_Mobile.GetMobilesInRange(Core.ML ? 10 : 12))
+                    foreach (Mobile m in m_Mobile.GetMobilesInRange(Core.ML ? 10 : 12))
                     {
-                        if (m != this.m_Mobile && this.CanDispel(m))
+                        if (m != m_Mobile && CanDispel(m))
                         {
-                            double prio = this.m_Mobile.GetDistanceToSqrt(m);
+                            double prio = m_Mobile.GetDistanceToSqrt(m);
 
                             if (!activeOnly && (inactive == null || prio < inactPrio))
                             {
@@ -913,7 +922,7 @@ namespace Server.Mobiles
                                 inactPrio = prio;
                             }
 
-                            if ((this.m_Mobile.Combatant == m || m.Combatant == this.m_Mobile) && (active == null || prio < actPrio))
+                            if ((m_Mobile.Combatant == m || m.Combatant == m_Mobile) && (active == null || prio < actPrio))
                             {
                                 active = m;
                                 actPrio = prio;
@@ -930,58 +939,58 @@ namespace Server.Mobiles
 
         public bool CanDispel(Mobile m)
         {
-            return (m is BaseCreature && ((BaseCreature)m).Summoned && this.m_Mobile.CanBeHarmful(m, false) && !((BaseCreature)m).IsAnimatedDead);
+            return (m is BaseCreature && ((BaseCreature)m).Summoned && m_Mobile.CanBeHarmful(m, false) && !((BaseCreature)m).IsAnimatedDead);
         }
 
         protected Spell CheckCastHealingSpell()
         {
             // If I'm poisoned, always attempt to cure.
-            if (this.m_Mobile.Poisoned)
-                return new CureSpell(this.m_Mobile, null);
+            if (m_Mobile.Poisoned)
+                return new CureSpell(m_Mobile, null);
 
             // Summoned creatures never heal themselves.
-            if (this.m_Mobile.Summoned)
+            if (m_Mobile.Summoned)
                 return null;
 
-            if (this.m_Mobile.Controlled)
+            if (m_Mobile.Controlled)
             {
-                if (DateTime.UtcNow < this.m_NextHealTime)
+                if (DateTime.UtcNow < m_NextHealTime)
                     return null;
             }
 
-            if (!this.SmartAI)
+            if (!SmartAI)
             {
                 if (ScaleByMagery(HealChance) < Utility.RandomDouble())
                     return null;
             }
             else
             {
-                if (Utility.Random(0, 4 + (this.m_Mobile.Hits == 0 ? this.m_Mobile.HitsMax : (this.m_Mobile.HitsMax / this.m_Mobile.Hits))) < 3)
+                if (Utility.Random(0, 4 + (m_Mobile.Hits == 0 ? m_Mobile.HitsMax : (m_Mobile.HitsMax / m_Mobile.Hits))) < 3)
                     return null;
             }
 
             Spell spell = null;
 
-            if (this.m_Mobile.Hits < (this.m_Mobile.HitsMax - 50))
+            if (m_Mobile.Hits < (m_Mobile.HitsMax - 50))
             {
-                spell = new GreaterHealSpell(this.m_Mobile, null);
+                spell = new GreaterHealSpell(m_Mobile, null);
 
                 if (spell == null)
-                    spell = new HealSpell(this.m_Mobile, null);
+                    spell = new HealSpell(m_Mobile, null);
             }
-            else if (this.m_Mobile.Hits < (this.m_Mobile.HitsMax - 10))
+            else if (m_Mobile.Hits < (m_Mobile.HitsMax - 10))
             {
-                spell = new HealSpell(this.m_Mobile, null);
+                spell = new HealSpell(m_Mobile, null);
             }
 
             double delay;
 
-            if (this.m_Mobile.Int >= 500)
+            if (m_Mobile.Int >= 500)
                 delay = Utility.RandomMinMax(7, 10);
             else
-                delay = Math.Sqrt(600 - this.m_Mobile.Int);
+                delay = Math.Sqrt(600 - m_Mobile.Int);
 
-            this.m_NextHealTime = DateTime.UtcNow + TimeSpan.FromSeconds(delay);
+            m_NextHealTime = DateTime.UtcNow + TimeSpan.FromSeconds(delay);
 
             return spell;
         }
@@ -1054,13 +1063,13 @@ namespace Server.Mobiles
 
         private TimeSpan GetDelay(Spell spell)
         {
-            if (this.SmartAI || (spell is DispelSpell))
+            if (SmartAI || (spell is DispelSpell))
             {
-                return TimeSpan.FromSeconds(this.m_Mobile.ActiveSpeed);
+                return TimeSpan.FromSeconds(m_Mobile.ActiveSpeed);
             }
             else
             {
-                double del = this.ScaleBySkill(3.0, SkillName.Magery);
+                double del = ScaleBySkill(3.0, SkillName.Magery);
                 double min = 6.0 - (del * 0.75);
                 double max = 6.0 - (del * 1.25);
 

--- a/Scripts/Mobiles/AI/MageAI.cs
+++ b/Scripts/Mobiles/AI/MageAI.cs
@@ -791,37 +791,9 @@ namespace Server.Mobiles
                     Action = ActionType.Guard;
                 }
             }
-            // We only want enemies we know want to attack us, not those we want to attack
-            else if (AcquireFocusMob(m_Mobile.RangePerception, FightMode.Aggressor, false, false, true) || c != null)
-            {
-                // If I found a new target, set it as my combatant
-                if (m_Mobile.FocusMob != null)
-                {
-                    m_Mobile.Combatant = m_Mobile.FocusMob;
-                    c = m_Mobile.Combatant as Mobile;
-                    m_Mobile.FocusMob = null;
-                }
-
-                // If my combatant is bad, guard
-                if (c == null || c.Deleted || c.Map != m_Mobile.Map ||
-                    m_Mobile.GetDistanceToSqrt(c) > m_Mobile.RangePerception * 2)
-                {
-                    m_Mobile.DebugSay("I have lost him");
-                    m_Mobile.Combatant = null;
-                    Action = ActionType.Guard;
-                    return true;
-                }
-
-                m_Mobile.DebugSay("I am scared of {0}", c.Name);
-                RunFrom(c);
-
-                if (m_Mobile.Poisoned && Utility.Random(0, 5) == 0)
-                    new CureSpell(m_Mobile, null).Cast();
-            }
             else
             {
-                m_Mobile.DebugSay("Area seems clear, but my guard is up");
-                Action = ActionType.Guard;
+                base.DoActionFlee();
             }
 
             return true;

--- a/Scripts/Mobiles/AI/MageAI.cs
+++ b/Scripts/Mobiles/AI/MageAI.cs
@@ -780,7 +780,7 @@ namespace Server.Mobiles
             if ((m_Mobile.Mana > 20 || m_Mobile.Mana == m_Mobile.ManaMax) && m_Mobile.Hits > (m_Mobile.HitsMax / 2))
             {
                 // If I have a target, go back and fight them
-                if (c != null)
+                if (c != null && m_Mobile.GetDistanceToSqrt(c) <= m_Mobile.RangePerception * 2)
                 {
                     m_Mobile.DebugSay("I am stronger now, reengaging {0}", c.Name);
                     Action = ActionType.Combat;

--- a/Scripts/Mobiles/AI/MeleeAI.cs
+++ b/Scripts/Mobiles/AI/MeleeAI.cs
@@ -135,7 +135,7 @@ namespace Server.Mobiles
             if (m_Mobile.Hits > (m_Mobile.HitsMax / 2))
             {
                 // If I have a target, go back and fight them
-                if (c != null)
+                if (c != null && m_Mobile.GetDistanceToSqrt(c) <= m_Mobile.RangePerception * 2)
                 {
                     m_Mobile.DebugSay("I am stronger now, reengaging {0}", c.Name);
                     Action = ActionType.Combat;

--- a/Scripts/Mobiles/AI/Omni AI/OmniAI Core.cs
+++ b/Scripts/Mobiles/AI/Omni AI/OmniAI Core.cs
@@ -34,7 +34,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return (this.m_Mobile.Skills[SkillName.Musicianship].Base > 10.0);
+                return (m_Mobile.Skills[SkillName.Musicianship].Base > 10.0);
             }
         }
 
@@ -42,7 +42,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return (this.m_Mobile.Skills[SkillName.Bushido].Base > 10.0);
+                return (m_Mobile.Skills[SkillName.Bushido].Base > 10.0);
             }
         }
 
@@ -50,7 +50,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return (this.m_Mobile.Skills[SkillName.Chivalry].Base > 10.0);
+                return (m_Mobile.Skills[SkillName.Chivalry].Base > 10.0);
             }
         }
 
@@ -58,7 +58,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return (this.m_Mobile.Skills[SkillName.Magery].Base > 10.0);
+                return (m_Mobile.Skills[SkillName.Magery].Base > 10.0);
             }
         }
 
@@ -66,7 +66,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return (this.m_Mobile.Skills[SkillName.Necromancy].Base > 10.0);
+                return (m_Mobile.Skills[SkillName.Necromancy].Base > 10.0);
             }
         }
 
@@ -74,7 +74,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return (this.m_Mobile.Skills[SkillName.Ninjitsu].Base > 10.0);
+                return (m_Mobile.Skills[SkillName.Ninjitsu].Base > 10.0);
             }
         }
 
@@ -82,7 +82,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return (this.m_Mobile.Skills[SkillName.Spellweaving].Base >= 10.0);
+                return (m_Mobile.Skills[SkillName.Spellweaving].Base >= 10.0);
             }
         }
 
@@ -90,7 +90,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return (this.m_Mobile.Skills[SkillName.Mysticism].Base >= 10.0);
+                return (m_Mobile.Skills[SkillName.Mysticism].Base >= 10.0);
             }
         }
 
@@ -98,7 +98,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return this.m_CanUseBushido || this.m_CanUseNinjitsu;
+                return m_CanUseBushido || m_CanUseNinjitsu;
             }
         }
 
@@ -106,13 +106,13 @@ namespace Server.Mobiles
         {
             get
             {
-                if (this.m_ForceMelee)
+                if (m_ForceMelee)
                     return true;
-                else if (this.m_Mobile.Weapon is BaseRanged)
+                else if (m_Mobile.Weapon is BaseRanged)
                     return false;
-                if (this.m_CanUseChivalry || this.m_CanUseBushido || this.m_CanUseNinjitsu)
+                if (m_CanUseChivalry || m_CanUseBushido || m_CanUseNinjitsu)
                     return true;
-                else if (this.m_CanUseMagery || this.m_CanUseNecromancy)
+                else if (m_CanUseMagery || m_CanUseNecromancy)
                     return false;
                 else
                     return true;
@@ -135,22 +135,22 @@ namespace Server.Mobiles
         #region getoutofmyway
         public override bool Think()
         {
-            if (this.m_Mobile.Deleted)
+            if (m_Mobile.Deleted)
                 return false;
 
-            if (DateTime.UtcNow > this.m_NextFieldCheck)
+            if (DateTime.UtcNow > m_NextFieldCheck)
             {
-                this.CheckForFieldSpells();
-                this.m_NextFieldCheck = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+                CheckForFieldSpells();
+                m_NextFieldCheck = DateTime.UtcNow + TimeSpan.FromSeconds(3);
             }
 
-            if (DateTime.UtcNow > this.m_NextCheckArmed)
+            if (DateTime.UtcNow > m_NextCheckArmed)
             {
-                this.CheckArmed(this.m_SwapWeapons);
-                this.m_NextCheckArmed = DateTime.UtcNow + TimeSpan.FromSeconds(12);
+                CheckArmed(m_SwapWeapons);
+                m_NextCheckArmed = DateTime.UtcNow + TimeSpan.FromSeconds(12);
             }
 
-            if (this.ProcessTarget())
+            if (ProcessTarget())
                 return true;
             else
                 return base.Think();
@@ -158,31 +158,28 @@ namespace Server.Mobiles
 
         public override bool DoActionWander()
         {
-            if (this.m_Mobile.Debug)
-                this.m_Mobile.DebugSay("I have no combatant");
+            m_Mobile.DebugSay("I have no combatant");
 
-            if (!this.m_Mobile.Hidden && !this.m_Mobile.Poisoned && this.m_CanUseNinjitsu)
-                this.m_Mobile.UseSkill(SkillName.Hiding);
+            if (!m_Mobile.Hidden && !m_Mobile.Poisoned && m_CanUseNinjitsu)
+                m_Mobile.UseSkill(SkillName.Hiding);
 
-            if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+            if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I have detected {0}, attacking", this.m_Mobile.FocusMob.Name);
+                m_Mobile.DebugSay("I have detected {0}, attacking", m_Mobile.FocusMob.Name);
 
-                this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                this.Action = ActionType.Combat;
+                m_Mobile.Combatant = m_Mobile.FocusMob;
+                Action = ActionType.Combat;
             }
-            else if (this.m_Mobile.Mana < this.m_Mobile.ManaMax && this.m_Mobile.Skills[SkillName.Meditation].Value > 60.0)
+            else if (m_Mobile.Mana < m_Mobile.ManaMax && m_Mobile.Skills[SkillName.Meditation].Value > 60.0)
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I am going to meditate");
+                m_Mobile.DebugSay("I am going to meditate");
 
-                this.m_Mobile.UseSkill(SkillName.Meditation);
+                m_Mobile.UseSkill(SkillName.Meditation);
             }
             else
             {
                 base.DoActionWander();
-                this.TryToHeal();
+                TryToHeal();
             }
 
             return true;
@@ -192,13 +189,13 @@ namespace Server.Mobiles
 
         public override bool DoActionCombat()
         {
-            Mobile combatant = this.m_Mobile.Combatant as Mobile;
+            Mobile c = m_Mobile.Combatant as Mobile;
 
-            if (DateTime.UtcNow > this.m_NextPetCommand)
+            if (DateTime.UtcNow > m_NextPetCommand)
             {
                 BaseCreature bc = null;
 
-                foreach (Mobile m in this.m_Mobile.GetMobilesInRange(10))
+                foreach (Mobile m in m_Mobile.GetMobilesInRange(10))
                 {
                     if (m == null)
                         continue;
@@ -206,132 +203,112 @@ namespace Server.Mobiles
                     {
                         bc = m as BaseCreature;
 
-                        if (bc.ControlMaster == this.m_Mobile || bc.SummonMaster == this.m_Mobile)
+                        if (bc.ControlMaster == m_Mobile || bc.SummonMaster == m_Mobile)
                         {
-                            bc.ControlTarget = combatant;
+                            bc.ControlTarget = c;
                             bc.ControlOrder = OrderType.Attack;
                         }
                     }
                 }
 
-                this.m_NextPetCommand = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+                m_NextPetCommand = DateTime.UtcNow + TimeSpan.FromSeconds(10);
             }
 
-            if (combatant == null || combatant.Deleted || combatant.Map != this.m_Mobile.Map || !combatant.Alive || combatant.IsDeadBondedPet)
+            if (c == null || c.Deleted || c.Map != m_Mobile.Map || !c.Alive || c.IsDeadBondedPet)
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("My combatant is gone, so my guard is up");
+                m_Mobile.DebugSay("My combatant is gone, so my guard is up");
 
-                this.Action = ActionType.Guard;
+                Action = ActionType.Guard;
                 return true;
             }
 
-            if (!this.m_Mobile.InRange(combatant, this.m_Mobile.RangePerception))
+            if (!m_Mobile.InRange(c, m_Mobile.RangePerception))
             {
                 // They are somewhat far away, can we find something else?
-                if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+                if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
                 {
-                    this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                    this.m_Mobile.FocusMob = null;
+                    m_Mobile.Combatant = m_Mobile.FocusMob;
+                    m_Mobile.FocusMob = null;
                 }
-                else if (!this.m_Mobile.InRange(combatant, this.m_Mobile.RangePerception * 3))
+                else if (!m_Mobile.InRange(c, m_Mobile.RangePerception * 3))
                 {
-                    this.m_Mobile.Combatant = null;
+                    m_Mobile.Combatant = null;
                 }
 
-                combatant = this.m_Mobile.Combatant as Mobile;
+                c = m_Mobile.Combatant as Mobile;
 
-                if (combatant == null)
+                if (c == null)
                 {
-                    if (this.m_Mobile.Debug)
-                        this.m_Mobile.DebugSay("My combatant has fled, so I am on guard");
+                    m_Mobile.DebugSay("My combatant has fled, so I am on guard");
 
-                    this.Action = ActionType.Guard;
+                    Action = ActionType.Guard;
                     return true;
                 }
             }
 
-            if (this.MoveTo(combatant, true, this.m_Mobile.RangeFight))
+            if (MoveTo(c, true, m_Mobile.RangeFight))
             {
-                this.m_Mobile.Direction = this.m_Mobile.GetDirectionTo(combatant);
+                m_Mobile.Direction = m_Mobile.GetDirectionTo(c);
             }
-            else if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+            else if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("My move is blocked, so I am going to attack {0}", this.m_Mobile.FocusMob.Name);
+                m_Mobile.DebugSay("My move is blocked, so I am going to attack {0}", m_Mobile.FocusMob.Name);
 
-                this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                this.Action = ActionType.Combat;
+                m_Mobile.Combatant = m_Mobile.FocusMob;
+                Action = ActionType.Combat;
 
                 return true;
             }
-            else if (this.m_Mobile.GetDistanceToSqrt(combatant) > this.m_Mobile.RangePerception + 1)
+            else if (m_Mobile.GetDistanceToSqrt(c) > m_Mobile.RangePerception + 1)
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I cannot find {0}, so my guard is up", combatant.Name);
+                m_Mobile.DebugSay("I cannot find {0}, so my guard is up", c.Name);
 
-                this.Action = ActionType.Guard;
+                Action = ActionType.Guard;
 
                 return true;
             }
             else
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I should be closer to {0}", combatant.Name);
+                m_Mobile.DebugSay("I should be closer to {0}", c.Name);
             }
 
-            if (!this.m_Mobile.Controlled && !this.m_Mobile.Summoned && !this.m_Mobile.IsParagon)
+            if (!m_Mobile.Controlled && !m_Mobile.Summoned && m_Mobile.CanFlee)
             {
-                if (this.m_Mobile.Hits < this.m_Mobile.HitsMax * 20 / 100)
+                if (m_Mobile.Hits < m_Mobile.HitsMax * 20 / 100)
                 {
                     // We are low on health, should we flee?
-                    bool flee = false;
-
-                    if (this.m_Mobile.Hits < combatant.Hits)
+                    if (Utility.Random(100) <= Math.Max(10, 10 + c.Hits - m_Mobile.Hits))
                     {
-                        // We are more hurt than them
-                        int diff = combatant.Hits - this.m_Mobile.Hits;
-
-                        flee = (Utility.Random(0, 100) < (10 + diff)); // (10 + diff)% chance to flee
-                    }
-                    else
-                    {
-                        flee = Utility.Random(0, 100) < 10; // 10% chance to flee
-                    }
-
-                    if (flee)
-                    {
-                        if (this.m_Mobile.Debug)
-                            this.m_Mobile.DebugSay("I am going to flee from {0}", combatant.Name);
-
-                        this.Action = ActionType.Flee;
+                        m_Mobile.DebugSay("I am going to flee from {0}", c.Name);
+                        Action = ActionType.Flee;
+                        return true;
                     }
                 }
             }
 
-            if (this.TryToHeal())
+            if (TryToHeal())
                 return true;
-            else if (this.m_Mobile.Spell == null && DateTime.UtcNow > this.m_NextCastTime && this.m_Mobile.InRange(combatant, 12))
+            else if (m_Mobile.Spell == null && DateTime.UtcNow > m_NextCastTime && m_Mobile.InRange(c, 12))
             {
-                this.m_NextCastTime = DateTime.UtcNow + TimeSpan.FromSeconds(4);
+                m_NextCastTime = DateTime.UtcNow + TimeSpan.FromSeconds(4);
 
                 List<int> skill = new List<int>();
 
-                if (this.m_CanUseBushido)
+                if (m_CanUseBushido)
                     skill.Add(1);
-                if (this.m_CanUseChivalry)
+                if (m_CanUseChivalry)
                     skill.Add(2);
-                if (this.m_CanUseMagery)
+                if (m_CanUseMagery)
                     skill.Add(3);
-                if (this.m_CanUseNecromancy)
+                if (m_CanUseNecromancy)
                     skill.Add(4);
-                if (this.m_CanUseNinjitsu)
+                if (m_CanUseNinjitsu)
                     skill.Add(5);
-                if (this.m_CanUseSpellweaving)
+                if (m_CanUseSpellweaving)
                     skill.Add(6);
-                if (this.m_CanUseMystic)
+                if (m_CanUseMystic)
                     skill.Add(7);
-                if (this.m_CanUseBard)
+                if (m_CanUseBard)
                     skill.Add(8);
 
                 if (skill.Count == 0)
@@ -345,25 +322,25 @@ namespace Server.Mobiles
                 switch( whichone )
                 {
                     case 1:
-                        this.BushidoPower();
+                        BushidoPower();
                         break;
                     case 2:
-                        this.ChivalryPower();
+                        ChivalryPower();
                         break;
                     case 3:
-                        this.MageryPower();
+                        MageryPower();
                         break;
                     case 4:
-                        this.NecromancerPower();
+                        NecromancerPower();
                         break;
                     case 5:
-                        this.NinjitsuPower();
+                        NinjitsuPower();
                         break;
                     case 6:
-                        this.SpellweavingPower();
+                        SpellweavingPower();
                         break;
                     case 7:
-                        this.MysticPower();
+                        MysticPower();
                         break;
                 // case 8: BardPower(); break;
                 }
@@ -374,16 +351,15 @@ namespace Server.Mobiles
 
         public override bool DoActionGuard()
         {
-            if (!this.m_Mobile.Hidden && !this.m_Mobile.Poisoned && this.m_CanUseNinjitsu)
-                this.m_Mobile.UseSkill(SkillName.Hiding);
+            if (!m_Mobile.Hidden && !m_Mobile.Poisoned && m_CanUseNinjitsu)
+                m_Mobile.UseSkill(SkillName.Hiding);
 
-            if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+            if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I have detected {0}, attacking", this.m_Mobile.FocusMob.Name);
+                m_Mobile.DebugSay("I have detected {0}, attacking", m_Mobile.FocusMob.Name);
 
-                this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                this.Action = ActionType.Combat;
+                m_Mobile.Combatant = m_Mobile.FocusMob;
+                Action = ActionType.Combat;
             }
             else
             {
@@ -395,47 +371,56 @@ namespace Server.Mobiles
 
         public override bool DoActionFlee()
         {
-            if (this.m_Mobile.Hits > (this.m_Mobile.HitsMax / 2))
+            Mobile c = m_Mobile.Combatant as Mobile;
+
+            if (m_Mobile.Hits > (m_Mobile.HitsMax / 2))
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I am stronger now, so I will continue fighting");
-
-                this.Action = ActionType.Combat;
+                // If I have a target, go back and fight them
+                if (c != null)
+                {
+                    m_Mobile.DebugSay("I am stronger now, reengaging {0}", c.Name);
+                    Action = ActionType.Combat;
+                }
+                else
+                {
+                    m_Mobile.DebugSay("I am stronger now, my guard is up");
+                    Action = ActionType.Guard;
+                }
             }
-            else if (this.m_CanUseNinjitsu && this.m_Mobile.Combatant != null && this.m_SmokeBombs > 0 && this.m_Mobile.Mana >= 10 && this.m_Mobile.Hidden == false)
+            else
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I am using a smoke bomb. ");
+                if (m_CanUseNinjitsu && m_Mobile.Combatant != null && m_SmokeBombs > 0 && m_Mobile.Mana >= 10 && m_Mobile.Hidden == false)
+                {
+                    m_Mobile.DebugSay("I am using a smoke bomb. ");
 
-                --this.m_SmokeBombs;
+                    --m_SmokeBombs;
 
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I have {0} smoke bombs left.", this.m_SmokeBombs.ToString());
+                    m_Mobile.DebugSay("I have {0} smoke bombs left.", m_SmokeBombs.ToString());
 
-                this.m_Mobile.Mana -= 10;
-                this.m_Mobile.Hidden = true;
-                Server.SkillHandlers.Stealth.OnUse(this.m_Mobile);
-                this.m_Mobile.FixedParticles(0x3709, 1, 30, 9904, 1108, 6, EffectLayer.RightFoot);
-                this.m_Mobile.PlaySound(0x22F);
+                    m_Mobile.Mana -= 10;
+                    m_Mobile.Hidden = true;
+                    Server.SkillHandlers.Stealth.OnUse(m_Mobile);
+                    m_Mobile.FixedParticles(0x3709, 1, 30, 9904, 1108, 6, EffectLayer.RightFoot);
+                    m_Mobile.PlaySound(0x22F);
+                }
+
+                base.DoActionFlee();
             }
-
-            this.m_Mobile.FocusMob = this.m_Mobile.Combatant as Mobile;
-            base.DoActionFlee();
 
             return true;
         }
 
         public override bool MoveTo(IPoint3D p, bool run, int range)
         {
-            if (this.m_Mobile.Hidden && !this.m_Mobile.Poisoned && this.m_CanUseNinjitsu)
+            if (m_Mobile.Hidden && !m_Mobile.Poisoned && m_CanUseNinjitsu)
             {
-                Server.SkillHandlers.Stealth.OnUse(this.m_Mobile);
+                Server.SkillHandlers.Stealth.OnUse(m_Mobile);
 
                 if (base.MoveTo(p, false, range) == false)
                 {
-                    if (this.m_Mobile.Hidden && this.m_Mobile.AllowedStealthSteps >= 1 && this.m_CanUseNinjitsu)
+                    if (m_Mobile.Hidden && m_Mobile.AllowedStealthSteps >= 1 && m_CanUseNinjitsu)
                     {
-                        Spell spell = new Shadowjump(this.m_Mobile, null);
+                        Spell spell = new Shadowjump(m_Mobile, null);
                         spell.Cast();
                     }
 
@@ -444,13 +429,13 @@ namespace Server.Mobiles
                 else
                     return true;
             }
-            else if (!this.m_Melees && p != null) 
+            else if (!m_Melees && p != null)
             {
-                if (this.m_Mobile.InRange(p, 2) && this.CheckMove())
+                if (m_Mobile.InRange(p, 2) && CheckMove())
                 {
                     Direction d = Direction.North;
 
-                    switch( this.m_Mobile.GetDirectionTo(p) )
+                    switch( m_Mobile.GetDirectionTo(p) )
                     {
                         case Direction.North:
                             d = Direction.South;
@@ -478,10 +463,10 @@ namespace Server.Mobiles
                             break;
                     }
 
-                    return this.DoMove(d, run);
+                    return DoMove(d, run);
                     // base.DoActionFlee();
                 }
-                else if (this.m_Mobile.InRange(p, 4))
+                else if (m_Mobile.InRange(p, 4))
                     return true;
             }
 
@@ -490,9 +475,9 @@ namespace Server.Mobiles
 
         public override bool WalkMobileRange(IPoint3D p, int iSteps, bool bRun, int iWantDistMin, int iWantDistMax)
         {
-            if (this.m_Mobile.Hidden && !this.m_Mobile.Poisoned && this.m_CanUseNinjitsu)
+            if (m_Mobile.Hidden && !m_Mobile.Poisoned && m_CanUseNinjitsu)
             {
-                Server.SkillHandlers.Stealth.OnUse(this.m_Mobile);
+                Server.SkillHandlers.Stealth.OnUse(m_Mobile);
 
                 return base.WalkMobileRange(p, iSteps, false, iWantDistMin, iWantDistMax);
             }
@@ -502,9 +487,9 @@ namespace Server.Mobiles
 
         public override void WalkRandom(int iChanceToNotMove, int iChanceToDir, int iSteps)
         {
-            if (this.m_Mobile.Hidden && this.m_CanUseNinjitsu)
-                Server.SkillHandlers.Stealth.OnUse(this.m_Mobile);
-			
+            if (m_Mobile.Hidden && m_CanUseNinjitsu)
+                Server.SkillHandlers.Stealth.OnUse(m_Mobile);
+
             base.WalkRandom(iChanceToNotMove, iChanceToDir, iSteps);
         }
 
@@ -522,27 +507,27 @@ namespace Server.Mobiles
 
         private bool ProcessTarget()
         {
-            Target targ = this.m_Mobile.Target;
+            Target targ = m_Mobile.Target;
 
             if (targ == null)
                 return false;
 
             Mobile toTarget;
 
-            toTarget = this.m_Mobile.Combatant as Mobile;
+            toTarget = m_Mobile.Combatant as Mobile;
 
             //if ( toTarget != null )
             //RunTo( toTarget );
 
-            if (targ is DispelSpell.InternalTarget && !(this.m_Mobile.AutoDispel))
+            if (targ is DispelSpell.InternalTarget && !(m_Mobile.AutoDispel))
             {
                 List<Mobile> targets = new List<Mobile>();
 
-                foreach (Mobile m in this.m_Mobile.GetMobilesInRange(12))
+                foreach (Mobile m in m_Mobile.GetMobilesInRange(12))
                 {
                     if (m is BaseCreature)
                     {
-                        if (((BaseCreature)m).IsDispellable && CanTarget(this.m_Mobile, m))
+                        if (((BaseCreature)m).IsDispellable && CanTarget(m_Mobile, m))
                             targets.Add(m);
                     }
                 }
@@ -552,30 +537,30 @@ namespace Server.Mobiles
                     int whichone = Utility.RandomMinMax(0, targets.Count);
 
                     if (targets[whichone] != null)
-                        targ.Invoke(this.m_Mobile, targets[whichone]);
+                        targ.Invoke(m_Mobile, targets[whichone]);
                 }
             }
             else if (targ is TeleportSpell.InternalTarget || targ is Shadowjump.InternalTarget)
             {
-                if (targ is Shadowjump.InternalTarget && !this.m_Mobile.Hidden)
+                if (targ is Shadowjump.InternalTarget && !m_Mobile.Hidden)
                     return false;
 
-                Map map = this.m_Mobile.Map;
+                Map map = m_Mobile.Map;
 
                 if (map == null)
                 {
-                    targ.Cancel(this.m_Mobile, TargetCancelType.Canceled);
+                    targ.Cancel(m_Mobile, TargetCancelType.Canceled);
                     return true;
                 }
 
                 int px, py;
-                bool teleportAway = (this.m_Mobile.Hits < (this.m_Mobile.Hits / 10));
+                bool teleportAway = (m_Mobile.Hits < (m_Mobile.Hits / 10));
 
                 if (teleportAway)
                 {
-                    int rx = this.m_Mobile.X - toTarget.X;
-                    int ry = this.m_Mobile.Y - toTarget.Y;
-                    double d = this.m_Mobile.GetDistanceToSqrt(toTarget);
+                    int rx = m_Mobile.X - toTarget.X;
+                    int ry = m_Mobile.Y - toTarget.Y;
+                    double d = m_Mobile.GetDistanceToSqrt(toTarget);
 
                     px = toTarget.X + (int)(rx * (10 / d));
                     py = toTarget.Y + (int)(ry * (10 / d));
@@ -594,9 +579,9 @@ namespace Server.Mobiles
 
                     LandTarget lt = new LandTarget(p, map);
 
-                    if ((targ.Range == -1 || this.m_Mobile.InRange(p, targ.Range)) && this.m_Mobile.InLOS(lt) && map.CanSpawnMobile(px + x, py + y, lt.Z) && !SpellHelper.CheckMulti(p, map))
+                    if ((targ.Range == -1 || m_Mobile.InRange(p, targ.Range)) && m_Mobile.InLOS(lt) && map.CanSpawnMobile(px + x, py + y, lt.Z) && !SpellHelper.CheckMulti(p, map))
                     {
-                        targ.Invoke(this.m_Mobile, lt);
+                        targ.Invoke(m_Mobile, lt);
                         return true;
                     }
                 }
@@ -608,13 +593,13 @@ namespace Server.Mobiles
 
                 for (int i = 0; i < 10; ++i)
                 {
-                    Point3D randomPoint = new Point3D(this.m_Mobile.X - teleRange + Utility.Random(teleRange * 2 + 1), this.m_Mobile.Y - teleRange + Utility.Random(teleRange * 2 + 1), 0);
+                    Point3D randomPoint = new Point3D(m_Mobile.X - teleRange + Utility.Random(teleRange * 2 + 1), m_Mobile.Y - teleRange + Utility.Random(teleRange * 2 + 1), 0);
 
                     LandTarget lt = new LandTarget(randomPoint, map);
 
-                    if (this.m_Mobile.InLOS(lt) && map.CanSpawnMobile(lt.X, lt.Y, lt.Z) && !SpellHelper.CheckMulti(randomPoint, map))
+                    if (m_Mobile.InLOS(lt) && map.CanSpawnMobile(lt.X, lt.Y, lt.Z) && !SpellHelper.CheckMulti(randomPoint, map))
                     {
-                        targ.Invoke(this.m_Mobile, new LandTarget(randomPoint, map));
+                        targ.Invoke(m_Mobile, new LandTarget(randomPoint, map));
                         return true;
                     }
                 }
@@ -625,7 +610,7 @@ namespace Server.Mobiles
 
                 List<Item> itemtargets = new List<Item>();
 
-                foreach (Item itemstofind in this.m_Mobile.GetItemsInRange(5))
+                foreach (Item itemstofind in m_Mobile.GetItemsInRange(5))
                 {
                     if (itemstofind is Corpse)
                     {
@@ -644,28 +629,28 @@ namespace Server.Mobiles
                         continue;
                     else
                     {
-                        targ.Invoke(this.m_Mobile, items);
+                        targ.Invoke(m_Mobile, items);
                         break;
                     }
                 }
 
                 if (targ != null)
-                    targ.Cancel(this.m_Mobile, TargetCancelType.Canceled);
+                    targ.Cancel(m_Mobile, TargetCancelType.Canceled);
             }
             else if ((targ.Flags & TargetFlags.Harmful) != 0 && toTarget != null)
             {
-                if ((targ.Range == -1 || this.m_Mobile.InRange(toTarget, targ.Range)) && this.m_Mobile.CanSee(toTarget) && this.m_Mobile.InLOS(toTarget))
+                if ((targ.Range == -1 || m_Mobile.InRange(toTarget, targ.Range)) && m_Mobile.CanSee(toTarget) && m_Mobile.InLOS(toTarget))
                 {
-                    targ.Invoke(this.m_Mobile, toTarget);
+                    targ.Invoke(m_Mobile, toTarget);
                 }
             }
             else if ((targ.Flags & TargetFlags.Beneficial) != 0)
             {
-                targ.Invoke(this.m_Mobile, this.m_Mobile);
+                targ.Invoke(m_Mobile, m_Mobile);
             }
             else
             {
-                targ.Cancel(this.m_Mobile, TargetCancelType.Canceled);
+                targ.Cancel(m_Mobile, TargetCancelType.Canceled);
             }
 
             return true;

--- a/Scripts/Mobiles/AI/Omni AI/OmniAI Core.cs
+++ b/Scripts/Mobiles/AI/Omni AI/OmniAI Core.cs
@@ -376,7 +376,7 @@ namespace Server.Mobiles
             if (m_Mobile.Hits > (m_Mobile.HitsMax / 2))
             {
                 // If I have a target, go back and fight them
-                if (c != null)
+                if (c != null && m_Mobile.GetDistanceToSqrt(c) <= m_Mobile.RangePerception * 2)
                 {
                     m_Mobile.DebugSay("I am stronger now, reengaging {0}", c.Name);
                     Action = ActionType.Combat;

--- a/Scripts/Mobiles/AI/OppositionGroup.cs
+++ b/Scripts/Mobiles/AI/OppositionGroup.cs
@@ -31,8 +31,10 @@ namespace Server
                 typeof(OrcBomber),
                 typeof(OrcBrute),
                 typeof(OrcCaptain),
+                typeof(OrcChopper),
                 typeof(OrcishLord),
                 typeof(OrcishMage),
+                typeof(OrcScout),
                 typeof(SpawnedOrcishLord)
             },
             new Type[]

--- a/Scripts/Mobiles/AI/OrcScoutAI.cs
+++ b/Scripts/Mobiles/AI/OrcScoutAI.cs
@@ -189,7 +189,7 @@ namespace Server.Mobiles
 			if (/*hasAmmo && */m_Mobile.Hits > m_Mobile.HitsMax / 2)
 			{
                 // If I have a target, go back and fight them
-                if (c != null)
+                if (c != null && m_Mobile.GetDistanceToSqrt(c) <= m_Mobile.RangePerception * 2)
                 {
                     m_Mobile.DebugSay("I am stronger now, reengaging {0}", c.Name);
                     Action = ActionType.Combat;

--- a/Scripts/Mobiles/AI/SpellbinderAI.cs
+++ b/Scripts/Mobiles/AI/SpellbinderAI.cs
@@ -54,14 +54,14 @@ namespace Server.Mobiles
 
         public override bool Think()
         {
-            if (this.m_Mobile.Deleted)
+            if (m_Mobile.Deleted)
                 return false;
 
-            Target targ = this.m_Mobile.Target;
+            Target targ = m_Mobile.Target;
 
             if (targ != null)
             {
-                this.ProcessTarget(targ);
+                ProcessTarget(targ);
 
                 return true;
             }
@@ -73,53 +73,52 @@ namespace Server.Mobiles
 
         public virtual double ScaleByNecromancy(double v)
         {
-            return this.m_Mobile.Skills[SkillName.Necromancy].Value * v * 0.01;
+            return m_Mobile.Skills[SkillName.Necromancy].Value * v * 0.01;
         }
 
         public virtual double ScaleByMagery(double v)
         {
-            return this.m_Mobile.Skills[SkillName.Magery].Value * v * 0.01;
+            return m_Mobile.Skills[SkillName.Magery].Value * v * 0.01;
         }
 
         public override bool DoActionWander()
         {
-            if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+            if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I am going to attack {0}", this.m_Mobile.FocusMob.Name);
+                m_Mobile.DebugSay("I am going to attack {0}", m_Mobile.FocusMob.Name);
 
-                this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                this.Action = ActionType.Combat;
-                this.m_NextCastTime = DateTime.UtcNow;
+                m_Mobile.Combatant = m_Mobile.FocusMob;
+                Action = ActionType.Combat;
+                m_NextCastTime = DateTime.UtcNow;
             }
-            else if (this.m_Mobile.Mana < this.m_Mobile.ManaMax)
+            else if (m_Mobile.Mana < m_Mobile.ManaMax)
             {
-                this.m_Mobile.DebugSay("I am going to meditate");
+                m_Mobile.DebugSay("I am going to meditate");
 
-                this.m_Mobile.UseSkill(SkillName.Meditation);
+                m_Mobile.UseSkill(SkillName.Meditation);
             }
             else
             {
-                this.m_Mobile.DebugSay("I am wandering");
+                m_Mobile.DebugSay("I am wandering");
 
-                this.m_Mobile.Warmode = false;
+                m_Mobile.Warmode = false;
 
                 base.DoActionWander();
 
-                if (this.m_Mobile.Poisoned)
+                if (m_Mobile.Poisoned)
                 {
-                    new CureSpell(this.m_Mobile, null).Cast();
+                    new CureSpell(m_Mobile, null).Cast();
                 }
-                else if (!this.m_Mobile.Summoned)
+                else if (!m_Mobile.Summoned)
                 {
-                    if (this.m_Mobile.Hits < (this.m_Mobile.HitsMax - 50))
+                    if (m_Mobile.Hits < (m_Mobile.HitsMax - 50))
                     {
-                        if (!new GreaterHealSpell(this.m_Mobile, null).Cast())
-                            new HealSpell(this.m_Mobile, null).Cast();
+                        if (!new GreaterHealSpell(m_Mobile, null).Cast())
+                            new HealSpell(m_Mobile, null).Cast();
                     }
-                    else if (this.m_Mobile.Hits < (this.m_Mobile.HitsMax - 10))
+                    else if (m_Mobile.Hits < (m_Mobile.HitsMax - 10))
                     {
-                        new HealSpell(this.m_Mobile, null).Cast();
+                        new HealSpell(m_Mobile, null).Cast();
                     }
                 }
             }
@@ -131,104 +130,103 @@ namespace Server.Mobiles
         {
             if (m.Paralyzed || m.Frozen)
             {
-                if (this.m_Mobile.InRange(m, 1))
-                    this.RunFrom(m);
-                else if (!this.m_Mobile.InRange(m, this.m_Mobile.RangeFight > 2 ? this.m_Mobile.RangeFight : 2) && !this.MoveTo(m, true, 1))
-                    this.OnFailedMove();
+                if (m_Mobile.InRange(m, 1))
+                    RunFrom(m);
+                else if (!m_Mobile.InRange(m, m_Mobile.RangeFight > 2 ? m_Mobile.RangeFight : 2) && !MoveTo(m, true, 1))
+                    OnFailedMove();
             }
             else
             {
-                if (!this.m_Mobile.InRange(m, this.m_Mobile.RangeFight))
+                if (!m_Mobile.InRange(m, m_Mobile.RangeFight))
                 {
-                    if (!this.MoveTo(m, true, 1))
-                        this.OnFailedMove();
+                    if (!MoveTo(m, true, 1))
+                        OnFailedMove();
                 }
-                else if (this.m_Mobile.InRange(m, this.m_Mobile.RangeFight - 1))
+                else if (m_Mobile.InRange(m, m_Mobile.RangeFight - 1))
                 {
-                    this.RunFrom(m);
+                    RunFrom(m);
                 }
             }
         }
 
         public void RunFrom(IDamageable m)
         {
-            this.Run((Direction)((int)this.m_Mobile.GetDirectionTo(m) - 4) & Direction.Mask);
+            Run((Direction)((int)m_Mobile.GetDirectionTo(m) - 4) & Direction.Mask);
         }
 
         public void OnFailedMove()
         {
-            if (!this.m_Mobile.DisallowAllMoves && this.ScaleByMagery(TeleportChance) > Utility.RandomDouble())
+            if (!m_Mobile.DisallowAllMoves && ScaleByMagery(TeleportChance) > Utility.RandomDouble())
             {
-                if (this.m_Mobile.Target != null)
-                    this.m_Mobile.Target.Cancel(this.m_Mobile, TargetCancelType.Canceled);
+                if (m_Mobile.Target != null)
+                    m_Mobile.Target.Cancel(m_Mobile, TargetCancelType.Canceled);
 
-                new TeleportSpell(this.m_Mobile, null).Cast();
+                new TeleportSpell(m_Mobile, null).Cast();
 
-                this.m_Mobile.DebugSay("I am stuck, I'm going to try teleporting away");
+                m_Mobile.DebugSay("I am stuck, I'm going to try teleporting away");
             }
-            else if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+            else if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("My move is blocked, so I am going to attack {0}", this.m_Mobile.FocusMob.Name);
+                m_Mobile.DebugSay("My move is blocked, so I am going to attack {0}", m_Mobile.FocusMob.Name);
 
-                this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                this.Action = ActionType.Combat;
+                m_Mobile.Combatant = m_Mobile.FocusMob;
+                Action = ActionType.Combat;
             }
             else
             {
-                this.m_Mobile.DebugSay("I am stuck");
+                m_Mobile.DebugSay("I am stuck");
             }
         }
 
         public void Run(Direction d)
         {
-            if ((this.m_Mobile.Spell != null && this.m_Mobile.Spell.IsCasting) || this.m_Mobile.Paralyzed || this.m_Mobile.Frozen || this.m_Mobile.DisallowAllMoves)
+            if ((m_Mobile.Spell != null && m_Mobile.Spell.IsCasting) || m_Mobile.Paralyzed || m_Mobile.Frozen || m_Mobile.DisallowAllMoves)
                 return;
 
-            this.m_Mobile.Direction = d | Direction.Running;
+            m_Mobile.Direction = d | Direction.Running;
 
-            if (!this.DoMove(this.m_Mobile.Direction, true))
-                this.OnFailedMove();
+            if (!DoMove(m_Mobile.Direction, true))
+                OnFailedMove();
         }
 
         public virtual Spell GetRandomCurseSpell()
         {
-            int necro = (int)((this.m_Mobile.Skills[SkillName.Necromancy].Value + 50.0) / (100.0 / 7.0));
-            int mage = (int)((this.m_Mobile.Skills[SkillName.Magery].Value + 50.0) / (100.0 / 7.0));
-			
+            int necro = (int)((m_Mobile.Skills[SkillName.Necromancy].Value + 50.0) / (100.0 / 7.0));
+            int mage = (int)((m_Mobile.Skills[SkillName.Magery].Value + 50.0) / (100.0 / 7.0));
+
             if (mage < 1)
                 mage = 1;
-				
+
             if (necro < 1)
                 necro = 1;
-				
-            if (this.m_Mobile.Skills[SkillName.Necromancy].Value > 30 && Utility.Random(necro) > Utility.Random(mage))
-            { 
+
+            if (m_Mobile.Skills[SkillName.Necromancy].Value > 30 && Utility.Random(necro) > Utility.Random(mage))
+            {
                 switch ( Utility.Random(necro - 5) )
                 {
                     case 0:
                     case 1:
-                        return new CorpseSkinSpell(this.m_Mobile, null);
+                        return new CorpseSkinSpell(m_Mobile, null);
                     case 2:
                     case 3:
-                        return new MindRotSpell(this.m_Mobile, null);
+                        return new MindRotSpell(m_Mobile, null);
                     default:
-                        return new MindRotSpell(this.m_Mobile, null);
+                        return new MindRotSpell(m_Mobile, null);
                 }
             }
-			
+
             if (Utility.RandomBool() && mage > 3)
-                return new CurseSpell(this.m_Mobile, null);
+                return new CurseSpell(m_Mobile, null);
 
             switch ( Utility.Random(3) )
             {
                 default:
                 case 0:
-                    return new WeakenSpell(this.m_Mobile, null);
+                    return new WeakenSpell(m_Mobile, null);
                 case 1:
-                    return new ClumsySpell(this.m_Mobile, null);
+                    return new ClumsySpell(m_Mobile, null);
                 case 2:
-                    return new FeeblemindSpell(this.m_Mobile, null);
+                    return new FeeblemindSpell(m_Mobile, null);
             }
         }
 
@@ -236,24 +234,24 @@ namespace Server.Mobiles
         {
             if (Utility.RandomBool())
             {
-                if (this.m_Mobile.Skills[SkillName.Magery].Value >= 80.0)
-                    return new ManaVampireSpell(this.m_Mobile, null);
+                if (m_Mobile.Skills[SkillName.Magery].Value >= 80.0)
+                    return new ManaVampireSpell(m_Mobile, null);
             }
 
-            return new ManaDrainSpell(this.m_Mobile, null);
+            return new ManaDrainSpell(m_Mobile, null);
         }
 
         public virtual Spell DoDispel(Mobile toDispel)
         {
-            if (this.ScaleByMagery(DispelChance) > Utility.RandomDouble())
-                return new DispelSpell(this.m_Mobile, null);
+            if (ScaleByMagery(DispelChance) > Utility.RandomDouble())
+                return new DispelSpell(m_Mobile, null);
 
-            return this.ChooseSpell(toDispel);
+            return ChooseSpell(toDispel);
         }
 
         public virtual Spell ChooseSpell(IDamageable c)
         {
-            Spell spell = this.CheckCastHealingSpell();
+            Spell spell = CheckCastHealingSpell();
 
             if (spell != null)
                 return spell;
@@ -264,10 +262,10 @@ namespace Server.Mobiles
             }
 
             Mobile mob = c as Mobile;
-            double damage = ((this.m_Mobile.Skills[SkillName.SpiritSpeak].Value - mob.Skills[SkillName.MagicResist].Value) / 10) + (mob.Player ? 18 : 30);
-			
+            double damage = ((m_Mobile.Skills[SkillName.SpiritSpeak].Value - mob.Skills[SkillName.MagicResist].Value) / 10) + (mob.Player ? 18 : 30);
+
             if (damage > c.Hits)
-                spell = new ManaDrainSpell(this.m_Mobile, null);
+                spell = new ManaDrainSpell(m_Mobile, null);
 
             switch ( Utility.Random(16) )
             {
@@ -275,52 +273,52 @@ namespace Server.Mobiles
                 case 1:
                 case 2:	// Poison them
                     {
-                        this.m_Mobile.DebugSay("Attempting to BloodOath");
+                        m_Mobile.DebugSay("Attempting to BloodOath");
 
                         if (!mob.Poisoned)
-                            spell = new BloodOathSpell(this.m_Mobile, null);
+                            spell = new BloodOathSpell(m_Mobile, null);
 
                         break;
                     }
                 case 3:	// Bless ourselves.
                     {
-                        this.m_Mobile.DebugSay("Blessing myself");
+                        m_Mobile.DebugSay("Blessing myself");
 
-                        spell = new BlessSpell(this.m_Mobile, null);
+                        spell = new BlessSpell(m_Mobile, null);
                         break;
                     }
                 case 4:
                 case 5:
                 case 6: // Curse them.
                     {
-                        this.m_Mobile.DebugSay("Attempting to curse");
+                        m_Mobile.DebugSay("Attempting to curse");
 
-                        spell = this.GetRandomCurseSpell();
+                        spell = GetRandomCurseSpell();
                         break;
                     }
                 case 7:	// Paralyze them.
                     {
-                        this.m_Mobile.DebugSay("Attempting to paralyze");
+                        m_Mobile.DebugSay("Attempting to paralyze");
 
-                        if (this.m_Mobile.Skills[SkillName.Magery].Value > 50.0)
-                            spell = new ParalyzeSpell(this.m_Mobile, null);
+                        if (m_Mobile.Skills[SkillName.Magery].Value > 50.0)
+                            spell = new ParalyzeSpell(m_Mobile, null);
 
                         break;
                     }
                 case 8: // Drain mana
                     {
-                        this.m_Mobile.DebugSay("Attempting to drain mana");
+                        m_Mobile.DebugSay("Attempting to drain mana");
 
-                        spell = this.GetRandomManaDrainSpell();
+                        spell = GetRandomManaDrainSpell();
                         break;
                     }
                 case 9: // Blood oath them
                     {
-                        this.m_Mobile.DebugSay("Attempting to blood oath");
+                        m_Mobile.DebugSay("Attempting to blood oath");
 
-                        if (this.m_Mobile.Skills[SkillName.Necromancy].Value > 30 && BloodOathSpell.GetBloodOath(mob) != this.m_Mobile)
-                            spell = new BloodOathSpell(this.m_Mobile, null);
-						
+                        if (m_Mobile.Skills[SkillName.Necromancy].Value > 30 && BloodOathSpell.GetBloodOath(mob) != m_Mobile)
+                            spell = new BloodOathSpell(m_Mobile, null);
+
                         break;
                     }
             }
@@ -330,120 +328,103 @@ namespace Server.Mobiles
 
         public override bool DoActionCombat()
         {
-            IDamageable c = this.m_Mobile.Combatant;
-            this.m_Mobile.Warmode = true;
+            IDamageable c = m_Mobile.Combatant;
+            m_Mobile.Warmode = true;
 
-            if (c == null || c.Deleted || !c.Alive || (c is Mobile && ((Mobile)c).IsDeadBondedPet) || !this.m_Mobile.CanSee(c) || !this.m_Mobile.CanBeHarmful(c, false) || c.Map != this.m_Mobile.Map)
+            if (c == null || c.Deleted || !c.Alive || (c is Mobile && ((Mobile)c).IsDeadBondedPet) || !m_Mobile.CanSee(c) || !m_Mobile.CanBeHarmful(c, false) || c.Map != m_Mobile.Map)
             {
                 // Our combatant is deleted, dead, hidden, or we cannot hurt them
                 // Try to find another combatant
-                if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+                if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
                 {
-                    if (this.m_Mobile.Debug)
-                        this.m_Mobile.DebugSay("Something happened to my combatant, so I am going to fight {0}", this.m_Mobile.FocusMob.Name);
+                    m_Mobile.DebugSay("Something happened to my combatant, so I am going to fight {0}", m_Mobile.FocusMob.Name);
 
-                    this.m_Mobile.Combatant = c = this.m_Mobile.FocusMob;
-                    this.m_Mobile.FocusMob = null;
+                    m_Mobile.Combatant = c = m_Mobile.FocusMob;
+                    m_Mobile.FocusMob = null;
                 }
                 else
                 {
-                    this.m_Mobile.DebugSay("Something happened to my combatant, and nothing is around. I am on guard.");
-                    this.Action = ActionType.Guard;
+                    m_Mobile.DebugSay("Something happened to my combatant, and nothing is around. I am on guard.");
+                    Action = ActionType.Guard;
                     return true;
                 }
             }
 
-            if (!this.m_Mobile.InLOS(c))
+            if (!m_Mobile.InLOS(c))
             {
-                if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+                if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
                 {
-                    this.m_Mobile.Combatant = c = this.m_Mobile.FocusMob;
-                    this.m_Mobile.FocusMob = null;
+                    m_Mobile.Combatant = c = m_Mobile.FocusMob;
+                    m_Mobile.FocusMob = null;
                 }
             }
 
-            if (!this.m_Mobile.StunReady && this.m_Mobile.Skills[SkillName.Wrestling].Value >= 80.0 && this.m_Mobile.Skills[SkillName.Anatomy].Value >= 80.0)
-                EventSink.InvokeStunRequest(new StunRequestEventArgs(this.m_Mobile));
+            if (!m_Mobile.StunReady && m_Mobile.Skills[SkillName.Wrestling].Value >= 80.0 && m_Mobile.Skills[SkillName.Anatomy].Value >= 80.0)
+                EventSink.InvokeStunRequest(new StunRequestEventArgs(m_Mobile));
 
-            if (!this.m_Mobile.InRange(c, this.m_Mobile.RangePerception))
+            if (!m_Mobile.InRange(c, m_Mobile.RangePerception))
             {
                 // They are somewhat far away, can we find something else?
-                if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+                if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
                 {
-                    this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                    this.m_Mobile.FocusMob = null;
+                    m_Mobile.Combatant = m_Mobile.FocusMob;
+                    m_Mobile.FocusMob = null;
                 }
-                else if (!this.m_Mobile.InRange(c, this.m_Mobile.RangePerception * 3))
+                else if (!m_Mobile.InRange(c, m_Mobile.RangePerception * 3))
                 {
-                    this.m_Mobile.Combatant = null;
+                    m_Mobile.Combatant = null;
                 }
 
-                c = this.m_Mobile.Combatant;
+                c = m_Mobile.Combatant;
 
                 if (c == null)
                 {
-                    this.m_Mobile.DebugSay("My combatant has fled, so I am on guard");
-                    this.Action = ActionType.Guard;
+                    m_Mobile.DebugSay("My combatant has fled, so I am on guard");
+                    Action = ActionType.Guard;
 
                     return true;
                 }
             }
 
-            if (!this.m_Mobile.Controlled && !this.m_Mobile.Summoned && !this.m_Mobile.IsParagon)
+            if (!m_Mobile.Controlled && !m_Mobile.Summoned && m_Mobile.CanFlee)
             {
-                if (this.m_Mobile.Hits < this.m_Mobile.HitsMax * 20 / 100)
+                if (m_Mobile.Hits < m_Mobile.HitsMax * 20 / 100)
                 {
                     // We are low on health, should we flee?
-                    bool flee = false;
-
-                    if (this.m_Mobile.Hits < c.Hits)
+                    if (Utility.Random(100) <= Math.Max(10, 10 + c.Hits - m_Mobile.Hits))
                     {
-                        // We are more hurt than them
-                        int diff = c.Hits - this.m_Mobile.Hits;
-
-                        flee = (Utility.Random(0, 100) > (10 + diff)); // (10 + diff)% chance to flee
-                    }
-                    else
-                    {
-                        flee = Utility.Random(0, 100) > 10; // 10% chance to flee
-                    }
-					
-                    if (flee)
-                    {
-                        if (this.m_Mobile.Debug)
-                            this.m_Mobile.DebugSay("I am going to flee from {0}", c.Name);
-
-                        this.Action = ActionType.Flee;
+                        m_Mobile.DebugSay("I am going to flee from {0}", c.Name);
+                        Action = ActionType.Flee;
                         return true;
                     }
                 }
             }
 
-            if (this.m_Mobile.Spell == null && DateTime.UtcNow > this.m_NextCastTime && this.m_Mobile.InRange(c, 12))
+            if (m_Mobile.Spell == null && DateTime.UtcNow > m_NextCastTime && m_Mobile.InRange(c, 12))
             {
                 // We are ready to cast a spell
                 Spell spell = null;
-                Mobile toDispel = this.FindDispelTarget(true);
+                Mobile toDispel = FindDispelTarget(true);
 
-                if (this.m_Mobile.Poisoned) // Top cast priority is cure
+                if (m_Mobile.Poisoned) // Top cast priority is cure
                 {
-                    this.m_Mobile.DebugSay("I am going to cure myself");
+                    m_Mobile.DebugSay("I am going to cure myself");
 
-                    spell = new CureSpell(this.m_Mobile, null);
+                    spell = new CureSpell(m_Mobile, null);
                 }
                 else if (toDispel != null) // Something dispellable is attacking us
                 {
-                    this.m_Mobile.DebugSay("I am going to dispel {0}", toDispel);
+                    m_Mobile.DebugSay("I am going to dispel {0}", toDispel);
 
-                    spell = this.DoDispel(toDispel);
+                    spell = DoDispel(toDispel);
                 }
                 else if (c is Mobile && (((Mobile)c).Spell is HealSpell || ((Mobile)c).Spell is GreaterHealSpell) && !((Mobile)c).Poisoned) // They have a heal spell out
                 {
-                    spell = new BloodOathSpell(this.m_Mobile, null);
+                    spell = new BloodOathSpell(m_Mobile, null);
                 }
                 else
                 {
-                    spell = this.ChooseSpell(c);
+                    spell = ChooseSpell(c);
                 }
 
                 // Now we have a spell picked
@@ -451,14 +432,14 @@ namespace Server.Mobiles
 
                 if (toDispel != null)
                 {
-                    if (this.m_Mobile.InRange(toDispel, 10))
-                        this.RunFrom(toDispel);
-                    else if (!this.m_Mobile.InRange(toDispel, 12))
-                        this.RunTo(toDispel);
+                    if (m_Mobile.InRange(toDispel, 10))
+                        RunFrom(toDispel);
+                    else if (!m_Mobile.InRange(toDispel, 12))
+                        RunTo(toDispel);
                 }
                 else if(c is Mobile)
                 {
-                    this.RunTo((Mobile)c);
+                    RunTo((Mobile)c);
                 }
 
                 if (spell != null)
@@ -467,15 +448,15 @@ namespace Server.Mobiles
                 TimeSpan delay;
 
                 if (spell is DispelSpell)
-                    delay = TimeSpan.FromSeconds(this.m_Mobile.ActiveSpeed);
+                    delay = TimeSpan.FromSeconds(m_Mobile.ActiveSpeed);
                 else
-                    delay = this.GetDelay();
+                    delay = GetDelay();
 
-                this.m_NextCastTime = DateTime.UtcNow + delay;
+                m_NextCastTime = DateTime.UtcNow + delay;
             }
-            else if (c is Mobile && (this.m_Mobile.Spell == null || !this.m_Mobile.Spell.IsCasting))
+            else if (c is Mobile && (m_Mobile.Spell == null || !m_Mobile.Spell.IsCasting))
             {
-                this.RunTo((Mobile)c);
+                RunTo((Mobile)c);
             }
 
             return true;
@@ -483,30 +464,29 @@ namespace Server.Mobiles
 
         public override bool DoActionGuard()
         {
-            if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
+            if (AcquireFocusMob(m_Mobile.RangePerception, m_Mobile.FightMode, false, false, true))
             {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I am going to attack {0}", this.m_Mobile.FocusMob.Name);
+                m_Mobile.DebugSay("I am going to attack {0}", m_Mobile.FocusMob.Name);
 
-                this.m_Mobile.Combatant = this.m_Mobile.FocusMob;
-                this.Action = ActionType.Combat;
+                m_Mobile.Combatant = m_Mobile.FocusMob;
+                Action = ActionType.Combat;
             }
             else
             {
-                if (this.m_Mobile.Poisoned)
+                if (m_Mobile.Poisoned)
                 {
-                    new CureSpell(this.m_Mobile, null).Cast();
+                    new CureSpell(m_Mobile, null).Cast();
                 }
-                else if (!this.m_Mobile.Summoned && ((this.ScaleByMagery(HealChance) > Utility.RandomDouble())))
+                else if (!m_Mobile.Summoned && ((ScaleByMagery(HealChance) > Utility.RandomDouble())))
                 {
-                    if (this.m_Mobile.Hits < (this.m_Mobile.HitsMax - 50))
+                    if (m_Mobile.Hits < (m_Mobile.HitsMax - 50))
                     {
-                        if (!new GreaterHealSpell(this.m_Mobile, null).Cast())
-                            new HealSpell(this.m_Mobile, null).Cast();
+                        if (!new GreaterHealSpell(m_Mobile, null).Cast())
+                            new HealSpell(m_Mobile, null).Cast();
                     }
-                    else if (this.m_Mobile.Hits < (this.m_Mobile.HitsMax - 10))
+                    else if (m_Mobile.Hits < (m_Mobile.HitsMax - 10))
                     {
-                        new HealSpell(this.m_Mobile, null).Cast();
+                        new HealSpell(m_Mobile, null).Cast();
                     }
                     else
                     {
@@ -524,30 +504,25 @@ namespace Server.Mobiles
 
         public override bool DoActionFlee()
         {
-            Mobile c = this.m_Mobile.Combatant as Mobile;
+            Mobile c = m_Mobile.Combatant as Mobile;
 
-            if ((this.m_Mobile.Mana > 20 || this.m_Mobile.Mana == this.m_Mobile.ManaMax) && this.m_Mobile.Hits > (this.m_Mobile.HitsMax / 2))
+            if ((m_Mobile.Mana > 20 || m_Mobile.Mana == m_Mobile.ManaMax) && m_Mobile.Hits > (m_Mobile.HitsMax / 2))
             {
-                this.m_Mobile.DebugSay("I am stronger now, my guard is up");
-                this.Action = ActionType.Guard;
-            }
-            else if (this.AcquireFocusMob(this.m_Mobile.RangePerception, this.m_Mobile.FightMode, false, false, true))
-            {
-                if (this.m_Mobile.Debug)
-                    this.m_Mobile.DebugSay("I am scared of {0}", this.m_Mobile.FocusMob.Name);
-
-                this.RunFrom(this.m_Mobile.FocusMob);
-                this.m_Mobile.FocusMob = null;
-
-                if (this.m_Mobile.Poisoned && Utility.Random(0, 5) == 0)
-                    new CureSpell(this.m_Mobile, null).Cast();
+                // If I have a target, go back and fight them
+                if (c != null)
+                {
+                    m_Mobile.DebugSay("I am stronger now, reengaging {0}", c.Name);
+                    Action = ActionType.Combat;
+                }
+                else
+                {
+                    m_Mobile.DebugSay("I am stronger now, my guard is up");
+                    Action = ActionType.Guard;
+                }
             }
             else
             {
-                this.m_Mobile.DebugSay("Area seems clear, but my guard is up");
-
-                this.Action = ActionType.Guard;
-                this.m_Mobile.Warmode = true;
+                base.DoActionFlee();
             }
 
             return true;
@@ -555,23 +530,23 @@ namespace Server.Mobiles
 
         public Mobile FindDispelTarget(bool activeOnly)
         {
-            if (this.m_Mobile.Deleted || this.m_Mobile.Int < 95 || this.CanDispel(this.m_Mobile) || this.m_Mobile.AutoDispel)
+            if (m_Mobile.Deleted || m_Mobile.Int < 95 || CanDispel(m_Mobile) || m_Mobile.AutoDispel)
                 return null;
 
             if (activeOnly)
             {
-                List<AggressorInfo> aggressed = this.m_Mobile.Aggressed;
-                List<AggressorInfo> aggressors = this.m_Mobile.Aggressors;
+                List<AggressorInfo> aggressed = m_Mobile.Aggressed;
+                List<AggressorInfo> aggressors = m_Mobile.Aggressors;
 
                 Mobile active = null;
                 double activePrio = 0.0;
 
-                Mobile comb = this.m_Mobile.Combatant as Mobile;
+                Mobile comb = m_Mobile.Combatant as Mobile;
 
-                if (comb != null && !comb.Deleted && comb.Alive && !comb.IsDeadBondedPet && this.m_Mobile.InRange(comb, 12) && this.CanDispel(comb))
+                if (comb != null && !comb.Deleted && comb.Alive && !comb.IsDeadBondedPet && m_Mobile.InRange(comb, 12) && CanDispel(comb))
                 {
                     active = comb;
-                    activePrio = this.m_Mobile.GetDistanceToSqrt(comb);
+                    activePrio = m_Mobile.GetDistanceToSqrt(comb);
 
                     if (activePrio <= 2)
                         return active;
@@ -582,9 +557,9 @@ namespace Server.Mobiles
                     AggressorInfo info = (AggressorInfo)aggressed[i];
                     Mobile m = (Mobile)info.Defender;
 
-                    if (m != comb && m.Combatant == this.m_Mobile && this.m_Mobile.InRange(m, 12) && this.CanDispel(m))
+                    if (m != comb && m.Combatant == m_Mobile && m_Mobile.InRange(m, 12) && CanDispel(m))
                     {
-                        double prio = this.m_Mobile.GetDistanceToSqrt(m);
+                        double prio = m_Mobile.GetDistanceToSqrt(m);
 
                         if (active == null || prio < activePrio)
                         {
@@ -602,9 +577,9 @@ namespace Server.Mobiles
                     AggressorInfo info = (AggressorInfo)aggressors[i];
                     Mobile m = (Mobile)info.Attacker;
 
-                    if (m != comb && m.Combatant == this.m_Mobile && this.m_Mobile.InRange(m, 12) && this.CanDispel(m))
+                    if (m != comb && m.Combatant == m_Mobile && m_Mobile.InRange(m, 12) && CanDispel(m))
                     {
-                        double prio = this.m_Mobile.GetDistanceToSqrt(m);
+                        double prio = m_Mobile.GetDistanceToSqrt(m);
 
                         if (active == null || prio < activePrio)
                         {
@@ -621,26 +596,26 @@ namespace Server.Mobiles
             }
             else
             {
-                Map map = this.m_Mobile.Map;
+                Map map = m_Mobile.Map;
 
                 if (map != null)
                 {
                     Mobile active = null, inactive = null;
                     double actPrio = 0.0, inactPrio = 0.0;
 
-                    Mobile comb = this.m_Mobile.Combatant as Mobile;
+                    Mobile comb = m_Mobile.Combatant as Mobile;
 
-                    if (comb != null && !comb.Deleted && comb.Alive && !comb.IsDeadBondedPet && this.CanDispel(comb))
+                    if (comb != null && !comb.Deleted && comb.Alive && !comb.IsDeadBondedPet && CanDispel(comb))
                     {
                         active = inactive = comb;
-                        actPrio = inactPrio = this.m_Mobile.GetDistanceToSqrt(comb);
+                        actPrio = inactPrio = m_Mobile.GetDistanceToSqrt(comb);
                     }
 
-                    foreach (Mobile m in this.m_Mobile.GetMobilesInRange(12))
+                    foreach (Mobile m in m_Mobile.GetMobilesInRange(12))
                     {
-                        if (m != this.m_Mobile && this.CanDispel(m))
+                        if (m != m_Mobile && CanDispel(m))
                         {
-                            double prio = this.m_Mobile.GetDistanceToSqrt(m);
+                            double prio = m_Mobile.GetDistanceToSqrt(m);
 
                             if (!activeOnly && (inactive == null || prio < inactPrio))
                             {
@@ -648,7 +623,7 @@ namespace Server.Mobiles
                                 inactPrio = prio;
                             }
 
-                            if ((this.m_Mobile.Combatant == m || m.Combatant == this.m_Mobile) && (active == null || prio < actPrio))
+                            if ((m_Mobile.Combatant == m || m.Combatant == m_Mobile) && (active == null || prio < actPrio))
                             {
                                 active = m;
                                 actPrio = prio;
@@ -665,57 +640,57 @@ namespace Server.Mobiles
 
         public bool CanDispel(Mobile m)
         {
-            return (m is BaseCreature && ((BaseCreature)m).Summoned && this.m_Mobile.CanBeHarmful(m, false) && !((BaseCreature)m).IsAnimatedDead);
+            return (m is BaseCreature && ((BaseCreature)m).Summoned && m_Mobile.CanBeHarmful(m, false) && !((BaseCreature)m).IsAnimatedDead);
         }
 
         private Spell CheckCastHealingSpell()
         {
             // If I'm poisoned, always attempt to cure.
-            if (this.m_Mobile.Poisoned)
-                return new CureSpell(this.m_Mobile, null);
+            if (m_Mobile.Poisoned)
+                return new CureSpell(m_Mobile, null);
 
             // Summoned creatures never heal themselves.
-            if (this.m_Mobile.Summoned)
+            if (m_Mobile.Summoned)
                 return null;
 
-            if (this.m_Mobile.Controlled)
+            if (m_Mobile.Controlled)
             {
-                if (DateTime.UtcNow < this.m_NextHealTime)
+                if (DateTime.UtcNow < m_NextHealTime)
                     return null;
             }
-			
-            if (this.ScaleByMagery(HealChance) < Utility.RandomDouble())
+
+            if (ScaleByMagery(HealChance) < Utility.RandomDouble())
                 return null;
 
             Spell spell = null;
 
-            if (this.m_Mobile.Hits < (this.m_Mobile.HitsMax - 50))
+            if (m_Mobile.Hits < (m_Mobile.HitsMax - 50))
             {
-                spell = new GreaterHealSpell(this.m_Mobile, null);
+                spell = new GreaterHealSpell(m_Mobile, null);
 
                 if (spell == null)
-                    spell = new HealSpell(this.m_Mobile, null);
+                    spell = new HealSpell(m_Mobile, null);
             }
-            else if (this.m_Mobile.Hits < (this.m_Mobile.HitsMax - 10))
-                spell = new HealSpell(this.m_Mobile, null);
+            else if (m_Mobile.Hits < (m_Mobile.HitsMax - 10))
+                spell = new HealSpell(m_Mobile, null);
 
             double delay;
 
-            if (this.m_Mobile.Int >= 500)
+            if (m_Mobile.Int >= 500)
                 delay = Utility.RandomMinMax(7, 10);
             else
-                delay = Math.Sqrt(600 - this.m_Mobile.Int);
-				
-            this.m_Mobile.UseSkill(SkillName.SpiritSpeak);
+                delay = Math.Sqrt(600 - m_Mobile.Int);
 
-            this.m_NextHealTime = DateTime.UtcNow + TimeSpan.FromSeconds(delay);
+            m_Mobile.UseSkill(SkillName.SpiritSpeak);
+
+            m_NextHealTime = DateTime.UtcNow + TimeSpan.FromSeconds(delay);
 
             return spell;
         }
 
         private TimeSpan GetDelay()
         {
-            double del = this.ScaleByMagery(3.0);
+            double del = ScaleByMagery(3.0);
             double min = 6.0 - (del * 0.75);
             double max = 6.0 - (del * 1.25);
 
@@ -733,25 +708,25 @@ namespace Server.Mobiles
 
             if (isDispel)
             {
-                toTarget = this.FindDispelTarget(false);
+                toTarget = FindDispelTarget(false);
 
-                if (toTarget != null && this.m_Mobile.InRange(toTarget, 10))
-                    this.RunFrom(toTarget);
+                if (toTarget != null && m_Mobile.InRange(toTarget, 10))
+                    RunFrom(toTarget);
             }
             else if (isParalyze || isTeleport)
             {
-                toTarget = this.FindDispelTarget(true);
+                toTarget = FindDispelTarget(true);
 
                 if (toTarget == null)
                 {
-                    toTarget = this.m_Mobile.Combatant as Mobile;
+                    toTarget = m_Mobile.Combatant as Mobile;
 
                     if (toTarget != null)
-                        this.RunTo(toTarget);
+                        RunTo(toTarget);
                 }
-                else if (this.m_Mobile.InRange(toTarget, 10))
+                else if (m_Mobile.InRange(toTarget, 10))
                 {
-                    this.RunFrom(toTarget);
+                    RunFrom(toTarget);
                     teleportAway = true;
                 }
                 else
@@ -761,34 +736,34 @@ namespace Server.Mobiles
             }
             else
             {
-                toTarget = this.m_Mobile.Combatant as Mobile;
+                toTarget = m_Mobile.Combatant as Mobile;
 
                 if (toTarget != null)
-                    this.RunTo(toTarget);
+                    RunTo(toTarget);
             }
 
             if ((targ.Flags & TargetFlags.Harmful) != 0 && toTarget != null)
             {
-                if ((targ.Range == -1 || this.m_Mobile.InRange(toTarget, targ.Range)) && this.m_Mobile.CanSee(toTarget) && this.m_Mobile.InLOS(toTarget))
+                if ((targ.Range == -1 || m_Mobile.InRange(toTarget, targ.Range)) && m_Mobile.CanSee(toTarget) && m_Mobile.InLOS(toTarget))
                 {
-                    targ.Invoke(this.m_Mobile, toTarget);
+                    targ.Invoke(m_Mobile, toTarget);
                 }
                 else if (isDispel)
                 {
-                    targ.Cancel(this.m_Mobile, TargetCancelType.Canceled);
+                    targ.Cancel(m_Mobile, TargetCancelType.Canceled);
                 }
             }
             else if ((targ.Flags & TargetFlags.Beneficial) != 0)
             {
-                targ.Invoke(this.m_Mobile, this.m_Mobile);
+                targ.Invoke(m_Mobile, m_Mobile);
             }
             else if (isTeleport && toTarget != null)
             {
-                Map map = this.m_Mobile.Map;
+                Map map = m_Mobile.Map;
 
                 if (map == null)
                 {
-                    targ.Cancel(this.m_Mobile, TargetCancelType.Canceled);
+                    targ.Cancel(m_Mobile, TargetCancelType.Canceled);
                     return;
                 }
 
@@ -796,10 +771,10 @@ namespace Server.Mobiles
 
                 if (teleportAway)
                 {
-                    int rx = this.m_Mobile.X - toTarget.X;
-                    int ry = this.m_Mobile.Y - toTarget.Y;
+                    int rx = m_Mobile.X - toTarget.X;
+                    int ry = m_Mobile.Y - toTarget.Y;
 
-                    double d = this.m_Mobile.GetDistanceToSqrt(toTarget);
+                    double d = m_Mobile.GetDistanceToSqrt(toTarget);
 
                     px = toTarget.X + (int)(rx * (10 / d));
                     py = toTarget.Y + (int)(ry * (10 / d));
@@ -818,9 +793,9 @@ namespace Server.Mobiles
 
                     LandTarget lt = new LandTarget(p, map);
 
-                    if ((targ.Range == -1 || this.m_Mobile.InRange(p, targ.Range)) && this.m_Mobile.InLOS(lt) && map.CanSpawnMobile(px + x, py + y, lt.Z) && !SpellHelper.CheckMulti(p, map))
+                    if ((targ.Range == -1 || m_Mobile.InRange(p, targ.Range)) && m_Mobile.InLOS(lt) && map.CanSpawnMobile(px + x, py + y, lt.Z) && !SpellHelper.CheckMulti(p, map))
                     {
-                        targ.Invoke(this.m_Mobile, lt);
+                        targ.Invoke(m_Mobile, lt);
                         return;
                     }
                 }
@@ -832,22 +807,22 @@ namespace Server.Mobiles
 
                 for (int i = 0; i < 10; ++i)
                 {
-                    Point3D randomPoint = new Point3D(this.m_Mobile.X - teleRange + Utility.Random(teleRange * 2 + 1), this.m_Mobile.Y - teleRange + Utility.Random(teleRange * 2 + 1), 0);
+                    Point3D randomPoint = new Point3D(m_Mobile.X - teleRange + Utility.Random(teleRange * 2 + 1), m_Mobile.Y - teleRange + Utility.Random(teleRange * 2 + 1), 0);
 
                     LandTarget lt = new LandTarget(randomPoint, map);
 
-                    if (this.m_Mobile.InLOS(lt) && map.CanSpawnMobile(lt.X, lt.Y, lt.Z) && !SpellHelper.CheckMulti(randomPoint, map))
+                    if (m_Mobile.InLOS(lt) && map.CanSpawnMobile(lt.X, lt.Y, lt.Z) && !SpellHelper.CheckMulti(randomPoint, map))
                     {
-                        targ.Invoke(this.m_Mobile, new LandTarget(randomPoint, map));
+                        targ.Invoke(m_Mobile, new LandTarget(randomPoint, map));
                         return;
                     }
                 }
 
-                targ.Cancel(this.m_Mobile, TargetCancelType.Canceled);
+                targ.Cancel(m_Mobile, TargetCancelType.Canceled);
             }
             else
             {
-                targ.Cancel(this.m_Mobile, TargetCancelType.Canceled);
+                targ.Cancel(m_Mobile, TargetCancelType.Canceled);
             }
         }
     }

--- a/Scripts/Mobiles/AI/SpellbinderAI.cs
+++ b/Scripts/Mobiles/AI/SpellbinderAI.cs
@@ -509,7 +509,7 @@ namespace Server.Mobiles
             if ((m_Mobile.Mana > 20 || m_Mobile.Mana == m_Mobile.ManaMax) && m_Mobile.Hits > (m_Mobile.HitsMax / 2))
             {
                 // If I have a target, go back and fight them
-                if (c != null)
+                if (c != null && m_Mobile.GetDistanceToSqrt(c) <= m_Mobile.RangePerception * 2)
                 {
                     m_Mobile.DebugSay("I am stronger now, reengaging {0}", c.Name);
                     Action = ActionType.Combat;

--- a/Scripts/Mobiles/Normal/OrcChopper.cs
+++ b/Scripts/Mobiles/Normal/OrcChopper.cs
@@ -11,68 +11,68 @@ namespace Server.Mobiles
         public OrcChopper()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "an Orc Chopper";
-            this.Body = 7;
-            this.BaseSoundID = 0x45A;
-            this.Hue = 0x96D;
+            Name = "an orc chopper";
+            Body = 7;
+            BaseSoundID = 0x45A;
+            Hue = 0x96D;
 
-            this.SetStr(147, 245);
-            this.SetDex(101, 135);
-            this.SetInt(86, 110);
+            SetStr(147, 245);
+            SetDex(101, 135);
+            SetInt(86, 110);
 
-            this.SetHits(97, 139);
+            SetHits(97, 139);
 
-            this.SetDamage(4, 13);
+            SetDamage(4, 13);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 25, 35);
-            this.SetResistance(ResistanceType.Fire, 30, 40);
-            this.SetResistance(ResistanceType.Cold, 15, 25);
-            this.SetResistance(ResistanceType.Poison, 15, 25);
-            this.SetResistance(ResistanceType.Energy, 25, 30);
+            SetResistance(ResistanceType.Physical, 25, 35);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 15, 25);
+            SetResistance(ResistanceType.Poison, 15, 25);
+            SetResistance(ResistanceType.Energy, 25, 30);
 
-            this.SetSkill(SkillName.MagicResist, 60.1, 85.0);
-            this.SetSkill(SkillName.Swords, 75.1, 90.0);
-            this.SetSkill(SkillName.Tactics, 60.1, 85.0);
+            SetSkill(SkillName.MagicResist, 60.1, 85.0);
+            SetSkill(SkillName.Swords, 75.1, 90.0);
+            SetSkill(SkillName.Tactics, 60.1, 85.0);
 
-            this.Fame = 4500;
-            this.Karma = -4500;
+            Fame = 4500;
+            Karma = -4500;
 
-            this.VirtualArmor = 54;
+            VirtualArmor = 54;
 
-            this.PackItem(new Log(Utility.RandomMinMax(1, 10)));
-            this.PackItem(new Board(Utility.RandomMinMax(10, 20)));
-            this.PackItem(new ExecutionersAxe());
+            PackItem(new Log(Utility.RandomMinMax(1, 10)));
+            PackItem(new Board(Utility.RandomMinMax(10, 20)));
+            PackItem(new ExecutionersAxe());
 
             // TODO: Skull?
             switch (Utility.Random(7))
             {
                 case 0:
-                    this.PackItem(new Arrow());
+                    PackItem(new Arrow());
                     break;
                 case 1:
-                    this.PackItem(new Lockpick());
+                    PackItem(new Lockpick());
                     break;
                 case 2:
-                    this.PackItem(new Shaft());
+                    PackItem(new Shaft());
                     break;
                 case 3:
-                    this.PackItem(new Ribs());
+                    PackItem(new Ribs());
                     break;
                 case 4:
-                    this.PackItem(new Bandage());
+                    PackItem(new Bandage());
                     break;
                 case 5:
-                    this.PackItem(new BeverageBottle(BeverageType.Wine));
+                    PackItem(new BeverageBottle(BeverageType.Wine));
                     break;
                 case 6:
-                    this.PackItem(new Jug(BeverageType.Cider));
+                    PackItem(new Jug(BeverageType.Cider));
                     break;
             }
 
             if (Core.AOS)
-                this.PackItem(Loot.RandomNecromancyReagent());
+                PackItem(Loot.RandomNecromancyReagent());
 
             if (0.5 > Utility.RandomDouble())
                 PackItem(new Yeast());
@@ -104,6 +104,9 @@ namespace Server.Mobiles
                 return 1;
             }
         }
+
+        public override TribeType Tribe { get { return TribeType.Orc; } }
+
         public override OppositionGroup OppositionGroup
         {
             get
@@ -141,7 +144,7 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager, 2);
+            AddLoot(LootPack.Meager, 2);
         }
 
         public override bool IsEnemy(Mobile m)

--- a/Scripts/Mobiles/Normal/OrcScout.cs
+++ b/Scripts/Mobiles/Normal/OrcScout.cs
@@ -76,13 +76,16 @@ namespace Server.Mobiles
 			: base(serial)
 		{ }
 
-		public override InhumanSpeech SpeechType { get { return InhumanSpeech.Orc; } }
-		public override OppositionGroup OppositionGroup { get { return OppositionGroup.SavagesAndOrcs; } }
 		public override bool CanHeal { get { return true; } }
 		public override bool CanRummageCorpses { get { return true; } }
+        public override bool CanStealth { get { return true; } }
 		public override int Meat { get { return 1; } }
 
+		public override InhumanSpeech SpeechType { get { return InhumanSpeech.Orc; } }
+		public override OppositionGroup OppositionGroup { get { return OppositionGroup.SavagesAndOrcs; } }
+        public override TribeType Tribe { get { return TribeType.Orc; } }
 		public override void GenerateLoot()
+
 		{
 			AddLoot(LootPack.Rich);
 		}

--- a/Scripts/Skills/Stealth.cs
+++ b/Scripts/Skills/Stealth.cs
@@ -104,10 +104,7 @@ namespace Server.SkillHandlers
 
                     m.AllowedStealthSteps = steps;
 
-                    PlayerMobile pm = m as PlayerMobile; // IsStealthing should be moved to Server.Mobiles
-
-                    if (pm != null)
-                        pm.IsStealthing = true;
+                    m.IsStealthing = true;
 
                     m.SendLocalizedMessage(502730); // You begin to move quietly.
 


### PR DESCRIPTION
Overview:
Alright, so, apparently this problem is larger than I thought. It's pretty much the same 3-4 issues copy-pasted into almost every single AI. With the exception of AnimalAI and BaseAI, all of them changed received basically the same changes, with the occasional different fleeing condition or special fleeing ability. Basically, using FocusMob the way it was done here doesn't really work for the most part. It is constantly reset and can only be acquired once every ten seconds normally, meaning it either breaks the AI's ability to flee or just uses combatant anyway.

MageAI, ArcherAI, MeleeAI, SpellbinderAI, OmniAICore, ThiefAI, OrcScoutAI, AnimalAI, BaseAI

-Fixed Removed redundant 'this.' from all individual AI files
-Fixed removed redundant Debug checks for DebugSay from all individual AI files
-Changed IDamageable m_Mobile.Combatant's local variable to 'c' in DoActionCombat
-Fixed and simplified flee check algorithm on most individual AIs
--Many had inverted algorithm before, making it LESS likely for mobile to flee if combatant had more health. It was, in fact, IMPOSSIBLE for the creature to flee if its combatant had more than 90 hits more than it. Others were checking !IsParagon instead of CanFlee.
-Added When creatures are ready to reenter combat, they check if they have an active combatant, and if they do, they reengage it instead of going to guard mode
-Changed When most creatures are fleeing, they instead check new BaseAI flee code that is not based on checking FocusMob (which doesn't work except once every 50 or so AI ticks usually) but instead combatant
-Changed When creatures with abilities they use while fleeing, they use them in the same else check as base.DoActionFlee()
-Removed redundant settings when setting ActionType, which are already done in OnActionChanged
-Removed setting FocusMob for base.DoActionFlee's usage. It uses combatant now.

BaseAI.cs:
-DoActionFlee()
-Changed adapted with fleeing based on that made for MageAI, and is now called by most AI
--Fixed Now checks acquirefocusmob OR has a combatant within double perception range to run away from when fleeing.
---Required successful check of acquirefocusmob every AI tick before, which can only happen every 10 seconds normally
--Changed Now only attempts to acquire Aggressor fightmode targets: When a creature is fleeing it only wants to acquire things that will attack it, not things it wants to attack
---Fixed now sets combatant to focus mob if it found one, and then flees from combatant
---Added Added some bad target abort checks that remove combatant
-Added range check to reengage combatant after recovering rather than guarding

AnimalAI.cs: Completely removed DoActionFlee override, uses base completely.

ThiefAI.cs: Completely removed DoActionFlee override, uses base completely. (It was set to exit flee action when at high health, breaking its steal-and-flee ability) (Its steal ability still doesn't work very well, but this is primararily for fleeing)

ArcherAI.cs, OrcScout.cs:
-Added reference System
-DoActionCombat()
--Fixed nested, but commented ammo flee check inside the main able to flee check (They keep shooting anyway)
-Added DoActionFlee()
--Based on MageAI.cs with BaseAI.cs's movement method
---Commented out: Continues to flee if creature lacks ammo (They can shoot without ammo)

-OrcScout.cs: Added CanStealth, Tribe 		

-Stealth.cs: Removed playermoble requirement
--IsStealthing has long since been moved from playermobile to mobile

-OrcChopper.cs: removed 'this.', lowercased name, added Tribe 		

-OppositionGroup.cs: Added OrcChopper, OrcScout 		

Some post-process notes:
Creatures still keep using their bows (successfully!) even without any ammo, but that's fairly well known.
Why do animals flee at just under 10% health while other AI flee starting at just under 20% health?