### PR TITLE
BaseCreature.cs: Uncontrolled Mastered Summons are no longer targeted

### DIFF
--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -1206,7 +1206,8 @@ namespace Server.Mobiles
             BaseCreature c = m as BaseCreature;
 
             // Are we a non-aggressive FightMode?
-            if (FightMode == FightMode.Aggressor || FightMode == FightMode.Evil || FightMode == FightMode.Good)
+            if (FightMode == FightMode.Aggressor || FightMode == FightMode.Evil || FightMode == FightMode.Good ||
+                (c.m_bSummoned && !c.m_bControlled && c.SummonMaster != null))
             {
                 // Faction Opposed Players/Pets are my enemies
                 if (GetFactionAllegiance(m) == BaseCreature.Allegiance.Enemy)


### PR DESCRIPTION
Fixed: Uncontrolled summons with masters are no longer attacked (Controlled summons with masters are still targeted) (Unless faction, ethic, or karma enemy)