### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Items/Addons/GozaMats.cs
+++ b/Scripts/Items/Addons/GozaMats.cs
@@ -54,6 +54,8 @@ namespace Server.Items
 
     public class GozaMatEastDeed : BaseAddonDeed
     {
+        public override bool UseCraftResource { get { return false; } }
+
         [Constructable]
         public GozaMatEastDeed()
         {
@@ -145,6 +147,8 @@ namespace Server.Items
 
     public class GozaMatSouthDeed : BaseAddonDeed
     {
+        public override bool UseCraftResource { get { return false; } }
+
         [Constructable]
         public GozaMatSouthDeed()
         {
@@ -242,6 +246,8 @@ namespace Server.Items
 
     public class SquareGozaMatEastDeed : BaseAddonDeed
     {
+        public override bool UseCraftResource { get { return false; } }
+
         [Constructable]
         public SquareGozaMatEastDeed()
         {
@@ -332,6 +338,8 @@ namespace Server.Items
 
     public class SquareGozaMatSouthDeed : BaseAddonDeed
     {
+        public override bool UseCraftResource { get { return false; } }
+
         [Constructable]
         public SquareGozaMatSouthDeed()
         {
@@ -423,6 +431,8 @@ namespace Server.Items
 
     public class BrocadeGozaMatEastDeed : BaseAddonDeed
     {
+        public override bool UseCraftResource { get { return false; } }
+
         [Constructable]
         public BrocadeGozaMatEastDeed()
         {
@@ -514,6 +524,8 @@ namespace Server.Items
 
     public class BrocadeGozaMatSouthDeed : BaseAddonDeed
     {
+        public override bool UseCraftResource { get { return false; } }
+
         [Constructable]
         public BrocadeGozaMatSouthDeed()
         {
@@ -604,6 +616,8 @@ namespace Server.Items
 
     public class BrocadeSquareGozaMatEastDeed : BaseAddonDeed
     {
+        public override bool UseCraftResource { get { return false; } }
+
         [Constructable]
         public BrocadeSquareGozaMatEastDeed()
         {
@@ -694,6 +708,8 @@ namespace Server.Items
 
     public class BrocadeSquareGozaMatSouthDeed : BaseAddonDeed
     {
+        public override bool UseCraftResource { get { return false; } }
+
         [Constructable]
         public BrocadeSquareGozaMatSouthDeed()
         {

--- a/Scripts/Items/Containers/Container.cs
+++ b/Scripts/Items/Containers/Container.cs
@@ -238,6 +238,13 @@ namespace Server.Items
 			}
 		}
 
+        public override bool DropToWorld(Mobile m, Point3D p)
+        {
+            Server.Engines.Despise.WispOrb.CheckDrop(this, m);
+
+            return base.DropToWorld(m, p);
+        }
+
 		public virtual void Open(Mobile from)
         {
             DisplayTo(from);

--- a/Scripts/Items/Functional/DespiseAnkh.cs
+++ b/Scripts/Items/Functional/DespiseAnkh.cs
@@ -54,24 +54,12 @@ namespace Server.Engines.Despise
 				{
                     WispOrb orb = new WispOrb(from, alignment);
 					from.Backpack.DropItem(orb);
-
-                    Timer.DelayCall(TimeSpan.FromSeconds(0.5), new TimerStateCallback(SendMessage_Callback), new object[] { orb, from } );
+                    from.SendLocalizedMessage(1153355); // I will follow thy guidance.
 				}
 				else
 					LabelTo(from, 1153350); // Thy spirit be not compatible with our goals!
 			}
 		}
-
-        private void SendMessage_Callback(object o)
-        {
-            object[] obj = o as object[];
-
-            WispOrb orb = obj[0] as WispOrb;
-            Mobile from = obj[1] as Mobile;
-
-            if(orb != null && orb.IsChildOf(from.Backpack))
-                orb.LabelTo(from, 1153355); // I will follow thy guidance.
-        }
 		
 		public DespiseAnkh(Serial serial) : base(serial)
 		{

--- a/Scripts/Items/Internal/DespiseTeleporter.cs
+++ b/Scripts/Items/Internal/DespiseTeleporter.cs
@@ -3,6 +3,7 @@ using System;
 using Server.Mobiles;
 using Server.Engines.Despise;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Server.Items
 {
@@ -95,5 +96,249 @@ namespace Server.Items
 			base.Deserialize(reader);
 			int v = reader.ReadInt();
 		}
+    }
+
+    public class GateTeleporter : Item
+    {
+        private Point3D _Destination;
+        private Map _DestinationMap;
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public Point3D Destination
+        {
+            get { return _Destination; }
+            set
+            {
+                if (_Destination != value)
+                {
+                    _Destination = value;
+                    AssignDestination(value);
+                }
+            }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public Map DestinationMap
+        {
+            get { return _DestinationMap; }
+            set
+            {
+                if (DestinationMap != value)
+                {
+                    _DestinationMap = value;
+                    AssignMap(value);
+                }
+            }
+        }
+
+        public List<InternalTeleporter> Teleporters { get; set; }
+
+        [Constructable]
+        public GateTeleporter()
+            : this(19343, 0, Point3D.Zero, null)
+        {
+        }
+
+        public GateTeleporter(int id, int hue, Point3D destination, Map destinationMap)
+            : base(id)
+        {
+            Hue = hue;
+
+            Movable = false;
+
+            _Destination = destination;
+            _DestinationMap = destinationMap;
+
+            AssignTeleporters();
+        }
+
+        private void AssignTeleporters()
+        {
+            if (Teleporters != null)
+            {
+                foreach (var tele in Teleporters.Where(t => t != null && !t.Deleted))
+                {
+                    tele.Delete();
+                }
+
+                ColUtility.Free(Teleporters);
+            }
+
+            Teleporters = new List<InternalTeleporter>();
+
+            for (int i = 0; i <= 7; i++)
+            {
+                Direction offset = (Direction)i;
+
+                var tele = new InternalTeleporter(this, _Destination, _DestinationMap);
+
+                int x = this.X;
+                int y = this.Y;
+                int z = this.Z;
+
+                Movement.Movement.Offset(offset, ref x, ref y);
+                tele.MoveToWorld(new Point3D(x, y, z), this.Map);
+
+                Teleporters.Add(tele);
+            }
+        }
+
+        public void AssignDestination(Point3D p)
+        {
+            if (Teleporters == null)
+            {
+                AssignTeleporters();
+            }
+            else
+            {
+                Teleporters.ForEach(t => t.PointDest = p);
+            }
+        }
+
+        public void AssignMap(Map map)
+        {
+            if (Teleporters == null)
+            {
+                AssignTeleporters();
+            }
+            else
+            {
+                Teleporters.ForEach(t => t.MapDest = map);
+            }
+        }
+
+        public override void OnMapChange()
+        {
+            if (Teleporters != null)
+            {
+                Teleporters.ForEach(t => t.Map = Map);
+            }
+        }
+
+        public override void OnLocationChange(Point3D old)
+        {
+            if (Teleporters != null)
+            {
+                Teleporters.ForEach(t =>
+                    {
+                        t.Location = new Point3D(X + (t.X - old.X), Y + (t.Y - old.Y), Z + (t.Z - old.Z));
+                    });
+            }
+        }
+
+        public override void Delete()
+        {
+            base.Delete();
+
+            if (Teleporters != null)
+            {
+                Teleporters.ForEach(t => t.Delete());
+
+                ColUtility.Free(Teleporters);
+            }
+        }
+
+        public GateTeleporter(Serial serial)
+            : base(serial)
+		{
+		}
+		
+		public override void Serialize(GenericWriter writer)
+		{
+			base.Serialize(writer);
+			writer.Write((int)0);
+
+            writer.Write(_Destination);
+            writer.Write(_DestinationMap);
+
+            writer.Write(Teleporters == null ? 0 : Teleporters.Count);
+
+            if (Teleporters != null)
+            {
+                Teleporters.ForEach(t => writer.Write(t));
+            }
+		}
+		
+		public override void Deserialize(GenericReader reader)
+		{
+			base.Deserialize(reader);
+			int v = reader.ReadInt();
+
+            _Destination = reader.ReadPoint3D();
+            _DestinationMap = reader.ReadMap();
+
+            int count = reader.ReadInt();
+            for (int i = 0; i < count; i++)
+            {
+                if (Teleporters == null)
+                    Teleporters = new List<InternalTeleporter>();
+
+                var tele = reader.ReadItem() as InternalTeleporter;
+
+                if (tele != null)
+                {
+                    Teleporters.Add(tele);
+                    tele.Master = this;
+                }
+            }
+		}
+
+        public class InternalTeleporter : Teleporter
+        {
+            [CommandProperty(AccessLevel.GameMaster)]
+            public GateTeleporter Master { get; set; }
+
+            public InternalTeleporter(GateTeleporter master, Point3D dest, Map destMap)
+                : base(dest, destMap, true)
+            {
+                Master = master;
+            }
+
+            public override bool OnMoveOver(Mobile m)
+            {
+                return true;
+            }
+
+            public override bool HandlesOnMovement { get { return Master != null && Utility.InRange(Master.Location, Location, 1) && this.Map == Master.Map; } }
+            
+            public override void OnMovement(Mobile m, Point3D oldLocation)
+            {
+                if (Master == null || Master.Destination == Point3D.Zero || Master.Map == null || Master.Map == Map.Internal)
+                    return;
+
+                if (m.Location == Location)
+                {
+                    var eable = Map.GetItemsInRange(oldLocation, 0);
+
+                    foreach (Item item in eable)
+                    {
+                        if (item is InternalTeleporter || item == Master)
+                        {
+                            eable.Free();
+                            return;
+                        }
+                    }
+
+                    base.OnMoveOver(m);
+                }
+            }
+
+            public InternalTeleporter(Serial serial)
+                : base(serial)
+            {
+            }
+
+            public override void Serialize(GenericWriter writer)
+            {
+                base.Serialize(writer);
+                writer.Write((int)0);
+            }
+
+            public override void Deserialize(GenericReader reader)
+            {
+                base.Deserialize(reader);
+                int v = reader.ReadInt();
+            }
+        }
     }
 }

--- a/Scripts/Items/Quest/WispOrb.cs
+++ b/Scripts/Items/Quest/WispOrb.cs
@@ -282,12 +282,6 @@ namespace Server.Engines.Despise
 			
 			public override void OnClick()
 			{
-                /*if (m_Orb.Pet != null && m_Orb.IsChildOf(m_From.Backpack) && m_Orb.Conscripted)
-                {
-                    m_From.SendMessage("The creature you are controlling is no longer conscripted.");
-                    m_Orb.Conscripted = false;
-                }*/
-
                 if (m_Orb.Pet != null)
                 {
                     m_Orb.Pet.Unlink();
@@ -479,8 +473,8 @@ namespace Server.Engines.Despise
                 switch (m_Aggression)
                 {
                     case Aggression.Following: Hue = 1923; break; // Yellow
-                    case Aggression.Defensive: Hue = 1927; break; // blue
-                    case Aggression.Aggressive: Hue = 1925; break;  // green
+                    case Aggression.Defensive: Hue = 1917; break; // blue
+                    case Aggression.Aggressive: Hue = 1914; break;  // green
                 }
             }
         }

--- a/Scripts/Items/Quest/WispOrb.cs
+++ b/Scripts/Items/Quest/WispOrb.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Server.ContextMenus;
 using Server.Targeting;
 using Server.Network;
+using System.Linq;
 
 namespace Server.Engines.Despise
 {
@@ -52,7 +53,6 @@ namespace Server.Engines.Despise
 				if(m_Pet != null && value == null)
 				{
 					m_Pet.Unlink(); 
-					//m_Pet = null;
 				}
                 else
                 {
@@ -198,17 +198,14 @@ namespace Server.Engines.Despise
 				from.Target = new InternalTarget(this);
 			}
 		}
-		
-		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list )
-		{
-			base.GetContextMenuEntries(from, list);
 
-            if (CheckOwnerAlignment() && m_Pet != null && IsChildOf(from.Backpack) && from == m_Owner)
-			{
-				list.Add(new ConscriptEntry(from, this));
-				list.Add(new ReleaseEntry(from, this));
-			}
-		}
+        public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)
+        {
+            base.GetContextMenuEntries(from, list);
+
+            list.Add(new ReleaseEntry(from, this));
+            list.Add(new ConscriptEntry(from, this));
+        }
 		
 		public override void GetProperties(ObjectPropertyList list)
 		{
@@ -216,10 +213,8 @@ namespace Server.Engines.Despise
 			
 			list.Add(1153329, String.Format("#{0}", GetAlignment())); // Alignment: ~1_VAL~
 			list.Add(1153306, String.Format("{0}", GetArmyPower())); // Army Power: ~1_VAL~
-			
-			if(m_Pet != null)
-				list.Add(1153272, m_Pet.Name); // Controlling: ~1_VAL~
-			
+            list.Add(1153272, m_Pet != null ? m_Pet.Name : "None"); // Controlling: ~1_VAL~
+		
 			object name = GetAnchorName();
 			
 			if(name != null)					//Anchor: ~1_NAME~
@@ -236,6 +231,48 @@ namespace Server.Engines.Despise
 			list.Add(1153260, String.Format("#{0}", leash.ToString())); // Leash: ~1_VAL~
 			list.Add(1153267, String.Format("#{0}", aggr.ToString())); // Aggression: ~1_VAL~
 		}
+
+        public override bool DropToWorld(Mobile m, Point3D p)
+        {
+            m.SendLocalizedMessage(1153233); // The Wisp Orb vanishes to whence it came...
+            Delete();
+            return false;
+        }
+
+        public static void CheckDrop(Container c, Mobile m)
+        {
+            List<WispOrb> list = new List<WispOrb>(c.Items.OfType<WispOrb>());
+
+            foreach (var orb in list)
+            {
+                m.SendLocalizedMessage(1153233); // The Wisp Orb vanishes to whence it came...
+                orb.Delete();
+            }
+        }
+
+        public override bool OnDroppedInto(Mobile from, Container target, Point3D p)
+        {
+            if (target.RootParentEntity == from)
+            {
+                return base.OnDroppedInto(from, target, p);
+            }
+
+            from.SendLocalizedMessage(1153233); // The Wisp Orb vanishes to whence it came...
+            Delete();
+            return false;
+        }
+
+        public override bool OnDroppedOnto(Mobile from, Item target)
+        {
+            if (target is Container && target.RootParentEntity != from)
+            {
+                from.SendLocalizedMessage(1153233); // The Wisp Orb vanishes to whence it came...
+                Delete();
+                return false;
+            }
+
+            return base.OnDroppedOnto(from, target);
+        }
 		
 		private class ConscriptEntry : ContextMenuEntry
 		{
@@ -325,7 +362,7 @@ namespace Server.Engines.Despise
                             m_Orb.Pet.ControlOrder = OrderType.Follow;
 
                             from.SendLocalizedMessage(1153276); // Your Wisp Orb takes control of the creature!
-                            m_Orb.Pet.PublicOverheadMessage(MessageType.Regular, 0x59, 1153295, from.Name); // * This creature is now under the control of ~1_NAME~ *
+                            m_Orb.Pet.PublicOverheadMessage(MessageType.Regular, 0x3B2, 1153295, from.Name); // * This creature is now under the control of ~1_NAME~ *
                         }
                     }
                     else if (targeted == m_Orb.Pet)
@@ -465,14 +502,14 @@ namespace Server.Engines.Despise
         public void InvalidateHue()
         {
             if (m_Pet == null)
-                Hue = 1943; // shadow wisp color
+                Hue = 1910; // shadow wisp color
             else if (m_Pet.Combatant != null)
                 Hue = 1931; // Orange
             else
             {
                 switch (m_Aggression)
                 {
-                    case Aggression.Following: Hue = 1923; break; // Yellow
+                    case Aggression.Following: Hue = 1912; break; // Yellow
                     case Aggression.Defensive: Hue = 1917; break; // blue
                     case Aggression.Aggressive: Hue = 1914; break;  // green
                 }
@@ -485,7 +522,7 @@ namespace Server.Engines.Despise
 				m_Orbs.Remove(this);
 
             if (m_Pet != null && m_Pet.Alive)
-				m_Pet.Unlink();
+				m_Pet.Unlink(false);
 				
 			base.Delete();
 		}

--- a/Scripts/Misc/Extensions.cs
+++ b/Scripts/Misc/Extensions.cs
@@ -80,6 +80,28 @@ namespace Server.Items
             }
         }
 
+        public static void PrivateOverheadMessage(this Item item, MessageType type, int hue, bool ascii, string text, NetState state)
+        {
+            if (item.Map != null && state != null)
+            {
+                Point3D worldLoc = item.GetWorldLocation();
+
+                Mobile m = state.Mobile;
+
+                if (m != null && m.CanSee(item) && m.InRange(worldLoc, item.GetUpdateRange(m)))
+                {
+                    if (ascii)
+                    {
+                        state.Send(new AsciiMessage(item.Serial, item.ItemID, type, hue, 3, item.Name, text));
+                    }
+                    else
+                    {
+                        state.Send(new UnicodeMessage(item.Serial, item.ItemID, type, hue, 3, m.Language, item.Name, text));
+                    }
+                }
+            }
+        }
+
         public static void SendLocalizedMessage(this Item item, int number, string args)
         {
             if (item == null)
@@ -137,6 +159,11 @@ namespace Server.Mobiles
         public static void SayTo(this Mobile mobile, Mobile to, string text, int hue, bool ascii = false)
         {
             mobile.PrivateOverheadMessage(MessageType.Regular, hue, ascii, text, to.NetState);
+        }
+
+        public static void PrivateOverheadMessage(this Mobile mobile, MessageType type, int hue, int number, AffixType affixType, string affix, string args, NetState state)
+        {
+            state.Send(new MessageLocalizedAffix(mobile.Serial, mobile.Body, type, hue, 3, number, mobile.Name, affixType, affix, args));
         }
     }
 }

--- a/Scripts/Mobiles/Named/Drelgor.cs
+++ b/Scripts/Mobiles/Named/Drelgor.cs
@@ -1,0 +1,155 @@
+
+using System;
+using Server;
+using System.Collections;
+using System.Collections.Generic;
+using Server.Items;
+using Server.Misc;
+using Server.Regions;
+using Server.Network;
+using Server.Targeting;
+
+namespace Server.Mobiles
+{
+    [CorpseName("A Drelgor The Impaler Corpse")]
+    public class Drelgor : BaseCreature
+    {
+        private bool init = false; //Don't change this.
+        private double msgevery = 1.0; //Recurring message. Change to 0 to disable.
+        private DateTime m_NextMsgTime;
+
+        [Constructable]
+        public Drelgor()
+            : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
+        {
+            Name = "Drelgor the Impaler";
+            Body = 147;
+            BaseSoundID = 451;
+
+            SetStr(127, 137);
+            SetDex(82, 94);
+            SetInt(48, 55);
+
+            SetHits(131, 136);
+
+            SetDamage(6, 8);
+
+            SetDamageType(ResistanceType.Physical, 40);
+            SetDamageType(ResistanceType.Cold, 60);
+
+            SetResistance(ResistanceType.Physical, 35, 45);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 20, 30);
+            SetResistance(ResistanceType.Energy, 30, 40);
+
+            SetSkill(SkillName.Wrestling, 60);
+            SetSkill(SkillName.Tactics, 60);
+            SetSkill(SkillName.MagicResist, 60);
+
+            Fame = 3600;
+            Karma = -3600;
+
+            VirtualArmor = 40;
+
+            PackItem(new Scimitar());
+            PackItem(new WoodenShield());
+
+            switch (Utility.Random(5))
+            {
+                case 0:
+                    this.PackItem(new BoneArms());
+                    break;
+                case 1:
+                    this.PackItem(new BoneChest());
+                    break;
+                case 2:
+                    this.PackItem(new BoneGloves());
+                    break;
+                case 3:
+                    this.PackItem(new BoneLegs());
+                    break;
+                case 4:
+                    this.PackItem(new BoneHelm());
+                    break;
+            }
+        }
+
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Meager);
+        }
+
+        public override bool BleedImmune { get { return true; } }
+
+        #region Start/Stop
+        private void Start()
+        {
+            m_NextMsgTime = DateTime.UtcNow + TimeSpan.FromMinutes(msgevery);
+
+            BroadcastMessage();
+            init = true;
+        }
+        #endregion
+        
+        #region Broadcast Message
+        public void BroadcastMessage()
+        {
+            foreach (NetState state in NetState.Instances)
+            {
+                Mobile m = state.Mobile;
+
+                if (m != null && this.Region.Name == "Old Haven Training" && m.Region.Name == "Old Haven Training")
+                {
+                    m.SendLocalizedMessage(1077840, "", 34); // // Who dares to defile Haven? I am Drelgor the Impaler! I shall claim your souls as payment for this intrusion!
+                    m.PlaySound(0x14);
+                }
+            }
+        }
+        #endregion
+
+        #region OnThink
+        public override void OnThink()
+        {
+            if (!init)
+                Start();
+
+            if (msgevery != 0 && DateTime.UtcNow >= m_NextMsgTime)
+            {
+                BroadcastMessage();
+                m_NextMsgTime = DateTime.UtcNow + TimeSpan.FromMinutes(msgevery);
+            }
+
+            base.OnThink();
+        }
+        #endregion
+
+        public Drelgor(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override OppositionGroup OppositionGroup
+        {
+            get { return OppositionGroup.FeyAndUndead; }
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0);
+            writer.Write(init);
+            writer.Write(m_NextMsgTime);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+            init = reader.ReadBool();
+            m_NextMsgTime = reader.ReadDateTime();
+        }
+    }
+}
+

--- a/Scripts/Mobiles/Normal/BaseMount.cs
+++ b/Scripts/Mobiles/Normal/BaseMount.cs
@@ -454,7 +454,7 @@ namespace Server.Mobiles
             if (attacker == null)
                 attacker = this.m_Rider.FindMostRecentDamager(true);
 
-            if (!(attacker == this || attacker == this.m_Rider || willKill || DateTime.UtcNow < this.m_NextMountAbility))
+            if (!(attacker == this || attacker == this.m_Rider || willKill || DateTime.UtcNow > this.m_NextMountAbility))
             {
                 if (this.DoMountAbility(amount, from))
                     this.m_NextMountAbility = DateTime.UtcNow + this.MountAbilityDelay;

--- a/Scripts/Mobiles/Normal/DespiseCreature.cs
+++ b/Scripts/Mobiles/Normal/DespiseCreature.cs
@@ -192,14 +192,18 @@ namespace Server.Engines.Despise
             return false;
         }
 
+        public override void GetContextMenuEntries(Mobile from, System.Collections.Generic.List<Server.ContextMenus.ContextMenuEntry> list)
+        {
+        }
+
         public override void GetProperties(ObjectPropertyList list)
         {
             base.GetProperties(list);
 
-            list.Add(1153297, String.Format("#{0}\t{1}", GetPowerLabel(m_Power), m_Power.ToString())); // Power Level: ~1_LEVEL~: ~2_VAL~
-
             if (ControlMaster != null)
                 list.Add(1153303, ControlMaster.Name); // Controller: ~1_NAME~
+
+            list.Add(1153297, String.Format("#{0}\t{1}", m_Power.ToString(), GetPowerLabel(m_Power))); // Power Level: ~1_LEVEL~: ~2_VAL~
         }
 
         public override void OnCombatantChange()
@@ -229,10 +233,7 @@ namespace Server.Engines.Despise
 
             if (m_Orb != null)
             {
-                if (m_Orb.Owner != null)
-                    m_Orb.Owner.SendLocalizedMessage(1153312); // The Wisp Orb dissolves into aether.
-
-                m_Orb.Delete();
+                Unlink(false);
             }
         }
 
@@ -265,11 +266,19 @@ namespace Server.Engines.Despise
             m_Orb.InvalidateHue();
         }
 
-        public void Unlink()
+        public void Unlink(bool message = true)
         {
             RangeHome = 10;
             SetControlMaster(null);
-            PublicOverheadMessage(MessageType.Regular, 0x59, 1153296); // * This creature is no longer influenced by a Wisp Orb *
+
+            if (Alive && message)
+            {
+                if (m_Orb != null && m_Orb.Owner != null)
+                {
+                    m_Orb.Owner.SendLocalizedMessage(1153335, Name); // You have released control of ~1_NAME~.
+                    NonlocalOverheadMessage(MessageType.Regular, 0x59, 1153296, Name); // * This creature is no longer influenced by a Wisp Orb *
+                }
+            }
 
             if (m_Orb != null)
             {

--- a/Scripts/Mobiles/Normal/DespiseCreature.cs
+++ b/Scripts/Mobiles/Normal/DespiseCreature.cs
@@ -148,6 +148,24 @@ namespace Server.Engines.Despise
             SetDamage(MinDamStart, MaxDamStart);
         }
 
+        public override bool IsEnemy(Mobile m)
+        {
+            if (m is PlayerMobile)
+            {
+                if (m.Karma <= 1000 && Alignment == Alignment.Good)
+                    return true;
+
+                if (m.Karma >= 1000 && Alignment == Alignment.Evil)
+                    return true;
+            }
+            else if (m is DespiseCreature)
+            {
+                return ((DespiseCreature)m).Alignment != this.Alignment;
+            }
+
+            return false;
+        }
+
         public override void GenerateLoot(bool spawning)
         {
             if (spawning)

--- a/Scripts/Mobiles/Normal/DespiseEvilCreatures.cs
+++ b/Scripts/Mobiles/Normal/DespiseEvilCreatures.cs
@@ -18,8 +18,9 @@ namespace Server.Engines.Despise
 		public Phantom(int powerLevel) : base(AIType.AI_Melee, FightMode.Good)
 		{
 			Name = "Phantom";
-			Body =  310;
+			Body =  0xFC;
 			BaseSoundID = 0x482;
+            Hue = 2671;
 
 			SetDamageType( ResistanceType.Physical, 100 );
 
@@ -114,8 +115,9 @@ namespace Server.Engines.Despise
 		public Naba(int powerLevel) : base(AIType.AI_Mage, FightMode.Good)
 		{
 			Name = "Naba";
-			Body = 85;
+			Body = 0x88;
 			BaseSoundID = 639;
+            Hue = 2707;
 
 			SetDamageType( ResistanceType.Physical, 50 );
 			SetDamageType( ResistanceType.Fire, 15 );
@@ -176,6 +178,7 @@ namespace Server.Engines.Despise
 		public Darkmane(int powerLevel) : base(AIType.AI_Melee, FightMode.Good)
 		{
 			Name = "Darkmane";
+            Hue = 1910;
 			BaseSoundID = 0xA8;
 			
 			switch(Utility.Random(3))
@@ -250,6 +253,7 @@ namespace Server.Engines.Despise
 			Name = "Skeletrex";
 			Body = 147;
 			BaseSoundID = 451;
+            Hue = 2075;
 
 			SetDamageType( ResistanceType.Physical, 100 );
 
@@ -380,6 +384,7 @@ namespace Server.Engines.Despise
 			Name = "Echidnite";
 			Body = 250;
 			BaseSoundID = 0x52A;
+            Hue = 2671;
 
 			SetDamageType( ResistanceType.Physical, 100 );
 
@@ -434,17 +439,18 @@ namespace Server.Engines.Despise
 		}
 	}
 	
-	public class BerlingBlades : DespiseCreature
+    [TypeAlias("Server.Engines.Despise.BerlingBlades")]
+	public class BirlingBlades : DespiseCreature
 	{	
 		[Constructable]
-		public BerlingBlades() : this(1)
+		public BirlingBlades() : this(1)
 		{
 		}
 		
 		[Constructable]
-		public BerlingBlades(int powerLevel) : base(AIType.AI_Melee, FightMode.Good)
+		public BirlingBlades(int powerLevel) : base(AIType.AI_Melee, FightMode.Good)
 		{
-			Name = "Berling Blades";
+			Name = "Birling Blades";
 			Body = 574;
 			BaseSoundID = 224;
 
@@ -498,8 +504,9 @@ namespace Server.Engines.Despise
 		{
 			return 0x23A;
 		}
-		
-		public BerlingBlades(Serial serial) : base(serial)
+
+        public BirlingBlades(Serial serial)
+            : base(serial)
 		{
 		}
 		
@@ -535,6 +542,7 @@ namespace Server.Engines.Despise
 			Name = "Prometheoid";
 			Body = 305;
 			BaseSoundID = 224;
+            Hue = 2671;
 
 			SetDamageType( ResistanceType.Physical, 100 );
 

--- a/Scripts/Mobiles/Normal/DespiseGoodCreatures.cs
+++ b/Scripts/Mobiles/Normal/DespiseGoodCreatures.cs
@@ -234,17 +234,18 @@ namespace Server.Engines.Despise
 		}
 	}
 	
-	public class Sagittari : DespiseCreature
+    [TypeAlias("Server.Engines.Despise.Sagittari")]
+	public class Sagittarri : DespiseCreature
 	{
 		[Constructable]
-		public Sagittari() : this(1)
+		public Sagittarri() : this(1)
 		{
 		}
 		
 		[Constructable]
-		public Sagittari(int powerLevel) : base(AIType.AI_Melee, FightMode.Evil)
+		public Sagittarri(int powerLevel) : base(AIType.AI_Melee, FightMode.Evil)
 		{
-			Name = "Sagittari";
+            Name = "Sagittarri";
 			Body = 101;
 			BaseSoundID = 679;
 
@@ -279,8 +280,9 @@ namespace Server.Engines.Despise
 		public override int MinDamMax { get { return 15; } }
 		public override int MaxDamMax { get { return 26; } }
 		public override bool RaiseDamage { get { return true; } }
-		
-		public Sagittari(Serial serial) : base(serial)
+
+        public Sagittarri(Serial serial)
+            : base(serial)
 		{
 		}
 		
@@ -529,7 +531,7 @@ namespace Server.Engines.Despise
 		public Fairy(int powerLevel) : base(AIType.AI_Melee, FightMode.Evil)
 		{
 			Name = "Fairy";
-			Body = 128;
+			Body = 0x108;
 			BaseSoundID = 0x467;
 
 			SetDamageType( ResistanceType.Physical, 100 );

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -615,8 +615,14 @@ namespace Server.Mobiles
 		{
 			get
 			{
-				string title = Titles.ComputeFameTitle(this);
-				return title.Length > 0 ? title : RawName;
+                string name;
+
+                if (Fame >= 10000)
+                    name = String.Format("{0} {1}", Female ? "Lady" : "Lord", RawName);
+                else
+                    name = RawName;
+
+                return name;
 			}
 		}
 

--- a/Scripts/Multis/BaseHouse.cs
+++ b/Scripts/Multis/BaseHouse.cs
@@ -335,7 +335,7 @@ namespace Server.Multis
         {
             get
             {
-                return (Core.ML ? 1.2 : 1.0);
+                return (Core.ML ? Core.SA ? 1.4 : 1.2 : 1.0);
             }
         }
 

--- a/Scripts/Multis/HousePlacementTool.cs
+++ b/Scripts/Multis/HousePlacementTool.cs
@@ -14,8 +14,8 @@ namespace Server.Items
         public HousePlacementTool()
             : base(0x14F6)
         {
-            this.Weight = 3.0;
-            this.LootType = LootType.Blessed;
+            Weight = 3.0;
+            LootType = LootType.Blessed;
         }
 
         public HousePlacementTool(Serial serial)
@@ -32,7 +32,7 @@ namespace Server.Items
         }// a house placement tool
         public override void OnDoubleClick(Mobile from)
         {
-            if (this.IsChildOf(from.Backpack))
+            if (IsChildOf(from.Backpack))
                 from.SendGump(new HousePlacementCategoryGump(from));
             else
                 from.SendLocalizedMessage(1042001); // That must be in your pack for you to use it.
@@ -51,8 +51,8 @@ namespace Server.Items
 
             int version = reader.ReadInt();
 
-            if (this.Weight == 0.0)
-                this.Weight = 3.0;
+            if (Weight == 0.0)
+                Weight = 3.0;
         }
     }
 
@@ -64,53 +64,53 @@ namespace Server.Items
         public HousePlacementCategoryGump(Mobile from)
             : base(50, 50)
         {
-            this.m_From = from;
+            m_From = from;
 
             from.CloseGump(typeof(HousePlacementCategoryGump));
             from.CloseGump(typeof(HousePlacementListGump));
 
-            this.AddPage(0);
+            AddPage(0);
 
-            this.AddBackground(0, 0, 270, 145, 5054);
+            AddBackground(0, 0, 270, 145, 5054);
 
-            this.AddImageTiled(10, 10, 250, 125, 2624);
-            this.AddAlphaRegion(10, 10, 250, 125);
+            AddImageTiled(10, 10, 250, 125, 2624);
+            AddAlphaRegion(10, 10, 250, 125);
 
-            this.AddHtmlLocalized(10, 10, 250, 20, 1060239, LabelColor, false, false); // <CENTER>HOUSE PLACEMENT TOOL</CENTER>
+            AddHtmlLocalized(10, 10, 250, 20, 1060239, LabelColor, false, false); // <CENTER>HOUSE PLACEMENT TOOL</CENTER>
 
-            this.AddButton(10, 110, 4017, 4019, 0, GumpButtonType.Reply, 0);
-            this.AddHtmlLocalized(45, 110, 150, 20, 3000363, LabelColor, false, false); // Close
+            AddButton(10, 110, 4017, 4019, 0, GumpButtonType.Reply, 0);
+            AddHtmlLocalized(45, 110, 150, 20, 3000363, LabelColor, false, false); // Close
 
-            this.AddButton(10, 40, 4005, 4007, 1, GumpButtonType.Reply, 0);
-            this.AddHtmlLocalized(45, 40, 200, 20, 1060390, LabelColor, false, false); // Classic Houses
+            AddButton(10, 40, 4005, 4007, 1, GumpButtonType.Reply, 0);
+            AddHtmlLocalized(45, 40, 200, 20, 1060390, LabelColor, false, false); // Classic Houses
 
-            this.AddButton(10, 60, 4005, 4007, 2, GumpButtonType.Reply, 0);
-            this.AddHtmlLocalized(45, 60, 200, 20, 1060391, LabelColor, false, false); // 2-Story Customizable Houses
+            AddButton(10, 60, 4005, 4007, 2, GumpButtonType.Reply, 0);
+            AddHtmlLocalized(45, 60, 200, 20, 1060391, LabelColor, false, false); // 2-Story Customizable Houses
 
-            this.AddButton(10, 80, 4005, 4007, 3, GumpButtonType.Reply, 0);
-            this.AddHtmlLocalized(45, 80, 200, 20, 1060392, LabelColor, false, false); // 3-Story Customizable Houses
+            AddButton(10, 80, 4005, 4007, 3, GumpButtonType.Reply, 0);
+            AddHtmlLocalized(45, 80, 200, 20, 1060392, LabelColor, false, false); // 3-Story Customizable Houses
         }
 
         public override void OnResponse(Server.Network.NetState sender, RelayInfo info)
         {
-            if (!this.m_From.CheckAlive() || this.m_From.Backpack == null || this.m_From.Backpack.FindItemByType(typeof(HousePlacementTool)) == null)
+            if (!m_From.CheckAlive() || m_From.Backpack == null || m_From.Backpack.FindItemByType(typeof(HousePlacementTool)) == null)
                 return;
 
             switch ( info.ButtonID )
             {
                 case 1: // Classic Houses
                     {
-                        this.m_From.SendGump(new HousePlacementListGump(this.m_From, HousePlacementEntry.ClassicHouses));
+                        m_From.SendGump(new HousePlacementListGump(m_From, HousePlacementEntry.ClassicHouses));
                         break;
                     }
                 case 2: // 2-Story Customizable Houses
                     {
-                        this.m_From.SendGump(new HousePlacementListGump(this.m_From, HousePlacementEntry.TwoStoryFoundations));
+                        m_From.SendGump(new HousePlacementListGump(m_From, HousePlacementEntry.TwoStoryFoundations));
                         break;
                     }
                 case 3: // 3-Story Customizable Houses
                     {
-                        this.m_From.SendGump(new HousePlacementListGump(this.m_From, HousePlacementEntry.ThreeStoryFoundations));
+                        m_From.SendGump(new HousePlacementListGump(m_From, HousePlacementEntry.ThreeStoryFoundations));
                         break;
                     }
             }
@@ -126,43 +126,43 @@ namespace Server.Items
         public HousePlacementListGump(Mobile from, HousePlacementEntry[] entries)
             : base(50, 50)
         {
-            this.m_From = from;
-            this.m_Entries = entries;
+            m_From = from;
+            m_Entries = entries;
 
             from.CloseGump(typeof(HousePlacementCategoryGump));
             from.CloseGump(typeof(HousePlacementListGump));
 
-            this.AddPage(0);
+            AddPage(0);
 
-            this.AddBackground(0, 0, 520, 420, 5054);
+            AddBackground(0, 0, 520, 420, 5054);
 
-            this.AddImageTiled(10, 10, 500, 20, 2624);
-            this.AddAlphaRegion(10, 10, 500, 20);
+            AddImageTiled(10, 10, 500, 20, 2624);
+            AddAlphaRegion(10, 10, 500, 20);
 
-            this.AddHtmlLocalized(10, 10, 500, 20, 1060239, LabelColor, false, false); // <CENTER>HOUSE PLACEMENT TOOL</CENTER>
+            AddHtmlLocalized(10, 10, 500, 20, 1060239, LabelColor, false, false); // <CENTER>HOUSE PLACEMENT TOOL</CENTER>
 
-            this.AddImageTiled(10, 40, 500, 20, 2624);
-            this.AddAlphaRegion(10, 40, 500, 20);
+            AddImageTiled(10, 40, 500, 20, 2624);
+            AddAlphaRegion(10, 40, 500, 20);
 
-            this.AddHtmlLocalized(50, 40, 225, 20, 1060235, LabelColor, false, false); // House Description
-            this.AddHtmlLocalized(275, 40, 75, 20, 1060236, LabelColor, false, false); // Storage
-            this.AddHtmlLocalized(350, 40, 75, 20, 1060237, LabelColor, false, false); // Lockdowns
-            this.AddHtmlLocalized(425, 40, 75, 20, 1060034, LabelColor, false, false); // Cost
+            AddHtmlLocalized(50, 40, 225, 20, 1060235, LabelColor, false, false); // House Description
+            AddHtmlLocalized(275, 40, 75, 20, 1060236, LabelColor, false, false); // Storage
+            AddHtmlLocalized(350, 40, 75, 20, 1060237, LabelColor, false, false); // Lockdowns
+            AddHtmlLocalized(425, 40, 75, 20, 1060034, LabelColor, false, false); // Cost
 
-            this.AddImageTiled(10, 70, 500, 280, 2624);
-            this.AddAlphaRegion(10, 70, 500, 280);
+            AddImageTiled(10, 70, 500, 280, 2624);
+            AddAlphaRegion(10, 70, 500, 280);
 
-            this.AddImageTiled(10, 360, 500, 20, 2624);
-            this.AddAlphaRegion(10, 360, 500, 20);
+            AddImageTiled(10, 360, 500, 20, 2624);
+            AddAlphaRegion(10, 360, 500, 20);
 
-            this.AddHtmlLocalized(10, 360, 250, 20, 1060645, LabelColor, false, false); // Bank Balance:
-            this.AddLabel(250, 360, LabelHue, Banker.GetBalance(from).ToString());
+            AddHtmlLocalized(10, 360, 250, 20, 1060645, LabelColor, false, false); // Bank Balance:
+            AddLabel(250, 360, LabelHue, Banker.GetBalance(from).ToString());
 
-            this.AddImageTiled(10, 390, 500, 20, 2624);
-            this.AddAlphaRegion(10, 390, 500, 20);
+            AddImageTiled(10, 390, 500, 20, 2624);
+            AddAlphaRegion(10, 390, 500, 20);
 
-            this.AddButton(10, 390, 4017, 4019, 0, GumpButtonType.Reply, 0);
-            this.AddHtmlLocalized(50, 390, 100, 20, 3000363, LabelColor, false, false); // Close
+            AddButton(10, 390, 4017, 4019, 0, GumpButtonType.Reply, 0);
+            AddHtmlLocalized(50, 390, 100, 20, 3000363, LabelColor, false, false); // Close
 
             for (int i = 0; i < entries.Length; ++i)
             {
@@ -173,16 +173,16 @@ namespace Server.Items
                 {
                     if (page > 1)
                     {
-                        this.AddButton(450, 390, 4005, 4007, 0, GumpButtonType.Page, page);
-                        this.AddHtmlLocalized(400, 390, 100, 20, 3000406, LabelColor, false, false); // Next
+                        AddButton(450, 390, 4005, 4007, 0, GumpButtonType.Page, page);
+                        AddHtmlLocalized(400, 390, 100, 20, 3000406, LabelColor, false, false); // Next
                     }
 
-                    this.AddPage(page);
+                    AddPage(page);
 
                     if (page > 1)
                     {
-                        this.AddButton(200, 390, 4014, 4016, 0, GumpButtonType.Page, page - 1);
-                        this.AddHtmlLocalized(250, 390, 100, 20, 3000405, LabelColor, false, false); // Previous
+                        AddButton(200, 390, 4014, 4016, 0, GumpButtonType.Page, page - 1);
+                        AddHtmlLocalized(250, 390, 100, 20, 3000405, LabelColor, false, false); // Previous
                     }
                 }
 
@@ -190,31 +190,31 @@ namespace Server.Items
 
                 int y = 70 + (index * 20);
 
-                this.AddButton(10, y, 4005, 4007, 1 + i, GumpButtonType.Reply, 0);
-                this.AddHtmlLocalized(50, y, 225, 20, entry.Description, LabelColor, false, false);
-                this.AddLabel(275, y, LabelHue, entry.Storage.ToString());
-                this.AddLabel(350, y, LabelHue, entry.Lockdowns.ToString());
-                this.AddLabel(425, y, LabelHue, entry.Cost.ToString());
+                AddButton(10, y, 4005, 4007, 1 + i, GumpButtonType.Reply, 0);
+                AddHtmlLocalized(50, y, 225, 20, entry.Description, LabelColor, false, false);
+                AddLabel(275, y, LabelHue, entry.Storage.ToString());
+                AddLabel(350, y, LabelHue, entry.Lockdowns.ToString());
+                AddLabel(425, y, LabelHue, entry.Cost.ToString());
             }
         }
 
         public override void OnResponse(Server.Network.NetState sender, RelayInfo info)
         {
-            if (!this.m_From.CheckAlive() || this.m_From.Backpack == null || this.m_From.Backpack.FindItemByType(typeof(HousePlacementTool)) == null)
+            if (!m_From.CheckAlive() || m_From.Backpack == null || m_From.Backpack.FindItemByType(typeof(HousePlacementTool)) == null)
                 return;
 
             int index = info.ButtonID - 1;
 
-            if (index >= 0 && index < this.m_Entries.Length)
+            if (index >= 0 && index < m_Entries.Length)
             {
-                if (this.m_From.AccessLevel < AccessLevel.GameMaster && BaseHouse.HasAccountHouse(this.m_From))
-                    this.m_From.SendLocalizedMessage(501271); // You already own a house, you may not place another!
+                if (m_From.AccessLevel < AccessLevel.GameMaster && BaseHouse.HasAccountHouse(m_From))
+                    m_From.SendLocalizedMessage(501271); // You already own a house, you may not place another!
                 else
-                    this.m_From.Target = new NewHousePlacementTarget(this.m_Entries, this.m_Entries[index]);
+                    m_From.Target = new NewHousePlacementTarget(m_Entries, m_Entries[index]);
             }
             else
             {
-                this.m_From.SendGump(new HousePlacementCategoryGump(this.m_From));
+                m_From.SendGump(new HousePlacementCategoryGump(m_From));
             }
         }
     }
@@ -227,10 +227,10 @@ namespace Server.Items
         public NewHousePlacementTarget(HousePlacementEntry[] entries, HousePlacementEntry entry)
             : base(entry.MultiID, entry.Offset)
         {
-            this.Range = 14;
+            Range = 14;
 
-            this.m_Entries = entries;
-            this.m_Entry = entry;
+            m_Entries = entries;
+            m_Entry = entry;
         }
 
         protected override void OnTarget(Mobile from, object o)
@@ -250,7 +250,7 @@ namespace Server.Items
                 Region reg = Region.Find(new Point3D(p), from.Map);
 
                 if (from.AccessLevel >= AccessLevel.GameMaster || reg.AllowHousing(from, p))
-                    this.m_Placed = this.m_Entry.OnPlacement(from, p);
+                    m_Placed = m_Entry.OnPlacement(from, p);
                 else if (reg.IsPartOf<TempNoHousingRegion>())
                     from.SendLocalizedMessage(501270); // Lord British has decreed a 'no build' period, thus you cannot build this house at this time.
                 else if (reg.IsPartOf<TreasureRegion>() || reg.IsPartOf<HouseRegion>())
@@ -267,8 +267,8 @@ namespace Server.Items
             if (!from.CheckAlive() || from.Backpack == null || from.Backpack.FindItemByType(typeof(HousePlacementTool)) == null)
                 return;
 
-            if (!this.m_Placed)
-                from.SendGump(new HousePlacementListGump(from, this.m_Entries));
+            if (!m_Placed)
+                from.SendGump(new HousePlacementListGump(from, m_Entries));
         }
     }
 
@@ -276,134 +276,134 @@ namespace Server.Items
     {
         private static readonly HousePlacementEntry[] m_ClassicHouses = new HousePlacementEntry[]
         {
-            new HousePlacementEntry(typeof(SmallOldHouse), 1011303,	425,	212,	489,	244,	10,	37000, 0,	4,	0,	0x0064),
-            new HousePlacementEntry(typeof(SmallOldHouse), 1011304,	425,	212,	489,	244,	10,	37000, 0,	4,	0,	0x0066),
-            new HousePlacementEntry(typeof(SmallOldHouse), 1011305,	425,	212,	489,	244,	10,	36750, 0,	4,	0,	0x0068),
-            new HousePlacementEntry(typeof(SmallOldHouse), 1011306,	425,	212,	489,	244,	10,	35250, 0,	4,	0,	0x006A),
-            new HousePlacementEntry(typeof(SmallOldHouse), 1011307,	425,	212,	489,	244,	10,	36750, 0,	4,	0,	0x006C),
-            new HousePlacementEntry(typeof(SmallOldHouse), 1011308,	425,	212,	489,	244,	10,	36750, 0,	4,	0,	0x006E),
-            new HousePlacementEntry(typeof(SmallShop), 1011321,	425,	212,	489,	244,	10,	50500, -1,	4,	0,	0x00A0),
-            new HousePlacementEntry(typeof(SmallShop), 1011322,	425,	212,	489,	244,	10,	52500, 0,	4,	0,	0x00A2),
-            new HousePlacementEntry(typeof(SmallTower), 1011317,	580,	290,	667,	333,	14,	73500, 3,	4,	0,	0x0098),
-            new HousePlacementEntry(typeof(TwoStoryVilla), 1011319,	1100,	550,	1265,	632,	24,	113750, 3,	6,	0,	0x009E),
-            new HousePlacementEntry(typeof(SandStonePatio), 1011320,	850,	425,	1265,	632,	24,	76500, -1,	4,	0,	0x009C),
-            new HousePlacementEntry(typeof(LogCabin), 1011318,	1100,	550,	1265,	632,	24,	81750, 1,	6,	0,	0x009A),
-            new HousePlacementEntry(typeof(GuildHouse), 1011309,	1370,	685,	1576,	788,	28,	131500, -1,	7,	0,	0x0074),
-            new HousePlacementEntry(typeof(TwoStoryHouse), 1011310,	1370,	685,	1576,	788,	28,	162750, -3,	7,	0,	0x0076),
-            new HousePlacementEntry(typeof(TwoStoryHouse), 1011311,	1370,	685,	1576,	788,	28,	162000, -3,	7,	0,	0x0078),
-            new HousePlacementEntry(typeof(LargePatioHouse), 1011315,	1370,	685,	1576,	788,	28,	129250, -4,	7,	0,	0x008C),
-            new HousePlacementEntry(typeof(LargeMarbleHouse),	1011316,	1370,	685,	1576,	788,	28,	160500, -4,	7,	0,	0x0096),
-            new HousePlacementEntry(typeof(Tower), 1011312,	2119,	1059,	2437,	1218,	42,	366500, 0,	7,	0,	0x007A),
-            new HousePlacementEntry(typeof(Keep), 1011313,	2625,	1312,	3019,	1509,	52,	572750, 0, 11,	0,	0x007C),
-            new HousePlacementEntry(typeof(Castle), 1011314,	4076,	2038,	4688,	2344,	78,	865250, 0, 16,	0,	0x007E)
+            new HousePlacementEntry(typeof(SmallOldHouse),  1011303,	425,	212,	489,	244,	10,	36750, 0,	4,	0,	0x0064),
+            new HousePlacementEntry(typeof(SmallOldHouse),  1011304,	425,	212,	489,	244,	10,	36750, 0,	4,	0,	0x0066),
+            new HousePlacementEntry(typeof(SmallOldHouse),  1011305,	425,	212,	489,	244,	10,	36500, 0,	4,	0,	0x0068),
+            new HousePlacementEntry(typeof(SmallOldHouse),  1011306,	425,	212,	489,	244,	10,	35000, 0,	4,	0,	0x006A),
+            new HousePlacementEntry(typeof(SmallOldHouse),  1011307,	425,	212,	489,	244,	10,	36500, 0,	4,	0,	0x006C),
+            new HousePlacementEntry(typeof(SmallOldHouse),  1011308,	425,	212,	489,	244,	10,	36500, 0,	4,	0,	0x006E),
+            new HousePlacementEntry(typeof(SmallShop),      1011321,	425,	212,	489,	244,	10,	50250, -1,	4,	0,	0x00A0),
+            new HousePlacementEntry(typeof(SmallShop),      1011322,	425,	212,	489,	244,	10,	52250, 0,	4,	0,	0x00A2),
+            new HousePlacementEntry(typeof(SmallTower),     1011317,	580,	290,	667,	333,	14,	73250, 3,	4,	0,	0x0098),
+            new HousePlacementEntry(typeof(TwoStoryVilla),  1011319,	1100,	550,	1265,	632,	24,	113500, 3,	6,	0,	0x009E),
+            new HousePlacementEntry(typeof(SandStonePatio), 1011320,	850,	425,	1265,	632,	24,	76250, -1,	4,	0,	0x009C),
+            new HousePlacementEntry(typeof(LogCabin),       1011318,	1100,	550,	1265,	632,	24,	81250, 1,	6,	0,	0x009A),
+            new HousePlacementEntry(typeof(GuildHouse),     1011309,	1370,	685,	1576,	788,	28,	131250, -1,	7,	0,	0x0074),
+            new HousePlacementEntry(typeof(TwoStoryHouse),  1011310,	1370,	685,	1576,	788,	28,	162500, -3,	7,	0,	0x0076),
+            new HousePlacementEntry(typeof(TwoStoryHouse),  1011311,	1370,	685,	1576,	788,	28,	162750, -3,	7,	0,	0x0078),
+            new HousePlacementEntry(typeof(LargePatioHouse),1011315,	1370,	685,	1576,	788,	28,	129000, -4,	7,	0,	0x008C),
+            new HousePlacementEntry(typeof(LargeMarbleHouse),1011316,	1370,	685,	1576,	788,	28,	160250, -4,	7,	0,	0x0096),
+            new HousePlacementEntry(typeof(Tower),          1011312,	2119,	1059,	2437,	1218,	42,	366250, 0,	7,	0,	0x007A),
+            new HousePlacementEntry(typeof(Keep),           1011313,	2625,	1312,	3019,	1509,	52,	562500, 0, 11,	0,	0x007C),
+            new HousePlacementEntry(typeof(Castle),         1011314,	4076,	2038,	4688,	2344,	78,	865000, 0, 16,	0,	0x007E)
         };
         private static readonly HousePlacementEntry[] m_TwoStoryFoundations = new HousePlacementEntry[]
         {
-            new HousePlacementEntry(typeof(HouseFoundation), 1060241,	425,	212,	489,	244,	10,	30500, 0,	4,	0,	0x13EC), // 7x7 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060242,	580,	290,	667,	333,	14,	34500, 0,	5,	0,	0x13ED), // 7x8 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060243,	650,	325,	748,	374,	16,	38500, 0,	5,	0,	0x13EE), // 7x9 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060244,	700,	350,	805,	402,	16,	42500, 0,	6,	0,	0x13EF), // 7x10 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060245,	750,	375,	863,	431,	16,	46500, 0,	6,	0,	0x13F0), // 7x11 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060246,	800,	400,	920,	460,	18,	50500, 0,	7,	0,	0x13F1), // 7x12 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060253,	580,	290,	667,	333,	14,	34500, 0,	4,	0,	0x13F8), // 8x7 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060254,	650,	325,	748,	374,	16,	39000, 0,	5,	0,	0x13F9), // 8x8 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060255,	700,	350,	805,	402,	16,	43500, 0,	5,	0,	0x13FA), // 8x9 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060256,	750,	375,	863,	431,	16,	48000, 0,	6,	0,	0x13FB), // 8x10 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060257,	800,	400,	920,	460,	18,	52500, 0,	6,	0,	0x13FC), // 8x11 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060258,	850,	425,	1265,	632,	24,	57000, 0,	7,	0,	0x13FD), // 8x12 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060259,	1100,	550,	1265,	632,	24,	61500, 0,	7,	0,	0x13FE), // 8x13 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060265,	650,	325,	748,	374,	16,	38500, 0,	4,	0,	0x1404), // 9x7 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060266,	700,	350,	805,	402,	16,	43500, 0,	5,	0,	0x1405), // 9x8 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060267,	750,	375,	863,	431,	16,	48500, 0,	5,	0,	0x1406), // 9x9 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060268,	800,	400,	920,	460,	18,	53500, 0,	6,	0,	0x1407), // 9x10 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060269,	850,	425,	1265,	632,	24,	58500, 0,	6,	0,	0x1408), // 9x11 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060270,	1100,	550,	1265,	632,	24,	63500, 0,	7,	0,	0x1409), // 9x12 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060271,	1100,	550,	1265,	632,	24,	68500, 0,	7,	0,	0x140A), // 9x13 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060277,	700,	350,	805,	402,	16,	42500, 0,	4,	0,	0x1410), // 10x7 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060278,	750,	375,	863,	431,	16,	48000, 0,	5,	0,	0x1411), // 10x8 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060279,	800,	400,	920,	460,	18,	53500, 0,	5,	0,	0x1412), // 10x9 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060280,	850,	425,	1265,	632,	24,	59000, 0,	6,	0,	0x1413), // 10x10 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060281,	1100,	550,	1265,	632,	24,	64500, 0,	6,	0,	0x1414), // 10x11 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060282,	1100,	550,	1265,	632,	24,	70000, 0,	7,	0,	0x1415), // 10x12 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060283,	1150,	575,	1323,	661,	24,	75500, 0,	7,	0,	0x1416), // 10x13 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060289,	750,	375,	863,	431,	16,	46500, 0,	4,	0,	0x141C), // 11x7 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060290,	800,	400,	920,	460,	18,	52500, 0,	5,	0,	0x141D), // 11x8 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060291,	850,	425,	1265,	632,	24,	58500, 0,	5,	0,	0x141E), // 11x9 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060292,	1100,	550,	1265,	632,	24,	64500, 0,	6,	0,	0x141F), // 11x10 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060293,	1100,	550,	1265,	632,	24,	70500, 0,	6,	0,	0x1420), // 11x11 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060294,	1150,	575,	1323,	661,	24,	76500, 0,	7,	0,	0x1421), // 11x12 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060295,	1200,	600,	1380,	690,	26,	82500, 0,	7,	0,	0x1422), // 11x13 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060301,	800,	400,	920,	460,	18,	50500, 0,	4,	0,	0x1428), // 12x7 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060302,	850,	425,	1265,	632,	24,	57000, 0,	5,	0,	0x1429), // 12x8 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060303,	1100,	550,	1265,	632,	24,	63500, 0,	5,	0,	0x142A), // 12x9 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060304,	1100,	550,	1265,	632,	24,	70000, 0,	6,	0,	0x142B), // 12x10 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060305,	1150,	575,	1323,	661,	24,	76500, 0,	6,	0,	0x142C), // 12x11 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060306,	1200,	600,	1380,	690,	26,	83000, 0,	7,	0,	0x142D), // 12x12 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060307,	1250,	625,	1438,	719,	26,	89500, 0,	7,	0,	0x142E), // 12x13 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060314,	1100,	550,	1265,	632,	24,	61500, 0,	5,	0,	0x1435), // 13x8 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060315,	1100,	550,	1265,	632,	24,	68500, 0,	5,	0,	0x1436), // 13x9 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060316,	1150,	575,	1323,	661,	24,	75500, 0,	6,	0,	0x1437), // 13x10 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060317,	1200,	600,	1380,	690,	26,	82500, 0,	6,	0,	0x1438), // 13x11 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060318,	1250,	625,	1438,	719,	26,	89500, 0,	7,	0,	0x1439), // 13x12 2-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060319,	1300,	650,	1495,	747,	28,	96500, 0,	7,	0,	0x143A)// 13x13 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060241,	425,	212,	489,	244,	10,	33000, 0,	4,	0,	0x13EC), // 7x7 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060242,	580,	290,	667,	333,	14,	37000, 0,	5,	0,	0x13ED), // 7x8 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060243,	650,	325,	748,	374,	16,	41000, 0,	5,	0,	0x13EE), // 7x9 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060244,	700,	350,	805,	402,	16,	45000, 0,	6,	0,	0x13EF), // 7x10 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060245,	750,	375,	863,	431,	16,	49000, 0,	6,	0,	0x13F0), // 7x11 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060246,	800,	400,	920,	460,	18,	53000, 0,	7,	0,	0x13F1), // 7x12 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060253,	580,	290,	667,	333,	14,	37500, 0,	4,	0,	0x13F8), // 8x7 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060254,	650,	325,	748,	374,	16,	42000, 0,	5,	0,	0x13F9), // 8x8 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060255,	700,	350,	805,	402,	16,	46500, 0,	5,	0,	0x13FA), // 8x9 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060256,	750,	375,	863,	431,	16,	51000, 0,	6,	0,	0x13FB), // 8x10 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060257,	800,	400,	920,	460,	18,	55500, 0,	6,	0,	0x13FC), // 8x11 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060258,	850,	425,	1265,	632,	24,	60000, 0,	7,	0,	0x13FD), // 8x12 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060259,	1100,	550,	1265,	632,	24,	64500, 0,	7,	0,	0x13FE), // 8x13 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060265,	650,	325,	748,	374,	16,	42000, 0,	4,	0,	0x1404), // 9x7 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060266,	700,	350,	805,	402,	16,	47000, 0,	5,	0,	0x1405), // 9x8 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060267,	750,	375,	863,	431,	16,	52000, 0,	5,	0,	0x1406), // 9x9 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060268,	800,	400,	920,	460,	18,	57000, 0,	6,	0,	0x1407), // 9x10 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060269,	850,	425,	1265,	632,	24,	62000, 0,	6,	0,	0x1408), // 9x11 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060270,	1100,	550,	1265,	632,	24,	67000, 0,	7,	0,	0x1409), // 9x12 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060271,	1100,	550,	1265,	632,	24,	72000, 0,	7,	0,	0x140A), // 9x13 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060277,	700,	350,	805,	402,	16,	46500, 0,	4,	0,	0x1410), // 10x7 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060278,	750,	375,	863,	431,	16,	52000, 0,	5,	0,	0x1411), // 10x8 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060279,	800,	400,	920,	460,	18,	57500, 0,	5,	0,	0x1412), // 10x9 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060280,	850,	425,	1265,	632,	24,	63000, 0,	6,	0,	0x1413), // 10x10 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060281,	1100,	550,	1265,	632,	24,	68500, 0,	6,	0,	0x1414), // 10x11 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060282,	1100,	550,	1265,	632,	24,	74000, 0,	7,	0,	0x1415), // 10x12 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060283,	1150,	575,	1323,	661,	24,	79500, 0,	7,	0,	0x1416), // 10x13 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060289,	750,	375,	863,	431,	16,	51000, 0,	4,	0,	0x141C), // 11x7 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060290,	800,	400,	920,	460,	18,	57000, 0,	5,	0,	0x141D), // 11x8 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060291,	850,	425,	1265,	632,	24,	63000, 0,	5,	0,	0x141E), // 11x9 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060292,	1100,	550,	1265,	632,	24,	69000, 0,	6,	0,	0x141F), // 11x10 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060293,	1100,	550,	1265,	632,	24,	75000, 0,	6,	0,	0x1420), // 11x11 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060294,	1150,	575,	1323,	661,	24,	81000, 0,	7,	0,	0x1421), // 11x12 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060295,	1200,	600,	1380,	690,	26,	87000, 0,	7,	0,	0x1422), // 11x13 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060301,	800,	400,	920,	460,	18,	55500, 0,	4,	0,	0x1428), // 12x7 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060302,	850,	425,	1265,	632,	24,	62000, 0,	5,	0,	0x1429), // 12x8 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060303,	1100,	550,	1265,	632,	24,	68500, 0,	5,	0,	0x142A), // 12x9 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060304,	1100,	550,	1265,	632,	24,	75000, 0,	6,	0,	0x142B), // 12x10 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060305,	1150,	575,	1323,	661,	24,	81500, 0,	6,	0,	0x142C), // 12x11 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060306,	1200,	600,	1380,	690,	26,	88000, 0,	7,	0,	0x142D), // 12x12 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060307,	1250,	625,	1438,	719,	26,	94500, 0,	7,	0,	0x142E), // 12x13 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060314,	1100,	550,	1265,	632,	24,	67000, 0,	5,	0,	0x1435), // 13x8 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060315,	1100,	550,	1265,	632,	24,	74000, 0,	5,	0,	0x1436), // 13x9 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060316,	1150,	575,	1323,	661,	24,	81000, 0,	6,	0,	0x1437), // 13x10 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060317,	1200,	600,	1380,	690,	26,	88000, 0,	6,	0,	0x1438), // 13x11 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060318,	1250,	625,	1438,	719,	26,	95000, 0,	7,	0,	0x1439), // 13x12 2-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060319,	1300,	650,	1495,	747,	28,	102000, 0,	7,	0,	0x143A)// 13x13 2-Story Customizable House
         };
         private static readonly HousePlacementEntry[] m_ThreeStoryFoundations = new HousePlacementEntry[]
         {
-            new HousePlacementEntry(typeof(HouseFoundation), 1060272,	1150,	575,	1323,	661,	24,	73500, 0,	8,	0,	0x140B), // 9x14 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060284,	1200,	600,	1380,	690,	26,	81000, 0,	8,	0,	0x1417), // 10x14 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060285,	1250,	625,	1438,	719,	26,	86500, 0,	8,	0,	0x1418), // 10x15 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060296,	1250,	625,	1438,	719,	26,	88500, 0,	8,	0,	0x1423), // 11x14 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060297,	1300,	650,	1495,	747,	28,	94500, 0,	8,	0,	0x1424), // 11x15 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060298,	1350,	675,	1553,	776,	28,	100500, 0,	9,	0,	0x1425), // 11x16 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060308,	1300,	650,	1495,	747,	28,	96000, 0,	8,	0,	0x142F), // 12x14 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060309,	1350,	675,	1553,	776,	28,	102500, 0,	8,	0,	0x1430), // 12x15 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060310,	1370,	685,	1576,	788,	28,	109000, 0,	9,	0,	0x1431), // 12x16 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060311,	1370,	685,	1576,	788,	28,	115500, 0,	9,	0,	0x1432), // 12x17 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060320,	1350,	675,	1553,	776,	28,	103500, 0,	8,	0,	0x143B), // 13x14 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060321,	1370,	685,	1576,	788,	28,	110500, 0,	8,	0,	0x143C), // 13x15 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060322,	1370,	685,	1576,	788,	28,	117500, 0,	9,	0,	0x143D), // 13x16 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060323,	2119,	1059,	2437,	1218,	42,	124500, 0,	9,	0,	0x143E), // 13x17 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060324,	2119,	1059,	2437,	1218,	42,	131500, 0,	10,	0,	0x143F), // 13x18 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060327,	1150,	575,	1323,	661,	24,	73500, 0,	5,	0,	0x1442), // 14x9 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060328,	1200,	600,	1380,	690,	26,	81000, 0,	6,	0,	0x1443), // 14x10 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060329,	1250,	625,	1438,	719,	26,	88500, 0,	6,	0,	0x1444), // 14x11 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060330,	1300,	650,	1495,	747,	28,	96000, 0,	7,	0,	0x1445), // 14x12 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060331,	1350,	675,	1553,	776,	28,	103500, 0,	7,	0,	0x1446), // 14x13 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060332,	1370,	685,	1576,	788,	28,	111000, 0,	8,	0,	0x1447), // 14x14 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060333,	1370,	685,	1576,	788,	28,	118500, 0,	8,	0,	0x1448), // 14x15 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060334,	2119,	1059,	2437,	1218,	42,	126000, 0,	9,	0,	0x1449), // 14x16 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060335,	2119,	1059,	2437,	1218,	42,	133500, 0,	9,	0,	0x144A), // 14x17 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060336,	2119,	1059,	2437,	1218,	42,	141000, 0,	10,	0,	0x144B), // 14x18 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060340,	1250,	625,	1438,	719,	26,	86500, 0,	6,	0,	0x144F), // 15x10 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060341,	1300,	650,	1495,	747,	28,	94500, 0,	6,	0,	0x1450), // 15x11 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060342,	1350,	675,	1553,	776,	28,	102500, 0,	7,	0,	0x1451), // 15x12 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060343,	1370,	685,	1576,	788,	28,	110500, 0,	7,	0,	0x1452), // 15x13 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060344,	1370,	685,	1576,	788,	28,	118500, 0,	8,	0,	0x1453), // 15x14 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060345,	2119,	1059,	2437,	1218,	42,	126500, 0,	8,	0,	0x1454), // 15x15 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060346,	2119,	1059,	2437,	1218,	42,	134500, 0,	9,	0,	0x1455), // 15x16 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060347,	2119,	1059,	2437,	1218,	42,	142500, 0,	9,	0,	0x1456), // 15x17 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060348,	2119,	1059,	2437,	1218,	42,	150500, 0,	10,	0,	0x1457), // 15x18 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060353,	1350,	675,	1553,	776,	28,	100500, 0,	6,	0,	0x145C), // 16x11 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060354,	1370,	685,	1576,	788,	28,	109000, 0,	7,	0,	0x145D), // 16x12 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060355,	1370,	685,	1576,	788,	28,	117500, 0,	7,	0,	0x145E), // 16x13 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060356,	2119,	1059,	2437,	1218,	42,	126000, 0,	8,	0,	0x145F), // 16x14 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060357,	2119,	1059,	2437,	1218,	42,	134500, 0,	8,	0,	0x1460), // 16x15 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060358,	2119,	1059,	2437,	1218,	42,	143000, 0,	9,	0,	0x1461), // 16x16 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060359,	2119,	1059,	2437,	1218,	42,	151500, 0,	9,	0,	0x1462), // 16x17 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060360,	2119,	1059,	2437,	1218,	42,	160000, 0,	10,	0,	0x1463), // 16x18 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060366,	1370,	685,	1576,	788,	28,	115500, 0,	7,	0,	0x1469), // 17x12 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060367,	2119,	1059,	2437,	1218,	42,	124500, 0,	7,	0,	0x146A), // 17x13 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060368,	2119,	1059,	2437,	1218,	42,	133500, 0,	8,	0,	0x146B), // 17x14 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060369,	2119,	1059,	2437,	1218,	42,	142500, 0,	8,	0,	0x146C), // 17x15 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060370,	2119,	1059,	2437,	1218,	42,	151500, 0,	9,	0,	0x146D), // 17x16 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060371,	2119,	1059,	2437,	1218,	42,	160500, 0,	9,	0,	0x146E), // 17x17 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060372,	2119,	1059,	2437,	1218,	42,	169500, 0,	10,	0,	0x146F), // 17x18 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060379,	2119,	1059,	2437,	1218,	42,	131500, 0,	7,	0,	0x1476), // 18x13 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060380,	2119,	1059,	2437,	1218,	42,	141000, 0,	8,	0,	0x1477), // 18x14 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060381,	2119,	1059,	2437,	1218,	42,	150500, 0,	8,	0,	0x1478), // 18x15 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060382,	2119,	1059,	2437,	1218,	42,	160000, 0,	9,	0,	0x1479), // 18x16 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060383,	2119,	1059,	2437,	1218,	42,	169500, 0,	9,	0,	0x147A), // 18x17 3-Story Customizable House
-            new HousePlacementEntry(typeof(HouseFoundation), 1060384,	2119,	1059,	2437,	1218,	42,	179000, 0,	10,	0,	0x147B)// 18x18 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060272,	1150,	575,	1323,	661,	24,	77000, 0,	8,	0,	0x140B), // 9x14 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060284,	1200,	600,	1380,	690,	26,	85000, 0,	8,	0,	0x1417), // 10x14 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060285,	1250,	625,	1438,	719,	26,	90500, 0,	8,	0,	0x1418), // 10x15 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060296,	1250,	625,	1438,	719,	26,	93000, 0,	8,	0,	0x1423), // 11x14 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060297,	1300,	650,	1495,	747,	28,	99000, 0,	8,	0,	0x1424), // 11x15 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060298,	1350,	675,	1553,	776,	28,	105000, 0,	9,	0,	0x1425), // 11x16 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060308,	1300,	650,	1495,	747,	28,	101000, 0,	8,	0,	0x142F), // 12x14 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060309,	1350,	675,	1553,	776,	28,	107500, 0,	8,	0,	0x1430), // 12x15 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060310,	1370,	685,	1576,	788,	28,	114000, 0,	9,	0,	0x1431), // 12x16 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060311,	1370,	685,	1576,	788,	28,	120500, 0,	9,	0,	0x1432), // 12x17 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060320,	1350,	675,	1553,	776,	28,	109000, 0,	8,	0,	0x143B), // 13x14 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060321,	1370,	685,	1576,	788,	28,	116000, 0,	8,	0,	0x143C), // 13x15 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060322,	1370,	685,	1576,	788,	28,	123000, 0,	9,	0,	0x143D), // 13x16 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060323,	2119,	1059,	2437,	1218,	42,	130000, 0,	9,	0,	0x143E), // 13x17 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060324,	2119,	1059,	2437,	1218,	42,	137000, 0,	10,	0,	0x143F), // 13x18 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060327,	1150,	575,	1323,	661,	24,	79000, 0,	5,	0,	0x1442), // 14x9 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060328,	1200,	600,	1380,	690,	26,	87000, 0,	6,	0,	0x1443), // 14x10 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060329,	1250,	625,	1438,	719,	26,	94500, 0,	6,	0,	0x1444), // 14x11 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060330,	1300,	650,	1495,	747,	28,	102000, 0,	7,	0,	0x1445), // 14x12 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060331,	1350,	675,	1553,	776,	28,	109500, 0,	7,	0,	0x1446), // 14x13 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060332,	1370,	685,	1576,	788,	28,	117000, 0,	8,	0,	0x1447), // 14x14 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060333,	1370,	685,	1576,	788,	28,	124500, 0,	8,	0,	0x1448), // 14x15 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060334,	2119,	1059,	2437,	1218,	42,	132000, 0,	9,	0,	0x1449), // 14x16 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060335,	2119,	1059,	2437,	1218,	42,	139500, 0,	9,	0,	0x144A), // 14x17 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060336,	2119,	1059,	2437,	1218,	42,	147000, 0,	10,	0,	0x144B), // 14x18 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060340,	1250,	625,	1438,	719,	26,	93000, 0,	6,	0,	0x144F), // 15x10 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060341,	1300,	650,	1495,	747,	28,	101000, 0,	6,	0,	0x1450), // 15x11 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060342,	1350,	675,	1553,	776,	28,	109000, 0,	7,	0,	0x1451), // 15x12 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060343,	1370,	685,	1576,	788,	28,	117000, 0,	7,	0,	0x1452), // 15x13 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060344,	1370,	685,	1576,	788,	28,	125000, 0,	8,	0,	0x1453), // 15x14 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060345,	2119,	1059,	2437,	1218,	42,	133000, 0,	8,	0,	0x1454), // 15x15 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060346,	2119,	1059,	2437,	1218,	42,	141000, 0,	9,	0,	0x1455), // 15x16 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060347,	2119,	1059,	2437,	1218,	42,	149000, 0,	9,	0,	0x1456), // 15x17 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060348,	2119,	1059,	2437,	1218,	42,	157000, 0,	10,	0,	0x1457), // 15x18 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060353,	1350,	675,	1553,	776,	28,	107500, 0,	6,	0,	0x145C), // 16x11 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060354,	1370,	685,	1576,	788,	28,	116000, 0,	7,	0,	0x145D), // 16x12 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060355,	1370,	685,	1576,	788,	28,	124500, 0,	7,	0,	0x145E), // 16x13 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060356,	2119,	1059,	2437,	1218,	42,	133000, 0,	8,	0,	0x145F), // 16x14 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060357,	2119,	1059,	2437,	1218,	42,	141500, 0,	8,	0,	0x1460), // 16x15 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060358,	2119,	1059,	2437,	1218,	42,	150000, 0,	9,	0,	0x1461), // 16x16 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060359,	2119,	1059,	2437,	1218,	42,	158500, 0,	9,	0,	0x1462), // 16x17 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060360,	2119,	1059,	2437,	1218,	42,	167000, 0,	10,	0,	0x1463), // 16x18 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060366,	1370,	685,	1576,	788,	28,	123000, 0,	7,	0,	0x1469), // 17x12 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060367,	2119,	1059,	2437,	1218,	42,	132000, 0,	7,	0,	0x146A), // 17x13 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060368,	2119,	1059,	2437,	1218,	42,	141000, 0,	8,	0,	0x146B), // 17x14 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060369,	2119,	1059,	2437,	1218,	42,	150000, 0,	8,	0,	0x146C), // 17x15 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060370,	2119,	1059,	2437,	1218,	42,	159000, 0,	9,	0,	0x146D), // 17x16 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060371,	2119,	1059,	2437,	1218,	42,	168000, 0,	9,	0,	0x146E), // 17x17 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060372,	2119,	1059,	2437,	1218,	42,	177000, 0,	10,	0,	0x146F), // 17x18 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060379,	2119,	1059,	2437,	1218,	42,	139500, 0,	7,	0,	0x1476), // 18x13 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060380,	2119,	1059,	2437,	1218,	42,	149000, 0,	8,	0,	0x1477), // 18x14 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060381,	2119,	1059,	2437,	1218,	42,	158500, 0,	8,	0,	0x1478), // 18x15 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060382,	2119,	1059,	2437,	1218,	42,	168000, 0,	9,	0,	0x1479), // 18x16 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060383,	2119,	1059,	2437,	1218,	42,	177500, 0,	9,	0,	0x147A), // 18x17 3-Story Customizable House
+            new HousePlacementEntry(typeof(HouseFoundation), 1060384,	2119,	1059,	2437,	1218,	42,	187000, 0,	10,	0,	0x147B)// 18x18 3-Story Customizable House
         };
         private static Hashtable m_Table;
         private readonly Type m_Type;
@@ -418,18 +418,19 @@ namespace Server.Items
         private readonly Point3D m_Offset;
         public HousePlacementEntry(Type type, int description, int storage, int lockdowns, int newStorage, int newLockdowns, int vendors, int cost, int xOffset, int yOffset, int zOffset, int multiID)
         {
-            this.m_Type = type;
-            this.m_Description = description;
-            this.m_Storage = storage;
-            this.m_Lockdowns = lockdowns;
-            this.m_NewStorage = newStorage;
-            this.m_NewLockdowns = newLockdowns;
-            this.m_Vendors = vendors;
-            this.m_Cost = cost;
+            m_Type = type;
+            m_Description = description;
+            m_Storage = storage;
+            m_Lockdowns = lockdowns;
+            m_NewStorage = newStorage;
+            m_NewLockdowns = newLockdowns;
+            m_Vendors = vendors;
 
-            this.m_Offset = new Point3D(xOffset, yOffset, zOffset);
+            m_Cost = Siege.SiegeShard ? cost * 2 : cost;
 
-            this.m_MultiID = multiID;
+            m_Offset = new Point3D(xOffset, yOffset, zOffset);
+
+            m_MultiID = multiID;
         }
 
         static HousePlacementEntry()
@@ -466,56 +467,56 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Type;
+                return m_Type;
             }
         }
         public int Description
         {
             get
             {
-                return this.m_Description;
+                return m_Description;
             }
         }
         public int Storage
         {
             get
             {
-                return BaseHouse.NewVendorSystem ? this.m_NewStorage : this.m_Storage;
+                return BaseHouse.NewVendorSystem ? m_NewStorage : m_Storage;
             }
         }
         public int Lockdowns
         {
             get
             {
-                return BaseHouse.NewVendorSystem ? this.m_NewLockdowns : this.m_Lockdowns;
+                return BaseHouse.NewVendorSystem ? m_NewLockdowns : m_Lockdowns;
             }
         }
         public int Vendors
         {
             get
             {
-                return this.m_Vendors;
+                return m_Vendors;
             }
         }
         public int Cost
         {
             get
             {
-                return this.m_Cost;
+                return m_Cost;
             }
         }
         public int MultiID
         {
             get
             {
-                return this.m_MultiID;
+                return m_MultiID;
             }
         }
         public Point3D Offset
         {
             get
             {
-                return this.m_Offset;
+                return m_Offset;
             }
         }
         public static HousePlacementEntry Find(BaseHouse house)
@@ -557,14 +558,14 @@ namespace Server.Items
             {
                 object[] args;
 
-                if (this.m_Type == typeof(HouseFoundation))
-                    args = new object[4] { from, this.m_MultiID, this.m_Storage, this.m_Lockdowns };
-                else if (this.m_Type == typeof(SmallOldHouse) || this.m_Type == typeof(SmallShop) || this.m_Type == typeof(TwoStoryHouse))
-                    args = new object[2] { from, this.m_MultiID };
+                if (m_Type == typeof(HouseFoundation))
+                    args = new object[4] { from, m_MultiID, m_Storage, m_Lockdowns };
+                else if (m_Type == typeof(SmallOldHouse) || m_Type == typeof(SmallShop) || m_Type == typeof(TwoStoryHouse))
+                    args = new object[2] { from, m_MultiID };
                 else
                     args = new object[1] { from };
 
-                return Activator.CreateInstance(this.m_Type, args) as BaseHouse;
+                return Activator.CreateInstance(m_Type, args) as BaseHouse;
             }
             catch
             {
@@ -603,7 +604,7 @@ namespace Server.Items
 
             ArrayList toMove;
             //Point3D center = new Point3D( p.X - m_Offset.X, p.Y - m_Offset.Y, p.Z - m_Offset.Z );
-            HousePlacementResult res = HousePlacement.Check(from, this.m_MultiID, center, out toMove);
+            HousePlacementResult res = HousePlacement.Check(from, m_MultiID, center, out toMove);
 
             switch ( res )
             {
@@ -615,22 +616,22 @@ namespace Server.Items
                         }
                         else
                         {
-                            BaseHouse house = this.ConstructHouse(from);
+                            BaseHouse house = ConstructHouse(from);
 
                             if (house == null)
                                 return;
 
-                            house.Price = this.m_Cost;
+                            house.Price = m_Cost;
 
                             if (from.AccessLevel >= AccessLevel.GameMaster)
                             {
-                                from.SendMessage("{0} gold would have been withdrawn from your bank if you were not a GM.", this.m_Cost.ToString());
+                                from.SendMessage("{0} gold would have been withdrawn from your bank if you were not a GM.", m_Cost.ToString());
                             }
                             else
                             {
-                                if (Banker.Withdraw(from, this.m_Cost))
+                                if (Banker.Withdraw(from, m_Cost))
                                 {
-                                    from.SendLocalizedMessage(1060398, this.m_Cost.ToString()); // ~1_AMOUNT~ gold has been withdrawn from your bank box.
+                                    from.SendLocalizedMessage(1060398, m_Cost.ToString()); // ~1_AMOUNT~ gold has been withdrawn from your bank box.
                                 }
                                 else
                                 {
@@ -699,8 +700,8 @@ namespace Server.Items
                 return false;
 
             ArrayList toMove;
-            Point3D center = new Point3D(p.X - this.m_Offset.X, p.Y - this.m_Offset.Y, p.Z - this.m_Offset.Z);
-            HousePlacementResult res = HousePlacement.Check(from, this.m_MultiID, center, out toMove);
+            Point3D center = new Point3D(p.X - m_Offset.X, p.Y - m_Offset.Y, p.Z - m_Offset.Z);
+            HousePlacementResult res = HousePlacement.Check(from, m_MultiID, center, out toMove);
 
             switch ( res )
             {
@@ -714,7 +715,7 @@ namespace Server.Items
                         {
                             from.SendLocalizedMessage(1011576); // This is a valid location.
 
-                            PreviewHouse prev = new PreviewHouse(this.m_MultiID);
+                            PreviewHouse prev = new PreviewHouse(m_MultiID);
 
                             MultiComponentList mcl = prev.Components;
 

--- a/Scripts/Regions/HouseRegion.cs
+++ b/Scripts/Regions/HouseRegion.cs
@@ -291,14 +291,14 @@ namespace Server.Regions
                 }
                 else
                 {
-                    from.SendLocalizedMessage(502094); // You must be in your house to do 
+                    from.SendLocalizedMessage(502094); // You must be in your house to do this.
                 }
             }
             else if (e.HasKeyword(0x34)) // I ban thee
             {
                 if (!isFriend)
                 {
-                    from.SendLocalizedMessage(502094); // You must be in your house to do 
+                    from.SendLocalizedMessage(502094); // You must be in your house to do this.
                 }
                 else if (!m_House.Public && m_House.IsAosRules)
                 {
@@ -323,7 +323,7 @@ namespace Server.Regions
                 }
                 else
                 {
-                    from.SendLocalizedMessage(502094); // You must be in your house to do 
+                    from.SendLocalizedMessage(502094); // You must be in your house to do this.
                 }
             }
             else if (e.HasKeyword(0x24)) // I wish to release this
@@ -339,7 +339,7 @@ namespace Server.Regions
                 }
                 else
                 {
-                    from.SendLocalizedMessage(502094); // You must be in your house to do 
+                    from.SendLocalizedMessage(502094); // You must be in your house to do this. 
                 }
             }
             else if (e.HasKeyword(0x25)) // I wish to secure this
@@ -351,7 +351,7 @@ namespace Server.Regions
                 }
                 else
                 {
-                    from.SendLocalizedMessage(502094); // You must be in your house to do 
+                    from.SendLocalizedMessage(502094); // You must be in your house to do this. 
                 }
             }
             else if (e.HasKeyword(0x26)) // I wish to unsecure this
@@ -363,7 +363,7 @@ namespace Server.Regions
                 }
                 else
                 {
-                    from.SendLocalizedMessage(502094); // You must be in your house to do 
+                    from.SendLocalizedMessage(502094); // You must be in your house to do this. 
                 }
             }
             else if (e.HasKeyword(0x27)) // I wish to place a strongbox
@@ -382,7 +382,7 @@ namespace Server.Regions
                 }
                 else
                 {
-                    from.SendLocalizedMessage(502094); // You must be in your house to do 
+                    from.SendLocalizedMessage(502094); // You must be in your house to do this. 
                 }
             }
             else if (e.HasKeyword(0x28)) // trash barrel
