### PR TITLE
Bug fixes/Additions

### DIFF
--- a/Scripts/Items/Decorative/DecorativeVine.cs
+++ b/Scripts/Items/Decorative/DecorativeVine.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace Server.Items
+{
+    public class DecorativeVines : Item
+    {
+        [Constructable]
+        public DecorativeVines()
+            : this(Utility.Random(4))
+        {
+        }
+
+        [Constructable]
+        public DecorativeVines(int v)
+            : base(0x2CF9)
+        {
+            if (v < 0 || v > 3)
+                v = 0;
+
+            this.ItemID += v;
+            this.Weight = 1.0;
+        }
+
+        public DecorativeVines(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override bool ForceShowProperties
+        {
+            get
+            {
+                return ObjectPropertyList.Enabled;
+            }
+        }
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Decorative/Origami.cs
+++ b/Scripts/Items/Decorative/Origami.cs
@@ -22,9 +22,10 @@ namespace Server.Items
                 return 1030288;
             }
         }// origami paper
+
         public override void OnDoubleClick(Mobile from)
         {
-            if (!this.IsChildOf(from.Backpack))
+            if (!IsChildOf(from.Backpack))
             {
                 from.SendLocalizedMessage(1042001); // That must be in your pack for you to use it.
             }
@@ -34,26 +35,16 @@ namespace Server.Items
 
                 Item i = null;
 
-                switch ( Utility.Random((from.BAC >= 5) ? 6 : 5) )
+                switch (Utility.Random((from.BAC >= 7) ? 8 : 7)) //switch ( Utility.Random( (from.BAC >= 5) ? 6 : 5) )
                 {
-                    case 0:
-                        i = new OrigamiButterfly();
-                        break;
-                    case 1:
-                        i = new OrigamiSwan();
-                        break;
-                    case 2:
-                        i = new OrigamiFrog();
-                        break;
-                    case 3:
-                        i = new OrigamiShape();
-                        break;
-                    case 4:
-                        i = new OrigamiSongbird();
-                        break;
-                    case 5:
-                        i = new OrigamiFish();
-                        break;
+                    case 0: i = new OrigamiButterfly(); break;
+                    case 1: i = new OrigamiSwan(); break;
+                    case 2: i = new OrigamiFrog(); break;
+                    case 3: i = new OrigamiShape(); break;
+                    case 4: i = new OrigamiSongbird(); break;
+                    case 5: i = new OrigamiFish(); break;
+                    case 6: i = new OrigamiDragon(); break;
+                    case 7: i = new OrigamiBunny(); break;
                 }
 
                 if (i != null)
@@ -279,6 +270,74 @@ namespace Server.Items
                 return 1030301;
             }
         }// a delicate origami fish
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.WriteEncodedInt(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadEncodedInt();
+        }
+    }
+
+    public class OrigamiDragon : Item
+    {
+        //public override int LabelNumber{ get{ return 1030296; } } // a delicate origami butterfly
+
+        [Constructable]
+        public OrigamiDragon()
+            : base(0x4B1C)
+        {
+
+            Name = "a delicate origami dragon";
+            Weight = 1.0;
+            LootType = LootType.Blessed;
+        }
+
+        public OrigamiDragon(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.WriteEncodedInt(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadEncodedInt();
+        }
+    }
+
+    // [FlipableAttribute( 0x4B1E, 0x4B1F )]
+    public class OrigamiBunny : Item
+    {
+        //public override int LabelNumber{ get{ return 1030296; } } // a delicate origami butterfly
+
+        [Constructable]
+        public OrigamiBunny()
+            : base(0x4B1F)
+        {
+            Name = "a delicate origami bunny";
+            Weight = 1.0;
+            LootType = LootType.Blessed;
+        }
+
+        public OrigamiBunny(Serial serial)
+            : base(serial)
+        {
+        }
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/BaseArmor.cs
+++ b/Scripts/Items/Equipment/Armor/BaseArmor.cs
@@ -578,7 +578,7 @@ namespace Server.Items
 
             foreach (BaseArmor armor in from.Items.OfType<BaseArmor>())
             {
-                if (armor.ArmorAttributes.MageArmor > 1 || armor is WoodlandArms || armor is WoodlandChest || armor is WoodlandGloves || armor is WoodlandLegs || armor is WoodlandGorget || armor is BaseShield)
+                if (armor.ArmorAttributes.MageArmor > 0 || armor is WoodlandArms || armor is WoodlandChest || armor is WoodlandGloves || armor is WoodlandLegs || armor is WoodlandGorget || armor is BaseShield)
                     continue;
 
                 else if (armor.MaterialType == ArmorMaterialType.Studded || armor.MaterialType == ArmorMaterialType.Bone ||

--- a/Scripts/Items/Resource/RecallRune.cs
+++ b/Scripts/Items/Resource/RecallRune.cs
@@ -18,8 +18,8 @@ namespace Server.Items
         public RecallRune()
             : base(0x1F14)
         {
-            this.Weight = 1.0;
-            this.CalculateHue();
+            Weight = 1.0;
+            CalculateHue();
         }
 
         public RecallRune(Serial serial)
@@ -32,16 +32,16 @@ namespace Server.Items
         {
             get
             {
-                if (this.m_House != null && this.m_House.Deleted)
-                    this.House = null;
+                if (m_House != null && m_House.Deleted)
+                    House = null;
 
-                return this.m_House;
+                return m_House;
             }
             set
             {
-                this.m_House = value;
-                this.CalculateHue();
-                this.InvalidateProperties();
+                m_House = value;
+                CalculateHue();
+                InvalidateProperties();
             }
         }
         [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
@@ -49,12 +49,12 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Description;
+                return m_Description;
             }
             set
             {
-                this.m_Description = value;
-                this.InvalidateProperties();
+                m_Description = value;
+                InvalidateProperties();
             }
         }
         [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
@@ -62,15 +62,15 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Marked;
+                return m_Marked;
             }
             set
             {
-                if (this.m_Marked != value)
+                if (m_Marked != value)
                 {
-                    this.m_Marked = value;
-                    this.CalculateHue();
-                    this.InvalidateProperties();
+                    m_Marked = value;
+                    CalculateHue();
+                    InvalidateProperties();
                 }
             }
         }
@@ -79,11 +79,11 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Target;
+                return m_Target;
             }
             set
             {
-                this.m_Target = value;
+                m_Target = value;
             }
         }
         [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
@@ -91,15 +91,15 @@ namespace Server.Items
         {
             get
             {
-                return this.m_TargetMap;
+                return m_TargetMap;
             }
             set
             {
-                if (this.m_TargetMap != value)
+                if (m_TargetMap != value)
                 {
-                    this.m_TargetMap = value;
-                    this.CalculateHue();
-                    this.InvalidateProperties();
+                    m_TargetMap = value;
+                    CalculateHue();
+                    InvalidateProperties();
                 }
             }
         }
@@ -107,21 +107,21 @@ namespace Server.Items
         {
             base.Serialize(writer);
 
-            if (this.m_House != null && !this.m_House.Deleted)
+            if (m_House != null && !m_House.Deleted)
             {
                 writer.Write((int)1); // version
 
-                writer.Write((Item)this.m_House);
+                writer.Write((Item)m_House);
             }
             else
             {
                 writer.Write((int)0); // version
             }
 
-            writer.Write((string)this.m_Description);
-            writer.Write((bool)this.m_Marked);
-            writer.Write((Point3D)this.m_Target);
-            writer.Write((Map)this.m_TargetMap);
+            writer.Write((string)m_Description);
+            writer.Write((bool)m_Marked);
+            writer.Write((Point3D)m_Target);
+            writer.Write((Map)m_TargetMap);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -134,17 +134,17 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        this.m_House = reader.ReadItem() as BaseHouse;
+                        m_House = reader.ReadItem() as BaseHouse;
                         goto case 0;
                     }
                 case 0:
                     {
-                        this.m_Description = reader.ReadString();
-                        this.m_Marked = reader.ReadBool();
-                        this.m_Target = reader.ReadPoint3D();
-                        this.m_TargetMap = reader.ReadMap();
+                        m_Description = reader.ReadString();
+                        m_Marked = reader.ReadBool();
+                        m_Target = reader.ReadPoint3D();
+                        m_TargetMap = reader.ReadMap();
 
-                        this.CalculateHue();
+                        CalculateHue();
 
                         break;
                     }
@@ -153,106 +153,106 @@ namespace Server.Items
 
         public void Mark(Mobile m)
         {
-            this.m_Marked = true;
+            m_Marked = true;
 
             bool setDesc = false;
             if (Core.AOS)
             {
-                this.m_House = BaseHouse.FindHouseAt(m);
+                m_House = BaseHouse.FindHouseAt(m);
 
-                if (this.m_House == null)
+                if (m_House == null)
                 {
-                    this.m_Target = m.Location;
-                    this.m_TargetMap = m.Map;
+                    m_Target = m.Location;
+                    m_TargetMap = m.Map;
                 }
                 else
                 {
-                    HouseSign sign = this.m_House.Sign;
+                    HouseSign sign = m_House.Sign;
 
                     if (sign != null)
-                        this.m_Description = sign.Name;
+                        m_Description = sign.Name;
                     else
-                        this.m_Description = null;
+                        m_Description = null;
 
-                    if (this.m_Description == null || (this.m_Description = this.m_Description.Trim()).Length == 0)
-                        this.m_Description = "an unnamed house";
+                    if (m_Description == null || (m_Description = m_Description.Trim()).Length == 0)
+                        m_Description = "an unnamed house";
 
                     setDesc = true;
 
-                    int x = this.m_House.BanLocation.X;
-                    int y = this.m_House.BanLocation.Y + 2;
-                    int z = this.m_House.BanLocation.Z;
+                    int x = m_House.BanLocation.X;
+                    int y = m_House.BanLocation.Y + 2;
+                    int z = m_House.BanLocation.Z;
 
-                    Map map = this.m_House.Map;
+                    Map map = m_House.Map;
 
                     if (map != null && !map.CanFit(x, y, z, 16, false, false))
                         z = map.GetAverageZ(x, y);
 
-                    this.m_Target = new Point3D(x, y, z);
-                    this.m_TargetMap = map;
+                    m_Target = new Point3D(x, y, z);
+                    m_TargetMap = map;
                 }
             }
             else
             {
-                this.m_House = null;
-                this.m_Target = m.Location;
-                this.m_TargetMap = m.Map;
+                m_House = null;
+                m_Target = m.Location;
+                m_TargetMap = m.Map;
             }
 
             if (!setDesc)
-                this.m_Description = BaseRegion.GetRuneNameFor(Region.Find(this.m_Target, this.m_TargetMap));
+                m_Description = BaseRegion.GetRuneNameFor(Region.Find(m_Target, m_TargetMap));
 
-            this.CalculateHue();
-            this.InvalidateProperties();
+            CalculateHue();
+            InvalidateProperties();
         }
 
         public override void GetProperties(ObjectPropertyList list)
         {
             base.GetProperties(list);
 
-            if (this.m_Marked)
+            if (m_Marked)
             {
                 string desc;
 
-                if ((desc = this.m_Description) == null || (desc = desc.Trim()).Length == 0)
+                if ((desc = m_Description) == null || (desc = desc.Trim()).Length == 0)
                     desc = "an unknown location";
 
-                if (this.m_TargetMap == Map.Tokuno)
-                    list.Add((this.House != null ? 1063260 : 1063259), RuneFormat, desc); // ~1_val~ (Tokuno Islands)[(House)]
-                else if (this.m_TargetMap == Map.Malas)
-                    list.Add((this.House != null ? 1062454 : 1060804), RuneFormat, desc); // ~1_val~ (Malas)[(House)]
-                else if (this.m_TargetMap == Map.Felucca)
-                    list.Add((this.House != null ? 1062452 : 1060805), RuneFormat, desc); // ~1_val~ (Felucca)[(House)]
-                else if (this.m_TargetMap == Map.Trammel)
-                    list.Add((this.House != null ? 1062453 : 1060806), RuneFormat, desc); // ~1_val~ (Trammel)[(House)]
+                if (m_TargetMap == Map.Tokuno)
+                    list.Add((House != null ? 1063260 : 1063259), RuneFormat, desc); // ~1_val~ (Tokuno Islands)[(House)]
+                else if (m_TargetMap == Map.Malas)
+                    list.Add((House != null ? 1062454 : 1060804), RuneFormat, desc); // ~1_val~ (Malas)[(House)]
+                else if (m_TargetMap == Map.Felucca)
+                    list.Add((House != null ? 1062452 : 1060805), RuneFormat, desc); // ~1_val~ (Felucca)[(House)]
+                else if (m_TargetMap == Map.Trammel)
+                    list.Add((House != null ? 1062453 : 1060806), RuneFormat, desc); // ~1_val~ (Trammel)[(House)]
                 else
-                    list.Add((this.House != null ? "{0} ({1})(House)" : "{0} ({1})"), String.Format(RuneFormat, desc), this.m_TargetMap);
+                    list.Add((House != null ? "{0} ({1})(House)" : "{0} ({1})"), String.Format(RuneFormat, desc), m_TargetMap);
             }
         }
 
         public override void OnSingleClick(Mobile from)
         {
-            if (this.m_Marked)
+            if (m_Marked)
             {
                 string desc;
 
-                if ((desc = this.m_Description) == null || (desc = desc.Trim()).Length == 0)
+                if ((desc = m_Description) == null || (desc = desc.Trim()).Length == 0)
                     desc = "an unknown location";
 
-                if (this.m_TargetMap == Map.Tokuno)
-                    this.LabelTo(from, (this.House != null ? 1063260 : 1063259), String.Format(RuneFormat, desc)); // ~1_val~ (Tokuno Islands)[(House)]
-                else if (this.m_TargetMap == Map.Malas)
-                    this.LabelTo(from, (this.House != null ? 1062454 : 1060804), String.Format(RuneFormat, desc)); // ~1_val~ (Malas)[(House)]
-                else if (this.m_TargetMap == Map.Felucca)
-                    this.LabelTo(from, (this.House != null ? 1062452 : 1060805), String.Format(RuneFormat, desc)); // ~1_val~ (Felucca)[(House)]
-                else if (this.m_TargetMap == Map.Trammel)
-                    this.LabelTo(from, (this.House != null ? 1062453 : 1060806), String.Format(RuneFormat, desc)); // ~1_val~ (Trammel)[(House)]
+                if (m_TargetMap == Map.Tokuno)
+                    LabelTo(from, (House != null ? 1063260 : 1063259), String.Format(RuneFormat, desc)); // ~1_val~ (Tokuno Islands)[(House)]
+                else if (m_TargetMap == Map.Malas)
+                    LabelTo(from, (House != null ? 1062454 : 1060804), String.Format(RuneFormat, desc)); // ~1_val~ (Malas)[(House)]
+                else if (m_TargetMap == Map.Felucca)
+                    LabelTo(from, (House != null ? 1062452 : 1060805), String.Format(RuneFormat, desc)); // ~1_val~ (Felucca)[(House)]
+                else if (m_TargetMap == Map.Trammel)
+                    LabelTo(from, (House != null ? 1062453 : 1060806), String.Format(RuneFormat, desc)); // ~1_val~ (Trammel)[(House)]
                 else
-                    this.LabelTo(from, (this.House != null ? "{0} ({1})(House)" : "{0} ({1})"), String.Format(RuneFormat, desc), this.m_TargetMap);
+                    LabelTo(from, (House != null ? "{0} ({1})(House)" : "{0} ({1})"), String.Format(RuneFormat, desc), m_TargetMap);
             }
             else
             {
-                this.LabelTo(from, "an unmarked recall rune");
+                LabelTo(from, "an unmarked recall rune");
             }
         }
 
@@ -260,17 +260,17 @@ namespace Server.Items
         {
             int number;
 
-            if (!this.IsChildOf(from.Backpack))
+            if (!IsChildOf(from.Backpack))
             {
                 number = 1042001; // That must be in your pack for you to use it.
             }
-            else if (this.House != null)
+            else if (House != null)
             {
                 number = 1062399; // You cannot edit the description for this rune.
             }
-            else if (this.m_Marked)
+            else if (m_Marked)
             {
-                number = 501804; // Please enter a description for this marked object.
+                number = 0;
 
                 from.Prompt = new RenamePrompt(this);
             }
@@ -279,23 +279,24 @@ namespace Server.Items
                 number = 501805; // That rune is not yet marked.
             }
 
-            from.SendLocalizedMessage(number);
+            if(number > 0)
+                from.SendLocalizedMessage(number);
         }
 
         private void CalculateHue()
         {
-            if (!this.m_Marked)
-                this.Hue = 0;
-            else if (this.m_TargetMap == Map.Trammel)
-                this.Hue = (this.House != null ? 0x47F : 50);
-            else if (this.m_TargetMap == Map.Felucca)
-                this.Hue = (this.House != null ? 0x66D : 0);
-            else if (this.m_TargetMap == Map.Ilshenar)
-                this.Hue = (this.House != null ? 0x55F : 1102);
-            else if (this.m_TargetMap == Map.Malas)
-                this.Hue = (this.House != null ? 0x55F : 1102);
-            else if (this.m_TargetMap == Map.Tokuno)
-                this.Hue = (this.House != null ? 0x47F : 1154);
+            if (!m_Marked)
+                Hue = 0;
+            else if (m_TargetMap == Map.Trammel)
+                Hue = (House != null ? 0x47F : 50);
+            else if (m_TargetMap == Map.Felucca)
+                Hue = (House != null ? 0x66D : 0);
+            else if (m_TargetMap == Map.Ilshenar)
+                Hue = (House != null ? 0x55F : 1102);
+            else if (m_TargetMap == Map.Malas)
+                Hue = (House != null ? 0x55F : 1102);
+            else if (m_TargetMap == Map.Tokuno)
+                Hue = (House != null ? 0x47F : 1154);
         }
 
         private class RenamePrompt : Prompt
