### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Accounting/AccountHandler.cs
+++ b/Scripts/Accounting/AccountHandler.cs
@@ -39,7 +39,14 @@ namespace Server.Misc
             new CityInfo("Trinsic",	"The Traveler's Inn",	1075076, 1845,	2745,	0),
             new CityInfo("Jhelom", "The Mercenary Inn",	1075078, 1374,	3826,	0),
             new CityInfo("Skara Brae",	"The Falconer's Inn",	1075079, 618,	2234,	0),
-            new CityInfo("Vesper", "The Ironwood Inn",	1075080, 2771,	976,	0)
+            new CityInfo("Vesper", "The Ironwood Inn",	1075080, 2771,	976,	0),
+            new CityInfo("Royal City", "Royal City Inn", 1150169, 738, 3486, -19, Map.TerMur)
+        };
+
+        private static readonly CityInfo[] SiegeStartingCities = new CityInfo[]
+        {
+            new CityInfo("Britain",	"The Wayfarer's Inn",	1075074, 1602,	1591,	20, Map.Felucca),
+            new CityInfo("Royal City", "Royal City Inn", 1150169, 738, 3486, -19, Map.TerMur)
         };
 
         /* Old Haven/Magincia Locations
@@ -351,7 +358,7 @@ namespace Server.Misc
                 Utility.PopColor();
                 e.State.Account = acct;
                 e.Accepted = true;
-                e.CityInfo = StartingCities;
+                e.CityInfo = Siege.SiegeShard ? SiegeStartingCities : StartingCities;
             }
 
             if (!e.Accepted)

--- a/Scripts/Items/Functional/HouseCraftables.cs
+++ b/Scripts/Items/Functional/HouseCraftables.cs
@@ -157,7 +157,7 @@ namespace Server.Items
         }
 
         public override BaseAddonDeed Deed { get { return new CraftableHouseAddonDeed(AddonType); } }
-        public override bool RestrictToClassicHouses { get { return true; } }
+        //public override bool RestrictToClassicHouses { get { return true; } }
         public override bool RetainDeedHue { get { return true; } }
 
         [Constructable]

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -2973,7 +2973,7 @@ namespace Server
                 list.Add(1151782);
         }
 
-        public const double CombatDecayChance = 0.05;
+        public const double CombatDecayChance = 0.02;
 
         public static void OnCombatAction(Mobile m)
         {
@@ -3001,15 +3001,17 @@ namespace Server
 
                 if (dur.HitPoints >= 1)
                 {
-                    dur.HitPoints--;
-                }
-                else
-                {
-                    if (dur.HitPoints > 0)
+                    if (dur.HitPoints >= 4)
+                    {
+                        dur.HitPoints -= 4;
+                    }
+                    else
                     {
                         dur.HitPoints = 0;
                     }
-
+                }
+                else
+                {
                     if (dur.MaxHitPoints > 1)
                     {
                         dur.MaxHitPoints--;

--- a/Scripts/Misc/CharacterCreation.cs
+++ b/Scripts/Misc/CharacterCreation.cs
@@ -11,6 +11,8 @@ namespace Server.Misc
     public class CharacterCreation
     {
         private static readonly CityInfo m_NewHavenInfo = new CityInfo("New Haven", "The Bountiful Harvest Inn", 3503, 2574, 14, Map.Trammel);
+        private static readonly CityInfo m_SiegeInfo = new CityInfo("Britain", "The Wayfarer's Inn", 1075074, 1602, 1591, 20, Map.Felucca);
+
         private static Mobile m_Mobile;
         public static void Initialize()
         {
@@ -198,7 +200,7 @@ namespace Server.Misc
                 }
                 pm.Profession = args.Profession;
 
-                if (pm.IsPlayer() && ((Account)pm.Account).Young)
+                if (pm.IsPlayer() && ((Account)pm.Account).Young && !Siege.SiegeShard)
                     young = pm.Young = true;
             }
 
@@ -263,98 +265,101 @@ namespace Server.Misc
 
         private static CityInfo GetStartLocation(CharacterCreatedEventArgs args, bool isYoung)
         {
-            bool siege = Siege.SiegeShard;
+            //bool siege = Siege.SiegeShard;
 
-            if (Core.ML && !siege)
-            {
+            // TODO: Find out how the client gives TerMur as an option. Find out how siege shards only give royal city and britain as an option
+            //if (Core.ML && !siege)
+            //{
                 //if( args.State != null && args.State.NewHaven )
-                return m_NewHavenInfo;	//We don't get the client Version until AFTER Character creation
+            //    return m_NewHavenInfo;	//We don't get the client Version until AFTER Character creation
                 //return args.City;  TODO: Uncomment when the old quest system is actually phased out
-            }
+            //}
 
-            bool useHaven = isYoung && !siege;
+            //bool useHaven = isYoung && !siege;
 
-            ClientFlags flags = args.State == null ? ClientFlags.None : args.State.Flags;
+            //ClientFlags flags = args.State == null ? ClientFlags.None : args.State.Flags;
             Mobile m = args.Mobile;
 
-            switch ( args.Profession )
-            {
-                case 4: //Necro
-                    {
-                        if ((flags & ClientFlags.Malas) != 0)
-                        {
-                            return new CityInfo("Umbra", "Mardoth's Tower", 2114, 1301, -50, Map.Malas);
-                        }
-                        else
-                        {
-                            useHaven = true; 
+            // Removed this as its not used in EA.
+            //switch ( args.Profession )
+            //{
+            //    case 4: //Necro
+            //        {
+            //            if ((flags & ClientFlags.Malas) != 0)
+            //            {
+            //                return new CityInfo("Umbra", "Mardoth's Tower", 2114, 1301, -50, Map.Malas);
+            //            }
+            //            else
+            //            {
+            //                useHaven = !siege; 
 
-                            new BadStartMessage(m, 1062205);
-                            /*
-                            * Unfortunately you are playing on a *NON-Age-Of-Shadows* game 
-                            * installation and cannot be transported to Malas.  
-                            * You will not be able to take your new player quest in Malas 
-                            * without an AOS client.  You are now being taken to the city of 
-                            * Haven on the Trammel facet.
-                            * */
-                        }
+            //                new BadStartMessage(m, 1062205);
+            //                /*
+            //                * Unfortunately you are playing on a *NON-Age-Of-Shadows* game 
+            //                * installation and cannot be transported to Malas.  
+            //                * You will not be able to take your new player quest in Malas 
+            //                * without an AOS client.  You are now being taken to the city of 
+            //                * Haven on the Trammel facet.
+            //                * */
+            //            }
 