@@ -397,7 +397,7 @@ namespace Server.Regions
                 }
                 else
                 {
-                    from.SendLocalizedMessage(502094); // You must be in your house to do 
+                    from.SendLocalizedMessage(502094); // You must be in your house to do this. 
                 }
             }
         }

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -1784,6 +1784,7 @@
     <Compile Include="Mobiles\Named\Chiikkaha.cs" />
     <Compile Include="Mobiles\Named\Coil.cs" />
     <Compile Include="Mobiles\Named\DevourerRenowned.cs" />
+    <Compile Include="Mobiles\Named\Drelgor.cs" />
     <Compile Include="Mobiles\Named\FireDaemonRenowned.cs" />
     <Compile Include="Mobiles\Named\FireElementalRenowned.cs" />
     <Compile Include="Mobiles\Named\Flurry.cs" />
@@ -2583,6 +2584,7 @@
     <Compile Include="Mobiles\Void Creatures\Relanord.cs" />
     <Compile Include="Mobiles\Void Creatures\UsagralemBallem.cs" />
     <Compile Include="Mobiles\Void Creatures\Vasanord.cs" />
+    <Compile Include="Multis\HouseTeleporterTile.cs" />
     <Compile Include="Quests\ALittleSomething.cs" />
     <Compile Include="Quests\AmbitiousSolenQueen\AmbitiousQueenQuest.cs" />
     <Compile Include="Quests\AmbitiousSolenQueen\Conversations.cs" />
