### PR TITLE
Frenzied Whirlwind Fix

### DIFF
--- a/Scripts/Abilities/FrenziedWhirlwind.cs
+++ b/Scripts/Abilities/FrenziedWhirlwind.cs
@@ -134,9 +134,8 @@ namespace Server.Items
                         m_Attacker.PlaySound(0x2A1);
 
                         int skill = (int)Math.Max(m_Attacker.Skills[SkillName.Bushido].Value, m_Attacker.Skills[SkillName.Ninjitsu].Value);
-                        //int amount = (int)(10.0 * (((Math.Max(m_Attacker.Skills[SkillName.Bushido].Value, m_Attacker.Skills[SkillName.Ninjitsu].Value) - 50.0) / 70.0) + 5));
+
                         int amount = Utility.RandomMinMax((int)(skill / 50) * 5, (int)(skill / 50) * 20) + 2;
-                        Console.WriteLine("Amount: {0}", amount);
                         AOS.Damage(m, m_Attacker, amount, 100, 0, 0, 0, 0);
 
                         //m_Attacker.SendLocalizedMessage(1060161); // The whirling attack strikes a target!

--- a/Scripts/Abilities/FrenziedWhirlwind.cs
+++ b/Scripts/Abilities/FrenziedWhirlwind.cs
@@ -133,8 +133,10 @@ namespace Server.Items
                         m_Attacker.FixedEffect(0x3728, 10, 15);
                         m_Attacker.PlaySound(0x2A1);
 
-                        int amount = (int)(10.0 * ((Math.Max(m_Attacker.Skills[SkillName.Bushido].Value, m_Attacker.Skills[SkillName.Ninjitsu].Value) - 50.0) / 70.0 )) + 5;
-
+                        int skill = (int)Math.Max(m_Attacker.Skills[SkillName.Bushido].Value, m_Attacker.Skills[SkillName.Ninjitsu].Value);
+                        //int amount = (int)(10.0 * (((Math.Max(m_Attacker.Skills[SkillName.Bushido].Value, m_Attacker.Skills[SkillName.Ninjitsu].Value) - 50.0) / 70.0) + 5));
+                        int amount = Utility.RandomMinMax((int)(skill / 50) * 5, (int)(skill / 50) * 20) + 2;
+                        Console.WriteLine("Amount: {0}", amount);
                         AOS.Damage(m, m_Attacker, amount, 100, 0, 0, 0, 0);
 
                         //m_Attacker.SendLocalizedMessage(1060161); // The whirling attack strikes a target!

--- a/Scripts/Items/Books/SpecialScrollBooks/SpecialScrollBookGump.cs
+++ b/Scripts/Items/Books/SpecialScrollBooks/SpecialScrollBookGump.cs
@@ -93,6 +93,7 @@ namespace Server.Gumps
 
             int x = 45;
             int y = 55;
+            int buttonX = 30;
             int split = list.Count >= 9 ? list.Count / 2 : -1;
 
             for (int i = 0; i < list.Count; i++)
@@ -103,13 +104,14 @@ namespace Server.Gumps
                 {
                     x = 205;
                     y = 55;
+                    buttonX = 190;
                 }
 
                 AddHtmlLocalized(x, y, 110, 20, SkillInfo.Table[(int)skill].Localization, false, false);
 
                 if (HasScroll(skill))
                 {
-                    AddButton(30, y + 4, 2103, 2104, 100 + i, GumpButtonType.Reply, 0);
+                    AddButton(buttonX, y + 4, 2103, 2104, 100 + i, GumpButtonType.Reply, 0);
                 }
 
                 y += 15;

--- a/Scripts/Misc/SpawnerPersistence.cs
+++ b/Scripts/Misc/SpawnerPersistence.cs
@@ -47,6 +47,9 @@ namespace Server
                     });
         }
 