-                        break;
-                    }
-                case 5:	//Paladin
-                    {
-                        return m_NewHavenInfo;
-                    }
-                case 6:	//Samurai
-                    {
-                        if ((flags & ClientFlags.Tokuno) != 0)
-                        {
-                            return new CityInfo("Samurai DE", "Haoti's Grounds", 368, 780, -1, Map.Malas);
-                        }
-                        else
-                        {
-                            useHaven = true;
+            //            break;
+            //        }
+            //    case 5:	//Paladin
+            //        {
+            //            return m_NewHavenInfo;
+            //        }
+            //    case 6:	//Samurai
+            //        {
+            //            if ((flags & ClientFlags.Tokuno) != 0)
+            //            {
+            //                return new CityInfo("Samurai DE", "Haoti's Grounds", 368, 780, -1, Map.Malas);
+            //            }
+            //            else
+            //            {
+            //                useHaven = !siege;
 
-                            new BadStartMessage(m, 1063487);
-                            /*
-                            * Unfortunately you are playing on a *NON-Samurai-Empire* game 
-                            * installation and cannot be transported to Tokuno. 
-                            * You will not be able to take your new player quest in Tokuno 
-                            * without an SE client. You are now being taken to the city of 
-                            * Haven on the Trammel facet.
-                            * */
-                        }
+            //                new BadStartMessage(m, 1063487);
+            //                /*
+            //                * Unfortunately you are playing on a *NON-Samurai-Empire* game 
+            //                * installation and cannot be transported to Tokuno. 
+            //                * You will not be able to take your new player quest in Tokuno 
+            //                * without an SE client. You are now being taken to the city of 
+            //                * Haven on the Trammel facet.
+            //                * */
+            //            }
 
-                        break;
-                    }
-                case 7:	//Ninja
-                    {
-                        if ((flags & ClientFlags.Tokuno) != 0)
-                        {
-                            return new CityInfo("Ninja DE", "Enimo's Residence", 414,	823, -1, Map.Malas);
-                        }
-                        else
-                        {
-                            useHaven = true;
+            //            break;
+            //        }
+            //    case 7:	//Ninja
+            //        {
+            //            if ((flags & ClientFlags.Tokuno) != 0)
+            //            {
+            //                return new CityInfo("Ninja DE", "Enimo's Residence", 414,	823, -1, Map.Malas);
+            //            }
+            //            else
+            //            {
+            //                useHaven = !siege;
 
-                            new BadStartMessage(m, 1063487);
-                            /*
-                            * Unfortunately you are playing on a *NON-Samurai-Empire* game 
-                            * installation and cannot be transported to Tokuno. 
-                            * You will not be able to take your new player quest in Tokuno 
-                            * without an SE client. You are now being taken to the city of 
-                            * Haven on the Trammel facet.
-                            * */
-                        }
+            //                new BadStartMessage(m, 1063487);
+            //                /*
+            //                * Unfortunately you are playing on a *NON-Samurai-Empire* game 
+            //                * installation and cannot be transported to Tokuno. 
+            //                * You will not be able to take your new player quest in Tokuno 
+            //                * without an SE client. You are now being taken to the city of 
+            //                * Haven on the Trammel facet.
+            //                * */
+            //            }
 
-                        break;
-                    }
-            }
+            //            break;
+            //        }
+            //}
 
