### PR TITLE
Fix about null delegate

### DIFF
--- a/Scripts/Services/Revamped Dungeons/DespiseRevamped/DespiseController.cs
+++ b/Scripts/Services/Revamped Dungeons/DespiseRevamped/DespiseController.cs
@@ -108,7 +108,6 @@ namespace Server.Engines.Despise
             m_Enabled = true;
             m_Instance = this;          
             
-            //If put this into the Initialize, instance wouldn't exist and give error because m_Instance would be null
             CommandSystem.Register("CheckSpawnersVersion3", AccessLevel.Administrator, m_Instance.CheckSpawnersVersion3);
 
             m_NextBossEncounter = DateTime.UtcNow;

--- a/Scripts/Services/Revamped Dungeons/DespiseRevamped/DespiseController.cs
+++ b/Scripts/Services/Revamped Dungeons/DespiseRevamped/DespiseController.cs
@@ -14,10 +14,14 @@ namespace Server.Engines.Despise
         {
             EventSink.Login += new LoginEventHandler(OnLogin);
             EventSink.OnEnterRegion += new OnEnterRegionEventHandler(OnEnterRegion);
+            
+            CommandSystem.Register("CheckSpawnersVersion3", AccessLevel.Administrator, CheckSpawnersVersion3);
         }
 
         private static DespiseController m_Instance;
         public static DespiseController Instance { get { return m_Instance; } set { m_Instance = value; } }
+        
+        public static void CheckSpawnersVersion
 
         private bool m_Enabled;
         private bool m_Sequencing;
@@ -107,8 +111,6 @@ namespace Server.Engines.Despise
 
             m_Enabled = true;
             m_Instance = this;          
-            
-            CommandSystem.Register("CheckSpawnersVersion3", AccessLevel.Administrator, m_Instance.CheckSpawnersVersion3);
 
             m_NextBossEncounter = DateTime.UtcNow;
             m_Boss = null;
@@ -726,9 +728,10 @@ namespace Server.Engines.Despise
                 Timer.DelayCall(TimeSpan.FromSeconds(30), RemoveAnkh);
 		}
 
-        public void CheckSpawnersVersion3(CommandEventArgs e)
+        public static void CheckSpawnersVersion3(CommandEventArgs e)
         {
-            CheckSpawnersVersion3();
+            if(m_Instance != null)
+                m_Instance.CheckSpawnersVersion3();
         }
 
         public void CheckSpawnersVersion3()

--- a/Scripts/Services/Revamped Dungeons/DespiseRevamped/DespiseController.cs
+++ b/Scripts/Services/Revamped Dungeons/DespiseRevamped/DespiseController.cs
@@ -14,8 +14,6 @@ namespace Server.Engines.Despise
         {
             EventSink.Login += new LoginEventHandler(OnLogin);
             EventSink.OnEnterRegion += new OnEnterRegionEventHandler(OnEnterRegion);
-
-            CommandSystem.Register("CheckSpawnersVersion3", AccessLevel.Administrator, m_Instance.CheckSpawnersVersion3);
         }
 
         private static DespiseController m_Instance;
@@ -108,7 +106,10 @@ namespace Server.Engines.Despise
             Visible = false;
 
             m_Enabled = true;
-            m_Instance = this;
+            m_Instance = this;          
+            
+            //If put this into the Initialize, instance wouldn't exist and give error because m_Instance would be null
+            CommandSystem.Register("CheckSpawnersVersion3", AccessLevel.Administrator, m_Instance.CheckSpawnersVersion3);
 
             m_NextBossEncounter = DateTime.UtcNow;
             m_Boss = null;


### PR DESCRIPTION
If put the CommandRegister into the Initialize, would not compile because of the m_Instance result to be null, so by putting it into the Constructor, it would work anyway because of the constructor be called by Setup.cs with his Initialize, and not give error anymore to compile.