+        /// <summary>
+        /// Checks version, and calls code appropriately.  Do not use goto keyword unless you want to call the previous version.
+        /// </summary>
         public static void CheckVersion()
         {
             switch (_Version)
@@ -180,7 +183,7 @@ namespace Server
         /// <param name="current">What we're looing for</param>
         /// <param name="replace">What we're replacing it with</param>
         /// <param name="check">if the SpawnObject line contains check, we ignore this line altogether</param>
-        public static void Relpace(string current, string replace, string check)
+        public static void Replace(string current, string replace, string check)
         {
             int count = 0;
 
@@ -198,9 +201,9 @@ namespace Server
         /// </summary>
         /// <param name="current">What we're looing for</param>
         /// <param name="replace">What we're replacing it with</param>
-        /// <param name="name">executes replace only if spawner name contains name</param>
+        /// <param name="name">executes replace only if spawner name contains parameter</param>
         /// <param name="check">if the SpawnObject line contains check, we ignore this line altogether</param>
-        public static void Relpace(string current, string replace, string name, string check)
+        public static void Replace(string current, string replace, string name, string check)
         {
             int count = 0;
 
@@ -219,13 +222,14 @@ namespace Server
 
             foreach (var obj in spawner.SpawnObjects)
             {
-                string typeName = obj.TypeName;
+                string typeName = obj.TypeName.ToLower();
+                string lookingFor = current.ToLower();
 
-                if (typeName != null && typeName.IndexOf(current) >= 0)
+                if (typeName != null && typeName.IndexOf(lookingFor) >= 0)
                 {
-                    if (check == null || typeName.IndexOf(check) < 0)
+                    if (String.IsNullOrEmpty(check) || typeName.IndexOf(check) < 0)
                     {
-                        obj.TypeName = typeName.Replace(current, replace);
+                        obj.TypeName = typeName.Replace(lookingFor, replace);
 
                         if (!replaced)
                             replaced = true;
@@ -259,9 +263,10 @@ namespace Server
 
             foreach (var obj in spawner.SpawnObjects)
             {
-                string typeName = obj.TypeName;
+                string typeName = obj.TypeName.ToLower();
+                string lookingFor = toRemove.ToLower();
 
-                if (typeName != null && typeName.IndexOf(toRemove) >= 0)
+                if (typeName != null && typeName.IndexOf(lookingFor) >= 0)
                 {
                     if (entireLine)
                     {
@@ -271,12 +276,56 @@ namespace Server
                     else
                     {
                         count++;
-                        obj.TypeName = typeName.Replace(toRemove, "");
+                        obj.TypeName = typeName.Replace(lookingFor, "");
                     }
                 }
             }
 
             return count;
+        }
+
+        /// <summary>
+        /// performs a pre-specified action (use lamba with action) if the conditions are met
+        /// </summary>
+        /// <param name="lineCheck">Condition for a specific string in the spawn object line</param>
+        /// <param name="nameCheck">Condition for the spawner name</param>
+        /// <param name="exempt">Condition to prevent action being performed on spawner</param>
+        /// <param name="action">action to be performed, setup in calling method</param>
+        public static void ActionOnSpawner(string lineCheck, string nameCheck, string exempt, Action<XmlSpawner> action)
+        {
+            int count = 0;
+
+            if (action != null)
+            {
+                List<XmlSpawner> list = World.Items.Values.OfType<XmlSpawner>().Where(s => nameCheck == null || s.Name.ToLower().IndexOf(nameCheck.ToLower()) >= 0).ToList();
+
+                foreach (var spawner in list)
+                {
+                    if (ActionOnSpawner(spawner, lineCheck, exempt, action))
+                        count++;
+                }
+
+                ColUtility.Free(list);
+            }
+
+            ToConsole(String.Format("Spawner Action: Performed action to {0} spawners{1}.", count.ToString(), lineCheck != null ? " containing " + lineCheck + "." : "."));
+        }
+
+        public static bool ActionOnSpawner(XmlSpawner spawner, string lineCheck, string exempt, Action<XmlSpawner> action)
+        {
+            foreach (var obj in spawner.SpawnObjects.Where(o => !String.IsNullOrEmpty(o.TypeName)))
+            {
+                string spawnObject = obj.TypeName.ToLower();
+                string lookFor = lineCheck != null ? lineCheck.ToLower() : null;
+
+                if ((lookFor == null || spawnObject.IndexOf(lookFor) >= 0) && (exempt == null || spawnObject.IndexOf(exempt.ToLower()) >= 0))
+                {
+                    action(spawner);
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Scripts/Misc/SpawnerPersistence.cs
+++ b/Scripts/Misc/SpawnerPersistence.cs
@@ -68,6 +68,7 @@ namespace Server
             Utility.PopColor();
         }
 
+        #region Version 0
         public static Dictionary<Type, Type[]> QuestQuesterTypes;
 
         /// <summary>
@@ -176,6 +177,7 @@ namespace Server
 
             return false;
         }
+        #endregion
 
         /// <summary>
         /// Replaces a certain string value with another in any XmlSpawner SpawnObject line

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -5128,6 +5128,46 @@ namespace Server.Mobiles
             PackItem(reg);
         }
 
+        public void PackBodyPart()
+        {
+            switch (Utility.Random(5))
+            {
+                case 0: PackItem(new LeftArm()); break;
+                case 1: PackItem(new RightArm()); break;
+                case 2: PackItem(new Torso()); break;
+                case 3: PackItem(new RightLeg()); break;
+                case 4: PackItem(new LeftLeg()); break;
+            }
+        }
+
+        public void PackBones()
+        {
+            switch (Utility.Random(6))
+            {
+                case 0: PackItem(new Bone()); break;
+                case 1: PackItem(new RibCage()); break;
+                case 2: PackItem(new RibCage()); break;
+                case 3: PackItem(new BonePile()); break;
+                case 4: PackItem(new BonePile()); break;
+                case 5: PackItem(new BonePile()); break;
+            }
+        }
+
+        public void PackBodyPartOrBones()
+        {
+            switch (Utility.Random(8))
+            {
+                case 0: PackItem(new LeftArm()); break;
+                case 1: PackItem(new RightArm()); break;
+                case 2: PackItem(new Torso()); break;
+                case 3: PackItem(new RightLeg()); break;
+                case 4: PackItem(new LeftLeg()); break;
+                case 5: PackItem(new Bone()); break;
+                case 6: PackItem(new RibCage()); break;
+                case 7: PackItem(new BonePile()); break;
+            }
+        }
+
         public void PackItem(Item item)
         {
             if (Summoned || item == null)

--- a/Scripts/Mobiles/Normal/CursedSoul.cs
+++ b/Scripts/Mobiles/Normal/CursedSoul.cs
@@ -11,63 +11,31 @@ namespace Server.Engines.Quests.Samurai
         public CursedSoul()
             : base(AIType.AI_Melee, FightMode.Aggressor, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a cursed soul";
-            this.Body = 3;
-            this.BaseSoundID = 471;
+            Name = "a cursed soul";
+            Body = 3;
+            BaseSoundID = 471;
 
-            this.SetStr(20, 40);
-            this.SetDex(40, 60);
-            this.SetInt(15, 25);
+            SetStr(20, 40);
+            SetDex(40, 60);
+            SetInt(15, 25);
 
-            this.SetHits(10, 20);
+            SetHits(10, 20);
 
-            this.SetDamage(3, 7);
+            SetDamage(3, 7);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 15, 20);
-            this.SetResistance(ResistanceType.Fire, 8, 12);
+            SetResistance(ResistanceType.Physical, 15, 20);
+            SetResistance(ResistanceType.Fire, 8, 12);
 
-            this.SetSkill(SkillName.Wrestling, 35.0, 39.0);
-            this.SetSkill(SkillName.Tactics, 5.0, 15.0);
-            this.SetSkill(SkillName.MagicResist, 10.0);
+            SetSkill(SkillName.Wrestling, 35.0, 39.0);
+            SetSkill(SkillName.Tactics, 5.0, 15.0);
+            SetSkill(SkillName.MagicResist, 10.0);
 
-            this.Fame = 200;
-            this.Karma = -200;
+            Fame = 200;
+            Karma = -200;
 
-            switch ( Utility.Random(10) )
-            {
-                case 0:
-                    this.PackItem(new LeftArm());
-                    break;
-                case 1:
-                    this.PackItem(new RightArm());
-                    break;
-                case 2:
-                    this.PackItem(new Torso());
-                    break;
-                case 3:
-                    this.PackItem(new Bone());
-                    break;
-                case 4:
-                    this.PackItem(new RibCage());
-                    break;
-                case 5:
-                    this.PackItem(new RibCage());
-                    break;
-                case 6:
-                    this.PackItem(new BonePile());
-                    break;
-                case 7:
-                    this.PackItem(new BonePile());
-                    break;
-                case 8:
-                    this.PackItem(new BonePile());
-                    break;
-                case 9:
-                    this.PackItem(new BonePile());
-                    break;
-            }
+            PackBodyPartOrBones();
         }
 
         public CursedSoul(Serial serial)

--- a/Scripts/Mobiles/Normal/IceSerpent.cs
+++ b/Scripts/Mobiles/Normal/IceSerpent.cs
@@ -11,36 +11,36 @@ namespace Server.Mobiles
         public IceSerpent()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a giant ice serpent";
-            this.Body = 89;
-            this.BaseSoundID = 219;
+            Name = "a giant ice serpent";
+            Body = 89;
+            BaseSoundID = 219;
 
-            this.SetStr(216, 245);
-            this.SetDex(26, 50);
-            this.SetInt(66, 85);
+            SetStr(216, 245);
+            SetDex(26, 50);
+            SetInt(66, 85);
 
-            this.SetHits(130, 147);
-            this.SetMana(0);
+            SetHits(130, 147);
+            SetMana(0);
 
-            this.SetDamage(7, 17);
+            SetDamage(7, 17);
 
-            this.SetDamageType(ResistanceType.Physical, 10);
-            this.SetDamageType(ResistanceType.Cold, 90);
+            SetDamageType(ResistanceType.Physical, 10);
+            SetDamageType(ResistanceType.Cold, 90);
 
-            this.SetResistance(ResistanceType.Physical, 30, 35);
-            this.SetResistance(ResistanceType.Cold, 80, 90);
-            this.SetResistance(ResistanceType.Poison, 15, 25);
-            this.SetResistance(ResistanceType.Energy, 10, 20);
+            SetResistance(ResistanceType.Physical, 30, 35);
+            SetResistance(ResistanceType.Cold, 80, 90);
+            SetResistance(ResistanceType.Poison, 15, 25);
+            SetResistance(ResistanceType.Energy, 10, 20);
 
-            this.SetSkill(SkillName.Anatomy, 27.5, 50.0);
-            this.SetSkill(SkillName.MagicResist, 25.1, 40.0);
-            this.SetSkill(SkillName.Tactics, 75.1, 80.0);
-            this.SetSkill(SkillName.Wrestling, 60.1, 80.0);
+            SetSkill(SkillName.Anatomy, 27.5, 50.0);
+            SetSkill(SkillName.MagicResist, 25.1, 40.0);
+            SetSkill(SkillName.Tactics, 75.1, 80.0);
+            SetSkill(SkillName.Wrestling, 60.1, 80.0);
 
-            this.Fame = 3500;
-            this.Karma = -3500;
+            Fame = 3500;
+            Karma = -3500;
 
-            this.VirtualArmor = 32;
+            VirtualArmor = 32;
 
         }
 
@@ -79,45 +79,13 @@ namespace Server.Mobiles
         }
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
-            this.PackItem(Loot.RandomArmorOrShieldOrWeapon());
+            AddLoot(LootPack.Meager);
+            PackItem(Loot.RandomArmorOrShieldOrWeapon());
 
-            switch (Utility.Random(10))
-            {
-                case 0:
-                    this.PackItem(new LeftArm());
-                    break;
-                case 1:
-                    this.PackItem(new RightArm());
-                    break;
-                case 2:
-                    this.PackItem(new Torso());
-                    break;
-                case 3:
-                    this.PackItem(new Bone());
-                    break;
-                case 4:
-                    this.PackItem(new RibCage());
-                    break;
-                case 5:
-                    this.PackItem(new RibCage());
-                    break;
-                case 6:
-                    this.PackItem(new BonePile());
-                    break;
-                case 7:
-                    this.PackItem(new BonePile());
-                    break;
-                case 8:
-                    this.PackItem(new BonePile());
-                    break;
-                case 9:
-                    this.PackItem(new BonePile());
-                    break;
-            }
+            PackBodyPartOrBones();
 
             if (0.025 > Utility.RandomDouble())
-                this.PackItem(new GlacialStaff());
+                PackItem(new GlacialStaff());
         }
 
         public override void Serialize(GenericWriter writer)
@@ -133,8 +101,8 @@ namespace Server.Mobiles
 
             int version = reader.ReadInt();
 
-            if (this.BaseSoundID == -1)
-                this.BaseSoundID = 219;
+            if (BaseSoundID == -1)
+                BaseSoundID = 219;
         }
     }
 }

