### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Artifacts/Equipment/Armor/AegisOfGrace.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/AegisOfGrace.cs
@@ -100,7 +100,7 @@ namespace Server.Items
         {
             get
             {
-                return Race.Elf;
+                return ItemID == 0x2B6E ? Race.Elf : null;
             }
         }
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -305,6 +305,24 @@ namespace Server
                 SwarmContext.CheckRemove(m);
             #endregion
 
+            #region Skill Mastery
+            SkillMasterySpell spell = SkillMasterySpell.GetSpellForParty(m, typeof(PerseveranceSpell));
+
+            if (spell != null)
+                spell.AbsorbDamage(ref totalDamage);
+
+            if (type >= DamageType.Spell)
+            {
+                spell = SkillMasterySpell.GetHarmfulSpell(from, typeof(TribulationSpell));
+
+                if (spell != null)
+                    spell.AbsorbDamage(ref damage);
+            }
+
+            ManaShieldSpell.CheckManaShield(m, ref totalDamage);
+            SkillMasterySpell.OnDamaged(m, from, ref totalDamage);
+            #endregion
+
             if (keepAlive && totalDamage > m.Hits)
                 totalDamage = m.Hits;
 
@@ -320,11 +338,6 @@ namespace Server
             m.Damage(totalDamage, from, true, false);
 
             SpiritSpeak.CheckDisrupt(m);
-
-            #region Skill Mastery Spells
-            ManaShieldSpell.CheckManaShield(m, ref totalDamage);
-            SkillMasterySpell.OnDamaged(m, from, ref totalDamage);
-            #endregion
 
             #region Stygian Abyss
             if (m.Spell != null)

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -2002,6 +2002,13 @@ namespace Server.Mobiles
             }
             #endregion
 
+            #region Skill Mastery
+            SkillMasterySpell spell = SkillMasterySpell.GetHarmfulSpell(this, typeof(TribulationSpell));
+
+            if (spell != null)
+                spell.DoDamage(this, amount);
+            #endregion
+
             base.OnDamage(amount, from, willKill);
         }
 

--- a/Scripts/Skills/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Skills/Imbuing/Core/Imbuing.cs
@@ -1444,7 +1444,7 @@ namespace Server.SkillHandlers
 			m_Table[39] = new ImbuingDefinition(AosWeaponAttribute.HitDispel,		1079702, 100, 	typeof(MagicalResidue), typeof(Amber), 		    typeof(SlithTongue),        50, 2, 1111959, true, true, false, false, false);
 			m_Table[40] = new ImbuingDefinition(AosWeaponAttribute.UseBestSkill, 	1079592, 150, 	typeof(EnchantedEssence), typeof(Amber), 		    typeof(DelicateScales), 1, 0, 1111946, true, false, false, false, false);
 			m_Table[41] = new ImbuingDefinition(AosWeaponAttribute.MageWeapon,		1079759, 100, 	typeof(EnchantedEssence), typeof(Emerald), 		typeof(ArcanicRuneStone),   10, 1, 1112001, true, true, false, false, false);
-			m_Table[42] = new ImbuingDefinition(AosWeaponAttribute.DurabilityBonus,	1017323, 100, 	typeof(EnchantedEssence), typeof(Diamond), 		typeof(PowderedIron),       100, 10, 1112949, true, true, false, false, false);
+			m_Table[42] = new ImbuingDefinition(AosWeaponAttribute.DurabilityBonus,	1017323, 100, 	typeof(EnchantedEssence), typeof(Diamond), 		typeof(PowderedIron),       100, 10, 1111949, true, true, false, false, false);
 
             m_Table[49] = new ImbuingDefinition(AosArmorAttribute.MageArmor,        1079758, 0,     typeof(EnchantedEssence), typeof(Diamond),        typeof(AbyssalCloth), 1, 0, 1112000, false, false, true, false, false);
 

--- a/Scripts/Skills/Imbuing/Gumps/ImbuingB.cs
+++ b/Scripts/Skills/Imbuing/Gumps/ImbuingB.cs
@@ -278,7 +278,7 @@ namespace Server.Gumps
                     AddHtmlLocalized(295, 90 + (yOffset * 20), 150, 18, 1075626, LabelColor, false, false);       //Reflect Physical Damage
                     yOffset += 1;
 
-                    AddButton(250, 90 + (yOffset * 20), 4005, 4007, 10121, GumpButtonType.Reply, 0);
+                    AddButton(250, 90 + (yOffset * 20), 4005, 4007, 10124, GumpButtonType.Reply, 0);
                     AddHtmlLocalized(295, 90 + (yOffset * 20), 150, 18, 1079757, LabelColor, false, false);       //Lower Requirements
                     yOffset += 1;
 
