### PR TITLE
Update BladedItemTarget.cs

### DIFF
--- a/Scripts/Targets/BladedItemTarget.cs
+++ b/Scripts/Targets/BladedItemTarget.cs
@@ -37,7 +37,11 @@ namespace Server.Targets
 
             if (targeted is ICarvable)
             {
-                if (((ICarvable)targeted).Carve(from, this.m_Item) && Siege.SiegeShard)
+                if (targeted is Item && !((Item)targeted).Movable)
+                {
+                    from.SendLocalizedMessage(500494); // You can't use a bladed item on that!
+                }
+                else if (((ICarvable)targeted).Carve(from, this.m_Item) && Siege.SiegeShard)
                 {
                     Siege.CheckUsesRemaining(from, m_Item);
                 }


### PR DESCRIPTION
Prevents non-movable / locked down / secured ICarvable items from being carved.