--- a/Scripts/Mobiles/Normal/RevenantLion.cs
+++ b/Scripts/Mobiles/Normal/RevenantLion.cs
@@ -10,72 +10,40 @@ namespace Server.Mobiles
         public RevenantLion()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a Revenant Lion";
-            this.Body = 251;
+            Name = "a Revenant Lion";
+            Body = 251;
 
-            this.SetStr(276, 325);
-            this.SetDex(156, 175);
-            this.SetInt(76, 105);
+            SetStr(276, 325);
+            SetDex(156, 175);
+            SetInt(76, 105);
 
-            this.SetHits(251, 280);
+            SetHits(251, 280);
 
-            this.SetDamage(18, 24);
+            SetDamage(18, 24);
 
-            this.SetDamageType(ResistanceType.Physical, 30);
-            this.SetDamageType(ResistanceType.Cold, 30);
-            this.SetDamageType(ResistanceType.Poison, 10);
-            this.SetDamageType(ResistanceType.Energy, 30);
+            SetDamageType(ResistanceType.Physical, 30);
+            SetDamageType(ResistanceType.Cold, 30);
+            SetDamageType(ResistanceType.Poison, 10);
+            SetDamageType(ResistanceType.Energy, 30);
 
-            this.SetResistance(ResistanceType.Physical, 40, 60);
-            this.SetResistance(ResistanceType.Fire, 20, 30);
-            this.SetResistance(ResistanceType.Cold, 50, 60);
-            this.SetResistance(ResistanceType.Poison, 55, 65);
-            this.SetResistance(ResistanceType.Energy, 40, 50);
+            SetResistance(ResistanceType.Physical, 40, 60);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 55, 65);
+            SetResistance(ResistanceType.Energy, 40, 50);
 