@@ -304,14 +305,14 @@ namespace Server.Items
             private readonly RecallRune m_Rune;
             public RenamePrompt(RecallRune rune)
             {
-                this.m_Rune = rune;
+                m_Rune = rune;
             }
 
             public override void OnResponse(Mobile from, string text)
             {
-                if (this.m_Rune.House == null && this.m_Rune.Marked)
+                if (m_Rune.House == null && m_Rune.Marked)
                 {
-                    this.m_Rune.Description = text;
+                    m_Rune.Description = text;
                     from.SendLocalizedMessage(1010474); // The etching on the rune has been changed.
                 }
             }

--- a/Scripts/Items/Tools/BagOfSending.cs
+++ b/Scripts/Items/Tools/BagOfSending.cs
@@ -28,11 +28,11 @@ namespace Server.Items
         public BagOfSending(BagOfSendingHue hue)
             : base(0xE76)
         {
-            this.Weight = 2.0;
+            Weight = 2.0;
 
-            this.BagOfSendingHue = hue;
+            BagOfSendingHue = hue;
 
-            this.m_Charges = Utility.RandomMinMax(3, 9);
+            m_Charges = Utility.RandomMinMax(3, 9);
         }
 
         public BagOfSending(Serial serial)
@@ -45,18 +45,18 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Charges;
+                return m_Charges;
             }
             set
             {
-                if (value > this.MaxCharges)
-                    this.m_Charges = this.MaxCharges;
+                if (value > MaxCharges)
+                    m_Charges = MaxCharges;
                 else if (value < 0)
-                    this.m_Charges = 0;
+                    m_Charges = 0;
                 else
-                    this.m_Charges = value;
+                    m_Charges = value;
 
-                this.InvalidateProperties();
+                InvalidateProperties();
             }
         }
         [CommandProperty(AccessLevel.GameMaster)]
