### PR TITLE
Bug Fixes

### DIFF
--- a/Data/bodyTable.cfg
+++ b/Data/bodyTable.cfg
@@ -1162,7 +1162,11 @@
 1424	Animal		# Frost Mite
 1425	Animal		# Ossein Ram 
 1426	Animal		# Lion
-
+1427	Animal		# Titan_Water_Tentacle
+1428	Monster		# Jack in the Box
+1431	Animal		# Titan_Earth_Head
+1432	Animal		# Titan_Air_Whirlwind
+1433	Monster		# Titan_Fire_Demon
 
 # TOL Wearables
 1261 	Equipment	# Human Robe BG (Male)
@@ -1195,3 +1199,5 @@
 1412	Equipment	#	EQUIP_Hat_TopHat
 1413	Equipment	#	EQUIP_Shirt_Tux
 1414	Equipment	#	EQUIP_Pants_Wedding
+1429	Equipment	#	Haunted_Vale
+1430	Equipment	#	Hat_Wed_Haunted

--- a/Scripts/Abilities/SAPropEffects.cs
+++ b/Scripts/Abilities/SAPropEffects.cs
@@ -179,7 +179,7 @@ namespace Server.Items
         private bool m_Active;
 
         public SoulChargeContext(Mobile from, Item item)
-            : base(from, null, item, EffectsType.SoulCharge, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(15))
+            : base(from, null, item, EffectsType.SoulCharge, TimeSpan.FromSeconds(40), TimeSpan.FromSeconds(40))
         {
             m_Active = true;
         }
@@ -191,6 +191,9 @@ namespace Server.Items
                 double mod = BaseFishPie.IsUnderEffects(this.Mobile, FishPieEffect.SoulCharge) ? .50 : .30;
                 this.Mobile.Mana += (int)Math.Min(this.Mobile.ManaMax, damage * mod);
                 m_Active = false;
+
+                Server.Effects.SendTargetParticles(this.Mobile, 0x375A, 0x1, 0xA, 0x71, 0x2, 0x1AE9, (EffectLayer)0, 0);
+
                 this.Mobile.SendLocalizedMessage(1113636); //The soul charge effect converts some of the damage you received into mana.
             }
         }