-            if (useHaven)
-                return m_NewHavenInfo;
-            else
-                return args.City;
+            //if (useHaven)
+            //    return m_NewHavenInfo;
+            //else
+
+            return args.City;
         }
 
         private static void FixStats(ref int str, ref int dex, ref int intel, int max)

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -9994,6 +9994,7 @@
     <Compile Include="Services\Revamped Dungeons\WrongDungeon\Mobile\WrongPrisoner.cs" />
     <Compile Include="Services\Revamped Dungeons\WrongDungeon\Items\MysteriousTunnel.cs" />
     <Compile Include="Services\Revamped Dungeons\WrongDungeon\Items\WrongMazeWall.cs" />
+    <Compile Include="Services\RunicReforging\ReforgingContext.cs" />
     <Compile Include="Services\Tomb of Kings\Arisen Invasion\ArisenController.cs" />
     <Compile Include="Services\Tomb of Kings\Chambers\Chamber.cs" />
     <Compile Include="Services\Tomb of Kings\Chambers\ChamberBarrier.cs" />

--- a/Scripts/Services/Craft/Core/CraftContext.cs
+++ b/Scripts/Services/Craft/Core/CraftContext.cs
@@ -36,7 +36,7 @@ namespace Server.Engines.Craft
         private PlantHue m_RequiredPlantHue;
 
         #region Hue State Vars
