### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Items/Containers/TreasureMapChest.cs
+++ b/Scripts/Items/Containers/TreasureMapChest.cs
@@ -482,24 +482,25 @@ namespace Server.Items
 
             if (rnd <= 1)
             {
-                min = 500; max = 1000;
+                min = 500; max = 1300;
             }
             else if (rnd < 5)
             {
-                min = 400; max = 900;
+                min = 400; max = 1100;
             }
             else if (rnd < 25)
             {
-                min = 350; max = 800;
+                min = 350; max = 900;
             }
             else if (rnd < 50)
             {
-                min = 250; max = 600;
+                min = 250; max = 800;
             }
             else
             {
-                min = 100; max = 400;
+                min = 100; max = 600;
             }
+
 			min = (int)(min * scale);
 			max = (int)(max * scale);
         }

--- a/Scripts/Items/Equipment/Quivers/BaseQuiver.cs
+++ b/Scripts/Items/Equipment/Quivers/BaseQuiver.cs
@@ -315,6 +315,9 @@ namespace Server.Items
 
         public override bool CheckHold(Mobile m, Item item, bool message, bool checkItems, int plusItems, int plusWeight)
         {
+            if (!Movable)
+                return false;
+
             if (!CheckType(item))
             {
                 if (message)

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -5284,7 +5284,7 @@ namespace Server.Mobiles
         {
             base.AddNameProperties(list);
 
-            if (!String.IsNullOrEmpty(EngravedText))
+            if (Controlled && !String.IsNullOrEmpty(EngravedText))
             {
                 list.Add(1157315, EngravedText); // <BASEFONT COLOR=#668cff>Branded: ~1_VAL~<BASEFONT COLOR=#FFFFFF>
             }

--- a/Scripts/Services/Expansions/Time Of Legends/AuctionSafe/Gumps.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/AuctionSafe/Gumps.cs
@@ -436,7 +436,7 @@ namespace Server.Engines.Auction
 
         private bool IsBadItem(Item item)
         {
-            return item == null || item.Weight > 300 || item is Container || item is Gold || item is BankCheck || !item.Movable;
+            return item == null || item.Weight > 300 || (item is Container && !(item is BaseQuiver)) || item is Gold || item is BankCheck || !item.Movable || item.Items.Count > 0;
         }
     }
 

--- a/Scripts/Services/Revamped Dungeons/WrongDungeon/EnchantedHotItem.cs
+++ b/Scripts/Services/Revamped Dungeons/WrongDungeon/EnchantedHotItem.cs
@@ -25,14 +25,6 @@ namespace Server.Items
         public static Timer Timer { get; set; }
         public static Dictionary<Item, Container> HotItems { get; set; }
 
-        public static Item Create()
-        {
-            Item loot = Loot.RandomArmorOrShieldOrWeaponOrJewelry(false, false, true);
-            loot.Hue = 1258;
-
-            return loot;
-        }
-
         public static void CheckTimer()
         {
             if (HotItems.Count > 0)
@@ -288,19 +280,19 @@ namespace Server.Items
                 }
                 else
                 {
-                    item = EnchantedHotItem.Create();
+                    Item item = Loot.RandomArmorOrShieldOrWeaponOrJewelry(false, false, true);
 
                     if (item is BaseWeapon && 0.01 > Utility.RandomDouble())
                     {
                         ((BaseWeapon)item).ExtendedWeaponAttributes.AssassinHoned = 1;
                     }
 
-
-                    int min, max;
-                    TreasureMapChest.GetRandomItemStat(out min, out max, 1.0);
+                    int min = 400;
+                    int max = 1400;
 
                     RunicReforging.GenerateRandomItem(item, 0, min, max, this.Map);
 
+                    item.Hue = 1258;
                     EnchantedHotItem.AddItem(item, this);
                 }
 

--- a/Scripts/Services/Revamped Dungeons/WrongDungeon/EnchantedHotItem.cs
+++ b/Scripts/Services/Revamped Dungeons/WrongDungeon/EnchantedHotItem.cs
@@ -280,7 +280,7 @@ namespace Server.Items
                 }
                 else
                 {
-                    Item item = Loot.RandomArmorOrShieldOrWeaponOrJewelry(false, false, true);
+                    item = Loot.RandomArmorOrShieldOrWeaponOrJewelry(false, false, true);
 
                     if (item is BaseWeapon && 0.01 > Utility.RandomDouble())
                     {


### PR DESCRIPTION
- Increased quality of TMap loot.  It was rather lacking.
- Increased quality of Enchanted Hot Item Chest Loot
- Fixed bug where elemental damage enchanted hot items would override the orange hue
- Auction Safes now support Quivers
- Town Crier entries and global entries are now serialized and should remain after server restart
- Pet Branding no longer shows if the pet is released back the wild