### PR TITLE
Bug Fixes/Enhancements

### DIFF
--- a/Scripts/Items/Equipment/Armor/BaseArmor.cs
+++ b/Scripts/Items/Equipment/Armor/BaseArmor.cs
@@ -2564,12 +2564,10 @@ namespace Server.Items
                 }
                 else
                 {
-                    int wear;
+                    int wear = 1;
 
                     if (weapon.Type == WeaponType.Bashing)
                         wear = Absorbed / 2;
-                    else
-                        wear = Utility.Random(2);
 
                     if (wear > 0 && m_MaxHitPoints > 0)
                     {

--- a/Scripts/Items/Equipment/Clothing/BaseClothing.cs
+++ b/Scripts/Items/Equipment/Clothing/BaseClothing.cs
@@ -935,12 +935,10 @@ namespace Server.Items
                 }
                 else
                 {
-                    int wear;
+                    int wear = 1;
 
                     if (weapon.Type == WeaponType.Bashing)
                         wear = Absorbed / 2;
-                    else
-                        wear = Utility.Random(2);
 
                     if (wear > 0 && m_MaxHitPoints > 0)
                     {

--- a/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
+++ b/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
@@ -608,7 +608,7 @@ namespace Server.Items
 
             if (chance >= Utility.Random(100)) // 25% chance to lower durability
             {
-                int wear = Utility.Random(2);
+                int wear = 1;
 
                 if (wear > 0)
                 {

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -2187,7 +2187,7 @@ namespace Server.Items
             bool acidicTarget = MaxRange <= 1 && (defender is Slime || defender is ToxicElemental || defender is CorrosiveSlime);
 
             if ((m_AosAttributes.SpellChanneling == 0 || MaxRange > 1) &&
-                (acidicTarget || (defender != null && splintering) || Utility.Random(250) <= chance))    // Stratics says 50% chance, seems more like 4%..
+                (acidicTarget || (defender != null && splintering) || Utility.Random(20) <= chance))    // Stratics says 50% chance, seems more like 4%..
             {
                 if (MaxRange <= 1 && acidicTarget)
                 {
@@ -2873,6 +2873,7 @@ namespace Server.Items
 				}
 			}
 
+            BaseFamiliar.OnHit(attacker, damageable);
 			XmlAttach.OnWeaponHit(this, attacker, defender, damageGiven);
 		}
 

--- a/Scripts/Items/Resource/Bandage.cs
+++ b/Scripts/Items/Resource/Bandage.cs
@@ -142,6 +142,7 @@ namespace Server.Items
 					{
 						if (BandageContext.BeginHeal(from, (Mobile)targeted, m_Bandage is EnhancedBandage) != null)
 						{
+                            NegativeAttributes.OnCombatAction(from);
 							m_Bandage.Consume();
 						}
 					}
@@ -154,6 +155,7 @@ namespace Server.Items
 				{
 					if (((PlagueBeastInnard)targeted).OnBandage(from))
 					{
+                        NegativeAttributes.OnCombatAction(from);
 						m_Bandage.Consume();
 					}
 				}

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -15,6 +15,7 @@ using Server.Spells.Spellweaving;
 using Server.SkillHandlers;
 using Server.Engines.CityLoyalty;
 using Server.Spells.SkillMasteries;
+using System.Linq;
 
 namespace Server
 {
@@ -2970,6 +2971,60 @@ namespace Server
 
             if (NoRepair > 0)
                 list.Add(1151782);
+        }
+
+        public const double CombatDecayChance = 0.05;
+
+        public static void OnCombatAction(Mobile m)
+        {
+            if (m == null || !m.Alive)
+                return;
+
+            var list = new List<Item>();
+
+            foreach (var item in m.Items.Where(i => i is IWearableDurability))
+            {
+                NegativeAttributes attrs = RunicReforging.GetNegativeAttributes(item);
+
+                if (attrs != null && attrs.Antique > 0 && CombatDecayChance > Utility.RandomDouble())
+                {
+                    list.Add(item);
+                }
+            }
+
+            foreach (var item in list)
+            {
+                IDurability dur = item as IDurability;
+
+                if (dur == null)
+                    continue;
+
+                if (dur.HitPoints >= 1)
+                {
+                    dur.HitPoints--;
+                }
+                else
+                {
+                    if (dur.HitPoints > 0)
+                    {
+                        dur.HitPoints = 0;
+                    }
+
+                    if (dur.MaxHitPoints > 1)
+                    {
+                        dur.MaxHitPoints--;
+
+                        if (item.Parent is Mobile)
+                            ((Mobile)item.Parent).LocalOverheadMessage(Server.Network.MessageType.Regular, 0x3B2, 1061121); // Your equipment is severely damaged.
+                    }
+                    else
+                    {
+                        item.Delete();
+                    }
+                }
+            }
+
+            ColUtility.Free(list);
         }
 
         public int this[NegativeAttribute attribute]

--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -1418,27 +1418,6 @@ namespace Server.Mobiles
 
 			if (distance < 1 || distance > 15)
 			{
-				if (distance < 1 && target.X == 1076 && target.Y == 450 && (m_Mobile is HordeMinionFamiliar))
-				{
-					PlayerMobile pm = m_Mobile.ControlMaster as PlayerMobile;
-
-					if (pm != null)
-					{
-						QuestSystem qs = pm.Quest;
-
-						if (qs is DarkTidesQuest)
-						{
-							QuestObjective obj = qs.FindObjective(typeof(FetchAbraxusScrollObjective));
-
-							if (obj != null && !obj.Completed)
-							{
-								m_Mobile.AddToBackpack(new ScrollOfAbraxus());
-								obj.Complete();
-							}
-						}
-					}
-				}
-
 				m_Mobile.TargetLocation = null;
 				return false; // At the target or too far away
 			}

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -3135,7 +3135,7 @@ namespace Server.Mobiles
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public Point3D Home { get { return m_pHome; } set { m_pHome = value; } }
+        public virtual Point3D Home { get { return m_pHome; } set { m_pHome = value; } }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool Controlled
@@ -3334,7 +3334,7 @@ namespace Server.Mobiles
         public Point3D ControlDest { get { return m_ControlDest; } set { m_ControlDest = value; } }
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public OrderType ControlOrder
+        public virtual OrderType ControlOrder
         {
             get { return m_ControlOrder; }
             set

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -3135,7 +3135,7 @@ namespace Server.Mobiles
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public virtual Point3D Home { get { return m_pHome; } set { m_pHome = value; } }
+        public Point3D Home { get { return m_pHome; } set { m_pHome = value; } }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool Controlled

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -1526,6 +1526,8 @@ namespace Server.Mobiles
 				ScrollofAlacrity.AlacrityEnd(e.Mobile);
 			}
 			#endregion
+
+            BaseFamiliar.OnLogout(e.Mobile as PlayerMobile);
 		}
 
 		private static void EventSink_Connected(ConnectedEventArgs e)

--- a/Scripts/Mobiles/Summons/BaseFamiliar.cs
+++ b/Scripts/Mobiles/Summons/BaseFamiliar.cs
@@ -142,11 +142,6 @@ namespace Server.Mobiles
 
             if (RangeCheck())
             {
-                if (ControlOrder != OrderType.Come)
-                {
-                    ControlOrder = OrderType.Come;
-                }
-
                 if (AIObject != null && AIObject.WalkMobileRange(master, 5, true, 1, 1))
                 {
                     if (master.Combatant != null && master.InRange(master.Combatant, 1) && Core.TickCount > m_NextMove)
@@ -177,17 +172,17 @@ namespace Server.Mobiles
                         }
                         else
                         {
-                            CurrentSpeed = .04;
+                            CurrentSpeed = .1;
                         }
                     }
                     else if (master.Combatant == null)
                     {
-                        CurrentSpeed = .04;
+                        CurrentSpeed = .1;
                     }
                 }
                 else
                 {
-                    CurrentSpeed = .01;
+                    CurrentSpeed = .1;
                 }
             }
 		}