@@ -9980,6 +9982,7 @@
     <Compile Include="Services\Revamped Dungeons\TheExodusEncounter\Resources\GoldDust.cs" />
     <Compile Include="Services\Revamped Dungeons\TheExodusEncounter\Resources\NexusCore.cs" />
     <Compile Include="Services\Revamped Dungeons\TheExodusEncounter\Resources\SmallPieceofBlackrock.cs" />
+    <Compile Include="Services\Revamped Dungeons\WrongDungeon\EnchantedHotItem.cs" />
     <Compile Include="Services\Revamped Dungeons\WrongDungeon\Items\Soap.cs" />
     <Compile Include="Services\Revamped Dungeons\WrongDungeon\Items\Artifacts\TortureRackArtifact.cs" />
     <Compile Include="Services\Revamped Dungeons\WrongDungeon\Items\BedrollSpawner.cs" />

--- a/Scripts/Services/Craft/Core/CraftGump.cs
+++ b/Scripts/Services/Craft/Core/CraftGump.cs
@@ -400,6 +400,10 @@ namespace Server.Engines.Craft
 
             CraftGroupCol craftGroupCol = this.m_CraftSystem.CraftGroups;
             CraftGroup craftGroup = craftGroupCol.GetAt(selectedGroup);
+
+            if (craftGroup == null)
+                return;
+
             CraftItemCol craftItemCol = craftGroup.CraftItems;
 
             for (int i = 0; i < craftItemCol.Count; ++i)