-        private bool m_CheckedHues;
+        /*private bool m_CheckedHues;
         private List<int> m_Hues;
         private Item m_CompareHueTo;
 
@@ -44,97 +44,97 @@ namespace Server.Engines.Craft
         {
             get
             {
-                return this.m_CheckedHues;
+                return m_CheckedHues;
             }
             set
             {
-                this.m_CheckedHues = value;
+                m_CheckedHues = value;
             }
         }
         public List<int> Hues
         {
             get
             {
-                return this.m_Hues;
+                return m_Hues;
             }
             set
             {
-                this.m_Hues = value;
+                m_Hues = value;
             }
         }
         public Item CompareHueTo
         {
             get
             {
-                return this.m_CompareHueTo;
+                return m_CompareHueTo;
             }
             set
             {
-                this.m_CompareHueTo = value;
+                m_CompareHueTo = value;
             }
-        }
+        }*/
         #endregion
 
         public List<CraftItem> Items
         {
             get
             {
-                return this.m_Items;
+                return m_Items;
             }
         }
         public int LastResourceIndex
         {
             get
             {
-                return this.m_LastResourceIndex;
+                return m_LastResourceIndex;
             }
             set
             {
-                this.m_LastResourceIndex = value;
+                m_LastResourceIndex = value;
             }
         }
         public int LastResourceIndex2
         {
             get
             {
-                return this.m_LastResourceIndex2;
+                return m_LastResourceIndex2;
             }
             set
             {
-                this.m_LastResourceIndex2 = value;
+                m_LastResourceIndex2 = value;
             }
         }
         public int LastGroupIndex
         {
             get
             {
-                return this.m_LastGroupIndex;
+                return m_LastGroupIndex;
             }
             set
             {
-                this.m_LastGroupIndex = value;
+                m_LastGroupIndex = value;
             }
         }
         public bool DoNotColor
         {
             get
             {
-                return this.m_DoNotColor;
+                return m_DoNotColor;
             }
             set
             {
-                this.m_DoNotColor = value;
+                m_DoNotColor = value;
             }
         }
         public CraftMarkOption MarkOption
         {
             get
             {
-                return this.m_MarkOption;
+                return m_MarkOption;
             }
             set
             {
-                this.m_MarkOption = value;
+                m_MarkOption = value;
             }
         }
         #region SA
@@ -142,11 +142,11 @@ namespace Server.Engines.Craft
         {
             get
             {
-                return this.m_QuestOption;
+                return m_QuestOption;
             }
             set
             {
-                this.m_QuestOption = value;
+                m_QuestOption = value;
             }
         }
 
@@ -176,15 +176,12 @@ namespace Server.Engines.Craft
             Owner = owner;
             System = system;
 
-            this.m_Items = new List<CraftItem>();
-            this.m_LastResourceIndex = -1;
-            this.m_LastResourceIndex2 = -1;
-            this.m_LastGroupIndex = -1;
+            m_Items = new List<CraftItem>();
+            m_LastResourceIndex = -1;
+            m_LastResourceIndex2 = -1;
+            m_LastGroupIndex = -1;
 
-            this.m_CheckedHues = false;
-            this.m_Hues = new List<int>();
-            this.m_CompareHueTo = null;
-            this.m_QuestOption = CraftQuestOption.NonQuestItem;
+            m_QuestOption = CraftQuestOption.NonQuestItem;
             m_RequiredPlantHue = PlantHue.None;
             RequiredPigmentHue = PlantPigmentHue.None;
 
@@ -195,8 +192,8 @@ namespace Server.Engines.Craft
         {
             get
             {
-                if (this.m_Items.Count > 0)
-                    return this.m_Items[0];
+                if (m_Items.Count > 0)
+                    return m_Items[0];
 
                 return null;
             }
@@ -204,19 +201,12 @@ namespace Server.Engines.Craft
 
         public void OnMade(CraftItem item)
         {
-            this.m_Items.Remove(item);
+            m_Items.Remove(item);
 
-            if (this.m_Items.Count == 10)
-                this.m_Items.RemoveAt(9);
+            if (m_Items.Count == 10)
+                m_Items.RemoveAt(9);
 
-            this.m_Items.Insert(0, item);
-        }
-		
-        public void ResetHueStateVars()
-        {
-            this.m_CheckedHues = false;
-            this.m_Hues = new List<int>();
-            this.m_CompareHueTo = null;
+            m_Items.Insert(0, item);
         }
 
         public virtual void Serialize(GenericWriter writer)

--- a/Scripts/Services/Harvest/HarvestSystem.cs
+++ b/Scripts/Services/Harvest/HarvestSystem.cs
@@ -223,7 +223,7 @@ namespace Server.Engines.Harvest
                         }
 
                         // Siege rules will take into account axes and polearms used for lumberjacking