@@ -64,18 +64,18 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Recharges;
+                return m_Recharges;
             }
             set
             {
-                if (value > this.MaxRecharges)
-                    this.m_Recharges = this.MaxRecharges;
+                if (value > MaxRecharges)
+                    m_Recharges = MaxRecharges;
                 else if (value < 0)
-                    this.m_Recharges = 0;
+                    m_Recharges = 0;
                 else
-                    this.m_Recharges = value;
+                    m_Recharges = value;
 
-                this.InvalidateProperties();
+                InvalidateProperties();
             }
         }
         [CommandProperty(AccessLevel.GameMaster)]
@@ -113,22 +113,22 @@ namespace Server.Items
         {
             get
             {
-                return this.m_BagOfSendingHue;
+                return m_BagOfSendingHue;
             }
             set
             {
-                this.m_BagOfSendingHue = value;
+                m_BagOfSendingHue = value;
 
                 switch ( value )
                 {
                     case BagOfSendingHue.Yellow:
-                        this.Hue = 0x8A5;
+                        Hue = 0x8A5;
                         break;
                     case BagOfSendingHue.Blue:
-                        this.Hue = 0x8AD;
+                        Hue = 0x8AD;
                         break;
                     case BagOfSendingHue.Red:
-                        this.Hue = 0x89B;
+                        Hue = 0x89B;
                         break;
                 }
             }
@@ -150,14 +150,14 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1060741, this.m_Charges.ToString()); // charges: ~1_val~
+            list.Add(1060741, m_Charges.ToString()); // charges: ~1_val~
         }
 
         public override void OnSingleClick(Mobile from)
         {
             base.OnSingleClick(from);
 
-            this.LabelTo(from, 1060741, this.m_Charges.ToString()); // charges: ~1_val~
+            LabelTo(from, 1060741, m_Charges.ToString()); // charges: ~1_val~
         }
 
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)
@@ -165,7 +165,7 @@ namespace Server.Items
             base.GetContextMenuEntries(from, list);
 
             if (from.Alive)
-                list.Add(new UseBagEntry(this, this.Charges > 0 && this.IsChildOf(from.Backpack)));
+                list.Add(new UseBagEntry(this, Charges > 0 && IsChildOf(from.Backpack)));
         }
 
         public override void OnDoubleClick(Mobile from)
@@ -174,11 +174,11 @@ namespace Server.Items
             {
                 from.SendMessage("You may not do that in jail.");
             }
-            else if (!this.IsChildOf(from.Backpack))
+            else if (!IsChildOf(from.Backpack))
             {
                 MessageHelper.SendLocalizedMessageTo(this, from, 1062334, 0x59); // The bag of sending must be in your backpack.
             }
-            else if (this.Charges == 0)
+            else if (Charges == 0)
             {
                 MessageHelper.SendLocalizedMessageTo(this, from, 1042544, 0x59); // This item is out of charges.
             }
@@ -194,10 +194,10 @@ namespace Server.Items
 
             writer.WriteEncodedInt((int)1); // version
 
-            writer.WriteEncodedInt((int)this.m_Recharges);
+            writer.WriteEncodedInt((int)m_Recharges);
 
-            writer.WriteEncodedInt((int)this.m_Charges);
-            writer.WriteEncodedInt((int)this.m_BagOfSendingHue);
+            writer.WriteEncodedInt((int)m_Charges);
+            writer.WriteEncodedInt((int)m_BagOfSendingHue);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -210,13 +210,13 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        this.m_Recharges = reader.ReadEncodedInt();
+                        m_Recharges = reader.ReadEncodedInt();
                         goto case 0;
                     }
                 case 0:
                     {
-                        this.m_Charges = Math.Min(reader.ReadEncodedInt(), this.MaxCharges);
-                        this.m_BagOfSendingHue = (BagOfSendingHue)reader.ReadEncodedInt();
+                        m_Charges = Math.Min(reader.ReadEncodedInt(), MaxCharges);
+                        m_BagOfSendingHue = (BagOfSendingHue)reader.ReadEncodedInt();
                         break;
                     }
             }
@@ -228,21 +228,21 @@ namespace Server.Items
             public UseBagEntry(BagOfSending bag, bool enabled)
                 : base(6189)
             {
-                this.m_Bag = bag;
+                m_Bag = bag;
 
                 if (!enabled)
-                    this.Flags |= CMEFlags.Disabled;
+                    Flags |= CMEFlags.Disabled;
             }
 
             public override void OnClick()
             {
-                if (this.m_Bag.Deleted)
+                if (m_Bag.Deleted)
                     return;
 
-                Mobile from = this.Owner.From;
+                Mobile from = Owner.From;
 
                 if (from.CheckAlive())
-                    this.m_Bag.OnDoubleClick(from);
+                    m_Bag.OnDoubleClick(from);
             }
         }
 
@@ -252,46 +252,47 @@ namespace Server.Items
             public SendTarget(BagOfSending bag)
                 : base(-1, false, TargetFlags.None)
             {
-                this.m_Bag = bag;
+                m_Bag = bag;
             }
 
             protected override void OnTarget(Mobile from, object targeted)
             {
-                if (this.m_Bag.Deleted)
+                if (m_Bag.Deleted)
                     return;
 
                 if (from.Region.IsPartOf<Regions.Jail>())
                 {
                     from.SendMessage("You may not do that in jail.");
                 }
-                else if (!this.m_Bag.IsChildOf(from.Backpack))
+                else if (!m_Bag.IsChildOf(from.Backpack))
                 {
-                    MessageHelper.SendLocalizedMessageTo(this.m_Bag, from, 1062334, 0x59); // The bag of sending must be in your backpack. 1054107 is gone from client, using generic response
+                    MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1062334, 0x59); // The bag of sending must be in your backpack. 1054107 is gone from client, using generic response
                 }
-                else if (this.m_Bag.Charges == 0)
+                else if (m_Bag.Charges == 0)
                 {
-                    MessageHelper.SendLocalizedMessageTo(this.m_Bag, from, 1042544, 0x59); // This item is out of charges.
+                    MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1042544, 0x59); // This item is out of charges.
                 }
                 else if (targeted is Item)
                 {
                     Item item = (Item)targeted;
-                    int reqCharges = (int)Math.Max(1, Math.Ceiling(item.TotalWeight / 10.0));
+                    int reqCharges = 1; // (int)Math.Max(1, Math.Ceiling(item.TotalWeight / 10.0));
+                                        // change was ML, however reverted during ML period so we can put it at 1
 
                     if (!item.IsChildOf(from.Backpack))
                     {
-                        MessageHelper.SendLocalizedMessageTo(this.m_Bag, from, 1054152, 0x59); // You may only send items from your backpack to your bank box.
+                        MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1054152, 0x59); // You may only send items from your backpack to your bank box.
                     }
                     else if (item is BagOfSending || item is Container)
                     {
-                        from.Send(new AsciiMessage(this.m_Bag.Serial, this.m_Bag.ItemID, MessageType.Regular, 0x3B2, 3, "", "You cannot send a container through the bag of sending."));
+                        from.Send(new AsciiMessage(m_Bag.Serial, m_Bag.ItemID, MessageType.Regular, 0x3B2, 3, "", "You cannot send a container through the bag of sending."));
                     }
                     else if (item.LootType == LootType.Cursed)
                     {
-                        MessageHelper.SendLocalizedMessageTo(this.m_Bag, from, 1054108, 0x59); // The bag of sending rejects the cursed item.
+                        MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1054108, 0x59); // The bag of sending rejects the cursed item.
                     }
                     else if (!item.VerifyMove(from) || item is Server.Engines.Quests.QuestItem)
                     {
-                        MessageHelper.SendLocalizedMessageTo(this.m_Bag, from, 1054109, 0x59); // The bag of sending rejects that item.
+                        MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1054109, 0x59); // The bag of sending rejects that item.
                     }
                     else if (Spells.SpellHelper.IsDoomGauntlet(from.Map, from.Location))
                     {
@@ -299,16 +300,16 @@ namespace Server.Items
                     }
                     else if (!from.BankBox.TryDropItem(from, item, false))
                     {
-                        MessageHelper.SendLocalizedMessageTo(this.m_Bag, from, 1054110, 0x59); // Your bank box is full.
+                        MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1054110, 0x59); // Your bank box is full.
                     }
