### PR TITLE
Toolbar crash fix: improved

### DIFF
--- a/Scripts/Services/Toolbar/Core/ToolbarCore.cs
+++ b/Scripts/Services/Toolbar/Core/ToolbarCore.cs
@@ -45,7 +45,7 @@ namespace Services.Toolbar.Core
 
 		public static void OnPlayerDeath(PlayerDeathEventArgs e)
 		{
-			if (e.Mobile.AccessLevel < AccessLevel.VIP)
+			if (e.Mobile.AccessLevel < AccessLevel.VIP || e.Mobile.NetState == null)
 			{
 				return;
 			}

--- a/Scripts/Services/Toolbar/Gumps/Toolbar.cs
+++ b/Scripts/Services/Toolbar/Gumps/Toolbar.cs
@@ -32,11 +32,6 @@ namespace Services.Toolbar.Gumps
 		public ToolbarGump(ToolbarInfo info, Mobile m)
 			: base(0, 28)
 		{
-            if (m.NetState == null)
-            {
-                return;
-            }
-
 			_Info = info;
 
 			if (_Info.Lock)


### PR DESCRIPTION
ToolbarCore.cs: Added null netstate abort
 #-Prevents crashes due to offline staff characters being killed and a gump attempting to be sent to a non-existant client.

Toolbar.cs: Reverted File, removed ad hoc sanity check and file returned to original configuration.

At Dexter's advisement, source was located very easily with GitHub's search function (much better than what I can do at home offline). Was an EventSink, specifically, that didn't abort when a staff character was killed while not connected, trying to send the gump to a non-existant client causing a crash. Now also checks if there's a null netstate to abort before sending gump.