-                        if (tool is IUsesRemaining && (tool is BaseHarvestTool || tool is Pickaxe || Siege.SiegeShard))
+                        if (tool is IUsesRemaining && (tool is BaseHarvestTool || tool is Pickaxe || tool is SturdyPickaxe || tool is GargoylesPickaxe || Siege.SiegeShard))
                         {
                             IUsesRemaining toolWithUses = (IUsesRemaining)tool;
 

--- a/Scripts/Services/RunicReforging/ReforgingContext.cs
+++ b/Scripts/Services/RunicReforging/ReforgingContext.cs
@@ -1,0 +1,121 @@
+using System;
+using Server;
+using System.Collections.Generic;
+using Server.Items;
+using Server.Gumps;
+using System.IO;
+
+namespace Server.Items
+{
+    public class ReforgingContext
+    {
+        public Dictionary<BaseTool, ReforgingOption> Contexts { get; set; }
+
+        public ReforgedPrefix Prefix { get; set; }
+        public ReforgedSuffix Suffix { get; set; }
+
+        public ReforgingContext(Mobile m)
+        {
+            Contexts = new Dictionary<BaseTool, ReforgingOption>();
+
+            ReforgingContexts[m] = this;
+        }
+
+        public ReforgingContext(GenericReader reader)
+        {
+            Contexts = new Dictionary<BaseTool, ReforgingOption>();
+
+            int version = reader.ReadInt();
+
+            Prefix = (ReforgedPrefix)reader.ReadInt();
+            Suffix = (ReforgedSuffix)reader.ReadInt();
+
+            int count = reader.ReadInt();
+            for (int i = 0; i < count; i++)
+            {
+                BaseTool tool = reader.ReadItem() as BaseTool;
+                ReforgingOption option = (ReforgingOption)reader.ReadInt();
+
+                if (tool != null)
+                    Contexts[tool] = option;
+            }
+        }
+
+        public void Serialize(GenericWriter writer)
+        {
+            writer.Write(0);
+
+            writer.Write((int)Prefix);
+            writer.Write((int)Suffix);
+
+            writer.Write(Contexts.Count);
+            foreach (var kvp in Contexts)
+            {
+                writer.Write(kvp.Key);
+                writer.Write((int)kvp.Value);
+            }
+        }
+
+        #region Serialize/Deserialize Persistence
+        private static string FilePath = Path.Combine("Saves", "CraftContext", "ReforgingContexts.bin");
+
+        public static Dictionary<Mobile, ReforgingContext> ReforgingContexts { get; set; }
+
+        public static ReforgingContext GetContext(Mobile m)
+        {
+            if (ReforgingContexts.ContainsKey(m))
+            {
+                return ReforgingContexts[m];
+            }
+
+            return new ReforgingContext(m);
+        }
+
+        public static void Configure()
+        {
+            EventSink.WorldSave += OnSave;
+            EventSink.WorldLoad += OnLoad;
+        }
+
+        public static void OnSave(WorldSaveEventArgs e)
+        {
+            Persistence.Serialize(
+                FilePath,
+                writer =>
+                {
+                    writer.Write(0); // version
+
+                    writer.Write(ReforgingContexts.Count);
+
+                    foreach (var kvp in ReforgingContexts)
+                    {
+                        writer.Write(kvp.Key);
+                        kvp.Value.Serialize(writer);
+                    }
+                });
+        }
+
+        public static void OnLoad()
+        {
+            ReforgingContexts = new Dictionary<Mobile, ReforgingContext>();
+
+            Persistence.Deserialize(
+                FilePath,
+                reader =>
+                {
+                    int version = reader.ReadInt();
+
+                    int count = reader.ReadInt();
+                    for (int i = 0; i < count; i++)
+                    {
+                        Mobile m = reader.ReadMobile();
+                        var context = new ReforgingContext(reader);
+
+                        if (m != null)
+                            ReforgingContexts[m] = context;
+                    }
+                });
+        }
+        #endregion
+    }
+}

--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -129,6 +129,11 @@ namespace Server.Spells
             {
                 ((IDamageableItem)d).OnHarmfulSpell(m_Caster);
             }
+
+            NegativeAttributes.OnCombatAction(Caster);
+
+            if (d is Mobile && (Mobile)d != m_Caster)
+                NegativeAttributes.OnCombatAction((Mobile)d);
 		}
 
 		public Spell(Mobile caster, Item scroll, SpellInfo info)
