### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -2799,18 +2799,42 @@ namespace Server.Items
 				}
 				#endregion
 
-				int laChance = (int)(AosWeaponAttributes.GetValue(attacker, AosWeaponAttribute.HitLowerAttack) * propertyBonus);
-				int ldChance = (int)(AosWeaponAttributes.GetValue(attacker, AosWeaponAttribute.HitLowerDefend) * propertyBonus);
+                int laChance = (int)(AosWeaponAttributes.GetValue(attacker, AosWeaponAttribute.HitLowerAttack) * propertyBonus);
 
 				if (laChance != 0 && laChance > Utility.Random(100))
 				{
 					DoLowerAttack(attacker, defender);
 				}
 
-				if (ldChance != 0 && ldChance > Utility.Random(100))
-				{
-					DoLowerDefense(attacker, defender);
-				}
+                if (!Core.HS)
+                {
+                    int ldChance = (int)(AosWeaponAttributes.GetValue(attacker, AosWeaponAttribute.HitLowerDefend) * propertyBonus);
+
+                    if (ldChance != 0 && ldChance > Utility.Random(100))
+                    {
+                        DoLowerDefense(attacker, defender);
+                    }
+                }
+                else
+                {
+                    int hldWep = m_AosWeaponAttributes.HitLowerDefend;
+                    int hldGlasses = 0;
+                    
+                    var helm = attacker.FindItemOnLayer(Layer.Helm);
+
+                    if (helm != null)
+                    {
+                        var attrs = RunicReforging.GetAosWeaponAttributes(helm);
+
+                        if(attrs != null)
+                            hldGlasses = attrs.HitLowerDefend;
+                    }
+
+                    if ((hldWep > 0 && hldWep > Utility.Random(100)) || (hldGlasses > 0 && hldGlasses > Utility.Random(100)))
+                    {
+                        DoLowerDefense(attacker, defender);
+                    }
+                }
 			}
 
 			if (attacker is BaseCreature)

