### PR TITLE
Bug fixes

### DIFF
--- a/Config/Vendors.cfg
+++ b/Config/Vendors.cfg
@@ -1,11 +1,11 @@
 # The frequency between vendor restocks.
 # Default: 1 hour
-# Format: dd:hh:mm:ss
-@RestockDelay=00:01:00:00
+# Format: minutes
+RestockDelay=60
 
 # The amount a Vendor will accept from players at once.
 # Default: 500
-@MaxSell=500
+MaxSell=500
 
 # Vendor Economy System, publish 21
 # this determines how many of an item needs to be bought in order for the price to increase

--- a/Scripts/Items/Equipment/Clothing/BaseClothing.cs
+++ b/Scripts/Items/Equipment/Clothing/BaseClothing.cs
@@ -89,11 +89,11 @@ namespace Server.Items
         private int m_GorgonLenseCharges;
         private LenseType m_GorgonLenseType;
 
-        private int m_PhysImbuing;
-        private int m_FireImbuing;
-        private int m_ColdImbuing;
-        private int m_PoisonImbuing;
-        private int m_EnergyImbuing;
+        private int m_PhysNonImbuing;
+        private int m_FireNonImbuing;
+        private int m_ColdNonImbuing;
+        private int m_PoisonNonImbuing;
+        private int m_EnergyNonImbuing;
         #endregion
 
         #region Runic Reforging
@@ -242,34 +242,34 @@ namespace Server.Items
             set { m_GorgonLenseType = value; InvalidateProperties(); }
         }
 
-        public int PhysImbuing
+        public int PhysNonImbuing
         {
-            get { return m_PhysImbuing; }
-            set { m_PhysImbuing = value; }
+            get { return m_PhysNonImbuing; }
+            set { m_PhysNonImbuing = value; }
         }
 
-        public int FireImbuing
+        public int FireNonImbuing
         {
-            get { return m_FireImbuing; }
-            set { m_FireImbuing = value; }
+            get { return m_FireNonImbuing; }
+            set { m_FireNonImbuing = value; }
         }
 
-        public int ColdImbuing
+        public int ColdNonImbuing
         {
-            get { return m_ColdImbuing; }
-            set { m_ColdImbuing = value; }
+            get { return m_ColdNonImbuing; }
+            set { m_ColdNonImbuing = value; }
         }
 
-        public int PoisonImbuing
+        public int PoisonNonImbuing
         {
-            get { return m_PoisonImbuing; }
-            set { m_PoisonImbuing = value; }
+            get { return m_PoisonNonImbuing; }
+            set { m_PoisonNonImbuing = value; }
         }
 
-        public int EnergyImbuing
+        public int EnergyNonImbuing
         {
-            get { return m_EnergyImbuing; }
-            set { m_EnergyImbuing = value; }
+            get { return m_EnergyNonImbuing; }
+            set { m_EnergyNonImbuing = value; }
         }
         #endregion
 
@@ -1539,11 +1539,11 @@ namespace Server.Items
             writer.Write(m_GorgonLenseCharges);
             writer.Write((int)m_GorgonLenseType);
 
-            writer.Write(m_PhysImbuing);
-            writer.Write(m_FireImbuing);
-            writer.Write(m_ColdImbuing);
-            writer.Write(m_PoisonImbuing);
-            writer.Write(m_EnergyImbuing);
+            writer.Write(m_PhysNonImbuing);
+            writer.Write(m_FireNonImbuing);
+            writer.Write(m_ColdNonImbuing);
+            writer.Write(m_PoisonNonImbuing);
+            writer.Write(m_EnergyNonImbuing);
 
             // Version 6
             writer.Write((int)m_TimesImbued);
@@ -1694,11 +1694,11 @@ namespace Server.Items
                         m_GorgonLenseCharges = reader.ReadInt();
                         m_GorgonLenseType = (LenseType)reader.ReadInt();
 
-                        m_PhysImbuing = reader.ReadInt();
-                        m_FireImbuing = reader.ReadInt();
-                        m_ColdImbuing = reader.ReadInt();
-                        m_PoisonImbuing = reader.ReadInt();
-                        m_EnergyImbuing = reader.ReadInt();
+                        m_PhysNonImbuing = reader.ReadInt();
+                        m_FireNonImbuing = reader.ReadInt();
+                        m_ColdNonImbuing = reader.ReadInt();
+                        m_PoisonNonImbuing = reader.ReadInt();
+                        m_EnergyNonImbuing = reader.ReadInt();
                         goto case 6;
                     }
                 case 6:
@@ -1978,11 +1978,11 @@ namespace Server.Items
             }
 
             #region Stygian Abyss
-            m_PhysImbuing = m_AosResistances.Physical;
-            m_FireImbuing = m_AosResistances.Fire;
-            m_ColdImbuing = m_AosResistances.Cold;
-            m_PoisonImbuing = m_AosResistances.Poison;
-            m_EnergyImbuing = m_AosResistances.Energy;
+            m_PhysNonImbuing = m_AosResistances.Physical;
+            m_FireNonImbuing = m_AosResistances.Fire;
+            m_ColdNonImbuing = m_AosResistances.Cold;
+            m_PoisonNonImbuing = m_AosResistances.Poison;
+            m_EnergyNonImbuing = m_AosResistances.Energy;
             #endregion
 
             InvalidateProperties();

--- a/Scripts/Items/Quest/BlightedGroveKey.cs
+++ b/Scripts/Items/Quest/BlightedGroveKey.cs
@@ -45,9 +45,32 @@ namespace Server.Items
         public override bool CanOfferConfirmation(Mobile from)
         {
             if (from.Region != null && from.Region.IsPartOf("Blighted Grove"))
+            {
                 return base.CanOfferConfirmation(from);
-				
+            }
+
+            if (Altar == null)
+            {
+                return false;
+            }
+
+            Map map = Altar.Map;
+
+            foreach (var rect in _EntryLocs)
+            {
+                if (rect.Contains(from.Location))
+                {
+                    return base.CanOfferConfirmation(from);
+                }
+            }
+
             return false;
         }
+
+        private Rectangle2D[] _EntryLocs =
+        {
+            new Rectangle2D(574, 1630, 20, 15),
+            new Rectangle2D(579, 1645, 12, 4)
+        };
     }
 }

--- a/Scripts/Mobiles/Bosses/BaseChampion.cs
+++ b/Scripts/Mobiles/Bosses/BaseChampion.cs
@@ -203,24 +203,29 @@ namespace Server.Mobiles
                 GivePowerScrollTo(m, ps, this);
             }
 
-            // Randomize - Primers
-            for (int i = 0; i < toGive.Count; ++i)
+            if (Core.TOL)
             {
-                int rand = Utility.Random(toGive.Count);
-                Mobile hold = toGive[i];
-                toGive[i] = toGive[rand];
-                toGive[rand] = hold;
+                // Randomize - Primers
+                for (int i = 0; i < toGive.Count; ++i)
+                {
+                    int rand = Utility.Random(toGive.Count);
+                    Mobile hold = toGive[i];
+                    toGive[i] = toGive[rand];
+                    toGive[rand] = hold;
+                }
+
+                for (int i = 0; i < ChampionSystem.PowerScrollAmount; ++i)
+                {
+                    Mobile m = toGive[i % toGive.Count];
+
+                    SkillMasteryPrimer p = CreateRandomPrimer();
+                    m.SendLocalizedMessage(1156209); // You have received a mastery primer!
+
+                    GivePowerScrollTo(m, p, this);
+                }
             }
 