-            this.SetSkill(SkillName.EvalInt, 80.1, 90.0);
-            this.SetSkill(SkillName.Magery, 80.1, 90.0);
-            this.SetSkill(SkillName.Poisoning, 120.1, 130.0);
-            this.SetSkill(SkillName.MagicResist, 70.1, 90.0);
-            this.SetSkill(SkillName.Tactics, 60.1, 80.0);
-            this.SetSkill(SkillName.Wrestling, 80.1, 88.0);
+            SetSkill(SkillName.EvalInt, 80.1, 90.0);
+            SetSkill(SkillName.Magery, 80.1, 90.0);
+            SetSkill(SkillName.Poisoning, 120.1, 130.0);
+            SetSkill(SkillName.MagicResist, 70.1, 90.0);
+            SetSkill(SkillName.Tactics, 60.1, 80.0);
+            SetSkill(SkillName.Wrestling, 80.1, 88.0);
 
-            this.Fame = 4000;
-            this.Karma = -4000;
-            this.PackNecroReg(6, 8);
-			
-            switch ( Utility.Random(10))
-            {
-                case 0:
-                    this.PackItem(new LeftArm());
-                    break;
-                case 1:
-                    this.PackItem(new RightArm());
-                    break;
-                case 2:
-                    this.PackItem(new Torso());
-                    break;
-                case 3:
-                    this.PackItem(new Bone());
-                    break;
-                case 4:
-                    this.PackItem(new RibCage());
-                    break;
-                case 5:
-                    this.PackItem(new RibCage());
-                    break;
-                case 6:
-                    this.PackItem(new BonePile());
-                    break;
-                case 7:
-                    this.PackItem(new BonePile());
-                    break;
-                case 8:
-                    this.PackItem(new BonePile());
-                    break;
-                case 9:
-                    this.PackItem(new BonePile());
-                    break;
-            }
+            Fame = 4000;
+            Karma = -4000;
+            PackNecroReg(6, 8);
+
+            PackBodyPartOrBones();
         }
 
         public RevenantLion(Serial serial)