@@ -198,6 +201,7 @@ namespace Server.Items
         public static void CheckHit(Mobile attacker, Mobile defender, int damage)
         {
             BaseShield shield = defender.FindItemOnLayer(Layer.TwoHanded) as BaseShield;
+
             if (shield != null && shield.ArmorAttributes.SoulCharge > 0 && shield.ArmorAttributes.SoulCharge > Utility.Random(100))
             {
                 SoulChargeContext sc = PropertyEffect.GetContext<SoulChargeContext>(defender, EffectsType.SoulCharge);

--- a/Scripts/Items/Equipment/Armor/BaseArmor.cs
+++ b/Scripts/Items/Equipment/Armor/BaseArmor.cs
@@ -2891,6 +2891,9 @@ namespace Server.Items
             if (Core.ML && (prop = m_AosAttributes.IncreasedKarmaLoss) != 0)
                 list.Add(1075210, prop.ToString()); // Increased Karma Loss ~1val~%
 
+            if ((prop = m_AosArmorAttributes.SoulCharge) != 0)
+                list.Add(1113630, prop.ToString()); // Soul Charge ~1_val~%
+
             if ((prop = m_SAAbsorptionAttributes.EaterFire) != 0)
                 list.Add(1113593, prop.ToString()); // Fire Eater ~1_Val~%
 
@@ -2924,11 +2927,11 @@ namespace Server.Items
             if ((prop = m_SAAbsorptionAttributes.ResonanceKinetic) != 0)
                 list.Add(1113695, prop.ToString()); // Kinetic Resonance ~1_val~%
 
+            if((prop = m_AosArmorAttributes.ReactiveParalyze) != 0)
+                list.Add(1112364); // reactive paralyze
+
             if ((prop = m_SAAbsorptionAttributes.CastingFocus) != 0)
                 list.Add(1113696, prop.ToString()); // Casting Focus ~1_val~%
-
-			if ((prop = m_AosArmorAttributes.SoulCharge) != 0)
-				list.Add(1113630, prop.ToString()); // Soul Charge ~1_val~%
 
             if (this is SurgeShield && ((SurgeShield)this).Surge > SurgeType.None)
                 list.Add(1153098, ((SurgeShield)this).Charges.ToString());

--- a/Scripts/Items/Equipment/Talismans/BaseTalisman.cs
+++ b/Scripts/Items/Equipment/Talismans/BaseTalisman.cs
@@ -1122,7 +1122,7 @@ namespace Server.Items
 
                         if (GetSaveFlag(flags, SaveFlag.Skill))
                         {
-                            if (version == 3)
+                            if (version <= 3)
                             {
                                 m_Skill = GetTalismanSkill((SkillName)reader.ReadEncodedInt());
                             }

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -2557,10 +2557,6 @@ namespace Server.Items
 				false,
 				ranged ? Server.DamageType.Ranged : Server.DamageType.Melee);
 
-            #region Stygian Abyss
-            SoulChargeContext.CheckHit(attacker, defender, damageGiven);
-            #endregion
-
             if (sparks)
             {
                 int mana = attacker.Mana + damageGiven;

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -312,6 +312,8 @@ namespace Server
 
             m.Damage(totalDamage, from, true, false);
 
+            SpiritSpeak.CheckDisrupt(m);
+
             #region Skill Mastery Spells
             ManaShieldSpell.CheckManaShield(m, ref totalDamage);
             SkillMasterySpell.OnDamaged(m, from, ref totalDamage);
@@ -325,6 +327,8 @@ namespace Server
 
             if (ManaPhasingOrb.IsInManaPhase(m))
                 ManaPhasingOrb.RemoveFromTable(m);
+
+            SoulChargeContext.CheckHit(from, m, totalDamage);
 
             Spells.Mysticism.SleepSpell.OnDamage(m);
             Spells.Mysticism.PurgeMagicSpell.OnMobileDoDamage(from);

--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -3012,6 +3012,7 @@ namespace Server.Mobiles
 					}
 
 					chance /= 100;
+                    double shadow = Server.Spells.SkillMasteries.ShadowSpell.GetDifficultyFactor(trg);
 
 					if (chance > Utility.RandomDouble())
 					{

--- a/Scripts/Multis/BaseHouse.cs
+++ b/Scripts/Multis/BaseHouse.cs
@@ -628,7 +628,19 @@ namespace Server.Multis
 
         public override int GetUpdateRange(Mobile m)
         {
-            return Core.GlobalMaxUpdateRange;
+            int min = m.NetState != null ? m.NetState.UpdateRange : 18;
+            int max = Core.GlobalMaxUpdateRange;
+
+            int w = Components.Width;
+            int h = Components.Height - 1;
+            int v = min + ((w > h ? w : h) / 2);
+
+            if (v > max)
+                v = max;
+            else if (v < min)
+                v = min;
+
+            return v;
         }
 
         public List<Mobile> AvailableVendorsFor(Mobile m)
@@ -4596,6 +4608,9 @@ namespace Server.Multis
 
                 if (!isOwned)
                     isOwned = house.IsLockedDown(item);
+
+                if (!isOwned)
+                    isOwned = item is BaseAddon;
 
                 if (isOwned)
                     sec = (ISecurable)item;

--- a/Scripts/Services/VeteranRewards/CrystalPortals/CorruptedCrystalPortal.cs
+++ b/Scripts/Services/VeteranRewards/CrystalPortals/CorruptedCrystalPortal.cs
@@ -1,5 +1,7 @@
 #region References
 using System;
+using System.Collections.Generic;
+
 using Server.Factions;
 using Server.Gumps;
 using Server.Misc;
@@ -7,6 +9,7 @@ using Server.Mobiles;
 using Server.Network;
 using Server.Spells;
 using Server.Multis;
+using Server.ContextMenus;
 #endregion
 
 namespace Server.Items
@@ -39,17 +42,36 @@ namespace Server.Items
 			: base(serial)
 		{ }
 
+        public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)
+        {
+            base.GetContextMenuEntries(from, list);
+
+            SetSecureLevelEntry.AddTo(from, this, list);
+        }
+
 		public virtual bool ValidateUse(Mobile m, bool message)
 		{
-			if (Movable)
-			{
-				if (message)
-				{
-					m.SendMessage("This must be locked down in a house to use!");
-				}
+            BaseHouse house = BaseHouse.FindHouseAt(this);
 
-				return false;
-			}
+            if (house == null || !IsLockedDown)
+            {
+                if (message)
+                {
+                    m.SendMessage("This must be locked down in a house to use!");
+                }
+
+                return false;
+            }
+
+            if (!house.HasSecureAccess(m, m_Level))
+            {
+                if (message)
+                {
+                    m.SendLocalizedMessage(503301, "", 0x22); // You don't have permission to do that.
+                }
+
+                return false;
+            }
 
 			if (Sigil.ExistsOn(m))
 			{

--- a/Scripts/Services/VeteranRewards/CrystalPortals/CrystalPortal.cs
+++ b/Scripts/Services/VeteranRewards/CrystalPortals/CrystalPortal.cs
@@ -1,5 +1,7 @@
 #region References
 using System;
+using System.Collections.Generic;
+
 using Server.Factions;
 using Server.Gumps;
 using Server.Misc;
@@ -7,6 +9,7 @@ using Server.Mobiles;
 using Server.Network;
 using Server.Spells;
 using Server.Multis;
+using Server.ContextMenus;
 #endregion
 
 namespace Server.Items
@@ -38,6 +41,13 @@ namespace Server.Items
 		public CrystalPortal(Serial serial)
 			: base(serial)
 		{ }
+
+        public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)
+        {
+            base.GetContextMenuEntries(from, list);
+
+            SetSecureLevelEntry.AddTo(from, this, list);
+        }
 
 		public virtual bool ValidateUse(Mobile m, bool message)
 		{

--- a/Scripts/Services/VeteranRewards/DaviesLocker.cs
+++ b/Scripts/Services/VeteranRewards/DaviesLocker.cs
@@ -71,10 +71,17 @@ namespace Server.Engines.VeteranRewards
 
         public override void OnComponentUsed(AddonComponent component, Mobile from)
         {
-            if (from.InRange(component.Location, 2) && CanUse(from))
+            if (from.InRange(component.Location, 2))
             {
-                from.CloseGump(typeof(DaviesLockerGump));
-                from.SendGump(new DaviesLockerGump(from, this));
+                if (CanUse(from))
+                {
+                    from.CloseGump(typeof(DaviesLockerGump));
+                    from.SendGump(new DaviesLockerGump(from, this));
+                }
+                else
+                {
+                    from.SendLocalizedMessage(503301, "", 0x22); // You don't have permission to do that.
+                }
             }
         }
 
@@ -194,6 +201,8 @@ namespace Server.Engines.VeteranRewards
 
         public class DaviesLockerComponent : LocalizedAddonComponent
         {
+            public override bool ForceShowProperties { get { return true; } }
+
             public DaviesLockerComponent(int id)
                 : base(id, 1153534) // Davies' Locker
             {

--- a/Scripts/Skills/DetectHidden.cs
+++ b/Scripts/Skills/DetectHidden.cs
@@ -79,8 +79,9 @@ namespace Server.SkillHandlers
                         {
                             double ss = srcSkill + Utility.Random(21) - 10;
                             double ts = trg.Skills[SkillName.Hiding].Value + Utility.Random(21) - 10;
+                            double shadow = Server.Spells.SkillMasteries.ShadowSpell.GetDifficultyFactor(trg);
 
-                            if (src.AccessLevel >= trg.AccessLevel && (ss >= ts || (inHouse && house.IsInside(trg))))
+                            if (src.AccessLevel >= trg.AccessLevel && (ss >= ts || (inHouse && house.IsInside(trg))) && Utility.RandomDouble() > shadow)
                             {
                                 if (trg is ShadowKnight && (trg.X != p.X || trg.Y != p.Y))
                                     continue;

--- a/Scripts/Skills/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Skills/Imbuing/Core/Imbuing.cs
@@ -145,8 +145,8 @@ namespace Server.SkillHandlers
             if (RunicReforging.GetArtifactRarity(item) > 0)
                 return true;
 
-			if (item.GetType() == typeof(SilverRing) || item.GetType() == typeof(SilverBracelet))
-				return false;
+            if (NonCraftableImbuable(item))
+                return false;
 
             foreach (CraftSystem system in CraftSystem.Systems)
             {
@@ -175,6 +175,27 @@ namespace Server.SkillHandlers
         {
             typeof(ClockworkLeggings), typeof(GargishClockworkLeggings)
         };
+
+        private static Type[] _NonCraftables =
+        {
+            typeof(SilverRing), typeof(SilverBracelet)
+        };
+
+        public static bool NonCraftableImbuable(Item item)
+        {
+            if (item is BaseWand)
+                return true;
+
+            Type type = item.GetType();
+
+            foreach (var t in _NonCraftables)
+            {
+                if (t == type)
+                    return true;
+            }
+
+            return false;
+        }
 
         public static double GetSuccessChance(Mobile from, Item item, int totalItemWeight, int propWeight, out double dif)
         {
@@ -709,11 +730,6 @@ namespace Server.SkillHandlers
 
                 if (attr == AosWeaponAttribute.HitLeechMana || attr == AosWeaponAttribute.HitLeechHits)
                     return GetPropRange(item, attr)[1];
-            }
-
-            if ((item is BaseArmor || item is BaseHat) && def.Attribute is AosElementAttribute)
-            {
-                return GetPropRange(item, (AosElementAttribute)def.Attribute)[1];
             }
 
             return def.MaxIntensity;
@@ -1767,10 +1783,6 @@ namespace Server.SkillHandlers
                 {
                     max = GetPropRange((BaseWeapon)item, (AosWeaponAttribute)attr)[1];
                 }
-                else if(item is BaseArmor && attr is AosElementAttribute)
-                {
-                    max = GetPropRange((BaseArmor)item, (AosElementAttribute)attr)[1];
-                }
                 else if (item is BaseJewel && attr is AosAttribute && (AosAttribute)attr == AosAttribute.WeaponDamage)
                 {
                     max = 25;
@@ -2179,11 +2191,26 @@ namespace Server.SkillHandlers
             return new int[] { 1, 15 };
         }
 
-        public static int[] GetPropRange(Item item, AosElementAttribute attr)
+        /*public static int[] GetPropRange(Item item, AosElementAttribute attr)
         {
+            return new int[] { 1, 15 };
             int index = GetArmorIndex(item);
 
-            if (index < 0 || index > _MaxResistArmorTable.Length) // Default Value
+            if (item is BaseArmor)
+            {
+                BaseArmor ar = item as BaseArmor;
+
+                switch (attr)
+                {
+                    default:
+                    case AosElementAttribute.Physical: return new int[] { ar.BasePhysicalResistance + 1, ar.BasePhysicalResistance + 15 };
+                    case AosElementAttribute.Fire: return new int[] { ar.BaseFireResistance + 1, ar.BaseFireResistance + 15 };
+                    case AosElementAttribute.Cold: return new int[] { ar.BaseColdResistance + 1, ar.BaseColdResistance + 15 };
+                    case AosElementAttribute.Poison: return new int[] { ar.BasePoisonResistance + 1, ar.BasePoisonResistance + 15 };
+                    case AosElementAttribute.Energy: return new int[] { ar.BaseEnergyResistance + 1, ar.BaseEnergyResistance + 15 };
+                }
+            }*/
+            /*if (index < 0 || index > _MaxResistArmorTable.Length) // Default Value
                 return new int[] { 1, 15 };
 
             int attrIndex;
@@ -2199,7 +2226,7 @@ namespace Server.SkillHandlers
             }
 
             return new int[] { 1, _MaxResistArmorTable[index][attrIndex] };
-        }
+        }*/
 
         public static int[] GetPropRange(Item item, ExtendedWeaponAttribute attr)
         {
@@ -2213,7 +2240,7 @@ namespace Server.SkillHandlers
             }
         }
 
-        private static int GetArmorIndex(Item item)
+        /*private static int GetArmorIndex(Item item)
         {
             if (item is BaseHat)
                 return 0;
@@ -2283,7 +2310,7 @@ namespace Server.SkillHandlers
             new int[] { 18, 18, 18, 18, 18 }, // dragon
             new int[] { 22, 17, 17, 17, 17 }, // helmets
 
-        };
+        };*/
         #endregion
     }
 }        

--- a/Scripts/Skills/Imbuing/Gumps/ImbuingC.cs
+++ b/Scripts/Skills/Imbuing/Gumps/ImbuingC.cs
@@ -203,7 +203,24 @@ namespace Server.Gumps
                 else if (maxInt <= 8 || m_Mod == 21 || m_Mod == 17)  // - Show Property Value as just Number ( i.e [Mana Regen 2] )
                     AddHtml(240, 368, 40, 20, String.Format("<CENTER><BASEFONT COLOR=#CCCCFF> {0}</CENTER>", m_Value), false, false);
                 else                                                 // - Show Property Value as % ( i.e [Hit Fireball 25%] )
-                    AddHtml(240, 368, 40, 20, String.Format("<CENTER><BASEFONT COLOR=#CCCCFF> {0}%</CENTER>", m_Value), false, false);
+                {
+                    int val = m_Value;
+
+                    if (m_Mod >= 51 && m_Mod <= 55 && item is BaseArmor)
+                    {
+                        var armor = (BaseArmor)item;
+                        switch (m_Mod)
+                        {
+                            case 51: val += armor.BasePhysicalResistance; break;
+                            case 52: val += armor.BaseFireResistance; break;
+                            case 53: val += armor.BaseColdResistance; break;
+                            case 54: val += armor.BasePoisonResistance; break;
+                            case 55: val += armor.BaseEnergyResistance; break;
+                        }
+                    }
+
+                    AddHtml(240, 368, 40, 20, String.Format("<CENTER><BASEFONT COLOR=#CCCCFF> {0}%</CENTER>", val), false, false);
+                }
 
                 // == Buttons ==
                 AddButton(180, 370, 5230, 5230, 10053, GumpButtonType.Reply, 0); // To Minimum Value

--- a/Scripts/Skills/SpiritSpeak.cs
+++ b/Scripts/Skills/SpiritSpeak.cs
@@ -6,10 +6,12 @@
 
 #region References
 using System;
+using System.Collections.Generic;
 
 using Server.Items;
 using Server.Network;
 using Server.Spells;
+using Server.Mobiles;
 #endregion
 
 namespace Server.SkillHandlers
@@ -21,18 +23,16 @@ namespace Server.SkillHandlers
 			SkillInfo.Table[32].Callback = OnUse;
 		}
 
+        public static Dictionary<Mobile, Timer> _Table;
+
 		public static TimeSpan OnUse(Mobile m)
 		{
 			if (Core.AOS)
 			{
-				Spell spell = new SpiritSpeakSpell(m);
-
-				spell.Cast();
-
-				if (spell.IsCasting)
-				{
-					return TimeSpan.FromSeconds(5.0);
-				}
+                if (BeginSpiritSpeak(m))
+                {
+                    return TimeSpan.FromSeconds(5.0);
+                }
 
 				return TimeSpan.Zero;
 			}
@@ -86,133 +86,137 @@ namespace Server.SkillHandlers
 			}
 		}
 
-		private class SpiritSpeakSpell : Spell
-		{
-			private static readonly SpellInfo m_Info = new SpellInfo("Spirit Speak", "", 269);
+        public static bool BeginSpiritSpeak(Mobile m)
+        {
+            if (_Table == null || !_Table.ContainsKey(m))
+            {
+                m.SendSpeedControl(SpeedControlType.NoMove);
 
-			public SpiritSpeakSpell(Mobile caster)
-				: base(caster, null, m_Info)
-			{ }
+                m.Animate(AnimationType.Spell, 1);
+                m.PublicOverheadMessage(MessageType.Regular, 0x3B2, 1062074, "", false); // Anh Mi Sah Ko
+                m.PlaySound(0x24A);
 
-			public override bool BlockedByHorrificBeast { get { return false; } }
-			public override bool ClearHandsOnCast { get { return false; } }
-			public override double CastDelayFastScalar { get { return 0; } }
-			public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds(1.0); } }
-			public override bool CheckNextSpellTime { get { return false; } }
+                if (_Table == null)
+                    _Table = new Dictionary<Mobile, Timer>();
 
-			public override int GetMana()
-			{
-				return 0;
-			}
+                _Table[m] = new SpiritSpeakTimerNew(m);
+                return true;
+            }
 
-			public override void OnCasterHurt()
-			{
-				if (IsCasting)
-				{
-					Disturb(DisturbType.Hurt, false, true);
-				}
-			}
+            return false;
+        }
 
-			public override bool ConsumeReagents()
-			{
-				return true;
-			}
+        public static void Remove(Mobile m)
+        {
+            if (_Table != null && _Table.ContainsKey(m))
+            {
+                if(_Table[m] != null)
+                    _Table[m].Stop();
 
-			public override bool CheckFizzle()
-			{
-				return true;
-			}
+                m.SendSpeedControl(SpeedControlType.Disable);
+                _Table.Remove(m);
+            }
+        }
 
-			public override void OnDisturb(DisturbType type, bool message)
-			{
-				Caster.NextSkillTime = Core.TickCount;
+        public static void CheckDisrupt(Mobile m)
+        {
+            if (!Core.AOS)
+                return;
 
-				base.OnDisturb(type, message);
-			}
+            if (_Table != null && _Table.ContainsKey(m))
+            {
+                if (m is PlayerMobile)
+                {
+                    m.SendLocalizedMessage(500641); // Your concentration is disturbed, thus ruining thy spell.
+                }
 
-			public override bool CheckDisturb(DisturbType type, bool checkFirst, bool resistable)
-			{
-				if (type == DisturbType.EquipRequest || type == DisturbType.UseRequest)
-				{
-					return false;
-				}
+                m.FixedEffect(0x3735, 6, 30);
+                m.PlaySound(0x5C);
 
-				return true;
-			}
+                m.NextSkillTime = Core.TickCount;
 
-			public override void SayMantra()
-			{
-				// Anh Mi Sah Ko
-				Caster.PublicOverheadMessage(MessageType.Regular, 0x3B2, 1062074, "", false);
-				Caster.PlaySound(0x24A);
-			}
+                Remove(m);
+            }
+        }
 
-			public override void OnCast()
-			{
-				Corpse toChannel = null;
+        private class SpiritSpeakTimerNew : Timer
+        {
+            public Mobile Caster { get; set; }
 
-				foreach (Item item in Caster.GetItemsInRange(3))
-				{
-					if (item is Corpse && !((Corpse)item).Channeled)
-					{
-						toChannel = (Corpse)item;
-						break;
-					}
-				}
+            public SpiritSpeakTimerNew(Mobile m)
+                : base(TimeSpan.FromSeconds(1))
+            {
+                Start();
+                Caster = m;
+            }
 
-				int max, min, mana, number;
+            protected override void OnTick()
+            {
+                Corpse toChannel = null;
 
-				if (toChannel != null)
-				{
-					min = 1 + (int)(Caster.Skills[SkillName.SpiritSpeak].Value * 0.25);
-					max = min + 4;
-					mana = 0;
-					number = 1061287; // You channel energy from a nearby corpse to heal your wounds.
-				}
-				else
-				{
-					min = 1 + (int)(Caster.Skills[SkillName.SpiritSpeak].Value * 0.25);
-					max = min + 4;
-					mana = 10;
-					number = 1061286; // You channel your own spiritual energy to heal your wounds.
-				}
+                foreach (Item item in Caster.GetItemsInRange(3))
+                {
+                    if (item is Corpse && !((Corpse)item).Channeled)
+                    {
+                        toChannel = (Corpse)item;
+                        break;
+                    }
+                }
 
-				if (Caster.Mana < mana)
-				{
-					Caster.SendLocalizedMessage(1061285); // You lack the mana required to use this skill.
-				}
-				else
-				{
-					Caster.CheckSkill(SkillName.SpiritSpeak, 0.0, 120.0);
+                int max, min, mana, number;
 
-					if (Utility.RandomDouble() > (Caster.Skills[SkillName.SpiritSpeak].Value / 100.0))
-					{
-						Caster.SendLocalizedMessage(502443); // You fail your attempt at contacting the netherworld.
-					}
-					else
-					{
-						if (toChannel != null)
-						{
-							toChannel.Channeled = true;
-							toChannel.Hue = 0x835;
-						}
+                if (toChannel != null)
+                {
+                    min = 1 + (int)(Caster.Skills[SkillName.SpiritSpeak].Value * 0.25);
+                    max = min + 4;
+                    mana = 0;
+                    number = 1061287; // You channel energy from a nearby corpse to heal your wounds.
+                }
+                else
+                {
+                    min = 1 + (int)(Caster.Skills[SkillName.SpiritSpeak].Value * 0.25);
+                    max = min + 4;
+                    mana = 10;
+                    number = 1061286; // You channel your own spiritual energy to heal your wounds.
+                }
 
-						Caster.Mana -= mana;
-						Caster.SendLocalizedMessage(number);
+                if (Caster.Mana < mana)
+                {
+                    Caster.SendLocalizedMessage(1061285); // You lack the mana required to use this skill.
+                }
+                else
+                {
+                    Caster.CheckSkill(SkillName.SpiritSpeak, 0.0, 120.0);
 
-						if (min > max)
-						{
-							min = max;
-						}
+                    if (Utility.RandomDouble() > (Caster.Skills[SkillName.SpiritSpeak].Value / 100.0))
+                    {
+                        Caster.SendLocalizedMessage(502443); // You fail your attempt at contacting the netherworld.
+                    }
+                    else
+                    {
+                        if (toChannel != null)
+                        {
+                            toChannel.Channeled = true;
+                            toChannel.Hue = 0x835;
+                        }
 
-						Caster.Hits += Utility.RandomMinMax(min, max);
+                        Caster.Mana -= mana;
+                        Caster.SendLocalizedMessage(number);
 
-						Caster.FixedParticles(0x375A, 1, 15, 9501, 2100, 4, EffectLayer.Waist);
-					}
-				}
+                        if (min > max)
+                        {
+                            min = max;
+                        }
 
-				FinishSequence();
-			}
-		}
+                        Caster.Hits += Utility.RandomMinMax(min, max);
+
+                        Caster.FixedParticles(0x375A, 1, 15, 9501, 2100, 4, EffectLayer.Waist);
+                    }
+                }
+
+                SpiritSpeak.Remove(Caster);
+                Stop();
+            }
+        }
 	}
 }