-            for (int i = 0; i < ChampionSystem.PowerScrollAmount; ++i)
-            {
-                Mobile m = toGive[i % toGive.Count];
-
-                SkillMasteryPrimer p = CreateRandomPrimer();
-                m.SendLocalizedMessage(1156209); // You have received a mastery primer!
-
-                GivePowerScrollTo(m, p, this);
-            }
+            ColUtility.Free(toGive);
         }
 
         public override bool OnBeforeDeath()

--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -38,6 +38,8 @@ namespace Server.Mobiles
         public static int BuyItemChange = Config.Get("Vendors.BuyItemChange", 1000);
         public static int SellItemChange = Config.Get("Vendors.SellItemChange", 1000);
         public static int EconomyStockAmount = Config.Get("Vendors.EconomyStockAmount", 500);
+        public static TimeSpan DelayRestock = TimeSpan.FromMinutes(Config.Get("Vendors.RestockDelay", 60));
+        public static int MaxSell = Config.Get("Vendors.MaxSell", 500);
 
 		public static List<BaseVendor> AllVendors { get; private set; }
 
@@ -45,8 +47,6 @@ namespace Server.Mobiles
 		{
 			AllVendors = new List<BaseVendor>(0x4000);
 		}
-
-		private const int MaxSell = 500;
 
 		protected abstract List<SBInfo> SBInfos { get; }
 
@@ -341,7 +341,7 @@ namespace Server.Mobiles
 
 		public DateTime LastRestock { get { return m_LastRestock; } set { m_LastRestock = value; } }
 
-		public virtual TimeSpan RestockDelay { get { return TimeSpan.FromHours(1); } }
+        public virtual TimeSpan RestockDelay { get { return DelayRestock; } }
 
 		public Container BuyPack
 		{

--- a/Scripts/Mobiles/NPCs/ThiefGuildmaster.cs
+++ b/Scripts/Mobiles/NPCs/ThiefGuildmaster.cs
@@ -39,7 +39,7 @@ namespace Server.Mobiles
                 return Siege.SiegeShard ? TimeSpan.FromDays(0.0) : TimeSpan.FromDays(7.0);
             }
         }
-        public virtual TimeSpan JoinGameAge
+        public override TimeSpan JoinGameAge
         {
             get
             {

--- a/Scripts/Mobiles/NPCs/ThiefGuildmaster.cs
+++ b/Scripts/Mobiles/NPCs/ThiefGuildmaster.cs
@@ -39,6 +39,13 @@ namespace Server.Mobiles
                 return Siege.SiegeShard ? TimeSpan.FromDays(0.0) : TimeSpan.FromDays(7.0);
             }
         }
+        public virtual TimeSpan JoinGameAge
+        {
+            get
+            {
+                return Siege.SiegeShard ? TimeSpan.FromDays(0.0) : TimeSpan.FromDays(2.0);
+            }
+        }
         public override void InitOutfit()
         {
             base.InitOutfit();
@@ -61,7 +68,7 @@ namespace Server.Mobiles
                 this.SayTo(pm, 501050); // This guild is for cunning thieves, not oafish cutthroats.
                 return false;
             }
-            else if (pm.Skills[SkillName.Stealing].Base < 60.0)
+            else if (pm.Skills[SkillName.Stealing].Base < 60.0 && !Siege.SiegeShard)
             {
                 this.SayTo(pm, 501051); // You must be at least a journeyman pickpocket to join this elite organization.
                 return false;

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -4188,7 +4188,7 @@ namespace Server.Mobiles
             }
         }
 
-        public override void DoHarmful(IDamageable damageable, bool indirect)
+        /*public override void DoHarmful(IDamageable damageable, bool indirect)
         {
             base.DoHarmful(damageable, indirect);
 
@@ -4234,7 +4234,7 @@ namespace Server.Mobiles
                     return;
                 }
             }
-        }
+        }*/
 
         private static Mobile m_NoDupeGuards;
 

--- a/Scripts/Mobiles/Normal/Kraken.cs
+++ b/Scripts/Mobiles/Normal/Kraken.cs
@@ -48,9 +48,6 @@ namespace Server.Mobiles
             this.CanSwim = true;
             this.CantWalk = true;
 
-            if(.1 >= Utility.RandomDouble())
-                this.PackItem(new MessageInABottle());
-
             //Rope is supposed to be a rare drop.  ref UO Guide Kraken
             if (Utility.RandomDouble() < .05)
             {
@@ -58,6 +55,24 @@ namespace Server.Mobiles
                 rope.ItemID = 0x14F8;
                 this.PackItem(rope);
             }                       
+        }
+
+        public override void OnDeath(Container c)
+        {
+            if (CheckLocation() && .1 >= Utility.RandomDouble())
+                c.DropItem(new MessageInABottle());
+
+            base.OnDeath(c);
+        }
+
+        private bool CheckLocation()
+        {
+            Region r = this.Region;
+
+            if (r is Server.Regions.DungeonRegion || Server.Spells.SpellHelper.IsFeluccaWind(Map, Location) || Server.Spells.SpellHelper.IsTrammelWind(Map, Location))
+                return false;
+
+            return true;
         }
 
         public Kraken(Serial serial)

--- a/Scripts/Mobiles/Normal/OrcCaptain.cs
+++ b/Scripts/Mobiles/Normal/OrcCaptain.cs
@@ -73,6 +73,17 @@ namespace Server.Mobiles
                 PackItem(new Yeast());
         }
 
+        public override void OnDeath(Container c)
+        {
+            if (Core.ML)
+            {
+                if (Utility.RandomDouble() < 0.05)
+                    c.DropItem(new StoutWhip());
+            }
+
+            base.OnDeath(c);
+        }
+
         public OrcCaptain(Serial serial)
             : base(serial)
         {

--- a/Scripts/Mobiles/Normal/OrcChopper.cs
+++ b/Scripts/Mobiles/Normal/OrcChopper.cs
@@ -132,12 +132,6 @@ namespace Server.Mobiles
 
             c.DropItem(new DoubleAxe());
 
-            if (Core.ML)
-            {
-                if (Utility.RandomDouble() < 0.05)
-                    c.DropItem(new StoutWhip());
-            }
-
             if (Utility.RandomDouble() < 0.1)
                 c.DropItem(new EvilOrcHelm());
         }

--- a/Scripts/Services/ChampionSystem/ChampionSpawn.cs
+++ b/Scripts/Services/ChampionSystem/ChampionSpawn.cs
@@ -302,6 +302,25 @@ namespace Server.Engines.CannedEvil
             }
         }
 
+        private void RemoveSkulls()
+        {
+            if (m_WhiteSkulls != null)
+            {
+                for (int i = 0; i < m_WhiteSkulls.Count; ++i)
+                    m_WhiteSkulls[i].Delete();
+
+                m_WhiteSkulls.Clear();
+            }
+
+            if (m_RedSkulls != null)
+            {
+                for (int i = 0; i < m_RedSkulls.Count; i++)
+                    m_RedSkulls[i].Delete();
+
+                m_RedSkulls.Clear();
+            }
+        }
+
         public int MaxKills
         {
             get
@@ -371,6 +390,19 @@ namespace Server.Engines.CannedEvil
                 m_Platform.Hue = 0x452;
 
             PrimevalLichPuzzle.Update(this);
+
+            double chance = Utility.RandomDouble();
+
+            if (chance < 0.1)
+                Level = 4;
+            else if (chance < 0.25)
+                Level = 3;
+            else if (chance < 0.5)
+                Level = 2;
+            else if (Utility.RandomBool())
+                Level = 1;
+            else
+                Level = 0;
         }
 
         public void Stop()