@@ -831,8 +831,6 @@ namespace Server.Gumps
                         break;
                     }
             }
-
-            return;
         }
     }
 }

--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -200,23 +200,21 @@ namespace Server.Spells
 		{
             Mobile target = damageable as Mobile;
 
-            int damage = Utility.Dice(dice, sides, bonus) * 10;
-            int intBonus = Caster.Int / 10;
+            int damage = Utility.Dice(dice, sides, bonus) * 100;
 
-			int inscribeSkill = GetInscribeFixed(m_Caster);
+            int inscribeSkill = GetInscribeFixed(m_Caster);
+            int damageBonus = inscribeSkill >= 1000 ? 10 : inscribeSkill / 200 +
+                              (Caster.Int / 10) +
+                              SpellHelper.GetSpellDamageBonus(m_Caster, target, CastSkill, playerVsPlayer);
+
             int evalSkill = GetDamageFixed(m_Caster);
+            int evalScale = 30 + ((9 * evalSkill) / 100);
 
-            int inscribeBonus = inscribeSkill >= 1000 ? 10 : inscribeSkill / 200;
-            int damageBonus = intBonus + inscribeBonus + SpellHelper.GetSpellDamageBonus(m_Caster, target, CastSkill, playerVsPlayer);
+            damage = AOS.Scale(damage, evalScale);
+            damage = AOS.Scale(damage, 100 + damageBonus);
+            damage = AOS.Scale(damage, (int)(scalar * 100));
 
-			damage = AOS.Scale(damage, 100 + damageBonus);
-
-            int evalScale = (((evalSkill * 3) / 100) + 1) * 10;
-
-			damage = AOS.Scale(damage, evalScale);
-			damage = AOS.Scale(damage, (int)(scalar * 100));
-
-			return damage / 100;
+            return damage / 100;
 		}
 
 		public virtual bool IsCasting { get { return m_State == SpellState.Casting; } }

--- a/Scripts/Spells/First/MagicArrow.cs
+++ b/Scripts/Spells/First/MagicArrow.cs
@@ -72,7 +72,7 @@ namespace Server.Spells.First
 				
                 if (Core.AOS)
                 {
-                    damage = GetNewAosDamage(28, 1, 14, d);
+                    damage = GetNewAosDamage(10, 1, 4, d);
                 }
                 else if (m != null)
                 {

--- a/Scripts/Spells/Fourth/Lightning.cs
+++ b/Scripts/Spells/Fourth/Lightning.cs
@@ -55,7 +55,7 @@ namespace Server.Spells.Fourth
 
                 if (Core.AOS)
                 {
-                    damage = GetNewAosDamage(70, 1, 11, m);
+                    damage = GetNewAosDamage(23, 1, 4, m);
                 }
                 else if (mob != null)
                 {

--- a/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
@@ -77,7 +77,7 @@ namespace Server.Spells.Mysticism
                     target.Paralyze(TimeSpan.FromSeconds(3));
 				}
 
-                SpellHelper.Damage(this, target, (int)GetNewAosDamage(120, 1, 14, target), 100, 0, 0, 0, 0);
+                SpellHelper.Damage(this, target, (int)GetNewAosDamage(40, 1, 5, target), 100, 0, 0, 0, 0);
 			}
 
 			FinishSequence();

--- a/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
@@ -50,7 +50,7 @@ namespace Server.Spells.Mysticism
                     Caster.PlaySound(0x64D);
                 });
 
-                SpellHelper.Damage(this, target, (int)GetNewAosDamage(60, 1, 12, target), 0, 0, 0, 0, 100);
+                SpellHelper.Damage(this, target, (int)GetNewAosDamage(19, 1, 5, target), 0, 0, 0, 0, 100);
 			}
 
 			FinishSequence();

--- a/Scripts/Spells/Mysticism/SpellDefinitions/HailStormSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/HailStormSpell.cs
@@ -87,7 +87,7 @@ namespace Server.Spells.Mysticism
                     if (m.Deleted || !m.Alive)
                         continue;
 
-                    int damage = GetNewAosDamage(155, 1, 13, m is PlayerMobile, m);
+                    int damage = GetNewAosDamage(51, 1, 5, m is PlayerMobile, m);
 
                     if (toEffect.Count > 2)
                         damage = (damage * 2) / toEffect.Count;

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
@@ -38,7 +38,7 @@ namespace Server.Spells.Mysticism
 			}
 			else if ( CheckHSequence( target ) )
 			{
-                double damage = GetNewAosDamage(31, 1, 10, target);
+                double damage = GetNewAosDamage(10, 1, 4, target);
 
                 SpellHelper.Damage(this, target, damage, 0, 0, 0, 0, 0, 100, 0);
 

--- a/Scripts/Spells/Necromancy/EvilOmen.cs
+++ b/Scripts/Spells/Necromancy/EvilOmen.cs
@@ -71,9 +71,11 @@ namespace Server.Spells.Necromancy
             {
                 m_Table.Remove(m);
                 BuffInfo.RemoveBuff(m, BuffIcon.EvilOmen);
+
+                return true;
             }
 
-            return true;
+            return false;
         }
 
         public override void OnCast()