--- a/Scripts/Services/Revamped Dungeons/DespiseRevamped/Setup.cs
+++ b/Scripts/Services/Revamped Dungeons/DespiseRevamped/Setup.cs
@@ -39,7 +39,7 @@ namespace Server.Engines.Despise
                 WeakEntityCollection.Add("despise", ankh);
                 ankh.MoveToWorld(new Point3D(5472, 754, 10), Map.Trammel);
 
-                Moongate gate1 = new Moongate(false);
+                /*Moongate gate1 = new Moongate(false);
                 Moongate gate2 = new Moongate(false);
                 WeakEntityCollection.Add("despise", gate1);
                 WeakEntityCollection.Add("despise", gate2);
@@ -70,7 +70,8 @@ namespace Server.Engines.Despise
                 gate1.MoveToWorld(new Point3D(5388, 753, 5), Map.Trammel);
                 gate2.MoveToWorld(new Point3D(5387, 628, 30), Map.Trammel);
                 HueGates(gate1, gate2);
-                LinkGates(gate1, gate2);
+                LinkGates(gate1, gate2);*/
+                SetupTeleporters();
 
                 //Teleporters
                 IPooledEnumerable eable = Map.Trammel.GetItemsInRange(new Point3D(5588, 631, 30), 2);
@@ -104,18 +105,34 @@ namespace Server.Engines.Despise
                 e.Mobile.SendMessage("Despise appears to already be setup");
         }
 