@@ -407,6 +439,9 @@ namespace Server.Engines.CannedEvil
                 m_Platform.Hue = 0x497;
 
             PrimevalLichPuzzle.Update(this);
+
+            RemoveSkulls();
+            m_Kills = 0;
         }
 
         public void BeginRestart(TimeSpan ts)
@@ -1090,21 +1125,7 @@ namespace Server.Engines.CannedEvil
             if (m_Idol != null)
                 m_Idol.Delete();
 
-            if (m_RedSkulls != null)
-            {
-                for (int i = 0; i < m_RedSkulls.Count; ++i)
-                    m_RedSkulls[i].Delete();
-
-                m_RedSkulls.Clear();
-            }
-
-            if (m_WhiteSkulls != null)
-            {
-                for (int i = 0; i < m_WhiteSkulls.Count; ++i)
-                    m_WhiteSkulls[i].Delete();
-
-                m_WhiteSkulls.Clear();
-            }
+            RemoveSkulls();
 
             if (m_Creatures != null)
             {

--- a/Scripts/Services/Craft/Core/CraftGump.cs
+++ b/Scripts/Services/Craft/Core/CraftGump.cs
@@ -465,6 +465,12 @@ namespace Server.Engines.Craft
 
         public void CraftItem(CraftItem item)
         {
+            if (item.TryCraft != null)
+            {
+                item.TryCraft(m_From, item, m_Tool);
+                return;
+            }
+
             int num = this.m_CraftSystem.CanCraft(this.m_From, this.m_Tool, item.ItemType);
 
             if (num > 0)

--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -40,6 +40,11 @@ namespace Server.Engines.Craft
 
 	public class CraftItem
 	{
+        /*this delegate will handle all crafting functions, 
+         * such as resource check, actual crafting, etc. 
+         * For use for abnormal crafting, ie combine cloth, etc.*/
+        public Action<Mobile, CraftItem, BaseTool> TryCraft { get; set; }
+
 		private readonly CraftResCol m_arCraftRes;
 		private readonly CraftSkillCol m_arCraftSkill;
 		private readonly Type m_Type;

--- a/Scripts/Services/Craft/Core/CraftSystem.cs
+++ b/Scripts/Services/Craft/Core/CraftSystem.cs
@@ -36,21 +36,21 @@ namespace Server.Engines.Craft
         {
             get
             {
-                return this.m_MinCraftEffect;
+                return m_MinCraftEffect;
             }
         }
         public int MaxCraftEffect
         {
             get
             {
-                return this.m_MaxCraftEffect;
+                return m_MaxCraftEffect;
             }
         }
         public double Delay
         {
             get
             {
-                return this.m_Delay;
+                return m_Delay;
             }
         }
 
@@ -58,28 +58,28 @@ namespace Server.Engines.Craft
         {
             get
             {
-                return this.m_CraftItems;
+                return m_CraftItems;
             }
         }
         public CraftGroupCol CraftGroups
         {
             get
             {
-                return this.m_CraftGroups;
+                return m_CraftGroups;
             }
         }
         public CraftSubResCol CraftSubRes
         {
             get
             {
-                return this.m_CraftSubRes;
+                return m_CraftSubRes;
             }
         }
         public CraftSubResCol CraftSubRes2
         {
             get
             {
-                return this.m_CraftSubRes2;
+                return m_CraftSubRes2;
             }
         }
 		
@@ -132,22 +132,22 @@ namespace Server.Engines.Craft
 
             if (m.Deleted)
             {
-                this.m_ContextTable.Remove(m);
+                m_ContextTable.Remove(m);
                 return null;
             }
 
             CraftContext c = null;
-            this.m_ContextTable.TryGetValue(m, out c);
+            m_ContextTable.TryGetValue(m, out c);
 
             if (c == null)
-                this.m_ContextTable[m] = c = new CraftContext(m, this);
+                m_ContextTable[m] = c = new CraftContext(m, this);
 
             return c;
         }
 
         public void OnMade(Mobile m, CraftItem item)
         {
-            CraftContext c = this.GetContext(m);
+            CraftContext c = GetContext(m);
 
             if (c != null)
                 c.OnMade(item);
@@ -157,11 +157,11 @@ namespace Server.Engines.Craft
         {
             get
             {
-                return this.m_Resmelt;
+                return m_Resmelt;
             }
             set
             {
-                this.m_Resmelt = value;
+                m_Resmelt = value;
             }
         }
 
@@ -169,11 +169,11 @@ namespace Server.Engines.Craft
         {
             get
             {
-                return this.m_Repair;
+                return m_Repair;
             }
             set
             {
-                this.m_Repair = value;
+                m_Repair = value;
             }
         }
 
@@ -181,11 +181,11 @@ namespace Server.Engines.Craft
         {
             get
             {
-                return this.m_MarkOption;
+                return m_MarkOption;
             }
             set
             {
-                this.m_MarkOption = value;
+                m_MarkOption = value;
             }
         }
 
@@ -193,11 +193,11 @@ namespace Server.Engines.Craft
         {
             get
             {
-                return this.m_CanEnhance;
+                return m_CanEnhance;
             }
             set
             {
-                this.m_CanEnhance = value;
+                m_CanEnhance = value;
             }
         }
 		
@@ -206,11 +206,11 @@ namespace Server.Engines.Craft
         {
             get
             {
-                return this.m_QuestOption;
+                return m_QuestOption;
             }
             set
             {
-                this.m_QuestOption = value;
+                m_QuestOption = value;
             }
         }
 		
@@ -218,27 +218,27 @@ namespace Server.Engines.Craft
         {
             get
             {
-                return this.m_CanAlter;
+                return m_CanAlter;
             }
             set
             {
-                this.m_CanAlter = value;
+                m_CanAlter = value;
             }
         }
         #endregion
 
         public CraftSystem(int minCraftEffect, int maxCraftEffect, double delay)
         {
-            this.m_MinCraftEffect = minCraftEffect;
-            this.m_MaxCraftEffect = maxCraftEffect;
-            this.m_Delay = delay;
+            m_MinCraftEffect = minCraftEffect;
+            m_MaxCraftEffect = maxCraftEffect;
+            m_Delay = delay;
 
-            this.m_CraftItems = new CraftItemCol();
-            this.m_CraftGroups = new CraftGroupCol();
-            this.m_CraftSubRes = new CraftSubResCol();
-            this.m_CraftSubRes2 = new CraftSubResCol();
+            m_CraftItems = new CraftItemCol();
+            m_CraftGroups = new CraftGroupCol();
+            m_CraftSubRes = new CraftSubResCol();
+            m_CraftSubRes2 = new CraftSubResCol();
 
-            this.InitCraftList();
+            InitCraftList();
             AddSystem(this);
         }
 
@@ -277,7 +277,7 @@ namespace Server.Engines.Craft
         public void CreateItem(Mobile from, Type type, Type typeRes, BaseTool tool, CraftItem realCraftItem)
         { 
             // Verify if the type is in the list of the craftable item
-            CraftItem craftItem = this.m_CraftItems.SearchFor(type);
+            CraftItem craftItem = m_CraftItems.SearchFor(type);
             if (craftItem != null)
             {
                 // The item is in the list, try to create it
@@ -289,17 +289,17 @@ namespace Server.Engines.Craft
 
         public int AddCraft(Type typeItem, TextDefinition group, TextDefinition name, double minSkill, double maxSkill, Type typeRes, TextDefinition nameRes, int amount)
         {
-            return this.AddCraft(typeItem, group, name, this.MainSkill, minSkill, maxSkill, typeRes, nameRes, amount, "");
+            return AddCraft(typeItem, group, name, MainSkill, minSkill, maxSkill, typeRes, nameRes, amount, "");
         }
 
         public int AddCraft(Type typeItem, TextDefinition group, TextDefinition name, double minSkill, double maxSkill, Type typeRes, TextDefinition nameRes, int amount, TextDefinition message)
         {
-            return this.AddCraft(typeItem, group, name, this.MainSkill, minSkill, maxSkill, typeRes, nameRes, amount, message);
+            return AddCraft(typeItem, group, name, MainSkill, minSkill, maxSkill, typeRes, nameRes, amount, message);
         }
 
         public int AddCraft(Type typeItem, TextDefinition group, TextDefinition name, SkillName skillToMake, double minSkill, double maxSkill, Type typeRes, TextDefinition nameRes, int amount)
         {
-            return this.AddCraft(typeItem, group, name, skillToMake, minSkill, maxSkill, typeRes, nameRes, amount, "");
+            return AddCraft(typeItem, group, name, skillToMake, minSkill, maxSkill, typeRes, nameRes, amount, "");
         }
 
         public int AddCraft(Type typeItem, TextDefinition group, TextDefinition name, SkillName skillToMake, double minSkill, double maxSkill, Type typeRes, TextDefinition nameRes, int amount, TextDefinition message)
@@ -308,90 +308,89 @@ namespace Server.Engines.Craft
             craftItem.AddRes(typeRes, nameRes, amount, message);
             craftItem.AddSkill(skillToMake, minSkill, maxSkill);
 
-            this.DoGroup(group, craftItem);
-            return this.m_CraftItems.Add(craftItem);
+            DoGroup(group, craftItem);
+            return m_CraftItems.Add(craftItem);
         }
 
         private void DoGroup(TextDefinition groupName, CraftItem craftItem)
         {
-            int index = this.m_CraftGroups.SearchFor(groupName);
+            int index = m_CraftGroups.SearchFor(groupName);
 
             if (index == -1)
             {
                 CraftGroup craftGroup = new CraftGroup(groupName);
                 craftGroup.AddCraftItem(craftItem);
-                this.m_CraftGroups.Add(craftGroup);
+                m_CraftGroups.Add(craftGroup);
             }
             else
             {
-                this.m_CraftGroups.GetAt(index).AddCraftItem(craftItem);
+                m_CraftGroups.GetAt(index).AddCraftItem(craftItem);
             }
         }
 
         public void SetItemHue(int index, int hue)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.ItemHue = hue;
         }
 
         public void SetManaReq(int index, int mana)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.Mana = mana;
         }
 
         public void SetStamReq(int index, int stam)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.Stam = stam;
         }
 
         public void SetHitsReq(int index, int hits)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.Hits = hits;
         }
 		
         public void SetUseAllRes(int index, bool useAll)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.UseAllRes = useAll;
         }
 
 		public void SetForceTypeRes(int index, bool value)
 		{
-			CraftItem craftItem = this.m_CraftItems.GetAt(index);
+			CraftItem craftItem = m_CraftItems.GetAt(index);
 			craftItem.ForceTypeRes = value;
 		}
 
