### PR TITLE
Toolbar.cs: Sanity check for null netstate to prevent crash

### DIFF
--- a/Scripts/Services/Toolbar/Gumps/Toolbar.cs
+++ b/Scripts/Services/Toolbar/Gumps/Toolbar.cs
@@ -32,6 +32,11 @@ namespace Services.Toolbar.Gumps
 		public ToolbarGump(ToolbarInfo info, Mobile m)
 			: base(0, 28)
 		{
+            if (m.NetState == null)
+            {
+                return;
+            }
+
 			_Info = info;
 
 			if (_Info.Lock)


### PR DESCRIPTION
I believe the problem is that it is trying to send the admin toolbar to a player that is not online, thus having no netstate, causing a crash.