@@ -777,8 +782,6 @@ namespace Server.Spells
 					{
 						m_CastTimer.Tick();
 					}
-
-                    NegativeAttributes.OnCombatAction(Caster);
 
 					return true;
 				}

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -33,14 +33,14 @@ namespace Server
             public InternalTimer(Mobile m)
                 : base(TimeSpan.FromMinutes(1.0))
             {
-                this.m_Mobile = m;
+                m_Mobile = m;
 
-                this.Priority = TimerPriority.OneSecond;
+                Priority = TimerPriority.OneSecond;
             }
 
             protected override void OnTick()
             {
-                this.m_Mobile.EndAction(typeof(DefensiveSpell));
+                m_Mobile.EndAction(typeof(DefensiveSpell));
             }
         }
     }
@@ -1233,6 +1233,11 @@ namespace Server.Spells
                     Spells.Mysticism.SpellPlagueSpell.OnMobileDamaged(target);
 
                 WeightOverloading.DFA = DFAlgorithm.Standard;
+
+                NegativeAttributes.OnCombatAction(from);
+
+                if(from != target)
+                    NegativeAttributes.OnCombatAction(target);
             }
             else
             {
@@ -1319,28 +1324,28 @@ namespace Server.Spells
             public SpellDamageTimer(Spell s, Mobile target, Mobile from, int damage, TimeSpan delay)
                 : base(delay)
             {
-                this.m_Target = target;
-                this.m_From = from;
-                this.m_Damage = damage;
-                this.m_Spell = s;
+                m_Target = target;
+                m_From = from;
+                m_Damage = damage;
+                m_Spell = s;
 
-                if (this.m_Spell != null && this.m_Spell.DelayedDamage && !this.m_Spell.DelayedDamageStacking)
-                    this.m_Spell.StartDelayedDamageContext(target, this);
+                if (m_Spell != null && m_Spell.DelayedDamage && !m_Spell.DelayedDamageStacking)
+                    m_Spell.StartDelayedDamageContext(target, this);
 
-                this.Priority = TimerPriority.TwentyFiveMS;
+                Priority = TimerPriority.TwentyFiveMS;
             }
 
             protected override void OnTick()
             {
-                if (this.m_From is BaseCreature)
-                    ((BaseCreature)this.m_From).AlterSpellDamageTo(this.m_Target, ref this.m_Damage);
+                if (m_From is BaseCreature)
+                    ((BaseCreature)m_From).AlterSpellDamageTo(m_Target, ref m_Damage);
 
-                if (this.m_Target is BaseCreature)
-                    ((BaseCreature)this.m_Target).AlterSpellDamageFrom(this.m_From, ref this.m_Damage);
+                if (m_Target is BaseCreature)
+                    ((BaseCreature)m_Target).AlterSpellDamageFrom(m_From, ref m_Damage);
 
-                this.m_Target.Damage(this.m_Damage);
-                if (this.m_Spell != null)
-                    this.m_Spell.RemoveDelayedDamageContext(this.m_Target);
+                m_Target.Damage(m_Damage);
+                if (m_Spell != null)
+                    m_Spell.RemoveDelayedDamageContext(m_Target);
             }
         }
 