-
 		public void SetNeedHeat(int index, bool needHeat)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.NeedHeat = needHeat;
         }
 
         public void SetNeedOven(int index, bool needOven)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.NeedOven = needOven;
         }
 
         public void SetBeverageType(int index, BeverageType requiredBeverage)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.RequiredBeverage = requiredBeverage;
         }
 
         public void SetNeedMill(int index, bool needMill)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.NeedMill = needMill;
         }
 
         public void SetNeededExpansion(int index, Expansion expansion)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.RequiredExpansion = expansion;
         }
 
@@ -431,113 +430,119 @@ namespace Server.Engines.Craft
 
         public void AddRes(int index, Type type, TextDefinition name, int amount)
         {
-            this.AddRes(index, type, name, amount, "");
+            AddRes(index, type, name, amount, "");
         }
 
         public void AddRes(int index, Type type, TextDefinition name, int amount, TextDefinition message)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.AddRes(type, name, amount, message);
         }
 
         public void AddResCallback(int index, Func<Mobile, ConsumeType, int> func)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.ConsumeResCallback = func;
         }
 
         public void AddSkill(int index, SkillName skillToMake, double minSkill, double maxSkill)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.AddSkill(skillToMake, minSkill, maxSkill);
         }
 
         public void SetUseSubRes2(int index, bool val)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.UseSubRes2 = val;
         }
 
         public void AddRecipe(int index, int id)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.AddRecipe(id, this);
         }
 
         public void ForceNonExceptional(int index)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.ForceNonExceptional = true;
         }
 
         public void SetMinSkillOffset(int index, double skillOffset)
         {
-            CraftItem craftItem = this.m_CraftItems.GetAt(index);
+            CraftItem craftItem = m_CraftItems.GetAt(index);
             craftItem.MinSkillOffset = skillOffset;
+        }
+
+        public void AddCraftAction(int index, Action<Mobile, CraftItem, BaseTool> action)
+        {
+            CraftItem craftItem = m_CraftItems.GetAt(index);
+            craftItem.TryCraft = action;
         }
 
         public void SetSubRes(Type type, string name)
         {
-            this.m_CraftSubRes.ResType = type;
-            this.m_CraftSubRes.NameString = name;
-            this.m_CraftSubRes.Init = true;
+            m_CraftSubRes.ResType = type;
+            m_CraftSubRes.NameString = name;
+            m_CraftSubRes.Init = true;
         }
 
         public void SetSubRes(Type type, int name)
         {
-            this.m_CraftSubRes.ResType = type;
-            this.m_CraftSubRes.NameNumber = name;
-            this.m_CraftSubRes.Init = true;
+            m_CraftSubRes.ResType = type;
+            m_CraftSubRes.NameNumber = name;
+            m_CraftSubRes.Init = true;
         }
 
         public void AddSubRes(Type type, int name, double reqSkill, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, message);
-            this.m_CraftSubRes.Add(craftSubRes);
+            m_CraftSubRes.Add(craftSubRes);
         }
 
         public void AddSubRes(Type type, int name, double reqSkill, int genericName, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, genericName, message);
-            this.m_CraftSubRes.Add(craftSubRes);
+            m_CraftSubRes.Add(craftSubRes);
         }
 
         public void AddSubRes(Type type, string name, double reqSkill, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, message);
-            this.m_CraftSubRes.Add(craftSubRes);
+            m_CraftSubRes.Add(craftSubRes);
         }
 
         public void SetSubRes2(Type type, string name)
         {
-            this.m_CraftSubRes2.ResType = type;
-            this.m_CraftSubRes2.NameString = name;
-            this.m_CraftSubRes2.Init = true;
+            m_CraftSubRes2.ResType = type;
+            m_CraftSubRes2.NameString = name;
+            m_CraftSubRes2.Init = true;
         }
 
         public void SetSubRes2(Type type, int name)
         {
-            this.m_CraftSubRes2.ResType = type;
-            this.m_CraftSubRes2.NameNumber = name;
-            this.m_CraftSubRes2.Init = true;
+            m_CraftSubRes2.ResType = type;
+            m_CraftSubRes2.NameNumber = name;
+            m_CraftSubRes2.Init = true;
         }
 
         public void AddSubRes2(Type type, int name, double reqSkill, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, message);