@@ -136,8 +104,8 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich, 2);
-            this.AddLoot(LootPack.MedScrolls, 2);
+            AddLoot(LootPack.Rich, 2);
+            AddLoot(LootPack.MedScrolls, 2);
             // TODO: Bone Pile
         }
 

--- a/Scripts/Mobiles/Normal/Rotworm.cs
+++ b/Scripts/Mobiles/Normal/Rotworm.cs
@@ -43,16 +43,7 @@ namespace Server.Mobiles
 			Fame = 500;
 			Karma = -500;
 
-			switch ( Utility.Random( 10 ) )
-			{
-				case 0: PackItem( new LeftArm() ); break;
-				case 1: PackItem( new RightArm() ); break;
-				case 2: PackItem( new Torso() ); break;
-				case 3: PackItem( new Bone() ); break;
-				case 4: PackItem( new RibCage() ); break;
-				case 5: PackItem( new RibCage() ); break;
-				case 6: PackItem( new BonePile() ); break;
-			}
+            PackBodyPartOrBones();
 		}
 
 		public Rotworm( Serial serial )

--- a/Scripts/Mobiles/Normal/RuneBeetle.cs
+++ b/Scripts/Mobiles/Normal/RuneBeetle.cs
@@ -13,77 +13,45 @@ namespace Server.Mobiles
         public RuneBeetle()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a rune beetle";
-            this.Body = 244;
+            Name = "a rune beetle";
+            Body = 244;
 
-            this.SetStr(401, 460);
-            this.SetDex(121, 170);
-            this.SetInt(376, 450);
+            SetStr(401, 460);
+            SetDex(121, 170);
+            SetInt(376, 450);
 
-            this.SetHits(301, 360);
+            SetHits(301, 360);
 
-            this.SetDamage(15, 22);
+            SetDamage(15, 22);
 
-            this.SetDamageType(ResistanceType.Physical, 20);
-            this.SetDamageType(ResistanceType.Poison, 10);
-            this.SetDamageType(ResistanceType.Energy, 70);
+            SetDamageType(ResistanceType.Physical, 20);
+            SetDamageType(ResistanceType.Poison, 10);
+            SetDamageType(ResistanceType.Energy, 70);
 
-            this.SetResistance(ResistanceType.Physical, 40, 65);
-            this.SetResistance(ResistanceType.Fire, 35, 50);
-            this.SetResistance(ResistanceType.Cold, 35, 50);
-            this.SetResistance(ResistanceType.Poison, 75, 95);
-            this.SetResistance(ResistanceType.Energy, 40, 60);
+            SetResistance(ResistanceType.Physical, 40, 65);
+            SetResistance(ResistanceType.Fire, 35, 50);
+            SetResistance(ResistanceType.Cold, 35, 50);
+            SetResistance(ResistanceType.Poison, 75, 95);
+            SetResistance(ResistanceType.Energy, 40, 60);
 
-            this.SetSkill(SkillName.EvalInt, 100.1, 125.0);
-            this.SetSkill(SkillName.Magery, 100.1, 110.0);
-            this.SetSkill(SkillName.Poisoning, 120.1, 140.0);
-            this.SetSkill(SkillName.MagicResist, 95.1, 110.0);
-            this.SetSkill(SkillName.Tactics, 78.1, 93.0);
-            this.SetSkill(SkillName.Wrestling, 70.1, 77.5);
+            SetSkill(SkillName.EvalInt, 100.1, 125.0);
+            SetSkill(SkillName.Magery, 100.1, 110.0);
+            SetSkill(SkillName.Poisoning, 120.1, 140.0);
+            SetSkill(SkillName.MagicResist, 95.1, 110.0);
+            SetSkill(SkillName.Tactics, 78.1, 93.0);
+            SetSkill(SkillName.Wrestling, 70.1, 77.5);
 
-            this.Fame = 15000;
-            this.Karma = -15000;
+            Fame = 15000;
+            Karma = -15000;
 
             if (Utility.RandomDouble() < .25)
-                this.PackItem(Engines.Plants.Seed.RandomBonsaiSeed());
+                PackItem(Engines.Plants.Seed.RandomBonsaiSeed());
 
-            switch (Utility.Random(10))
-            {
-                case 0:
-                    this.PackItem(new LeftArm());
-                    break;
-                case 1:
-                    this.PackItem(new RightArm());
-                    break;
-                case 2:
-                    this.PackItem(new Torso());
-                    break;
-                case 3:
-                    this.PackItem(new Bone());
-                    break;
-                case 4:
-                    this.PackItem(new RibCage());
-                    break;
-                case 5:
-                    this.PackItem(new RibCage());
-                    break;
-                case 6:
-                    this.PackItem(new BonePile());
-                    break;
-                case 7:
-                    this.PackItem(new BonePile());
-                    break;
-                case 8:
-                    this.PackItem(new BonePile());
-                    break;
-                case 9:
-                    this.PackItem(new BonePile());
-                    break;
-            }
+            PackBodyPartOrBones();
 