-                    else if (Core.ML && reqCharges > this.m_Bag.Charges)
+                    else if (Core.ML && reqCharges > m_Bag.Charges)
                     {
                         from.SendLocalizedMessage(1079932); //You don't have enough charges to send that much weight
                     }
                     else
                     {
-                        this.m_Bag.Charges -= (Core.ML ? reqCharges : 1);
-                        MessageHelper.SendLocalizedMessageTo(this.m_Bag, from, 1054150, 0x59); // The item was placed in your bank box.
+                        m_Bag.Charges -= (Core.ML ? reqCharges : 1);
+                        MessageHelper.SendLocalizedMessageTo(m_Bag, from, 1054150, 0x59); // The item was placed in your bank box.
                     }
                 }
             }

--- a/Scripts/Misc/AttackMessage.cs
+++ b/Scripts/Misc/AttackMessage.cs
@@ -6,10 +6,13 @@ namespace Server.Misc
 {
     public class AttackMessage
     {
-        private static readonly TimeSpan Delay = TimeSpan.FromMinutes(1.0);
+        private static readonly TimeSpan Delay = TimeSpan.FromMinutes(2.0);
         private const string AggressorFormat = "You are attacking {0}!";
         private const string AggressedFormat = "{0} is attacking you!";
         private const int Hue = 0x22;
+
+        public static TimeSpan CombatHeatDelay { get { return Delay; } }
+
         public static void Initialize()
         {
             EventSink.AggressiveAction += new AggressiveActionEventHandler(EventSink_AggressiveAction);
@@ -29,8 +32,8 @@ namespace Server.Misc
                 aggressed.LocalOverheadMessage(MessageType.Regular, Hue, true, String.Format(AggressedFormat, aggressor.Name));
             }
 
-            BuffInfo.AddBuff(aggressor, new BuffInfo(BuffIcon.HeatOfBattleStatus, 1153801, 1153827, TimeSpan.FromMinutes(2), aggressor, true));
-            BuffInfo.AddBuff(aggressed, new BuffInfo(BuffIcon.HeatOfBattleStatus, 1153801, 1153827, TimeSpan.FromMinutes(2), aggressed, true));
+            BuffInfo.AddBuff(aggressor, new BuffInfo(BuffIcon.HeatOfBattleStatus, 1153801, 1153827, Delay, aggressor, true));
+            BuffInfo.AddBuff(aggressed, new BuffInfo(BuffIcon.HeatOfBattleStatus, 1153801, 1153827, Delay, aggressed, true));
         }
 
         public static bool CheckAggressions(Mobile m1, Mobile m2)

--- a/Scripts/Mobiles/Bosses/CrimsonDragon.cs
+++ b/Scripts/Mobiles/Bosses/CrimsonDragon.cs
@@ -76,13 +76,7 @@ namespace Server.Mobiles
                 return true;
             }
         }
-        public override bool GivesMLMinorArtifact
-        {
-            get
-            {
-                return true;
-            }
-        }
+
         public override bool ReacquireOnMovement
         {
             get

--- a/Scripts/Mobiles/Named/Flurry.cs
+++ b/Scripts/Mobiles/Named/Flurry.cs
@@ -49,6 +49,11 @@ namespace Server.Mobiles
             }
         }
 
+        public override bool GivesMLMinorArtifact
+        {
+            get { return true; }
+        }
+
         public Flurry(Serial serial)
             : base(serial)
         {

--- a/Scripts/Mobiles/Named/Gnaw.cs
+++ b/Scripts/Mobiles/Named/Gnaw.cs
@@ -1,3 +1,4 @@
+
 using System;
 using Server.Items;
 
@@ -59,13 +60,13 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool GivesMLMinorArtifact
+        /*public override bool GivesMLMinorArtifact
         {
             get
             {
                 return true;
             }
-        }
+        }*/
         public override int Hides
         {
             get

--- a/Scripts/Mobiles/Named/Grim.cs
+++ b/Scripts/Mobiles/Named/Grim.cs
@@ -48,6 +48,11 @@ namespace Server.Mobiles
             }
         }
 
+        public override bool GivesMLMinorArtifact
+        {
+            get { return true; }
+        }
+
         public Grim(Serial serial)
             : base(serial)
         {

--- a/Scripts/Mobiles/Named/Grobu.cs
+++ b/Scripts/Mobiles/Named/Grobu.cs
@@ -61,13 +61,6 @@ namespace Server.Mobiles
             c.DropItem( new GrobusFur() );
         }
 
-        public override bool GivesMLMinorArtifact
-        {
-            get
-            {
-                return true;
-            }
-        }
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.FilthyRich, 2);

--- a/Scripts/Mobiles/Named/Irk.cs
+++ b/Scripts/Mobiles/Named/Irk.cs
@@ -74,13 +74,13 @@ namespace Server.Mobiles
             }
         }
         // TODO: Angry fire
-        public override bool GivesMLMinorArtifact
+        /*public override bool GivesMLMinorArtifact
         {
             get
             {
                 return true;
             }
-        }
+        }*/
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.UltraRich, 2);

--- a/Scripts/Mobiles/Named/LadyJennifyr.cs
+++ b/Scripts/Mobiles/Named/LadyJennifyr.cs
@@ -63,13 +63,13 @@ namespace Server.Mobiles
             c.DropItem( new ParrotItem() );
         }
      
-        public override bool GivesMLMinorArtifact
+        /*public override bool GivesMLMinorArtifact
         {
             get
             {
                 return true;
             }
-        }
+        }*/
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.UltraRich, 3);

--- a/Scripts/Mobiles/Named/LadyLissith.cs
+++ b/Scripts/Mobiles/Named/LadyLissith.cs
@@ -65,13 +65,13 @@ namespace Server.Mobiles
             c.DropItem( new ParrotItem() );
         }
 
-        public override bool GivesMLMinorArtifact
+        /*public override bool GivesMLMinorArtifact
         {
             get
             {
                 return true;
             }
-        }
+        }*/
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.UltraRich, 2);

--- a/Scripts/Mobiles/Named/LadyMarai.cs
+++ b/Scripts/Mobiles/Named/LadyMarai.cs
@@ -59,13 +59,13 @@ namespace Server.Mobiles
             c.DropItem( new ParrotItem() );
         }
 
-        public override bool GivesMLMinorArtifact
+        /*public override bool GivesMLMinorArtifact
         {
             get
             {
                 return true;
             }
-        }
+        }*/
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.UltraRich, 3);

--- a/Scripts/Mobiles/Named/LadySabrix.cs
+++ b/Scripts/Mobiles/Named/LadySabrix.cs
@@ -70,13 +70,13 @@ namespace Server.Mobiles
             c.DropItem( new ParrotItem() );
         }
 
-        public override bool GivesMLMinorArtifact
+        /*public override bool GivesMLMinorArtifact
         {
             get
             {
                 return true;
             }
-        }
+        }*/
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.UltraRich, 2);

--- a/Scripts/Mobiles/Named/MasterJonath.cs
+++ b/Scripts/Mobiles/Named/MasterJonath.cs
@@ -69,13 +69,13 @@ namespace Server.Mobiles
 
         }
 
-        public override bool GivesMLMinorArtifact
+        /*public override bool GivesMLMinorArtifact
         {
             get
             {
                 return true;
             }
-        }
+        }*/
         public override int TreasureMapLevel
         {
             get

--- a/Scripts/Mobiles/Named/MasterMikael.cs
+++ b/Scripts/Mobiles/Named/MasterMikael.cs
@@ -64,13 +64,13 @@ namespace Server.Mobiles
             c.DropItem( new ParrotItem() );
         }
 
-        public override bool GivesMLMinorArtifact
+        /*public override bool GivesMLMinorArtifact
         {
             get
             {
                 return true;
             }
-        }
+        }*/
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.UltraRich, 2);

--- a/Scripts/Mobiles/Named/MasterTheophilus.cs
+++ b/Scripts/Mobiles/Named/MasterTheophilus.cs
@@ -72,13 +72,13 @@ namespace Server.Mobiles
 
         }
 
-        public override bool GivesMLMinorArtifact
+        /*public override bool GivesMLMinorArtifact
         {
             get
             {
                 return true;
             }
-        }
+        }*/
         public override bool AllureImmune
         {
             get

--- a/Scripts/Mobiles/Named/Mistral.cs
+++ b/Scripts/Mobiles/Named/Mistral.cs
@@ -50,6 +50,11 @@ namespace Server.Mobiles
             }
         }
 
+        public override bool GivesMLMinorArtifact
+        {
+            get { return true; }
+        }
+
         public Mistral(Serial serial)
             : base(serial)
         {

--- a/Scripts/Mobiles/Named/Pyre.cs
+++ b/Scripts/Mobiles/Named/Pyre.cs
@@ -47,6 +47,11 @@ namespace Server.Mobiles
             }
         }
 
+        public override bool GivesMLMinorArtifact
+        {
+            get { return true; }
+        }
+
         public Pyre(Serial serial)
             : base(serial)
         {
@@ -61,13 +66,6 @@ namespace Server.Mobiles
 
         }
 