-            this.m_CraftSubRes2.Add(craftSubRes);
+            m_CraftSubRes2.Add(craftSubRes);
         }
 
         public void AddSubRes2(Type type, int name, double reqSkill, int genericName, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, genericName, message);
-            this.m_CraftSubRes2.Add(craftSubRes);
+            m_CraftSubRes2.Add(craftSubRes);
         }
 
         public void AddSubRes2(Type type, string name, double reqSkill, object message)
         {
             CraftSubRes craftSubRes = new CraftSubRes(type, name, reqSkill, message);
-            this.m_CraftSubRes2.Add(craftSubRes);
+            m_CraftSubRes2.Add(craftSubRes);
         }
 
         public abstract void InitCraftList();

--- a/Scripts/Services/Harvest/HarvestSystem.cs
+++ b/Scripts/Services/Harvest/HarvestSystem.cs
@@ -221,28 +221,28 @@ namespace Server.Engines.Harvest
 								}
 							}
                         }
-
-                        // Siege rules will take into account axes and polearms used for lumberjacking
-                        if (tool is IUsesRemaining && (tool is BaseHarvestTool || tool is Pickaxe || tool is SturdyPickaxe || tool is GargoylesPickaxe || Siege.SiegeShard))
-                        {
-                            IUsesRemaining toolWithUses = (IUsesRemaining)tool;
-
-                            toolWithUses.ShowUsesRemaining = true;
-
-                            if (toolWithUses.UsesRemaining > 0)
-                                --toolWithUses.UsesRemaining;
-
-                            if (toolWithUses.UsesRemaining < 1)
-                            {
-                                tool.Delete();
-                                def.SendMessageTo(from, def.ToolBrokeMessage);
-                            }
-                        }
                     }
 
                     #region High Seas
                     OnToolUsed(from, tool, item != null);
                     #endregion
+                }
+
+                // Siege rules will take into account axes and polearms used for lumberjacking
+                if (tool is IUsesRemaining && (tool is BaseHarvestTool || tool is Pickaxe || tool is SturdyPickaxe || tool is GargoylesPickaxe || Siege.SiegeShard))
+                {
+                    IUsesRemaining toolWithUses = (IUsesRemaining)tool;
+
+                    toolWithUses.ShowUsesRemaining = true;
+
+                    if (toolWithUses.UsesRemaining > 0)
+                        --toolWithUses.UsesRemaining;
+
+                    if (toolWithUses.UsesRemaining < 1)
+                    {
+                        tool.Delete();
+                        def.SendMessageTo(from, def.ToolBrokeMessage);
+                    }
                 }
             }
 

--- a/Scripts/Services/Peerless/BasePeerless.cs
+++ b/Scripts/Services/Peerless/BasePeerless.cs
@@ -23,7 +23,7 @@ namespace Server.Mobiles
         }
 
 		public override bool CanBeParagon { get { return false; } }
-        public virtual bool DropPrimer { get { return true; } }
+        public virtual bool DropPrimer { get { return Core.TOL; } }
 
         public override bool Unprovokable
         {

--- a/Scripts/Services/Vendor Searching/VendorSearchGump.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearchGump.cs
@@ -509,51 +509,17 @@ namespace Server.Engines.VendorSearhing
             {
                 default: break;
                 case 1:
-                    if (VendorMap.SetLocation != Point3D.Zero)
-                    {
-                        User.Frozen = true;
-
-                        DoRecall(VendorMap.SetLocation, VendorMap.SetMap);
-                        User.PublicOverheadMessage(MessageType.Spell, User.SpeechHue, true, "Kal Ort Por", false);
-                    }
-                    else if (!VendorMap.CheckVendor())
+                    if (!VendorMap.CheckVendor())
                     {
                         User.SendLocalizedMessage(1154643); // That item is no longer for sale.
                     }
-                    else if (Banker.Withdraw(User, Cost, true))
-                    {
-                        User.Frozen = true;
-
-                        VendorMap.SetLocation = User.Location;
-                        VendorMap.SetMap = User.Map;
-
-                        User.PublicOverheadMessage(MessageType.Spell, User.SpeechHue, true, "Kal Ort Por", false);
-                        DoRecall(VendorMap.GetVendorLocation(), VendorMap.GetVendorMap());
-                    }
                     else
-                        User.SendLocalizedMessage(1019022); // You do not have enough gold.
+                    {
+                        new Server.Spells.Fourth.RecallSpell(User, null, VendorMap).Cast();
+                    }
+
                     break;
             }
-        }
-
-        private void DoRecall(Point3D loc, Map map)
-        {
-            Timer.DelayCall(TimeSpan.FromSeconds(1.5), () =>
-            {
-                User.Frozen = false;
-
-                if (VendorMap.CheckVendor())
-                {
-                    User.PlaySound(0x1FC);
-                    User.MoveToWorld(loc, map);
-                    User.PlaySound(0x1FC);
-
-                    if (loc == VendorMap.SetLocation && !VendorMap.Deleted)
-                        VendorMap.Delete();
-                }
-                else
-                    User.SendLocalizedMessage(1154700); // Item no longer for sale.
-            });
         }
     }
 }