-            this.Tamable = true;
-            this.ControlSlots = 3;
-            this.MinTameSkill = 93.9;
+            Tamable = true;
+            ControlSlots = 3;
+            MinTameSkill = 93.9;
         }
 
         public RuneBeetle(Serial serial)
@@ -151,8 +119,8 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.FilthyRich, 2);
-            this.AddLoot(LootPack.MedScrolls, 1);
+            AddLoot(LootPack.FilthyRich, 2);
+            AddLoot(LootPack.MedScrolls, 1);
         }
 
         int phy, fire, cold, poison, energy;
@@ -284,13 +252,13 @@ namespace Server.Mobiles
 
             if (version < 1)
             {
-                for (int i = 0; i < this.Skills.Length; ++i)
+                for (int i = 0; i < Skills.Length; ++i)
                 {
-                    this.Skills[i].Cap = Math.Max(100.0, this.Skills[i].Cap * 0.9);
+                    Skills[i].Cap = Math.Max(100.0, Skills[i].Cap * 0.9);
 
-                    if (this.Skills[i].Base > this.Skills[i].Cap)
+                    if (Skills[i].Base > Skills[i].Cap)
                     {
-                        this.Skills[i].Base = this.Skills[i].Cap;
+                        Skills[i].Base = Skills[i].Cap;
                     }
                 }
             }
@@ -303,24 +271,24 @@ namespace Server.Mobiles
             public ExpireTimer(Mobile m, List<ResistanceMod> mods, TimeSpan delay)
                 : base(delay)
             {
-                this.m_Mobile = m;
-                this.m_Mods = mods;
-                this.Priority = TimerPriority.TwoFiftyMS;
+                m_Mobile = m;
+                m_Mods = mods;
+                Priority = TimerPriority.TwoFiftyMS;
             }
 
             public void DoExpire()
             {
-                for (int i = 0; i < this.m_Mods.Count; ++i)
-                    this.m_Mobile.RemoveResistanceMod(this.m_Mods[i]);
+                for (int i = 0; i < m_Mods.Count; ++i)
+                    m_Mobile.RemoveResistanceMod(m_Mods[i]);
 
-                this.Stop();
-                m_Table.Remove(this.m_Mobile);
+                Stop();
+                m_Table.Remove(m_Mobile);
             }
 
             protected override void OnTick()
             {
-                this.m_Mobile.SendMessage("The corruption of your armor has worn off");
-                this.DoExpire();
+                m_Mobile.SendMessage("The corruption of your armor has worn off");
+                DoExpire();
             }
         }
     }

--- a/Scripts/Mobiles/Normal/ShadowWisp.cs
+++ b/Scripts/Mobiles/Normal/ShadowWisp.cs
@@ -10,71 +10,39 @@ namespace Server.Mobiles
         public ShadowWisp()
             : base(AIType.AI_Mage, FightMode.Aggressor, 10, 1, 0.3, 0.6)
         {
-            this.Name = "a shadow wisp";
-            this.Body = 165;
-            this.BaseSoundID = 466;
+            Name = "a shadow wisp";
+            Body = 165;
+            BaseSoundID = 466;
 
-            this.SetStr(16, 40);
-            this.SetDex(16, 45);
-            this.SetInt(11, 25);
+            SetStr(16, 40);
+            SetDex(16, 45);
+            SetInt(11, 25);
 
-            this.SetHits(10, 24);
+            SetHits(10, 24);
 
-            this.SetDamage(5, 10);
+            SetDamage(5, 10);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 15, 20);
-            this.SetResistance(ResistanceType.Fire, 5, 10);
-            this.SetResistance(ResistanceType.Poison, 5, 10);
-            this.SetResistance(ResistanceType.Energy, 15, 20);
+            SetResistance(ResistanceType.Physical, 15, 20);
+            SetResistance(ResistanceType.Fire, 5, 10);
+            SetResistance(ResistanceType.Poison, 5, 10);
+            SetResistance(ResistanceType.Energy, 15, 20);
 
-            this.SetSkill(SkillName.EvalInt, 40.0);
-            this.SetSkill(SkillName.Magery, 50.0);
-            this.SetSkill(SkillName.Meditation, 40.0);
-            this.SetSkill(SkillName.MagicResist, 10.0);
-            this.SetSkill(SkillName.Tactics, 0.1, 15.0);
-            this.SetSkill(SkillName.Wrestling, 25.1, 40.0);
+            SetSkill(SkillName.EvalInt, 40.0);
+            SetSkill(SkillName.Magery, 50.0);
+            SetSkill(SkillName.Meditation, 40.0);
+            SetSkill(SkillName.MagicResist, 10.0);
+            SetSkill(SkillName.Tactics, 0.1, 15.0);
+            SetSkill(SkillName.Wrestling, 25.1, 40.0);
 
-            this.Fame = 500;
+            Fame = 500;
 
-            this.VirtualArmor = 18;
+            VirtualArmor = 18;
 
-            this.AddItem(new LightSource());
+            AddItem(new LightSource());
 