--- a/Scripts/Items/Equipment/Weapons/HitLower.cs
+++ b/Scripts/Items/Equipment/Weapons/HitLower.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Collections;
+using System.Collections.Generic;
+using Server.Mobiles;
 
 namespace Server.Items
 {
@@ -7,11 +8,12 @@ namespace Server.Items
     {
         public static readonly TimeSpan AttackEffectDuration = TimeSpan.FromSeconds(10.0);
         public static readonly TimeSpan DefenseEffectDuration = TimeSpan.FromSeconds(8.0);
-        private static readonly Hashtable m_AttackTable = new Hashtable();
-        private static readonly Hashtable m_DefenseTable = new Hashtable();
+        private static readonly Dictionary<Mobile, AttackTimer> m_AttackTable = new Dictionary<Mobile, AttackTimer>();
+        private static readonly Dictionary<Mobile, DefenseTimer> m_DefenseTable = new Dictionary<Mobile, DefenseTimer>();
+
         public static bool IsUnderAttackEffect(Mobile m)
         {
-            return m_AttackTable.Contains(m);
+            return m_AttackTable.ContainsKey(m);
         }
 
         public static bool ApplyAttack(Mobile m)
@@ -27,67 +29,118 @@ namespace Server.Items
 
         public static bool IsUnderDefenseEffect(Mobile m)
         {
-            return m_DefenseTable.Contains(m);
+            return m_DefenseTable.ContainsKey(m);
         }
 
         public static bool ApplyDefense(Mobile m)
         {
-            if (IsUnderDefenseEffect(m))
-                return false;
+            if (!Core.HS)
+            {
+                if (IsUnderDefenseEffect(m))
+                    return false;
 
-            m_DefenseTable[m] = new DefenseTimer(m);
-            BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.HitLowerDefense, 1151313, 1151312, DefenseEffectDuration, m, "25"));
-            m.SendLocalizedMessage(1062318); // Your defense chance has been reduced!
-            return true;
+                m_DefenseTable[m] = new DefenseTimer(m, 25);
+                BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.HitLowerDefense, 1151313, 1151286, DefenseEffectDuration, m, "35"));
+                m.SendLocalizedMessage(1062318); // Your defense chance has been reduced!
+                return true;
+            }
+            else
+            {
+                if (m_DefenseTable.ContainsKey(m))
+                {
+                    var timer = m_DefenseTable[m];
+
+                    if (timer != null)
+                    {
+                        timer.Stop();
+                    }
+                }
+
+                int malus;
+
+                if (m is PlayerMobile)
+                {
+                    malus = (int)(Math.Min(45, AosAttributes.GetValue(m, AosAttribute.DefendChance)));
+                    malus = malus - (int)((double)malus * .35);
+                }
+                else
+                {
+                    malus = 25;
+                }
+
+                m_DefenseTable[m] = new DefenseTimer(m, malus);
+                BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.HitLowerDefense, 1151313, 1151286, DefenseEffectDuration, m, malus.ToString()));
+                m.SendLocalizedMessage(1062318); // Your defense chance has been reduced!
+                return true;
+            }
         }
 
         private static void RemoveAttack(Mobile m)
         {
-            m_AttackTable.Remove(m);
-            m.SendLocalizedMessage(1062320); // Your attack chance has returned to normal.
+            if (m_AttackTable.ContainsKey(m))
+            {
+                m_AttackTable.Remove(m);
+                m.SendLocalizedMessage(1062320); // Your attack chance has returned to normal.
+            }
         }
 
         private static void RemoveDefense(Mobile m)
         {
-            m_DefenseTable.Remove(m);
-            m.SendLocalizedMessage(1062321); // Your defense chance has returned to normal.
+            if (m_DefenseTable.ContainsKey(m))
+            {
+                m_DefenseTable.Remove(m);
+                m.SendLocalizedMessage(1062321); // Your defense chance has returned to normal.
+            }
+        }
+
+        public static int GetDefenseMalus(Mobile m)
+        {
+            if (m_DefenseTable.ContainsKey(m))
+            {
+                return m_DefenseTable[m].DefenseMalus;
+            }
+
+            return 0;
         }
 
         private class AttackTimer : Timer
         {
             private readonly Mobile m_Player;
+
             public AttackTimer(Mobile player)
                 : base(AttackEffectDuration)
             {
-                this.m_Player = player;
+                m_Player = player;
 
-                this.Priority = TimerPriority.TwoFiftyMS;
+                Priority = TimerPriority.TwoFiftyMS;
 
-                this.Start();
+                Start();
             }
 
             protected override void OnTick()
             {
-                RemoveAttack(this.m_Player);
+                RemoveAttack(m_Player);
             }
         }
 
         private class DefenseTimer : Timer
         {
             private readonly Mobile m_Player;
-            public DefenseTimer(Mobile player)
+            public int DefenseMalus { get; private set; }
+
+            public DefenseTimer(Mobile player, int malus)
                 : base(DefenseEffectDuration)
             {
-                this.m_Player = player;
+                m_Player = player;
+                DefenseMalus = malus;
 
-                this.Priority = TimerPriority.TwoFiftyMS;
-
-                this.Start();
+                Priority = TimerPriority.TwoFiftyMS;
+                Start();
             }
 
             protected override void OnTick()
             {
-                RemoveDefense(this.m_Player);
+                RemoveDefense(m_Player);
             }
         }
     }

