### PR TITLE
Toolbar.cs: Sanity check, abort sending gump to offline player

### DIFF
--- a/Scripts/Services/Toolbar/Gumps/Toolbar.cs
+++ b/Scripts/Services/Toolbar/Gumps/Toolbar.cs
@@ -32,6 +32,11 @@ namespace Services.Toolbar.Gumps
 		public ToolbarGump(ToolbarInfo info, Mobile m)
 			: base(0, 28)
 		{
+            if (m.NetState == null)
+            {
+                return;
+            }
+
 			_Info = info;
 
 			if (_Info.Lock)
@@ -80,7 +85,7 @@ namespace Services.Toolbar.Gumps
 				x = offset + ((i % _Info.Rows) * 110);
 				y = offset + (int)(Math.Floor((double)(i / _Info.Rows)) * 24) + cy;
 
-                if (ns != null && ns.IsEnhancedClient)
+                if (ns.IsEnhancedClient)
                 {
                     AddButton(x + 1, y, 2435, 2436, temp + 10, GumpButtonType.Reply, 0);//4005, 4007
                 }


### PR DESCRIPTION
Previous change did not fix the crash. No point in even trying to send a gump to a player that is not connected. New check aborts immediately if player is not connected.