-            switch ( Utility.Random(10))
-            {
-                case 0:
-                    this.PackItem(new LeftArm());
-                    break;
-                case 1:
-                    this.PackItem(new RightArm());
-                    break;
-                case 2:
-                    this.PackItem(new Torso());
-                    break;
-                case 3:
-                    this.PackItem(new Bone());
-                    break;
-                case 4:
-                    this.PackItem(new RibCage());
-                    break;
-                case 5:
-                    this.PackItem(new RibCage());
-                    break;
-                case 6:
-                    this.PackItem(new BonePile());
-                    break;
-                case 7:
-                    this.PackItem(new BonePile());
-                    break;
-                case 8:
-                    this.PackItem(new BonePile());
-                    break;
-                case 9:
-                    this.PackItem(new BonePile());
-                    break;
-            }
+            PackBones();
         }
 
         public ShadowWisp(Serial serial)

--- a/Scripts/Mobiles/Normal/TsukiWolf.cs
+++ b/Scripts/Mobiles/Normal/TsukiWolf.cs
@@ -12,89 +12,57 @@ namespace Server.Mobiles
         public TsukiWolf()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a tsuki wolf";
-            this.Body = 250;
+            Name = "a tsuki wolf";
+            Body = 250;
 
             switch( Utility.Random(3) )
             {
                 case 0:
-                    this.Hue = Utility.RandomNeutralHue();
+                    Hue = Utility.RandomNeutralHue();
                     break; //No, this really isn't accurate ;->
             }
 
-            this.SetStr(401, 450);
-            this.SetDex(151, 200);
-            this.SetInt(66, 76);
+            SetStr(401, 450);
+            SetDex(151, 200);
+            SetInt(66, 76);
 
-            this.SetHits(376, 450);
-            this.SetMana(40);
+            SetHits(376, 450);
+            SetMana(40);
 
-            this.SetDamage(14, 18);
+            SetDamage(14, 18);
 
-            this.SetDamageType(ResistanceType.Physical, 90);
-            this.SetDamageType(ResistanceType.Cold, 5);
-            this.SetDamageType(ResistanceType.Energy, 5);
+            SetDamageType(ResistanceType.Physical, 90);
+            SetDamageType(ResistanceType.Cold, 5);
+            SetDamageType(ResistanceType.Energy, 5);
 
-            this.SetResistance(ResistanceType.Physical, 40, 60);
-            this.SetResistance(ResistanceType.Fire, 50, 70);
-            this.SetResistance(ResistanceType.Cold, 50, 70);
-            this.SetResistance(ResistanceType.Poison, 50, 70);
-            this.SetResistance(ResistanceType.Energy, 50, 70);
+            SetResistance(ResistanceType.Physical, 40, 60);
+            SetResistance(ResistanceType.Fire, 50, 70);
+            SetResistance(ResistanceType.Cold, 50, 70);
+            SetResistance(ResistanceType.Poison, 50, 70);
+            SetResistance(ResistanceType.Energy, 50, 70);
 
-            this.SetSkill(SkillName.Anatomy, 65.1, 72.0);
-            this.SetSkill(SkillName.MagicResist, 65.1, 70.0);
-            this.SetSkill(SkillName.Tactics, 95.1, 110.0);
-            this.SetSkill(SkillName.Wrestling, 97.6, 107.5);
-            this.SetSkill(SkillName.Necromancy, 20.0);
-            this.SetSkill(SkillName.SpiritSpeak, 20.0);
-            this.SetSkill(SkillName.Anatomy, 40.0, 50.0);
-            this.SetSkill(SkillName.DetectHidden, 100.0);
-            this.SetSkill(SkillName.Parry, 90.0, 100.0);
+            SetSkill(SkillName.Anatomy, 65.1, 72.0);
+            SetSkill(SkillName.MagicResist, 65.1, 70.0);
+            SetSkill(SkillName.Tactics, 95.1, 110.0);
+            SetSkill(SkillName.Wrestling, 97.6, 107.5);
+            SetSkill(SkillName.Necromancy, 20.0);
+            SetSkill(SkillName.SpiritSpeak, 20.0);
+            SetSkill(SkillName.Anatomy, 40.0, 50.0);
+            SetSkill(SkillName.DetectHidden, 100.0);
+            SetSkill(SkillName.Parry, 90.0, 100.0);
 
-            this.Fame = 8500;
-            this.Karma = -8500;
+            Fame = 8500;
+            Karma = -8500;
 
             
             if (Core.ML && Utility.RandomDouble() < .33)
-                this.PackItem(Engines.Plants.Seed.RandomPeculiarSeed(1));
+                PackItem(Engines.Plants.Seed.RandomPeculiarSeed(1));
 
-            switch (Utility.Random(10))
-            {
-                case 0:
-                    this.PackItem(new LeftArm());
-                    break;
-                case 1:
-                    this.PackItem(new RightArm());
-                    break;
-                case 2:
-                    this.PackItem(new Torso());
-                    break;
-                case 3:
-                    this.PackItem(new Bone());
-                    break;
-                case 4:
-                    this.PackItem(new RibCage());
-                    break;
-                case 5:
-                    this.PackItem(new RibCage());
-                    break;
-                case 6:
-                    this.PackItem(new BonePile());
-                    break;
-                case 7:
-                    this.PackItem(new BonePile());
-                    break;
-                case 8:
-                    this.PackItem(new BonePile());
-                    break;
-                case 9:
-                    this.PackItem(new BonePile());
-                    break;
-            }
+            PackBodyPartOrBones();
             