-        public override bool GivesMLMinorArtifact
-        {
-            get
-            {
-                return true;
-            }
-        }
         public override int TreasureMapLevel
         {
             get

--- a/Scripts/Mobiles/Named/SirPatrick.cs
+++ b/Scripts/Mobiles/Named/SirPatrick.cs
@@ -63,13 +63,13 @@ namespace Server.Mobiles
             c.DropItem( new AssassinChest() );
         }
 
-        public override bool GivesMLMinorArtifact
+        /*public override bool GivesMLMinorArtifact
         {
             get
             {
                 return true;
             }
-        }
+        }*/
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.UltraRich, 2);

--- a/Scripts/Mobiles/Named/Tangle.cs
+++ b/Scripts/Mobiles/Named/Tangle.cs
@@ -50,6 +50,11 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool GivesMLMinorArtifact
+        {
+            get { return true; }
+        }
+
         public override bool BardImmune
         {
             get

--- a/Scripts/Mobiles/Named/Tempest.cs
+++ b/Scripts/Mobiles/Named/Tempest.cs
@@ -44,6 +44,11 @@ namespace Server.Mobiles
             this.ControlSlots = 2;
         }
 
+        public override bool GivesMLMinorArtifact
+        {
+            get { return true; }
+        }
+
         public Tempest(Serial serial)
             : base(serial)
         {

--- a/Scripts/Mobiles/Normal/WhippingVine.cs
+++ b/Scripts/Mobiles/Normal/WhippingVine.cs
@@ -47,7 +47,13 @@ namespace Server.Mobiles
             if (0.2 >= Utility.RandomDouble())
                 this.PackItem(new ExecutionersCap());
 
-            this.PackItem(new Vines());
+            PackItem(new Vines());  //this is correct
+            PackItem(new FertileDirt(Utility.RandomMinMax(1, 10)));
+
+            if (Utility.RandomDouble() < 0.10)
+            {
+                PackItem(new DecorativeVines());
+            }
         }
 
         public WhippingVine(Serial serial)

--- a/Scripts/Multis/BaseHouse.cs
+++ b/Scripts/Multis/BaseHouse.cs
@@ -1263,6 +1263,8 @@ namespace Server.Multis
                 return true;
             else if (item is RewardBrazier)
                 return true;
+            else if (item is TenthAnniversarySculpture)
+                return true;
 
             return false;
         }

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -663,6 +663,7 @@
     <Compile Include="Items\Consumables\TastyTreat.cs" />
     <Compile Include="Items\Decorative\AllegiancePouch.cs" />
     <Compile Include="Items\Decorative\DecorativeCarpet.cs" />
+    <Compile Include="Items\Decorative\DecorativeVine.cs" />
     <Compile Include="Items\Decorative\OrderChaosBanners.cs" />
     <Compile Include="Items\Decorative\SingingBall.cs" />
     <Compile Include="Items\Decorative\TatteredWallMap.cs" />

--- a/Scripts/Services/BulkOrders/Books/BOBGump.cs
+++ b/Scripts/Services/BulkOrders/Books/BOBGump.cs
@@ -330,81 +330,81 @@ namespace Server.Engines.BulkOrders
                     case 9:
                         return (mat == BulkMaterialType.None && deedType == BODType.Smith);
                     case 10:
-                        return (mat == BulkMaterialType.DullCopper);
+                        return (mat == BulkMaterialType.DullCopper && deedType == BODType.Smith);
                     case 11:
-                        return (mat == BulkMaterialType.ShadowIron);
+                        return (mat == BulkMaterialType.ShadowIron && deedType == BODType.Smith);
                     case 12:
-                        return (mat == BulkMaterialType.Copper);
+                        return (mat == BulkMaterialType.Copper && deedType == BODType.Smith);
                     case 13:
-                        return (mat == BulkMaterialType.Bronze);
+                        return (mat == BulkMaterialType.Bronze && deedType == BODType.Smith);
                     case 14:
-                        return (mat == BulkMaterialType.Gold);
+                        return (mat == BulkMaterialType.Gold && deedType == BODType.Smith);
                     case 15:
-                        return (mat == BulkMaterialType.Agapite);
+                        return (mat == BulkMaterialType.Agapite && deedType == BODType.Smith);
                     case 16:
-                        return (mat == BulkMaterialType.Verite);
+                        return (mat == BulkMaterialType.Verite && deedType == BODType.Smith);
                     case 17:
-                        return (mat == BulkMaterialType.Valorite);
+                        return (mat == BulkMaterialType.Valorite && deedType == BODType.Smith);
 
                     case 18:
                         return (mat == BulkMaterialType.None && BGTClassifier.Classify(deedType, itemType) == BulkGenericType.Cloth);
                     case 19:
                         return (mat == BulkMaterialType.None && BGTClassifier.Classify(deedType, itemType) == BulkGenericType.Leather);
                     case 20:
-                        return (mat == BulkMaterialType.Spined);
+                        return (mat == BulkMaterialType.Spined && BGTClassifier.Classify(deedType, itemType) == BulkGenericType.Leather);
                     case 21:
-                        return (mat == BulkMaterialType.Horned);
+                        return (mat == BulkMaterialType.Horned && BGTClassifier.Classify(deedType, itemType) == BulkGenericType.Leather);
                     case 22:
-                        return (mat == BulkMaterialType.Barbed);
+                        return (mat == BulkMaterialType.Barbed && BGTClassifier.Classify(deedType, itemType) == BulkGenericType.Leather);
 
                     case 23: // Tinkering
                         return (mat == BulkMaterialType.None && deedType == BODType.Tinkering);
                     case 24:
-                        return (mat == BulkMaterialType.DullCopper);
+                        return (mat == BulkMaterialType.DullCopper && deedType == BODType.Tinkering);
                     case 25:
-                        return (mat == BulkMaterialType.ShadowIron);
+                        return (mat == BulkMaterialType.ShadowIron && deedType == BODType.Tinkering);
                     case 26:
-                        return (mat == BulkMaterialType.Copper);
+                        return (mat == BulkMaterialType.Copper && deedType == BODType.Tinkering);
                     case 27:
-                        return (mat == BulkMaterialType.Bronze);
+                        return (mat == BulkMaterialType.Bronze && deedType == BODType.Tinkering);
                     case 28:
-                        return (mat == BulkMaterialType.Gold);
+                        return (mat == BulkMaterialType.Gold && deedType == BODType.Tinkering);
                     case 29:
-                        return (mat == BulkMaterialType.Agapite);
+                        return (mat == BulkMaterialType.Agapite && deedType == BODType.Tinkering);
                     case 30:
-                        return (mat == BulkMaterialType.Verite);
+                        return (mat == BulkMaterialType.Verite && deedType == BODType.Tinkering);
                     case 31:
-                        return (mat == BulkMaterialType.Valorite);
+                        return (mat == BulkMaterialType.Valorite && deedType == BODType.Tinkering);
 
                     case 32: // Carpentry
                         return (mat == BulkMaterialType.None && deedType == BODType.Carpentry);
                     case 33:
-                        return (mat == BulkMaterialType.OakWood);
+                        return (mat == BulkMaterialType.OakWood && deedType == BODType.Carpentry);
                     case 34:
-                        return (mat == BulkMaterialType.AshWood);
+                        return (mat == BulkMaterialType.AshWood && deedType == BODType.Carpentry);
                     case 35:
-                        return (mat == BulkMaterialType.YewWood);
+                        return (mat == BulkMaterialType.YewWood && deedType == BODType.Carpentry);
                     case 36:
-                        return (mat == BulkMaterialType.Bloodwood);
+                        return (mat == BulkMaterialType.Bloodwood && deedType == BODType.Carpentry);
                     case 37:
-                        return (mat == BulkMaterialType.Heartwood);
+                        return (mat == BulkMaterialType.Heartwood && deedType == BODType.Carpentry);
                     case 38:
-                        return (mat == BulkMaterialType.Frostwood);
+                        return (mat == BulkMaterialType.Frostwood && deedType == BODType.Carpentry);
 
                     case 39: // Fletching
                         return (mat == BulkMaterialType.None && deedType == BODType.Fletching);
                     case 40:
-                        return (mat == BulkMaterialType.OakWood);
+                        return (mat == BulkMaterialType.OakWood && deedType == BODType.Fletching);
                     case 41:
-                        return (mat == BulkMaterialType.AshWood);
+                        return (mat == BulkMaterialType.AshWood && deedType == BODType.Fletching);
                     case 42:
-                        return (mat == BulkMaterialType.YewWood);
+                        return (mat == BulkMaterialType.YewWood && deedType == BODType.Fletching);
                     case 43:
-                        return (mat == BulkMaterialType.Bloodwood);
+                        return (mat == BulkMaterialType.Bloodwood && deedType == BODType.Fletching);
                     case 44:
-                        return (mat == BulkMaterialType.Heartwood);
+                        return (mat == BulkMaterialType.Heartwood && deedType == BODType.Fletching);
                     case 45:
-                        return (mat == BulkMaterialType.Frostwood);
+                        return (mat == BulkMaterialType.Frostwood && deedType == BODType.Fletching);
                 }
             }
             else

--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -1577,8 +1577,6 @@ namespace Server.Engines.Craft
 					return;
 				}
 