-        private static void HueGates(Moongate one, Moongate two)
+        public static void SetupTeleporters()
         {
-            one.Hue = 2715;
-            two.Hue = 2677;
-        }
+            //Gate1
+            GateTeleporter gate1 = new GateTeleporter(3948, 1965, new Point3D(5458, 610, 50), Map.Trammel);
+            GateTeleporter gate2 = new GateTeleporter(3948, 1960, new Point3D(5476, 737, 5), Map.Trammel);
+            WeakEntityCollection.Add("despise", gate1);
+            WeakEntityCollection.Add("despise", gate2);
 
-        private static void LinkGates(Moongate one, Moongate two)
-        {
-            one.Target = two.Location;
-            two.Target = one.Location;
-            one.TargetMap = two.Map;
-            two.TargetMap = one.Map;
+            gate1.MoveToWorld(new Point3D(5476, 737, 5), Map.Trammel);
+            gate2.MoveToWorld(new Point3D(5458, 610, 50), Map.Trammel);
+
+            //Gate2
+            gate1 = new GateTeleporter(3948, 1960, new Point3D(5460, 675, 20), Map.Trammel);
+            gate2 = new GateTeleporter(3948, 1965, new Point3D(5460, 523, 60), Map.Trammel);
+            WeakEntityCollection.Add("despise", gate1);
+            WeakEntityCollection.Add("despise", gate2);
+
+            gate1.MoveToWorld(new Point3D(5460, 523, 60), Map.Trammel);
+            gate2.MoveToWorld(new Point3D(5460, 675, 20), Map.Trammel);
+
+            //Gate3
+            gate1 = new GateTeleporter(3948, 1965, new Point3D(5387, 628, 30), Map.Trammel);
+            gate2 = new GateTeleporter(3948, 1960, new Point3D(5388, 753, 5), Map.Trammel);
+            WeakEntityCollection.Add("despise", gate1);
+            WeakEntityCollection.Add("despise", gate2);
+
+            gate1.MoveToWorld(new Point3D(5388, 753, 5), Map.Trammel);
+            gate2.MoveToWorld(new Point3D(5387, 628, 30), Map.Trammel);
         }
     }
 }