-            this.Tamable = true;
-            this.ControlSlots = 3;
-            this.MinTameSkill = 96.0;
+            Tamable = true;
+            ControlSlots = 3;
+            MinTameSkill = 96.0;
         }
 
         public TsukiWolf(Serial serial)
@@ -111,8 +79,8 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Average);
-            this.AddLoot(LootPack.Rich);
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Rich);
         }
 
         public override void OnGaveMeleeAttack(Mobile defender)
@@ -191,33 +159,33 @@ namespace Server.Mobiles
             public ExpireTimer(Mobile m, Mobile from)
                 : base(TimeSpan.FromSeconds(1.0), TimeSpan.FromSeconds(1.0))
             {
-                this.m_Mobile = m;
-                this.m_From = from;
-                this.Priority = TimerPriority.TwoFiftyMS;
+                m_Mobile = m;
+                m_From = from;
+                Priority = TimerPriority.TwoFiftyMS;
             }
 
             public void DoExpire()
             {
-                this.Stop();
-                m_Table.Remove(this.m_Mobile);
+                Stop();
+                m_Table.Remove(m_Mobile);
             }
 
             public void DrainLife()
             {
-                if (this.m_Mobile.Alive)
-                    this.m_Mobile.Damage(2, this.m_From);
+                if (m_Mobile.Alive)
+                    m_Mobile.Damage(2, m_From);
                 else
-                    this.DoExpire();
+                    DoExpire();
             }
 
             protected override void OnTick()
             {
-                this.DrainLife();
+                DrainLife();
 
-                if (++this.m_Count >= 5)
+                if (++m_Count >= 5)
                 {
-                    this.DoExpire();
-                    this.m_Mobile.SendLocalizedMessage(1070824); // The creature's rage subsides.
+                    DoExpire();
+                    m_Mobile.SendLocalizedMessage(1070824); // The creature's rage subsides.
                 }
             }
         }

--- a/Scripts/Mobiles/Normal/Zombie.cs
+++ b/Scripts/Mobiles/Normal/Zombie.cs
@@ -10,66 +10,34 @@ namespace Server.Mobiles
         public Zombie()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a zombie";
-            this.Body = 3;
-            this.BaseSoundID = 471;
+            Name = "a zombie";
+            Body = 3;
+            BaseSoundID = 471;
 
-            this.SetStr(46, 70);
-            this.SetDex(31, 50);
-            this.SetInt(26, 40);
+            SetStr(46, 70);
+            SetDex(31, 50);
+            SetInt(26, 40);
 
-            this.SetHits(28, 42);
+            SetHits(28, 42);
 
-            this.SetDamage(3, 7);
+            SetDamage(3, 7);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 15, 20);
-            this.SetResistance(ResistanceType.Cold, 20, 30);
-            this.SetResistance(ResistanceType.Poison, 5, 10);
+            SetResistance(ResistanceType.Physical, 15, 20);
+            SetResistance(ResistanceType.Cold, 20, 30);
+            SetResistance(ResistanceType.Poison, 5, 10);
 
-            this.SetSkill(SkillName.MagicResist, 15.1, 40.0);
-            this.SetSkill(SkillName.Tactics, 35.1, 50.0);
-            this.SetSkill(SkillName.Wrestling, 35.1, 50.0);
+            SetSkill(SkillName.MagicResist, 15.1, 40.0);
+            SetSkill(SkillName.Tactics, 35.1, 50.0);
+            SetSkill(SkillName.Wrestling, 35.1, 50.0);
 
-            this.Fame = 600;
-            this.Karma = -600;
+            Fame = 600;
+            Karma = -600;
 
-            this.VirtualArmor = 18;
-			
-            switch ( Utility.Random(10))
-            {
-                case 0:
-                    this.PackItem(new LeftArm());
-                    break;
-                case 1:
-                    this.PackItem(new RightArm());
-                    break;
-                case 2:
-                    this.PackItem(new Torso());
-                    break;
-                case 3:
-                    this.PackItem(new Bone());
-                    break;
-                case 4:
-                    this.PackItem(new RibCage());
-                    break;
-                case 5:
-                    this.PackItem(new RibCage());
-                    break;
-                case 6:
-                    this.PackItem(new BonePile());
-                    break;
-                case 7:
-                    this.PackItem(new BonePile());
-                    break;
-                case 8:
-                    this.PackItem(new BonePile());
-                    break;
-                case 9:
-                    this.PackItem(new BonePile());
-                    break;
-            }
+            VirtualArmor = 18;
+
+            PackBodyPartOrBones();
         }
 
         public Zombie(Serial serial)
@@ -103,7 +71,7 @@ namespace Server.Mobiles
         }
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Meager);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Services/PlayerZombies.cs
+++ b/Scripts/Services/PlayerZombies.cs
@@ -259,6 +259,7 @@ namespace Server.Engines.Events
                 return Poison.Regular;
             }
         }
+
         public override void GenerateLoot()
         {
             switch( Utility.Random(10) )


### PR DESCRIPTION
- Adjusted timer to hold list, instead of each mobile getting its own timer
- SLow only applies to players
- increased range to 2, per EA
- Adjusted damage ticks, per EA