--- a/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
+++ b/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
@@ -43,6 +43,8 @@ namespace Server.Spells.SkillMasteries
         public virtual bool CancelsSpecialMove { get { return CancelsWeaponAbility; } }
         public virtual bool ClearOnSpecialAbility { get { return false; } }
 
+        public virtual bool RevealOnTick { get { return true; } }
+
         public virtual TimeSpan ExpirationPeriod { get { return TimeSpan.FromMinutes(30); } }
         public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds(2.25); } }
 
@@ -144,7 +146,11 @@ namespace Server.Spells.SkillMasteries
 
 		public virtual bool OnTick()
 		{
-            Caster.RevealingAction();
+            if (RevealOnTick)
+            {
+                Caster.RevealingAction();
+            }
+
             int upkeep = ScaleUpkeep();
 
             if (0.10 > Utility.RandomDouble())

--- a/Scripts/Spells/Skill Masteries/Shadow.cs
+++ b/Scripts/Spells/Skill Masteries/Shadow.cs
@@ -16,6 +16,7 @@ namespace Server.Spells.SkillMasteries
 
         public override double UpKeep { get { return 4; } }
         public override int RequiredMana { get { return 10; } }
+        public override bool RevealOnTick { get { return false; } }
 
         public override SkillName CastSkill { get { return SkillName.Ninjitsu; } }
         public override SkillName DamageSkill { get { return SkillName.Stealth; } }

--- a/Scripts/Spells/Skill Masteries/WhiteTigerForm.cs
+++ b/Scripts/Spells/Skill Masteries/WhiteTigerForm.cs
@@ -34,6 +34,17 @@ namespace Server.Spells.SkillMasteries
         {
         }
 
+        public override void SendCastEffect()
+        {
+            Caster.FixedEffect(0x37C4, 87, (int)(GetCastDelay().TotalSeconds * 28), 0x66C, 3);
+        }
+
+        public static void AutoCast(Mobile m)
+        {
+            var spell = new WhiteTigerFormSpell(m, null);
+            spell.Cast();
+        }
+
         public override bool CheckCast()
         {
             if (!Caster.CanBeginAction(typeof(PolymorphSpell)))
@@ -79,6 +90,8 @@ namespace Server.Spells.SkillMasteries
             {
                 AnimalFormContext context = AnimalForm.GetContext(Caster);
                 int mana = ScaleMana(RequiredMana);
+
+                Ninjitsu.AnimalForm.AddLastAnimalForm(Caster, 16);
 
                 if (mana > Caster.Mana)
                 {

--- a/Server/Skills.cs
+++ b/Server/Skills.cs
@@ -526,7 +526,8 @@ namespace Server
 			double gainFactor,
 			StatCode primary,
             StatCode secondary, 
-            bool mastery = false)
+            bool mastery = false,
+            bool usewhilecasting = false)
 		{
 			Name = name;
 			Title = title;
@@ -542,6 +543,7 @@ namespace Server
 			Primary = primary;
 			Secondary = secondary;
             IsMastery = mastery;
+            UseWhileCasting = usewhilecasting;
 
 			StatTotal = strScale + dexScale + intScale;
 		}
@@ -574,6 +576,8 @@ namespace Server
 		public double GainFactor { get; set; }
 
         public bool IsMastery { get; set; }
+
+        public bool UseWhileCasting { get; set; }
 
         public int Localization { get { return 1044060 + SkillID; } }
 
@@ -611,7 +615,7 @@ namespace Server
 			new SkillInfo(29, "Musicianship", 0.0, 0.0, 0.0, "Bard", null, 0.0, 0.8, 0.2, 1.0, StatCode.Dex, StatCode.Int),
 			new SkillInfo(30, "Poisoning", 0.0, 4.0, 16.0, "Assassin", null, 0.0, 0.4, 1.6, 1.0, StatCode.Int, StatCode.Dex, true ),
 			new SkillInfo(31, "Archery", 2.5, 7.5, 0.0, "Archer", null, 0.25, 0.75, 0.0, 1.0, StatCode.Dex, StatCode.Str, true ),
-			new SkillInfo(32, "Spirit Speak", 0.0, 0.0, 0.0, "Medium", null, 0.0, 0.0, 1.0, 1.0, StatCode.Int, StatCode.Str),
+			new SkillInfo(32, "Spirit Speak", 0.0, 0.0, 0.0, "Medium", null, 0.0, 0.0, 1.0, 1.0, StatCode.Int, StatCode.Str, false, true),
 			new SkillInfo(33, "Stealing", 0.0, 10.0, 0.0, "Pickpocket", null, 0.0, 1.0, 0.0, 1.0, StatCode.Dex, StatCode.Int),
 			new SkillInfo(34, "Tailoring", 3.75, 16.25, 5.0, "Tailor", null, 0.38, 1.63, 0.5, 1.0, StatCode.Dex, StatCode.Int),
 			new SkillInfo(35, "Animal Taming", 14.0, 2.0, 4.0, "Tamer", null, 1.4, 0.2, 0.4, 1.0, StatCode.Str, StatCode.Int, true ),
@@ -895,7 +899,7 @@ namespace Server
 
 				if (info.Callback != null)
 				{
-					if (Core.TickCount - from.NextSkillTime >= 0 && from.Spell == null)
+					if (Core.TickCount - from.NextSkillTime >= 0 && (info.UseWhileCasting || from.Spell == null))
 					{
 						from.DisruptiveAction();
 


### PR DESCRIPTION
- Fixed Soul Charge, now shows Effects
- Soul Charge now shows as properties on shields
- Spirit Speak no longer drops current spell. For this, it had to be converted from a spell to a timer. The only other option was several core edits.
- Shadow Spell now gives appropriate bonus to being revealed (not being revealed)
- Added update range check to BaseHouse. Keep an eye on this one.
- Added Security context entries to Crystal Portals and Davies Locker
- Fixed imbuing resistances on armor. It is not 15 + base resists.
- White Tiger Form now shows proper cast Effects
- White Tiger Form now can be activated by animal form when moving as last animal form

Added fix for those who havent updated since May.  There was a version issue in deserialize where talismans would show the wrong skill bonus.