--- a/Scripts/Skills/ItemIdentification.cs
+++ b/Scripts/Skills/ItemIdentification.cs
@@ -1,6 +1,9 @@
 using System;
 using Server.Mobiles;
 using Server.Targeting;
+using System.Collections.Generic;
+using Server.Network;
+using Server.SkillHandlers;
 
 namespace Server.Items
 {
@@ -30,7 +33,102 @@ namespace Server.Items
 
             protected override void OnTarget(Mobile from, object o)
             {
-                if (o is Item)
+                Item item = o as Item;
+                Mobile m = o as Mobile;
+
+                if (item == null && m == null)
+                {
+                    from.SendLocalizedMessage(500353); // You are not certain...
+                    return;
+                }
+                
+                if (!from.CheckTargetSkill(SkillName.ItemID, o, 0, 100))
+                {
+                    from.PrivateOverheadMessage(MessageType.Emote, 0x3B2, 1041352, from.NetState); // You have no idea how much it might be worth.
+                    return;
+                }
+
+                if (m != null)
+                {
+                    from.PrivateOverheadMessage(MessageType.Emote, 0x3B2, 1041349, AffixType.Append, "  " + m.Name, "", from.NetState); // It appears to be:
+                    return;
+                }
+                
+                if (item.Name != null)
+                {
+                    from.PrivateOverheadMessage(MessageType.Emote, 0x3B2, false, item.Name, from.NetState);
+                    item.PrivateOverheadMessage(MessageType.Label, 0x3B2, false, item.Name, from.NetState);
+                }
+                else
+                {
+                    from.PrivateOverheadMessage(MessageType.Emote, 0x3B2, item.LabelNumber, from.NetState);
+                    item.PrivateOverheadMessage(MessageType.Label, 0x3B2, item.LabelNumber, from.NetState);
+                }
+
+                if (Core.AOS)
+                {
+                    from.PrivateOverheadMessage(MessageType.Emote, 0x3B2, 1041351, AffixType.Append, "  " + GetPriceFor(item).ToString(), "", from.NetState); // You guess the value of that item at:
+
+                    if (item is BaseWeapon || item is BaseArmor || item is BaseJewel || item is BaseHat)
+                    {
+                        if (Imbuing.TimesImbued(item) > 0)
+                        {
+                            from.PrivateOverheadMessage(MessageType.Emote, 0x3B2, 1111877, from.NetState); // You conclude that item cannot be magically unraveled. The magic in that item has been weakened due to either low durability or the imbuing process.
+                        }
+                        else
+                        {
+                            int weight = Imbuing.GetTotalWeight(item);
+                            string imbIngred = null;
+                            double skill = from.Skills[SkillName.Imbuing].Base;
+                            bool badSkill = false;
+
+                            if (!Imbuing.CanUnravelItem(from, item, false))
+                            {
+                                weight = 0;
+                            }
+
+                            if (weight > 0 && weight <= 200)
+                            {
+                                imbIngred = "Magical Residue";
+                            }
+                            else if (weight > 200 && weight < 480)
+                            {
+                                imbIngred = "Enchanted Essence";
+
+                                if (skill < 45.0)
+                                    badSkill = true;
+                            }
+                            else if (weight >= 480)
+                            {
+                                imbIngred = "Relic Fragment";
+
+                                if (skill < 95.0)
+                                    badSkill = true;
+                            }
+
+                            if (imbIngred != null)
+                            {
+                                if (badSkill)
+                                {
+                                    from.PrivateOverheadMessage(MessageType.Emote, 0x3B2, 1111875, from.NetState); // Your Imbuing skill is not high enough to identify the imbuing ingredient.
+                                }
+                                else
+                                {
+                                    from.PrivateOverheadMessage(MessageType.Emote, 0x3B2, 1111874, imbIngred, from.NetState); //You conclude that item will magically unravel into: ~1_ingredient~
+                                }
+                            }
+                            else  // Cannot be Unravelled
+                            {
+                                from.PrivateOverheadMessage(MessageType.Emote, 0x3B2, 1111876, from.NetState); //You conclude that item cannot be magically unraveled. It appears to possess little to no magic.
+                            }
+                        }
+                    }
+                    else
+                    {
+                        from.LocalOverheadMessage(MessageType.Emote, 0x3B2, 1111878); //You conclude that item cannot be magically unraveled.
+                    }
+                }
+                else if (o is Item)
                 {
                     if (from.CheckTargetSkill(SkillName.ItemID, o, 0, 100))
                     {
@@ -55,8 +153,29 @@ namespace Server.Items
                 {
                     from.SendLocalizedMessage(500353); // You are not certain...
                 }
+
                 Server.Engines.XmlSpawner2.XmlAttach.RevealAttachments(from, o);
             }
+
+            public static int GetPriceFor(Item item)
+            {
+                Type type = item.GetType();
+
+                if (GenericBuyInfo.BuyPrices.ContainsKey(type))
+                {
+                    return GenericBuyInfo.BuyPrices[item.GetType()] * item.Amount;
+                }
+
+                if (TypeCostCache == null)
+                    TypeCostCache = new Dictionary<Type, int>();
+
+                if (!TypeCostCache.ContainsKey(type))
+                    TypeCostCache[type] = Utility.RandomMinMax(2, 7);
+
+                return TypeCostCache[type];
+            }
+
+            public static Dictionary<Type, int> TypeCostCache { get; set; }
         }
     }
 }


### PR DESCRIPTION
- Updated Housing Prices per EA
- Siege Shard Housing Prices doubled per EA
- Core.SA gives housing 40% house storage Bonus
- Added Drelgor, spawner needs to be manually added on pre-existing shards
- Fixed potential craft gump crash
- Re-added 'this.' in comments in HouseRegion *rolls eyes*
- Crafter name now only shows 'lord' or 'lady' as opposed to 'glorious lord' etc
- Goza mats are no longer crafted with special material
- Various body values and hue fixes to Despise creatures
- Despise creatures now only attack players with the proper karma levels (+- 1000)
- replaced Despise gates with gate teleporters with mechanics per EA
- Wisp Orb now displays the proper hues
- Despise Revamped battle warning now goes to all palyers in the dungeon
- Minor, probably un-noticable tweaks to Despise Revamped to match EA
- Item Identification now per EA