--- a/Scripts/Items/Resource/Bandage.cs
+++ b/Scripts/Items/Resource/Bandage.cs
@@ -271,7 +271,7 @@ namespace Server.Items
 
         public void CheckPoisonOrBleed()
         {
-            bool bleeding = BleedAttack.IsBleeding(m_Patient) || SplinteringWeaponContext.IsBleeding(m_Patient);
+            bool bleeding = BleedAttack.IsBleeding(m_Patient);
             bool poisoned = m_Patient.Poisoned;
 
             if (bleeding || poisoned)
@@ -298,10 +298,6 @@ namespace Server.Items
                         if (BleedAttack.IsBleeding(m_Patient))
                         {
                             BleedAttack.EndBleed(m_Patient, false);
-                        }
-                        else
-                        {
-                            SplinteringWeaponContext.EndBleeding(m_Patient, false);
                         }
 
                         m_Patient.SendLocalizedMessage(1060088); // You bind the wound and stop the bleeding
@@ -466,13 +462,6 @@ namespace Server.Items
                 patientNumber = 1060167; // The bleeding wounds have healed, you are no longer bleeding!
 
                 BleedAttack.EndBleed(m_Patient, false);
-            }
-            else if (SplinteringWeaponContext.IsBleeding(m_Patient))
-            {
-                healerNumber = 1060088; // You bind the wound and stop the bleeding
-                patientNumber = 1060167; // The bleeding wounds have healed, you are no longer bleeding!
-
-                SplinteringWeaponContext.EndBleeding(m_Patient);
             }
             else if (MortalStrike.IsWounded(m_Patient))
             {
@@ -654,7 +643,7 @@ namespace Server.Items
             {
                 healer.SendLocalizedMessage(500951); // You cannot heal that.
             }
-            else if (!patient.Poisoned && patient.Hits == patient.HitsMax && !BleedAttack.IsBleeding(patient) && !SplinteringWeaponContext.IsBleeding(patient) && !isDeadPet)
+            else if (!patient.Poisoned && patient.Hits == patient.HitsMax && !BleedAttack.IsBleeding(patient) && !isDeadPet)
             {
                 healer.SendLocalizedMessage(500955); // That being is not damaged!
             }

--- a/Scripts/Mobiles/Normal/BaseMount.cs
+++ b/Scripts/Mobiles/Normal/BaseMount.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using Server.Network;
 
 namespace Server.Mobiles
 {
@@ -20,10 +21,10 @@ namespace Server.Mobiles
         public BaseMount(string name, int bodyID, int itemID, AIType aiType, FightMode fightMode, int rangePerception, int rangeFight, double activeSpeed, double passiveSpeed)
             : base(aiType, fightMode, rangePerception, rangeFight, activeSpeed, passiveSpeed)
         {
-            this.Name = name;
-            this.Body = bodyID;
+            Name = name;
+            Body = bodyID;
 
-            this.m_InternalItem = new MountItem(this, itemID);
+            m_InternalItem = new MountItem(this, itemID);
         }
 
         public BaseMount(Serial serial)
@@ -43,11 +44,11 @@ namespace Server.Mobiles
         {
             get
             {
-                return this.m_NextMountAbility;
+                return m_NextMountAbility;
             }
             set
             {
-                this.m_NextMountAbility = value;
+                m_NextMountAbility = value;
             }
         }
         public virtual bool AllowMaleRider
@@ -75,8 +76,8 @@ namespace Server.Mobiles
             {
                 base.Hue = value;
 
-                if (this.m_InternalItem != null)
-                    this.m_InternalItem.Hue = value;
+                if (m_InternalItem != null)
+                    m_InternalItem.Hue = value;
             }
         }
         [CommandProperty(AccessLevel.GameMaster)]
@@ -84,15 +85,15 @@ namespace Server.Mobiles
         {
             get
             {
-                if (this.m_InternalItem != null)
-                    return this.m_InternalItem.ItemID;
+                if (m_InternalItem != null)
+                    return m_InternalItem.ItemID;
                 else
                     return 0;
             }
             set
             {
-                if (this.m_InternalItem != null)
-                    this.m_InternalItem.ItemID = value;
+                if (m_InternalItem != null)
+                    m_InternalItem.ItemID = value;
             }
         }
         [CommandProperty(AccessLevel.GameMaster)]
@@ -100,46 +101,53 @@ namespace Server.Mobiles
         {
             get
             {
-                return this.m_Rider;
+                return m_Rider;
             }
             set
             {
-                if (this.m_Rider != value)
+                if (m_Rider != value)
                 {
                     if (value == null)
                     {
-                        Point3D loc = this.m_Rider.Location;
-                        Map map = this.m_Rider.Map;
+                        Point3D loc = m_Rider.Location;
+                        Map map = m_Rider.Map;
 
                         if (map == null || map == Map.Internal)
                         {
-                            loc = this.m_Rider.LogoutLocation;
-                            map = this.m_Rider.LogoutMap;
+                            loc = m_Rider.LogoutLocation;
+                            map = m_Rider.LogoutMap;
                         }
 
-                        this.Direction = this.m_Rider.Direction;
-                        this.Location = loc;
-                        this.Map = map;
+                        Direction = m_Rider.Direction;
+                        Location = loc;
+                        Map = map;
 
-                        if (this.m_InternalItem != null)
-                            this.m_InternalItem.Internalize();
+                        NetState ns = m_Rider.NetState;
+
+                        if (ns != null && m_Rider is PlayerMobile && ns.IsEnhancedClient && Commandable)
+                        {
+                            ns.Send(new PetWindow((PlayerMobile)m_Rider, this));
+                        }
+
+                        if (m_InternalItem != null)
+                            m_InternalItem.Internalize();
                     }
                     else
                     {
-                        if (this.m_Rider != null)
-                            Dismount(this.m_Rider);
+                        if (m_Rider != null)
+                            Dismount(m_Rider);
 
                         Dismount(value);
 
-                        if (this.m_InternalItem != null)
-                            value.AddItem(this.m_InternalItem);
+                        if (m_InternalItem != null)
+                            value.AddItem(m_InternalItem);
 
-                        value.Direction = this.Direction;
+                        value.Direction = Direction;
 
-                        this.Internalize();
+                        Internalize();
                     }
 
-                    this.m_Rider = value;
+                    m_Rider = value;
                 }
             }
         }
@@ -148,7 +156,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return this.m_InternalItem;
+                return m_InternalItem;
             }
         }
 