--- a/Scripts/Services/Vendor Searching/VendorSearchMap.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearchMap.cs
@@ -11,11 +11,19 @@ namespace Server.Items
 {
     public class VendorSearchMap : MapItem
     {
+        [CommandProperty(AccessLevel.GameMaster)]
         public PlayerVendor Vendor { get; set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
         public Item SearchItem { get; set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
         public Point3D SetLocation { get; set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
         public Map SetMap { get; set; }
 
+        [CommandProperty(AccessLevel.GameMaster)]
         public DateTime DeleteTime { get; set; }
 
         public int TimeRemaining { get { return DeleteTime <= DateTime.UtcNow ? 0 : (int)(DeleteTime - DateTime.UtcNow).TotalMinutes; } }
@@ -93,6 +101,19 @@ namespace Server.Items
             }
 
             return "Unknown";
+        }
+
+        public void OnBeforeTravel(Mobile from)
+        {
+            if (SetLocation != Point3D.Zero)
+            {
+                Delete();
+            }
+            else
+            {
+                SetLocation = from.Location;
+                SetMap = from.Map;
+            }
         }
 
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)

--- a/Scripts/Services/Virtues/Valor.cs
+++ b/Scripts/Services/Virtues/Valor.cs
@@ -58,6 +58,7 @@ namespace Server
             else
             {
                 VirtueLevel vl = VirtueHelper.GetLevel(from, VirtueName.Valor);
+
                 if (idol.Spawn.Active)
                 {
                     if (idol.Spawn.Champion != null)	//TODO: Message?
@@ -107,7 +108,7 @@ namespace Server
                         VirtueHelper.Atrophy(from, VirtueName.Valor, 11000);
                         from.SendLocalizedMessage(1054037); // Your challenge is heard by the Champion of this region! Beware its wrath!
                         idol.Spawn.EndRestart();
-                        idol.Spawn.HasBeenAdvanced = true;
+                        //idol.Spawn.HasBeenAdvanced = true;
                     }
                     else
                     {

--- a/Scripts/Skills/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Skills/Imbuing/Core/Imbuing.cs
@@ -430,11 +430,11 @@ namespace Server.SkillHandlers
 
                             switch (attr)
                             {
-                                case AosElementAttribute.Physical: arm.PhysicalBonus = value; arm.PhysImbuing = 0; break;
-                                case AosElementAttribute.Fire: arm.FireBonus = value; arm.FireImbuing = 0; break;
-                                case AosElementAttribute.Cold: arm.ColdBonus = value; arm.ColdImbuing = 0; break;
-                                case AosElementAttribute.Poison: arm.PoisonBonus = value; arm.PoisonImbuing = 0; break;
-                                case AosElementAttribute.Energy: arm.EnergyBonus = value; arm.EnergyImbuing = 0; break;
+                                case AosElementAttribute.Physical: arm.PhysicalBonus = value; arm.PhysNonImbuing = 0; break;
+                                case AosElementAttribute.Fire: arm.FireBonus = value; arm.FireNonImbuing = 0; break;
+                                case AosElementAttribute.Cold: arm.ColdBonus = value; arm.ColdNonImbuing = 0; break;
+                                case AosElementAttribute.Poison: arm.PoisonBonus = value; arm.PoisonNonImbuing = 0; break;
+                                case AosElementAttribute.Energy: arm.EnergyBonus = value; arm.EnergyNonImbuing = 0; break;
                             }
                         }
 
@@ -495,11 +495,11 @@ namespace Server.SkillHandlers
 
                             switch (attr)
                             {
-                                case AosElementAttribute.Physical: hat.Resistances.Physical = value; hat.PhysImbuing = 0; break;
-                                case AosElementAttribute.Fire: hat.Resistances.Fire = value; hat.FireImbuing = 0; break;
-                                case AosElementAttribute.Cold: hat.Resistances.Cold = value; hat.ColdImbuing = 0; break;
-                                case AosElementAttribute.Poison: hat.Resistances.Poison = value; hat.PoisonImbuing = 0; break;
-                                case AosElementAttribute.Energy: hat.Resistances.Energy = value; hat.EnergyImbuing = 0; break;
+                                case AosElementAttribute.Physical: hat.Resistances.Physical = value; hat.PhysNonImbuing = 0; break;
+                                case AosElementAttribute.Fire: hat.Resistances.Fire = value; hat.FireNonImbuing = 0; break;
+                                case AosElementAttribute.Cold: hat.Resistances.Cold = value; hat.ColdNonImbuing = 0; break;
+                                case AosElementAttribute.Poison: hat.Resistances.Poison = value; hat.PoisonNonImbuing = 0; break;
+                                case AosElementAttribute.Energy: hat.Resistances.Energy = value; hat.EnergyNonImbuing = 0; break;
                             }
                         }
                     }
@@ -708,6 +708,11 @@ namespace Server.SkillHandlers
                     return GetPropRange(item, attr)[1];
             }
 
+            if ((item is BaseArmor || item is BaseHat) && def.Attribute is AosElementAttribute)
+            {
+                return GetPropRange(item, (AosElementAttribute)def.Attribute)[1];
+            }
+
             return def.MaxIntensity;
         }
 
@@ -842,12 +847,12 @@ namespace Server.SkillHandlers
                     if (wep.Attributes[attr] > 0)
                     {
                         if (!(prop is AosAttribute) || ((AosAttribute)prop) != attr)
-                            total += 1;
+                            total++;
                     }
                     else if (wep.Attributes[attr] == 0 && attr == AosAttribute.CastSpeed && wep.Attributes[AosAttribute.SpellChanneling] > 0)
                     {
                         if(!(prop is AosAttribute) || (AosAttribute)prop != attr)
-                            total += 1;
+                            total++;
                     }
                 }
 
@@ -866,7 +871,7 @@ namespace Server.SkillHandlers
                             continue;
 
                         if (!(prop is AosWeaponAttribute) || ((AosWeaponAttribute)prop) != attr)
-                            total += 1;
+                            total++;
                     }
                 }
 
@@ -880,18 +885,18 @@ namespace Server.SkillHandlers
                     if (wep.ExtendedWeaponAttributes[attr] > 0)
                     {
                         if (!(prop is AosWeaponAttribute) || ((ExtendedWeaponAttribute)prop) != attr)
-                            total += 1;
+                            total++;
                     }
                 }
 
                 if (wep.Slayer != SlayerName.None && (!(prop is SlayerName) || ((SlayerName)prop) != wep.Slayer))
-                    total += 1;
+                    total++;
 
                 if (wep.Slayer2 != SlayerName.None)
-                    total += 1;
+                    total++;
 
                 if (wep.Slayer3 != TalismanSlayerName.None)
-                    total += 1;
+                    total++;
 
                 foreach (int i in Enum.GetValues(typeof(SAAbsorptionAttribute)))
                 {
@@ -903,7 +908,7 @@ namespace Server.SkillHandlers
                     if (wep.AbsorptionAttributes[attr] > 0)
                     {
                         if (!(prop is SAAbsorptionAttribute) || ((SAAbsorptionAttribute)prop) != attr)
-                            total += 1;
+                            total++;
                     }
                 }
 
@@ -932,22 +937,22 @@ namespace Server.SkillHandlers
                     if (armor.Attributes[attr] > 0)
                     {
                         if (!(prop is AosAttribute) || ((AosAttribute)prop) != attr)
-                            total += 1;
+                            total++;
                     }
                     else if (armor.Attributes[attr] == 0 && attr == AosAttribute.CastSpeed && armor.Attributes[AosAttribute.SpellChanneling] > 0)
                     {
                         if (!(prop is AosAttribute) || (AosAttribute)prop == attr)
-                            total += 1;
+                            total++;
                     }
                 }
 
                 total += GetSkillBonuses(armor.SkillBonuses, prop);
 
-                if (armor.PhysicalBonus > armor.PhysImbuing && mod != 51) { total += 1; }
-                if (armor.FireBonus > armor.FireImbuing && mod != 52) { total += 1; }
-                if (armor.ColdBonus > armor.ColdImbuing && mod != 53) { total += 1; }
-                if (armor.PoisonBonus > armor.PoisonImbuing && mod != 54) { total += 1; }
-                if (armor.EnergyBonus > armor.EnergyImbuing && mod != 55) { total += 1; }
+                if (armor.PhysicalBonus > armor.PhysNonImbuing && mod != 51) { total++; }
+                if (armor.FireBonus > armor.FireNonImbuing && mod != 52) { total++; }
+                if (armor.ColdBonus > armor.ColdNonImbuing && mod != 53) { total++; }
+                if (armor.PoisonBonus > armor.PoisonNonImbuing && mod != 54) { total++; }
+                if (armor.EnergyBonus > armor.EnergyNonImbuing && mod != 55) { total++; }
 
                 foreach (int i in Enum.GetValues(typeof(AosArmorAttribute)))
                 {
@@ -959,7 +964,7 @@ namespace Server.SkillHandlers
                     if (armor.ArmorAttributes[attr] > 0)
                     {
                         if (!(prop is AosArmorAttribute) || ((AosArmorAttribute)prop) != attr)
-                            total += 1;
+                            total++;
                     }
                 }
 