-				tool.UsesRemaining--;
-
 				if (craftSystem is DefBlacksmithy)
 				{
 					AncientSmithyHammer hammer = from.FindItemOnLayer(Layer.OneHanded) as AncientSmithyHammer;
@@ -1609,28 +1607,6 @@ namespace Server.Engines.Craft
 						#endregion
 					}
 				}
-
-				#region Mondain's Legacy
-				if (tool is HammerOfHephaestus)
-				{
-					if (tool.UsesRemaining < 1)
-					{
-						tool.UsesRemaining = 0;
-					}
-				}
-				else
-				{
-					if (tool.UsesRemaining < 1 && tool.BreakOnDepletion)
-					{
-						toolBroken = true;
-					}
-
-					if (toolBroken)
-					{
-						tool.Delete();
-					}
-				}
-				#endregion
 
 				int num = 0;
 
@@ -1782,6 +1758,30 @@ namespace Server.Engines.Craft
                     AutoCraftTimer.OnSuccessfulCraft(from);
 					//from.PlaySound( 0x57 );
 				}
+
+                tool.UsesRemaining--;
+
+                #region Mondain's Legacy
+                if (tool is HammerOfHephaestus)
+                {
+                    if (tool.UsesRemaining < 1)
+                    {
+                        tool.UsesRemaining = 0;
+                    }
+                }
+                #endregion
+                else
+                {
+                    if (tool.UsesRemaining < 1 && tool.BreakOnDepletion)
+                    {
+                        toolBroken = true;
+                    }
+
+                    if (toolBroken)
+                    {
+                        tool.Delete();
+                    }
+                }
 
 				if (num == 0)
 				{

--- a/Scripts/Services/Craft/DefCarpentry.cs
+++ b/Scripts/Services/Craft/DefCarpentry.cs
@@ -267,12 +267,12 @@ namespace Server.Engines.Craft
             #endregion
 
             #region TOL
-            index = AddCraft(typeof(CraftableHouseAddonDeed), 1044294, 1155850, 42.1, 77.7, typeof(Log), 1044041, 5, 1044351);
+            index = AddCraft(typeof(CraftableHouseItem), 1044294, 1155850, 42.1, 77.7, typeof(Log), 1044041, 5, 1044351);
             SetData(index, CraftableItemType.LightWoodenSignHanger);
             SetDisplayID(index, 2969);
             SetNeededExpansion(index, Expansion.TOL);
 
-            index = AddCraft(typeof(CraftableHouseAddonDeed), 1044294, 1155849, 42.1, 77.7, typeof(Log), 1044041, 5, 1044351);
+            index = AddCraft(typeof(CraftableHouseItem), 1044294, 1155849, 42.1, 77.7, typeof(Log), 1044041, 5, 1044351);
             SetData(index, CraftableItemType.DarkWoodenSignHanger);
             SetDisplayID(index, 2967);
             SetNeededExpansion(index, Expansion.TOL);

--- a/Scripts/Services/Plants/ReproductionGump.cs
+++ b/Scripts/Services/Plants/ReproductionGump.cs
@@ -1,6 +1,7 @@
 using System;
 using Server.Gumps;
 using Server.Network;
+using Server.Items;
 
 namespace Server.Engines.Plants
 {
@@ -10,60 +11,60 @@ namespace Server.Engines.Plants
         public ReproductionGump(PlantItem plant)
             : base(20, 20)
         {
-            this.m_Plant = plant;
+            m_Plant = plant;
 
-            this.DrawBackground();
+            DrawBackground();
 
-            this.AddButton(70, 67, 0xD4, 0xD4, 1, GumpButtonType.Reply, 0); // Main menu
-            this.AddItem(57, 65, 0x1600);
+            AddButton(70, 67, 0xD4, 0xD4, 1, GumpButtonType.Reply, 0); // Main menu
+            AddItem(57, 65, 0x1600);
 
-            this.AddLabel(108, 67, 0x835, "Reproduction");
+            AddLabel(108, 67, 0x835, "Reproduction");
 
-            if (this.m_Plant.PlantStatus == PlantStatus.Stage9)
+            if (m_Plant.PlantStatus == PlantStatus.Stage9)
             {
-                this.AddButton(212, 67, 0xD4, 0xD4, 2, GumpButtonType.Reply, 0); // Set to decorative
-                this.AddItem(202, 68, 0xC61);
-                this.AddLabel(216, 66, 0x21, "/");
+                AddButton(212, 67, 0xD4, 0xD4, 2, GumpButtonType.Reply, 0); // Set to decorative
+                AddItem(202, 68, 0xC61);
+                AddLabel(216, 66, 0x21, "/");
             }
 
-            this.AddButton(80, 116, 0xD4, 0xD4, 3, GumpButtonType.Reply, 0); // Pollination
-            this.AddItem(66, 117, 0x1AA2);
-            this.AddPollinationState(106, 116);
+            AddButton(80, 116, 0xD4, 0xD4, 3, GumpButtonType.Reply, 0); // Pollination
+            AddItem(66, 117, 0x1AA2);
+            AddPollinationState(106, 116);
 
-            this.AddButton(128, 116, 0xD4, 0xD4, 4, GumpButtonType.Reply, 0); // Resources
-            this.AddItem(113, 120, 0x1021);
-            this.AddResourcesState(149, 116);
+            AddButton(128, 116, 0xD4, 0xD4, 4, GumpButtonType.Reply, 0); // Resources
+            AddItem(113, 120, 0x1021);
+            AddResourcesState(149, 116);
 
-            this.AddButton(177, 116, 0xD4, 0xD4, 5, GumpButtonType.Reply, 0); // Seeds
-            this.AddItem(160, 121, 0xDCF);
-            this.AddSeedsState(199, 116);
+            AddButton(177, 116, 0xD4, 0xD4, 5, GumpButtonType.Reply, 0); // Seeds
+            AddItem(160, 121, 0xDCF);
+            AddSeedsState(199, 116);
 
-            this.AddButton(70, 163, 0xD2, 0xD2, 6, GumpButtonType.Reply, 0); // Gather pollen
-            this.AddItem(56, 164, 0x1AA2);
+            AddButton(70, 163, 0xD2, 0xD2, 6, GumpButtonType.Reply, 0); // Gather pollen
+            AddItem(56, 164, 0x1AA2);
 
-            this.AddButton(138, 163, 0xD2, 0xD2, 7, GumpButtonType.Reply, 0); // Gather resources
-            this.AddItem(123, 167, 0x1021);
+            AddButton(138, 163, 0xD2, 0xD2, 7, GumpButtonType.Reply, 0); // Gather resources
+            AddItem(123, 167, 0x1021);
 
-            this.AddButton(212, 163, 0xD2, 0xD2, 8, GumpButtonType.Reply, 0); // Gather seeds
-            this.AddItem(195, 168, 0xDCF);
+            AddButton(212, 163, 0xD2, 0xD2, 8, GumpButtonType.Reply, 0); // Gather seeds
+            AddItem(195, 168, 0xDCF);
         }
 
         public override void OnResponse(NetState sender, RelayInfo info)
         {
             Mobile from = sender.Mobile;
 
-            if (info.ButtonID == 0 || this.m_Plant.Deleted || this.m_Plant.PlantStatus >= PlantStatus.DecorativePlant || this.m_Plant.PlantStatus == PlantStatus.BowlOfDirt)
+            if (info.ButtonID == 0 || m_Plant.Deleted || m_Plant.PlantStatus >= PlantStatus.DecorativePlant || m_Plant.PlantStatus == PlantStatus.BowlOfDirt)
                 return;
 
-            if ((info.ButtonID >= 6 && info.ButtonID <= 8) && !from.InRange(this.m_Plant.GetWorldLocation(), 3))
+            if ((info.ButtonID >= 6 && info.ButtonID <= 8) && !from.InRange(m_Plant.GetWorldLocation(), 3))
             {
                 from.LocalOverheadMessage(MessageType.Regular, 0x3E9, 500446); // That is too far away.
                 return;
             }
 			
-            if (!this.m_Plant.IsUsableBy(from))
+            if (!m_Plant.IsUsableBy(from))
             {
-                this.m_Plant.LabelTo(from, 1061856); // You must have the item in your backpack or locked down in order to use it.
+                m_Plant.LabelTo(from, 1061856); // You must have the item in your backpack or locked down in order to use it.
                 return;
             }
 
@@ -71,15 +72,15 @@ namespace Server.Engines.Plants
             {
                 case 1: // Main menu
                     {
-                        from.SendGump(new MainPlantGump(this.m_Plant));
+                        from.SendGump(new MainPlantGump(m_Plant));
 
                         break;
                     }
                 case 2: // Set to decorative
                     {
-                        if (this.m_Plant.PlantStatus == PlantStatus.Stage9)
+                        if (m_Plant.PlantStatus == PlantStatus.Stage9)
                         {
-                            from.SendGump(new SetToDecorativeGump(this.m_Plant));
+                            from.SendGump(new SetToDecorativeGump(m_Plant));
                         }
 
                         break;
@@ -88,7 +89,7 @@ namespace Server.Engines.Plants
                     {
                         from.Send(new DisplayHelpTopic(67, true)); // POLLINATION STATE
 
-                        from.SendGump(new ReproductionGump(this.m_Plant));
+                        from.SendGump(new ReproductionGump(m_Plant));
 
                         break;
                     }
@@ -96,7 +97,7 @@ namespace Server.Engines.Plants
                     {
                         from.Send(new DisplayHelpTopic(69, true)); // RESOURCE PRODUCTION
 
-                        from.SendGump(new ReproductionGump(this.m_Plant));
+                        from.SendGump(new ReproductionGump(m_Plant));
 
                         break;
                     }
@@ -104,51 +105,51 @@ namespace Server.Engines.Plants
                     {
                         from.Send(new DisplayHelpTopic(68, true)); // SEED PRODUCTION
 
-                        from.SendGump(new ReproductionGump(this.m_Plant));
+                        from.SendGump(new ReproductionGump(m_Plant));
 
                         break;
                     }
                 case 6: // Gather pollen
                     {
-                        if (!this.m_Plant.IsCrossable)
+                        if (!m_Plant.IsCrossable)
                         {
-                            this.m_Plant.LabelTo(from, 1053050); // You cannot gather pollen from a mutated plant!
+                            m_Plant.LabelTo(from, 1053050); // You cannot gather pollen from a mutated plant!
                         }
-                        else if (!this.m_Plant.PlantSystem.PollenProducing)
+                        else if (!m_Plant.PlantSystem.PollenProducing)
                         {
-                            this.m_Plant.LabelTo(from, 1053051); // You cannot gather pollen from a plant in this stage of development!
+                            m_Plant.LabelTo(from, 1053051); // You cannot gather pollen from a plant in this stage of development!
                         }
-                        else if (this.m_Plant.PlantSystem.Health < PlantHealth.Healthy)
+                        else if (m_Plant.PlantSystem.Health < PlantHealth.Healthy)
                         {
-                            this.m_Plant.LabelTo(from, 1053052); // You cannot gather pollen from an unhealthy plant!
+                            m_Plant.LabelTo(from, 1053052); // You cannot gather pollen from an unhealthy plant!
                         }
                         else
                         {
-                            from.Target = new PollinateTarget(this.m_Plant);
+                            from.Target = new PollinateTarget(m_Plant);
                             from.SendLocalizedMessage(1053054); // Target the plant you wish to cross-pollinate to.
 
                             break;
                         }
 
-                        from.SendGump(new ReproductionGump(this.m_Plant));
+                        from.SendGump(new ReproductionGump(m_Plant));
 
                         break;
                     }
                 case 7: // Gather resources
                     {
-                        PlantResourceInfo resInfo = PlantResourceInfo.GetInfo(this.m_Plant.PlantType, this.m_Plant.PlantHue);
-                        PlantSystem system = this.m_Plant.PlantSystem;
+                        PlantResourceInfo resInfo = PlantResourceInfo.GetInfo(m_Plant.PlantType, m_Plant.PlantHue);
+                        PlantSystem system = m_Plant.PlantSystem;
 
                         if (resInfo == null)
                         {
-                            if (this.m_Plant.IsCrossable)
-                                this.m_Plant.LabelTo(from, 1053056); // This plant has no resources to gather!
+                            if (m_Plant.IsCrossable)
+                                m_Plant.LabelTo(from, 1053056); // This plant has no resources to gather!
                             else
-                                this.m_Plant.LabelTo(from, 1053055); // Mutated plants do not produce resources!
+                                m_Plant.LabelTo(from, 1053055); // Mutated plants do not produce resources!
                         }
                         else if (system.AvailableResources == 0)
                         {
-                            this.m_Plant.LabelTo(from, 1053056); // This plant has no resources to gather!
+                            m_Plant.LabelTo(from, 1053056); // This plant has no resources to gather!
                         }
                         else
                         {
@@ -157,113 +158,131 @@ namespace Server.Engines.Plants
                             if (from.PlaceInBackpack(resource))
                             {
                                 system.AvailableResources--;
-                                this.m_Plant.LabelTo(from, 1053059); // You gather resources from the plant.
+                                m_Plant.LabelTo(from, 1053059); // You gather resources from the plant.
                             }
                             else
                             {
                                 resource.Delete();
-                                this.m_Plant.LabelTo(from, 1053058); // You attempt to gather as many resources as you can hold, but your backpack is full.
+                                m_Plant.LabelTo(from, 1053058); // You attempt to gather as many resources as you can hold, but your backpack is full.
                             }
                         }
 
-                        from.SendGump(new ReproductionGump(this.m_Plant));
+                        from.SendGump(new ReproductionGump(m_Plant));
 
                         break;
                     }
                 case 8: // Gather seeds
+                {
+                    PlantSystem system = m_Plant.PlantSystem;
+ 
+                    if ( !m_Plant.IsCrossable )
                     {
-                        PlantSystem system = this.m_Plant.PlantSystem;
-
-                        if (!this.m_Plant.IsCrossable)
+                        m_Plant.LabelTo( from, 1053060 ); // Mutated plants do not produce seeds!
+                    }
+                    else if ( system.AvailableSeeds == 0 )
+                    {
+                        m_Plant.LabelTo( from, 1053061 ); // This plant has no seeds to gather!
+                    }                //Seed of Renewal Edit
+                    else
+                    {
+                        if (Utility.RandomDouble() < 0.05)
                         {
-                            this.m_Plant.LabelTo(from, 1053060); // Mutated plants do not produce seeds!
-                        }
-                        else if (system.AvailableSeeds == 0)
-                        {
-                            this.m_Plant.LabelTo(from, 1053061); // This plant has no seeds to gather!
+                            Item Rseed = new SeedRenewal();
+ 
+                            if (from.PlaceInBackpack(Rseed))
+                            {
+                                system.AvailableSeeds--;
+                                m_Plant.LabelTo(from, 1053063); // You gather seeds from the plant.
+                            }
+                            else
+                            {
+                                Rseed.Delete();
+                                m_Plant.LabelTo(from, 1053062); // You attempt to gather as many seeds as you can hold, but your backpack is full.
+                            }
                         }
                         else
                         {
                             Seed seed = new Seed(system.SeedType, system.SeedHue, true);
-
+ 
                             if (from.PlaceInBackpack(seed))
                             {
                                 system.AvailableSeeds--;
-                                this.m_Plant.LabelTo(from, 1053063); // You gather seeds from the plant.
+                                m_Plant.LabelTo(from, 1053063); // You gather seeds from the plant.
                             }
                             else
                             {
                                 seed.Delete();
-                                this.m_Plant.LabelTo(from, 1053062); // You attempt to gather as many seeds as you can hold, but your backpack is full.
+                                m_Plant.LabelTo(from, 1053062); // You attempt to gather as many seeds as you can hold, but your backpack is full.
                             }
                         }
-
-                        from.SendGump(new ReproductionGump(this.m_Plant));
-
-                        break;
                     }
+ 
+                    from.SendGump( new ReproductionGump( m_Plant ) );
+ 
+                    break;
+                }
             }
         }
 
         private void DrawBackground()
         {
-            this.AddBackground(50, 50, 200, 150, 0xE10);
+            AddBackground(50, 50, 200, 150, 0xE10);
 
-            this.AddImage(60, 90, 0xE17);
-            this.AddImage(120, 90, 0xE17);
+            AddImage(60, 90, 0xE17);
+            AddImage(120, 90, 0xE17);
 
-            this.AddImage(60, 145, 0xE17);
-            this.AddImage(120, 145, 0xE17);
+            AddImage(60, 145, 0xE17);
+            AddImage(120, 145, 0xE17);
 
-            this.AddItem(45, 45, 0xCEF);
-            this.AddItem(45, 118, 0xCF0);
+            AddItem(45, 45, 0xCEF);
+            AddItem(45, 118, 0xCF0);
 
-            this.AddItem(211, 45, 0xCEB);
-            this.AddItem(211, 118, 0xCEC);
+            AddItem(211, 45, 0xCEB);
+            AddItem(211, 118, 0xCEC);
         }
 
         private void AddPollinationState(int x, int y)
         {
-            PlantSystem system = this.m_Plant.PlantSystem;
+            PlantSystem system = m_Plant.PlantSystem;
 
             if (!system.PollenProducing)
-                this.AddLabel(x, y, 0x35, "-");
+                AddLabel(x, y, 0x35, "-");
             else if (!system.Pollinated)
-                this.AddLabel(x, y, 0x21, "!");
+                AddLabel(x, y, 0x21, "!");
             else
-                this.AddLabel(x, y, 0x3F, "+");
+                AddLabel(x, y, 0x3F, "+");
         }
 
         private void AddResourcesState(int x, int y)
         {
-            PlantResourceInfo resInfo = PlantResourceInfo.GetInfo(this.m_Plant.PlantType, this.m_Plant.PlantHue);
+            PlantResourceInfo resInfo = PlantResourceInfo.GetInfo(m_Plant.PlantType, m_Plant.PlantHue);
 
-            PlantSystem system = this.m_Plant.PlantSystem;
+            PlantSystem system = m_Plant.PlantSystem;
             int totalResources = system.AvailableResources + system.LeftResources;
 
             if (resInfo == null || totalResources == 0)
             {
-                this.AddLabel(x + 5, y, 0x21, "X");
+                AddLabel(x + 5, y, 0x21, "X");
             }
             else
             {
-                this.AddLabel(x, y, PlantHueInfo.GetInfo(this.m_Plant.PlantHue).GumpHue,
+                AddLabel(x, y, PlantHueInfo.GetInfo(m_Plant.PlantHue).GumpHue,
                     string.Format("{0}/{1}", system.AvailableResources, totalResources));
             }
         }
 
         private void AddSeedsState(int x, int y)
         {
-            PlantSystem system = this.m_Plant.PlantSystem;
+            PlantSystem system = m_Plant.PlantSystem;
             int totalSeeds = system.AvailableSeeds + system.LeftSeeds;
 
-            if (!this.m_Plant.IsCrossable || totalSeeds == 0)
+            if (!m_Plant.IsCrossable || totalSeeds == 0)
             {
-                this.AddLabel(x + 5, y, 0x21, "X");
+                AddLabel(x + 5, y, 0x21, "X");
             }
             else
             {
-                this.AddLabel(x, y, PlantHueInfo.GetInfo(system.SeedHue).GumpHue,
+                AddLabel(x, y, PlantHueInfo.GetInfo(system.SeedHue).GumpHue,
                     string.Format("{0}/{1}", system.AvailableSeeds, totalSeeds));
             }
         }

--- a/Scripts/Services/Virtues/VirtueGump.cs
+++ b/Scripts/Services/Virtues/VirtueGump.cs
@@ -139,7 +139,7 @@ namespace Server
                 return 2402;
 
             if (value >= 30000)
-                value = 20000;	//Sanity
+                value = 30000;	//Sanity
 				
             int vl;
 			

--- a/Scripts/Skills/Fishing.cs
+++ b/Scripts/Skills/Fishing.cs
@@ -144,6 +144,18 @@ namespace Server.Engines.Harvest
 			new MutateEntry( 0.0, 200.0,  -200.0, false, new Type[1]{ null } )
 		};
 
+        private static MutateEntry[] m_SiegeMutateTable = new MutateEntry[]
+		{
+			new MutateEntry( 80.0,  80.0,  1865.0,  true, typeof( SpecialFishingNet ) ),
+            new MutateEntry( 0.0, 200.0,  -200.0, false, new Type[1]{ null } ),
+			new MutateEntry( 100.0,  80.0,  1865.0,  true, typeof( MessageInABottle ) ),			
+			new MutateEntry( 80.0,  80.0,  4080.0,  true, typeof( BigFish ) ),
+			new MutateEntry( 0.0, 125.0, -2375.0, false, typeof( PrizedFish ), typeof( WondrousFish ), typeof( TrulyRareFish ), typeof( PeculiarFish ) ),
+			new MutateEntry( 0.0, 105.0,  -420.0, false, typeof( Boots ), typeof( Shoes ), typeof( Sandals ), typeof( ThighBoots ) ),
+            new MutateEntry( 80.0,  80.0, 2500.0, false, typeof( MudPuppy ), typeof( RedHerring) ),
+			new MutateEntry( 0.0, 200.0,  -200.0, false, new Type[1]{ null } )
+		};
+
         private static MutateEntry[] m_LavaMutateTable = new MutateEntry[]
         {
             new MutateEntry( 0.0,  80.0,  1500,   false, typeof(StoneFootwear)),
@@ -260,16 +272,18 @@ namespace Server.Engines.Harvest
             double skillBase = from.Skills[SkillName.Fishing].Base;
             double skillValue = from.Skills[SkillName.Fishing].Value;
 
-            for (int i = 0; i < m_MutateTable.Length; ++i)
+            var table = Siege.SiegeShard ? m_SiegeMutateTable : m_MutateTable;
+
+            for (int i = 0; i < table.Length; ++i)
             {
-                // RedHerring/MudPuppy
+                MutateEntry entry = m_MutateTable[i];
+
+                // RedHerring / MudPuppy
                 if (i == 6 && (from.Region == null || !from.Region.IsPartOf("Underworld")))
                     continue;
 
                 if (junkproof && i == 5 && 0.80 >= Utility.RandomDouble())
                     continue;
-
-                MutateEntry entry = m_MutateTable[i];
 
                 if (!deepWater && entry.m_DeepWater)
                     continue;
@@ -284,14 +298,6 @@ namespace Server.Engines.Harvest
             }
 
             return type;
-        }
-
-        private static Map SafeMap(Map map)
-        {
-            if (map == null || map == Map.Internal)
-                return Map.Trammel;
-
-            return map;
         }
 
         public override bool CheckResources(Mobile from, Item tool, HarvestDefinition def, Map map, Point3D loc, bool timed)

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -213,19 +213,21 @@ namespace Server.Spells
             }
         }
 
-        private static readonly TimeSpan CombatHeatDelay = TimeSpan.FromSeconds(30.0);
         private static readonly bool RestrictTravelCombat = true;
 
+        //TODO: Check if aggressor leaves facet, if heat is removed
         public static bool CheckCombat(Mobile m)
         {
             if (!RestrictTravelCombat)
                 return false;
 
+            TimeSpan delay = Server.Misc.AttackMessage.CombatHeatDelay;
+
             for (int i = 0; i < m.Aggressed.Count; ++i)
             {
                 AggressorInfo info = m.Aggressed[i];
 
-                if (info.Defender.Player && (DateTime.UtcNow - info.LastCombatTime) < CombatHeatDelay)
+                if (info.Defender.Player && (DateTime.UtcNow - info.LastCombatTime) < delay)
                     return true;
             }
 
@@ -235,7 +237,7 @@ namespace Server.Spells
                 {
                     AggressorInfo info = m.Aggressors[i];
 
-                    if (info.Attacker.Player && (DateTime.UtcNow - info.LastCombatTime) < CombatHeatDelay)
+                    if (info.Attacker.Player && (DateTime.UtcNow - info.LastCombatTime) < delay)
                         return true;
                 }
             }

--- a/Scripts/Spells/Skill Masteries/CombatTraining.cs
+++ b/Scripts/Spells/Skill Masteries/CombatTraining.cs
@@ -6,21 +6,6 @@ using Server.Mobiles;
 using Server.Gumps;
 using Server.Targeting;
 
-/*
-"Combat Training" gives the option to give your pet "Empowerment", "Berserk" or "Consume Damage". Active Meditation can no longer be maintained during the use of "Combat Training".
- Not sure what "Combat Training: Empowerment" does yet, but sometimes when the pet is hit when under Empowerment, a bronzish sparkle briefly appears on the pet, no idea what this does.
- "Combat Training: Berserk", with further testing, appears to grant a 20-25% damage increase, and when the pet is low health (45% or below), grants extreme Stamina Regeneration.
- "Combat Training: Consume Damage" is incredibly powerful at 120 Taming/120 Lore. With Consume Damage on my fully trained Greater Dragon, he was able to take on an Ancient Wyrm Paragon
- along with 3 Wyverns at the same time, and they could barely even scratch him. I didn't have to vet him at all, and he never went below 80% Health the whole fight, which went on for about 5-10 minutes.
- "Combat Training: Consume Damage" does not appear to function in PvP.
- * 
- * "Combat Training" has been clarified by the devs in Part 3, and the observations i've made previously were only part of the Mastery's function. Some of the Mastery's appear to have changed, or gained more function.
-    "Empowerment" acts very similar to Consume Damage, in that it makes your pet very tanky (which was not the case prior to Part 3). This is because for a period of time your pet will store damage taken, and then use that store of damage to boost it's own damage output, both melee and magical (+DI/+SDI).
- "Berserk" has been changed to function exactly like the "Berserk" property from the Bestial Set. For 8 seconds, the more damage a pet takes, the more damage reduction it gains, and the more melee damage it deals. This effect has a 60 second cooldown. 
- The short duration and long cooldown make this ability rather pointless in comparison to Empowerment or Consume Damage.
- "Consume Damage" makes your pet very tanky. Your pet will store damage taken to increase it's HCI and Regeneration.
- Active Meditation can no longer be maintained while using Combat Training.*/
-
 namespace Server.Spells.SkillMasteries
 {
     public enum TrainingType
@@ -289,6 +274,12 @@ namespace Server.Spells.SkillMasteries
                 {
                     Spell.Caster.FixedEffect(0x3779, 10, 20, 1270, 0);
                     Spell.Caster.SendSound(0x64E);
+
+                    int taming = (int)from.Skills[SkillName.AnimalTaming].Value;
+                    int lore = (int)from.Skills[SkillName.AnimalLore].Value;
+
+                    from.CheckTargetSkill(SkillName.AnimalTaming, (BaseCreature)targeted, taming - 25, taming + 25);
+                    from.CheckTargetSkill(SkillName.AnimalLore, (BaseCreature)targeted, lore - 25, lore + 25);
 
                     from.SendGump(new ChooseTrainingGump(from, (BaseCreature)targeted, Spell));
                 }


### PR DESCRIPTION
- Added 2 new Origami (thanks redbeard)
- Removed redundant recall rune prompt Message
- Bag of Sending now only uses 1 charge, per EA
- Combat heat now normalized to 2 minutes, TODO: do aggressor map/alive Check
- Removed ML arty drops from key bearing creatures
- Added ML arty drops to various ML named monsters
- Added Decorative vine to whipping vines (thanks redbeard)
- bod filter gump should now filter the appropriate bod types
- 10th Anniversary Sculptures can now be used while locked down in houses
- Fixed crafted items not going in broken tool container
- Added Seed of renewal drops to plant system (thanks redbeard)
- Removed t-maps and reduced MIB drops on siege shards
- Combat training now gives taming/lore gains