@@ -308,32 +316,32 @@ namespace Server.Mobiles
 
             writer.Write((int)1); // version
 
-            writer.Write(this.m_NextMountAbility);
+            writer.Write(m_NextMountAbility);
 
-            writer.Write(this.m_Rider);
-            writer.Write(this.m_InternalItem);
+            writer.Write(m_Rider);
+            writer.Write(m_InternalItem);
         }
 
         public override bool OnBeforeDeath()
         {
-            this.Rider = null;
+            Rider = null;
 
             return base.OnBeforeDeath();
         }
 
         public override void OnAfterDelete()
         {
-            if (this.m_InternalItem != null)
-                this.m_InternalItem.Delete();
+            if (m_InternalItem != null)
+                m_InternalItem.Delete();
 
-            this.m_InternalItem = null;
+            m_InternalItem = null;
 
             base.OnAfterDelete();
         }
 
         public override void OnDelete()
         {
-            this.Rider = null;
+            Rider = null;
 
             base.OnDelete();
         }
@@ -348,16 +356,16 @@ namespace Server.Mobiles
             {
                 case 1:
                     {
-                        this.m_NextMountAbility = reader.ReadDateTime();
+                        m_NextMountAbility = reader.ReadDateTime();
                         goto case 0;
                     }
                 case 0:
                     {
-                        this.m_Rider = reader.ReadMobile();
-                        this.m_InternalItem = reader.ReadItem();
+                        m_Rider = reader.ReadMobile();
+                        m_InternalItem = reader.ReadItem();
 
-                        if (this.m_InternalItem == null)
-                            this.Delete();
+                        if (m_InternalItem == null)
+                            Delete();
 
                         break;
                     }
@@ -371,13 +379,13 @@ namespace Server.Mobiles
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (this.IsDeadPet)
+            if (IsDeadPet)
                 return;
 
             if (from.IsBodyMod && !from.Body.IsHuman)
             {
                 if (Core.AOS) // You cannot ride a mount in your current form.
-                    this.PrivateOverheadMessage(Network.MessageType.Regular, 0x3B2, 1062061, from.NetState);
+                    PrivateOverheadMessage(Network.MessageType.Regular, 0x3B2, 1062061, from.NetState);
                 else
                     from.SendLocalizedMessage(1061628); // You can't do that while polymorphed.
 
@@ -396,13 +404,13 @@ namespace Server.Mobiles
             if (from.Race == Race.Gargoyle && from.IsPlayer())
             {
                 from.SendLocalizedMessage(1112281);
-                this.OnDisallowedRider(from);
+                OnDisallowedRider(from);
                 return;
             }
 
-            if (from.Female ? !this.AllowFemaleRider : !this.AllowMaleRider)
+            if (from.Female ? !AllowFemaleRider : !AllowMaleRider)
             {
-                this.OnDisallowedRider(from);
+                OnDisallowedRider(from);
                 return;
             }
 
@@ -418,25 +426,25 @@ namespace Server.Mobiles
             if (from.InRange(this, 1))
             {
                 bool canAccess = (from.AccessLevel >= AccessLevel.GameMaster) ||
-                                 (this.Controlled && this.ControlMaster == from) ||
-                                 (this.Summoned && this.SummonMaster == from);
+                                 (Controlled && ControlMaster == from) ||
+                                 (Summoned && SummonMaster == from);
 
                 if (canAccess)
                 {
-                    if (this.Poisoned)
-                        this.PrivateOverheadMessage(Network.MessageType.Regular, 0x3B2, 1049692, from.NetState); // This mount is too ill to ride.
+                    if (Poisoned)
+                        PrivateOverheadMessage(Network.MessageType.Regular, 0x3B2, 1049692, from.NetState); // This mount is too ill to ride.
                     else
-                        this.Rider = from;
+                        Rider = from;
                 }
-                else if (!this.Controlled && !this.Summoned)
+                else if (!Controlled && !Summoned)
                 {
                     // That mount does not look broken! You would have to tame it to ride it.
-                    this.PrivateOverheadMessage(Network.MessageType.Regular, 0x3B2, 501263, from.NetState);
+                    PrivateOverheadMessage(Network.MessageType.Regular, 0x3B2, 501263, from.NetState);
                 }
                 else
                 {
                     // This isn't your mount; it refuses to let you ride.
-                    this.PrivateOverheadMessage(Network.MessageType.Regular, 0x3B2, 501264, from.NetState);
+                    PrivateOverheadMessage(Network.MessageType.Regular, 0x3B2, 501264, from.NetState);
                 }
             }
             else
@@ -447,17 +455,17 @@ namespace Server.Mobiles
 
         public virtual void OnRiderDamaged(int amount, Mobile from, bool willKill)
         {
-            if (this.m_Rider == null)
+            if (m_Rider == null)
                 return;
 
             Mobile attacker = from;
             if (attacker == null)
-                attacker = this.m_Rider.FindMostRecentDamager(true);
+                attacker = m_Rider.FindMostRecentDamager(true);
 
-            if (!(attacker == this || attacker == this.m_Rider || willKill || DateTime.UtcNow > this.m_NextMountAbility))
+            if (!(attacker == this || attacker == m_Rider || willKill || DateTime.UtcNow > m_NextMountAbility))
             {
-                if (this.DoMountAbility(amount, from))
-                    this.m_NextMountAbility = DateTime.UtcNow + this.MountAbilityDelay;
+                if (DoMountAbility(amount, from))
+                    m_NextMountAbility = DateTime.UtcNow + MountAbilityDelay;
             }
         }
 
@@ -472,15 +480,15 @@ namespace Server.Mobiles
             public DateTime m_Expiration;
             public BlockEntry(BlockMountType type, DateTime expiration)
             {
-                this.m_Type = type;
-                this.m_Expiration = expiration;
+                m_Type = type;
+                m_Expiration = expiration;
             }
 
             public bool IsExpired
             {
                 get
                 {
-                    return (DateTime.UtcNow >= this.m_Expiration);
+                    return (DateTime.UtcNow >= m_Expiration);
                 }
             }
         }
@@ -492,10 +500,10 @@ namespace Server.Mobiles
         public MountItem(BaseMount mount, int itemID)
             : base(itemID)
         {
-            this.Layer = Layer.Mount;
-            this.Movable = false;
+            Layer = Layer.Mount;
+            Movable = false;
 
-            this.m_Mount = mount;
+            m_Mount = mount;
         }
 
         public MountItem(Serial serial)
@@ -514,23 +522,23 @@ namespace Server.Mobiles
         {
             get
             {
-                return this.m_Mount;
+                return m_Mount;
             }
         }
         public override void OnAfterDelete()
         {
-            if (this.m_Mount != null)
-                this.m_Mount.Delete();
+            if (m_Mount != null)
+                m_Mount.Delete();
 
-            this.m_Mount = null;
+            m_Mount = null;
 
             base.OnAfterDelete();
         }
 
         public override DeathMoveResult OnParentDeath(Mobile parent)
         {
-            if (this.m_Mount != null)
-                this.m_Mount.Rider = null;
+            if (m_Mount != null)
+                m_Mount.Rider = null;
 
             return DeathMoveResult.RemainEquiped;
         }
@@ -541,7 +549,7 @@ namespace Server.Mobiles
 
             writer.Write((int)0); // version
 
-            writer.Write(this.m_Mount);
+            writer.Write(m_Mount);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -554,10 +562,10 @@ namespace Server.Mobiles
             {
                 case 0:
                     {
-                        this.m_Mount = reader.ReadMobile() as BaseMount;
+                        m_Mount = reader.ReadMobile() as BaseMount;
 
-                        if (this.m_Mount == null)
-                            this.Delete();
+                        if (m_Mount == null)
+                            Delete();
 
                         break;
                     }

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -779,7 +779,7 @@ namespace Server.Mobiles
             Mobile to = World.FindMobile(e.Target.Serial);
             Item toItem = World.FindItem(e.Target.Serial);
 
-            if (from != null)
+            if (from != null && e.Mobile.Target != null)
             {
                 if (to != null)
                 {

--- a/Scripts/Mobiles/Summons/BaseFamiliar.cs
+++ b/Scripts/Mobiles/Summons/BaseFamiliar.cs
@@ -121,12 +121,12 @@ namespace Server.Mobiles
 
 		public override void OnThink()
 		{
-			Mobile master = ControlMaster;
-
-			if (Deleted)
+            if (Deleted || Map == null)
 			{
 				return;
 			}
+
+            Mobile master = ControlMaster;
 
 			if (master == null || master.Deleted)
 			{


### PR DESCRIPTION
-Armor Pierce now applies 10% damage increase for 3 seconds (HS+)
-Bleed Attack now applies the proper debuff icon
-bleed duration is now reset when splintering is triggered with bleed attack already active, or vise versa
-bleed ticks now deal the proper amount of damage
-Hit Lower Defense no resets duration on successive triggers (HS+)
-Hit Lower Defense no longer ignores DCI cap (HS+)
-Hit Lower Defense now provides (PVP ONLY) a -35% of the defenders capped DCI (HS+)
-Mounted pets now show context icons in Enhanced Client once you Dismount
-Fixed crash regarding EC Auto Targeted_Item
-Fixed crash regarding base familiar on think