@@ -974,7 +979,7 @@ namespace Server.SkillHandlers
                     if (armor.AbsorptionAttributes[attr] > 0)
                     {
                         if (!(prop is SAAbsorptionAttribute) || ((SAAbsorptionAttribute)prop) != attr)
-                            total += 1;
+                            total++;
                     }
                 }
             }
@@ -992,7 +997,7 @@ namespace Server.SkillHandlers
                     if (j.Attributes[attr] > 0)
                     {
                         if (!(prop is AosAttribute) || ((AosAttribute)prop) != attr)
-                            total += 1;
+                            total++;
                     }
                 }
 
@@ -1006,17 +1011,17 @@ namespace Server.SkillHandlers
                     if (j.AbsorptionAttributes[attr] > 0)
                     {
                         if (!(prop is SAAbsorptionAttribute) || ((SAAbsorptionAttribute)prop) != attr)
-                            total += 1;
+                            total++;
                     }
                 }
 
                 total += GetSkillBonuses(j.SkillBonuses, prop);
 
-                if (j.Resistances.Physical > 0 && mod != 51) { total += 1; }
-                if (j.Resistances.Fire > 0 && mod != 52) { total += 1; }
-                if (j.Resistances.Cold > 0 && mod != 53) { total += 1; }
-                if (j.Resistances.Poison > 0 && mod != 54) { total += 1; }
-                if (j.Resistances.Energy > 0 && mod != 55) { total += 1; }
+                if (j.Resistances.Physical > 0 && mod != 51) { total++; }
+                if (j.Resistances.Fire > 0 && mod != 52) { total++; }
+                if (j.Resistances.Cold > 0 && mod != 53) { total++; }
+                if (j.Resistances.Poison > 0 && mod != 54) { total++; }
+                if (j.Resistances.Energy > 0 && mod != 55) { total++; }
             }
             else if (item is BaseHat)
             {
@@ -1032,7 +1037,7 @@ namespace Server.SkillHandlers
                     if (h.Attributes[attr] > 0)
                     {
                         if (!(prop is AosAttribute) || ((AosAttribute)prop) != attr)
-                            total += 1;
+                            total++;
                     }
                 }
 
@@ -1046,17 +1051,17 @@ namespace Server.SkillHandlers
                     if (h.SAAbsorptionAttributes[attr] > 0)
                     {
                         if (!(prop is SAAbsorptionAttribute) || ((SAAbsorptionAttribute)prop) != attr)
-                            total += 1;
+                            total++;
                     }
                 }
 
                 total += GetSkillBonuses(h.SkillBonuses, prop);
 
-                if (h.Resistances.Physical > h.PhysImbuing && mod != 51) { total += 1; }
-                if (h.Resistances.Fire > h.FireImbuing && mod != 52) { total += 1; }
-                if (h.Resistances.Cold > h.ColdImbuing && mod != 53) { total += 1; }
-                if (h.Resistances.Poison > h.PoisonImbuing && mod != 54) { total += 1; }
-                if (h.Resistances.Energy > h.EnergyImbuing && mod != 55) { total += 1; }
+                if (h.Resistances.Physical > h.PhysNonImbuing && mod != 51) { total++; }
+                if (h.Resistances.Fire > h.FireNonImbuing && mod != 52) { total++; }
+                if (h.Resistances.Cold > h.ColdNonImbuing && mod != 53) { total++; }
+                if (h.Resistances.Poison > h.PoisonNonImbuing && mod != 54) { total++; }
+                if (h.Resistances.Energy > h.EnergyNonImbuing && mod != 55) { total++; }
             }
 
             return total;
@@ -1154,7 +1159,7 @@ namespace Server.SkillHandlers
                 }
             }
             
-            if (item is BaseArmor)
+            if (item is BaseArmor && mod >= 51 && mod <= 55)
             {
                 weight += CheckResists((BaseArmor)item, mod);
             }
@@ -1215,23 +1220,24 @@ namespace Server.SkillHandlers
         private static int CheckResists(BaseArmor i, int mod)
         {
             double weight = 0;
+            int max = GetMaxIntensity(i, Imbuing.Table[mod]);
 
-            if (i.Quality != ItemQuality.Exceptional)
+            /*if (i.Quality != ItemQuality.Exceptional)
             {
-                if (i.PhysicalBonus > 0) { if (mod != 51) { weight += ((double)(100.0 / 15.0) * (double)i.PhysicalBonus); } }
-                if (i.FireBonus > 0) { if (mod != 52) { weight += ((double)(100.0 / 15.0) * (double)i.FireBonus); } }
-                if (i.ColdBonus > 0) { if (mod != 53) { weight += ((double)(100.0 / 15.0) * (double)i.ColdBonus); } }
-                if (i.PoisonBonus > 0) { if (mod != 54) { weight += ((double)(100.0 / 15.0) * (double)i.PoisonBonus); } }
-                if (i.EnergyBonus > 0) { if (mod != 55) { weight += ((double)(100.0 / 15.0) * (double)i.EnergyBonus); } }
+                if (i.PhysicalBonus > 0) { if (mod != 51) { weight += ((double)(100.0 / max) * (double)i.PhysicalBonus); } }
+                if (i.FireBonus > 0) { if (mod != 52) { weight += ((double)(100.0 / max) * (double)i.FireBonus); } }
+                if (i.ColdBonus > 0) { if (mod != 53) { weight += ((double)(100.0 / max) * (double)i.ColdBonus); } }
+                if (i.PoisonBonus > 0) { if (mod != 54) { weight += ((double)(100.0 / max) * (double)i.PoisonBonus); } }
+                if (i.EnergyBonus > 0) { if (mod != 55) { weight += ((double)(100.0 / max) * (double)i.EnergyBonus); } }
             }
             else if (i.Quality == ItemQuality.Exceptional)
-            {
-                if (i.PhysicalBonus > i.PhysImbuing) { if (mod != 51) { weight += ((double)(100.0 / 15.0) * (double)(i.PhysicalBonus - i.PhysImbuing)); } }
-                if (i.FireBonus > i.FireImbuing) { if (mod != 52) { weight += ((double)(100.0 / 15.0) * (double)(i.FireBonus - i.FireImbuing)); } }
-                if (i.ColdBonus > i.ColdImbuing) { if (mod != 53) { weight += ((double)(100.0 / 15.0) * (double)(i.ColdBonus - i.ColdImbuing)); } }
-                if (i.PoisonBonus > i.PoisonImbuing) { if (mod != 54) { weight += ((double)(100.0 / 15.0) * (double)(i.PoisonBonus - i.PoisonImbuing)); } }
-                if (i.EnergyBonus > i.EnergyImbuing) { if (mod != 55) { weight += ((double)(100.0 / 15.0) * (double)(i.EnergyBonus - i.EnergyImbuing)); } }
-            }
+            {*/
+                if (i.PhysicalBonus > i.PhysNonImbuing) { if (mod != 51) { weight += ((double)(100.0 / max) * (double)(i.PhysicalBonus - i.PhysNonImbuing)); } }
+                if (i.FireBonus > i.FireNonImbuing) { if (mod != 52) { weight += ((double)(100.0 / max) * (double)(i.FireBonus - i.FireNonImbuing)); } }
+                if (i.ColdBonus > i.ColdNonImbuing) { if (mod != 53) { weight += ((double)(100.0 / max) * (double)(i.ColdBonus - i.ColdNonImbuing)); } }
+                if (i.PoisonBonus > i.PoisonNonImbuing) { if (mod != 54) { weight += ((double)(100.0 / max) * (double)(i.PoisonBonus - i.PoisonNonImbuing)); } }
+                if (i.EnergyBonus > i.EnergyNonImbuing) { if (mod != 55) { weight += ((double)(100.0 / max) * (double)(i.EnergyBonus - i.EnergyNonImbuing)); } }
+            //}
 
             return (int)Math.Round(weight);
         }