--- a/Scripts/Spells/Second/Harm.cs
+++ b/Scripts/Spells/Second/Harm.cs
@@ -60,7 +60,7 @@ namespace Server.Spells.Second
 				
                 if (Core.AOS)
                 {
-                    damage = this.GetNewAosDamage(57, 1, 13, m);
+                    damage = GetNewAosDamage(17, 1, 5, m);
                 }
                 else if (mob != null)
                 {

--- a/Scripts/Spells/Seventh/ChainLightning.cs
+++ b/Scripts/Spells/Seventh/ChainLightning.cs
@@ -92,7 +92,7 @@ namespace Server.Spells.Seventh
                         Mobile m = id as Mobile;
 
                         if (Core.AOS)
-                            damage = GetNewAosDamage(155, 1, 13, id is PlayerMobile, id);
+                            damage = GetNewAosDamage(51, 1, 5, id is PlayerMobile, id);
                         else
                             damage = Utility.Random(27, 22);
 

--- a/Scripts/Spells/Seventh/FlameStrike.cs
+++ b/Scripts/Spells/Seventh/FlameStrike.cs
@@ -55,7 +55,7 @@ namespace Server.Spells.Seventh
 
                 if (Core.AOS)
                 {
-                    damage = this.GetNewAosDamage(155, 1, 13, m);
+                    damage = GetNewAosDamage(48, 1, 5, m);
                 }
                 else if (mob != null)
                 {

--- a/Scripts/Spells/Seventh/MeteorSwarm.cs
+++ b/Scripts/Spells/Seventh/MeteorSwarm.cs
@@ -94,7 +94,7 @@ namespace Server.Spells.Seventh
                         Mobile m = id as Mobile;
 
                         if (Core.AOS)
-                            damage = GetNewAosDamage(155, 1, 13, id is PlayerMobile, id);
+                            damage = GetNewAosDamage(51, 1, 5, id is PlayerMobile, id);
                         else
                             damage = Utility.Random(27, 22);
 

--- a/Scripts/Spells/Sixth/EnergyBolt.cs
+++ b/Scripts/Spells/Sixth/EnergyBolt.cs
@@ -64,7 +64,7 @@ namespace Server.Spells.Sixth
 
                 if (Core.AOS)
                 {
-                    damage = this.GetNewAosDamage(120, 1, 14, m);
+                    damage = GetNewAosDamage(40, 1, 5, m);
                 }
                 else if (mob != null)
                 {

--- a/Scripts/Spells/Sixth/Explosion.cs
+++ b/Scripts/Spells/Sixth/Explosion.cs
@@ -95,7 +95,7 @@ namespace Server.Spells.Sixth
 
                     if (Core.AOS)
                     {
-                        damage = this.m_Spell.GetNewAosDamage(120, 1, 14, m_Target);
+                        damage = m_Spell.GetNewAosDamage(40, 1, 5, m_Target);
                     }
                     else if (defender != null)
                     {

--- a/Scripts/Spells/Skill Masteries/FlamingShot.cs
+++ b/Scripts/Spells/Skill Masteries/FlamingShot.cs
@@ -85,7 +85,7 @@ namespace Server.Spells.SkillMasteries
 
                         if (weapon.CheckHit(Caster, mob))
                         {
-                            damage = GetNewAosDamage(165, 1, 13, mob);
+                            damage = GetNewAosDamage(40, 1, 5, mob);
 
                             if (targets.Count > 2)
                                 damage = damage / targets.Count;

--- a/Scripts/Spells/Third/Fireball.cs
+++ b/Scripts/Spells/Third/Fireball.cs
@@ -63,7 +63,7 @@ namespace Server.Spells.Third
 
                 if (Core.AOS)
                 {
-                    damage = this.GetNewAosDamage(60, 1, 12, m);
+                    damage = GetNewAosDamage(19, 1, 5, m);
                 }
                 else if (target != null)
                 {


### PR DESCRIPTION
- Spell Damage Fixes, found the bug!
- Evil Omen no longer always returns under effects true, which was causing all damage to be +25%
- Cleaned up GetNewAosDamage in Spell.cs. All damage modifiers have been moved to AOS.Damage
- Added missing support for Tribulation Spell
- fixed various imbuing cliloc errors 