@@ -1371,58 +1376,63 @@ namespace Server.Spells
             public SpellDamageTimerAOS(Spell s, IDamageable target, Mobile from, int damage, int phys, int fire, int cold, int pois, int nrgy, int chaos, int direct, TimeSpan delay, DFAlgorithm dfa)
                 : base(delay)
             {
-                this.m_Target = target;
-                this.m_From = from;
-                this.m_Damage = damage;
-                this.m_Phys = phys;
-                this.m_Fire = fire;
-                this.m_Cold = cold;
-                this.m_Pois = pois;
-                this.m_Nrgy = nrgy;
-                this.m_Chaos = chaos;
-                this.m_Direct = direct;
-                this.m_DFA = dfa;
-                this.m_Spell = s;
-                if (this.m_Spell != null && this.m_Spell.DelayedDamage && !this.m_Spell.DelayedDamageStacking)
-                    this.m_Spell.StartDelayedDamageContext(target, this);
+                m_Target = target;
+                m_From = from;
+                m_Damage = damage;
+                m_Phys = phys;
+                m_Fire = fire;
+                m_Cold = cold;
+                m_Pois = pois;
+                m_Nrgy = nrgy;
+                m_Chaos = chaos;
+                m_Direct = direct;
+                m_DFA = dfa;
+                m_Spell = s;
+                if (m_Spell != null && m_Spell.DelayedDamage && !m_Spell.DelayedDamageStacking)
+                    m_Spell.StartDelayedDamageContext(target, this);
 
-                this.Priority = TimerPriority.TwentyFiveMS;
+                Priority = TimerPriority.TwentyFiveMS;
             }
 
             protected override void OnTick()
             {
                 Mobile target = m_Target as Mobile;
 
-                if (this.m_From is BaseCreature && target != null)
-                    ((BaseCreature)this.m_From).AlterSpellDamageTo(target, ref this.m_Damage);
+                if (m_From is BaseCreature && target != null)
+                    ((BaseCreature)m_From).AlterSpellDamageTo(target, ref m_Damage);
 
-                if (this.m_Target is BaseCreature && this.m_From != null)
-                    ((BaseCreature)this.m_Target).AlterSpellDamageFrom(this.m_From, ref this.m_Damage);
+                if (m_Target is BaseCreature && m_From != null)
+                    ((BaseCreature)m_Target).AlterSpellDamageFrom(m_From, ref m_Damage);
 
-                WeightOverloading.DFA = this.m_DFA;
+                WeightOverloading.DFA = m_DFA;
 
-                int damageGiven = AOS.Damage(this.m_Target, this.m_From, this.m_Damage, this.m_Phys, this.m_Fire, this.m_Cold, this.m_Pois, this.m_Nrgy, this.m_Chaos, this.m_Direct);
+                int damageGiven = AOS.Damage(m_Target, m_From, m_Damage, m_Phys, m_Fire, m_Cold, m_Pois, m_Nrgy, m_Chaos, m_Direct);
 
-                if (this.m_From != null && target != null) // sanity check
+                if (m_From != null && target != null) // sanity check
                 {
-                    DoLeech(damageGiven, this.m_From, target);
+                    DoLeech(damageGiven, m_From, target);
                 }
 
                 WeightOverloading.DFA = DFAlgorithm.Standard;
 
-                if (this.m_Target is BaseCreature && this.m_From != null)
+                if (m_Target is BaseCreature && m_From != null)
                 {
-                    BaseCreature c = (BaseCreature)this.m_Target;
+                    BaseCreature c = (BaseCreature)m_Target;
 
-                    c.OnHarmfulSpell(this.m_From);
-                    c.OnDamagedBySpell(this.m_From);
+                    c.OnHarmfulSpell(m_From);
+                    c.OnDamagedBySpell(m_From);
                 }
 
                 if (target != null)
                     Spells.Mysticism.SpellPlagueSpell.OnMobileDamaged(target);
 
-                if (this.m_Spell != null)
-                    this.m_Spell.RemoveDelayedDamageContext(this.m_Target);
+                if (m_Spell != null)
+                    m_Spell.RemoveDelayedDamageContext(m_Target);
+
+                NegativeAttributes.OnCombatAction(m_From);
+
+                if (m_From != target)
+                    NegativeAttributes.OnCombatAction(target);
             }
         }
     }