--- a/Scripts/Mobiles/Summons/BaseFamiliar.cs
+++ b/Scripts/Mobiles/Summons/BaseFamiliar.cs
@@ -6,9 +6,10 @@
 
 #region References
 using System.Collections.Generic;
-
+using System;
 using Server.ContextMenus;
 using Server.Items;
+using Server.Spells.Necromancy;
 #endregion
 
 namespace Server.Mobiles
@@ -16,6 +17,30 @@ namespace Server.Mobiles
 	public abstract class BaseFamiliar : BaseCreature
 	{
 		private bool m_LastHidden;
+        private long m_NextMove;
+
+        private DateTime m_SeperationStart;
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public DateTime SeperationStart
+        {
+            get { return m_SeperationStart; }
+            set { m_SeperationStart = value; }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public override IDamageable Combatant
+        {
+            get { return null; }
+            set { }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public override OrderType ControlOrder
+        {
+            get { return OrderType.Come; }
+            set { }
+        }
 
 		public BaseFamiliar()
 			: base(AIType.AI_Melee, FightMode.Closest, 10, 1, -1, -1)
@@ -30,48 +55,69 @@ namespace Server.Mobiles
 		public override bool Commandable { get { return false; } }
 		public override bool PlayerRangeSensitive { get { return false; } }
 
-        public virtual bool AttacksMastersTarget { get { return false; } }
+        public virtual bool RangeCheck()
+        {
+            Mobile master = ControlMaster;
 
-		public virtual void RangeCheck()
-		{
-			if (!Deleted && ControlMaster != null && !ControlMaster.Deleted)
-			{
-				int range = (RangeHome - 2);
+            if (Deleted || master == null || master.Deleted)
+                return false;
 
-				if (!InRange(ControlMaster.Location, RangeHome))
-				{
-					Mobile master = ControlMaster;
+            int dist = (int)master.GetDistanceToSqrt(Location);
 
-					Point3D m_Loc = Point3D.Zero;
+            if (master.Map != Map || dist > 15)
+            {
+                if (m_SeperationStart == DateTime.MinValue)
+                {
+                    m_SeperationStart = DateTime.UtcNow + TimeSpan.FromMinutes(60);
+                }
+                else if (m_SeperationStart < DateTime.UtcNow)
+                {
+                    Delete();
+                }
 
-					if (Map == master.Map)
-					{
-						int x = (X > master.X) ? (master.X + range) : (master.X - range);
-						int y = (Y > master.Y) ? (master.Y + range) : (master.Y - range);
+                return false;
+            }
 
-						for (int i = 0; i < 10; i++)
-						{
-							m_Loc.X = x + Utility.RandomMinMax(-1, 1);
-							m_Loc.Y = y + Utility.RandomMinMax(-1, 1);
+            if (m_SeperationStart != DateTime.MinValue)
+            {
+                m_SeperationStart = DateTime.MinValue;
+            }
 
-							m_Loc.Z = Map.GetAverageZ(m_Loc.X, m_Loc.Y);
+            int range = (RangeHome / 2);
 
-							if (Map.CanSpawnMobile(m_Loc))
-							{
-								break;
-							}
+            if (!InRange(ControlMaster.Location, RangeHome))
+            {
+                Point3D loc = Point3D.Zero;
 
-							m_Loc = master.Location;
-						}
+                if (Map == master.Map)
+                {
+                    int x = (X > master.X) ? (master.X + range) : (master.X - range);
+                    int y = (Y > master.Y) ? (master.Y + range) : (master.Y - range);
 
-						if (!Deleted)
-						{
-							SetLocation(m_Loc, true);
-						}
-					}
-				}
-			}
-		}
+                    for (int i = 0; i < 10; i++)
+                    {
+                        loc.X = x + Utility.RandomMinMax(-1, 1);
+                        loc.Y = y + Utility.RandomMinMax(-1, 1);
+
+                        loc.Z = Map.GetAverageZ(loc.X, loc.Y);
+
+                        if (Map.CanSpawnMobile(loc))
+                        {
+                            break;
+                        }
+
+                        loc = master.Location;
+                    }
+
+                    if (!Deleted)
+                    {
+                        SetLocation(loc, true);
+                    }
+                }
+            }
+
+            return true;
+        }
 
 		public override void OnThink()
 		{
@@ -89,67 +135,61 @@ namespace Server.Mobiles
 				return;
 			}
 
-            if (AttacksMastersTarget)
-            {
-                if (Combatant == null)
-                {
-                    if (master.Combatant != null)
-                    {
-                        Combatant = master.Combatant;
-                    }
-                }
-                else
-                {
-                    if (Combatant.Deleted)
-                    {
-                        Combatant = null;
-                    }
-
-                    return;
-                }
-            }
-
-			RangeCheck();
-
 			if (m_LastHidden != master.Hidden)
 			{
 				Hidden = m_LastHidden = master.Hidden;
 			}
 
-			if (AIObject != null && AIObject.WalkMobileRange(master, 5, true, 1, 1))
-			{
-                if ((master.Combatant !=null) && (InRange(master.Combatant, 1)))
+            if (RangeCheck())
+            {
+                if (ControlOrder != OrderType.Come)
                 {
-		            Warmode = master.Warmode;
-		            Combatant = master.Combatant;
-
-		            CurrentSpeed = 0.10;
-			    }
-
-                if ((master.Combatant !=null) && (!InRange(master.Combatant, 1)))
-                {
-                    Warmode = false;
-                    FocusMob = null;
-                    Combatant = null;
-                    CurrentSpeed = 0.01;
+                    ControlOrder = OrderType.Come;
                 }
 
-                if (master.Combatant == null)
+                if (AIObject != null && AIObject.WalkMobileRange(master, 5, true, 1, 1))
                 {
-                    Warmode = false;
-                    FocusMob = null;
-                    Combatant = null;
-                    CurrentSpeed = 0.01;
+                    if (master.Combatant != null && master.InRange(master.Combatant, 1) && Core.TickCount > m_NextMove)
+                    {
+                        IDamageable combatant = master.Combatant;
+
+                        if (!InRange(combatant.Location, 1))
+                        {
+                            for (int x = combatant.X - 1; x <= combatant.X + 1; x++)
+                            {
+                                for (int y = combatant.Y - 1; y <= combatant.Y + 1; y++)
+                                {
+                                    if (x == combatant.X && y == combatant.Y)
+                                    {
+                                        continue;
+                                    }
+
+                                    Point2D p = new Point2D(x, y);
+
+                                    if (InRange(p, 1) && master.InRange(p, 1))
+                                    {
+                                        CurrentSpeed = .01;
+                                        AIObject.MoveTo(new Point3D(x, y, Map.GetAverageZ(x, y)), false, 0);
+                                        m_NextMove = Core.TickCount + 500;
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            CurrentSpeed = .04;
+                        }
+                    }
+                    else if (master.Combatant == null)
+                    {
+                        CurrentSpeed = .04;
+                    }
+                }
+                else
+                {
+                    CurrentSpeed = .01;
                 }
             }
-			else
-			{
-				Warmode = false;
-				FocusMob = null;
-                Combatant = null;
-
-				CurrentSpeed = .01;
-			}
 		}
 
 		public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)
@@ -196,6 +236,27 @@ namespace Server.Mobiles
 				}
 			}
 		}
+
+        public static void OnHit(Mobile attacker, IDamageable defender)
+        {
+            BaseCreature check = (BaseCreature)SummonFamiliarSpell.Table[attacker];
+
+            if (check != null && check is BaseFamiliar && check.Weapon != null && check.InRange(defender.Location, check.Weapon.MaxRange))
+            {
+                check.Weapon.OnSwing(check, defender);
+            }
+        }
+
+        public static void OnLogout(PlayerMobile pm)
+        {
+            if (pm == null)
+                return;
+
+            BaseCreature check = (BaseCreature)SummonFamiliarSpell.Table[pm];
+
+            if (check != null)
+                check.Delete();
+        }
 
 		public override void Serialize(GenericWriter writer)
 		{

--- a/Scripts/Mobiles/Summons/DeathAdder.cs
+++ b/Scripts/Mobiles/Summons/DeathAdder.cs
@@ -5,8 +5,6 @@ namespace Server.Mobiles
     [CorpseName("a death adder corpse")]
     public class DeathAdder : BaseFamiliar
     {
-        public override bool AttacksMastersTarget { get { return true; } }
-
         public DeathAdder()
         {
             this.Name = "a death adder";

--- a/Scripts/Mobiles/Summons/VampireBat.cs
+++ b/Scripts/Mobiles/Summons/VampireBat.cs
@@ -5,8 +5,6 @@ namespace Server.Mobiles
     [CorpseName("a vampire bat corpse")]
     public class VampireBatFamiliar : BaseFamiliar
     {
-        public override bool AttacksMastersTarget { get { return true; } }
-
         public VampireBatFamiliar()
         {
             this.Name = "a vampire bat";

--- a/Scripts/Quests/DarkTides/Objectives.cs
+++ b/Scripts/Quests/DarkTides/Objectives.cs
@@ -226,10 +226,18 @@ namespace Server.Engines.Quests.Necro
             {
                 HordeMinionFamiliar hmf = Spells.Necromancy.SummonFamiliarSpell.Table[this.System.From] as HordeMinionFamiliar;
 
-                if (hmf != null && hmf.InRange(this.System.From, 5) && hmf.TargetLocation == null)
+                if (hmf != null && hmf.InRange(this.System.From, 5) && !hmf.QuestOverride)
                 {
                     this.System.From.SendLocalizedMessage(1060113); // You instinctively will your familiar to fetch the scroll for you.
-                    hmf.TargetLocation = new Point2D(1076, 450);
+                    //hmf.TargetLocation = new Point2D(1076, 450);
+
+                    if (hmf.AIObject != null)
+                    {
+                        hmf.CurrentSpeed = .2;
+                        hmf.QuestOverride = true;
+                        hmf.AIObject.MoveTo(new Point3D(1076, 450, -89), false, 0);
+                    }
+                    
                 }
             }
         }

--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -778,6 +778,8 @@ namespace Server.Spells
 						m_CastTimer.Tick();
 					}
 
+                    NegativeAttributes.OnCombatAction(Caster);
+
 					return true;
 				}
 				else

--- a/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
+++ b/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
@@ -147,6 +147,11 @@ namespace Server.Spells.SkillMasteries
             Caster.RevealingAction();
             int upkeep = ScaleUpkeep();
 
+            if (0.10 > Utility.RandomDouble())
+            {
+                NegativeAttributes.OnCombatAction(Caster);
+            }
+
             if ((Caster is PlayerMobile && Caster.NetState == null) || Expires < DateTime.UtcNow)
                 Expire();
             else if (Target != null && !Target.Alive)


### PR DESCRIPTION
Combat actions now cause antique items to lose durability. The following actions call the method to check each antique item worn by the mobile:
- Spell.Cast
- Bandage.InternalTarget.OnTarget
- SkillMasterySpell.OnTick


-Items will still lose durability as normal while being hits by a melee weapon
-Increased the chance for weapons to lose durability.  The previous formula made them decay way too slow
-Added RANDOMITEM keyword to XmlSpawner to add new loot, syntax: RANDOMITEM,[basebudget,][prefix,][suffix,][rawluck,][artifact]
-Loot tweaks, specifically in the way special mods are handed out with prefix/suffix items.
-Fixed a very rare occurrence where Hit Area and Hit Spell and Resist Bonuses  properties were added more than once on weapons and armor.

Updated BaseFamiliar behavior to be more EA like. A couple of the changes:
-Familiars will never leave its masters side, unless the master recalls away
-Familiars will delete after an hour of not being near its master, ie over 15 tiles and/or on a different map
-Familiars will no longer tweak out and go crazy when the master is not around
-Familiars will now delete when its master logs from the world (not disconnect, but completely logs out)
-Familiars will now attempt to move within 1 tile of its master, and its masters combatant, as long as the master is attacking with a melee weapon (1 tile away from combatant)
-Familiars will now only attempt a melee attack when its master hits its combatant, as long as its within a tile of its masters combatant