@@ -1753,11 +1759,15 @@ namespace Server.SkillHandlers
                 BaseWeapon wep = item as BaseWeapon;
                 BaseJewel jewel = item as BaseJewel;
 
-                if (wep != null && attr is AosWeaponAttribute && (mod == 25 || mod == 27))
+                if (item is BaseWeapon && attr is AosWeaponAttribute && (mod == 25 || mod == 27))
                 {
-                    max = GetPropRange(wep, (AosWeaponAttribute)attr)[1];
+                    max = GetPropRange((BaseWeapon)item, (AosWeaponAttribute)attr)[1];
                 }
-                else if (jewel != null && attr is AosAttribute && (AosAttribute)attr == AosAttribute.WeaponDamage)
+                else if(item is BaseArmor && attr is AosElementAttribute)
+                {
+                    max = GetPropRange((BaseArmor)item, (AosElementAttribute)attr)[1];
+                }
+                else if (item is BaseJewel && attr is AosAttribute && (AosAttribute)attr == AosAttribute.WeaponDamage)
                 {
                     max = 25;
                 }
@@ -2104,6 +2114,28 @@ namespace Server.SkillHandlers
             return new int[] { 1, 15 };
         }
 
+        public static int[] GetPropRange(Item item, AosElementAttribute attr)
+        {
+            int index = GetArmorIndex(item);
+
+            if (index < 0 || index > _MaxResistArmorTable.Length) // Default Value
+                return new int[] { 1, 15 };
+
+            int attrIndex;
+
+            switch (attr)
+            {
+                default:
+                case AosElementAttribute.Physical: attrIndex = 0; break;
+                case AosElementAttribute.Fire: attrIndex = 1; break;
+                case AosElementAttribute.Cold: attrIndex = 2; break;
+                case AosElementAttribute.Poison: attrIndex = 3; break;
+                case AosElementAttribute.Energy: attrIndex = 4; break;
+            }
+
+            return new int[] { 1, _MaxResistArmorTable[index][attrIndex] };
+        }
+
         public static int[] GetPropRange(Item item, ExtendedWeaponAttribute attr)
         {
             switch (attr)
@@ -2115,6 +2147,78 @@ namespace Server.SkillHandlers
                 case ExtendedWeaponAttribute.HitSwarm: return new int[] { 1, 20 };
             }
         }
+
+        private static int GetArmorIndex(Item item)
+        {
+            if (item is BaseHat)
+                return 0;
+
+            BaseArmor armor = item as BaseArmor;
+
+            if (armor != null)
+            {
+                if (item.Layer == Layer.Helm)
+                    return 13;
+
+                if (armor.MaterialType == ArmorMaterialType.Dragon)
+                    return 12;
+
+                if (armor is GargishStoneKilt || armor is GargishStoneChest || armor is GargishStoneLegs || armor is GargishStoneArms || armor is GargishStoneAmulet)
+                    return 11;
+
+                if (armor is WoodlandGorget || armor is WoodlandLegs || armor is WoodlandGloves || armor is WoodlandChest || armor is WoodlandArms)
+                    return 10;
+
+                if (armor is HidePants || armor is HidePauldrons || armor is HideGorget || armor is HideFemaleChest || armor is HideGloves || armor is HideChest)
+                    return 9;
+
+                if (armor is LeafLegs || armor is LeafTonlet || armor is LeafGorget || armor is LeafGloves || armor is LeafArms || armor is LeafChest)
+                    return 8;
+
+                if (armor is PlateSuneate || armor is PlateMempo || armor is PlateHiroSode || armor is PlateHatsuburi || armor is PlateHaidate || armor is PlateDo || armor is PlateBattleKabuto)
+                    return 7;
+
+                if (armor.MaterialType == ArmorMaterialType.Plate)
+                    return 6;
+
+                if (armor.MaterialType == ArmorMaterialType.Chainmail)
+                    return 5;
+
+                if (armor.MaterialType == ArmorMaterialType.Ringmail)
+                    return 4;
+
+                if (armor.MaterialType == ArmorMaterialType.Bone)
+                    return 3;
+
+                if (armor.MaterialType == ArmorMaterialType.Leather || armor is StuddedMempo || armor is StuddedSuneate || armor is StuddedHiroSode ||
+                    armor is StuddedHaidate || armor is StuddedDo)
+                    return 2;
+
+                if (armor.MaterialType == ArmorMaterialType.Studded)
+                    return 1;
+            }
+
+            return -1; // Studded Armor
+        }
+
+        private static int[][] _MaxResistArmorTable = 
+        {
+            new int[] { 20, 22, 21, 21, 21 }, // cloth *hats
+            new int[] { 17, 19, 18, 18, 19 }, // studded leather
+            new int[] { 17, 19, 18, 18, 18 }, // leather & samurai studded leather
+            new int[] { 18, 18, 19, 17, 19 }, // bone
+            new int[] { 18, 18, 16, 20, 18 }, // ringmail
+            new int[] { 19, 19, 19, 16, 17 }, // chain
+            new int[] { 20, 18, 17, 18, 17 }, // platemail
+            new int[] { 20, 17, 17, 17, 19 }, // platemail/samurai
+            new int[] { 17, 18, 17, 19, 19 }, // leaf
+            new int[] { 18, 18, 19, 18, 17 }, // hide
+            new int[] { 20, 16, 17, 17, 20 }, // woodland
+            new int[] { 21, 21, 19, 23, 21 }, // stone
+            new int[] { 18, 18, 18, 18, 18 }, // dragon
+            new int[] { 22, 17, 17, 17, 17 }, // helmets
+
+        };
         #endregion
     }
 }        

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -1308,7 +1308,6 @@ namespace Server.Spells
                 SpiritualityVirtue.OnHeal(from, realAmount);
             }
 
-            //TODO: All Healing *spells* go through ArcaneEmpowerment
             target.Heal(amount, from, message);
         }
 

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -7462,8 +7462,11 @@ namespace Server
 
         public virtual void OnUpdateRangeChanged(int oldRange, int newRange)
         {
-            ClearScreen();
-            SendEverything();
+            if (oldRange != newRange)
+            {
+                ClearScreen();
+                SendEverything();
+            }
         }
 
 		[CommandProperty(AccessLevel.Counselor, AccessLevel.Decorator)]


### PR DESCRIPTION

- Vendors now use config property for restocking
- Fixed resistance caps for armor, per EA. Had to tweak the way resistances were added as resource bonuses to accommodate
- slightly reduced wear on weapons
- slightly increased wear on standard armor/jewels when hit by optimizing the way equipment is randomly choosen
- Blighted Grove keys now work near the dungeon entrance, per EA
- Added stout whip to Orc Captain and removed from Orc Chopper
- Redundant Remove/Incoming packets are no longer sent on login
- Added Vendor Search map support to recall spell to follow regular recall guidelines
- Champ Spawns now will can start with 0, 1, 2 , 3 or 4 red candles
- Champ spawns can now be bumped using Valor
- Tools will now decay uses on failed harvest, as oppopsed to successful harvest only.
- Removed time/skill restrictions to join thieves guild on siege shards
- Added era checks for primer drops