@@ -1640,37 +1650,37 @@ namespace Server.Spells
         {
             get
             {
-                return this.m_Timer;
+                return m_Timer;
             }
         }
         public List<ResistanceMod> Mods
         {
             get
             {
-                return this.m_Mods;
+                return m_Mods;
             }
         }
         public Type Type
         {
             get
             {
-                return this.m_Type;
+                return m_Type;
             }
         }
         public ITransformationSpell Spell
         {
             get
             {
-                return this.m_Spell;
+                return m_Spell;
             }
         }
 
         public TransformContext(Timer timer, List<ResistanceMod> mods, Type type, ITransformationSpell spell)
         {
-            this.m_Timer = timer;
-            this.m_Mods = mods;
-            this.m_Type = type;
-            this.m_Spell = spell;
+            m_Timer = timer;
+            m_Mods = mods;
+            m_Type = type;
+            m_Spell = spell;
         }
     }
 
@@ -1682,22 +1692,22 @@ namespace Server.Spells
         public TransformTimer(Mobile from, ITransformationSpell spell)
             : base(TimeSpan.FromSeconds(spell.TickRate), TimeSpan.FromSeconds(spell.TickRate))
         {
-            this.m_Mobile = from;
-            this.m_Spell = spell;
+            m_Mobile = from;
+            m_Spell = spell;
 
-            this.Priority = TimerPriority.TwoFiftyMS;
+            Priority = TimerPriority.TwoFiftyMS;
         }
 
         protected override void OnTick()
         {
-            if (this.m_Mobile.Deleted || !this.m_Mobile.Alive || this.m_Mobile.Body != this.m_Spell.Body || (this.m_Mobile.Hue != this.m_Spell.Hue && BestialSetHelper.IsBerserk(m_Mobile)))
+            if (m_Mobile.Deleted || !m_Mobile.Alive || m_Mobile.Body != m_Spell.Body || (m_Mobile.Hue != m_Spell.Hue && BestialSetHelper.IsBerserk(m_Mobile)))
             {
-                TransformationSpellHelper.RemoveContext(this.m_Mobile, true);
-                this.Stop();
+                TransformationSpellHelper.RemoveContext(m_Mobile, true);
+                Stop();
             }
             else
             {
-                this.m_Spell.OnTick(this.m_Mobile);
+                m_Spell.OnTick(m_Mobile);
             }
         }
     }


### PR DESCRIPTION
- Fixed issue in Dark Guardian Room where room wouldnt reset if the players die.
- Big Runic Reforging overhaul to make it more EA-like.
- Fixed Runic Reforging bug where named properties weren't being applied properly
- Added Runic Reforging Context to save selections based on runic tool
- Antique decay slightly changed.  Instead of merely casting a spell, it is checked during SpellHelper.Damage and HarmfulSpell which will cover the offensive de-buff/poison Spells
- Antique decay chance lowered, however items will lose 4 points per decay, per EA.
- House Craftables can now be placed in house foundations, exception of doors
- Gargoyle pickaxe will now lose charges

* Houseing crafting will need to be changed from addons to actual items, as they are not addons on EA.