### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Abilities/ArmorPierce.cs
+++ b/Scripts/Abilities/ArmorPierce.cs
@@ -51,6 +51,8 @@ namespace Server.Items
             ClearCurrentAbility(attacker);
 
             attacker.SendLocalizedMessage(1063350); // You pierce your opponent's armor!
+
+            defender.SendLocalizedMessage(1153764); // Your armor has been pierced!
             defender.SendLocalizedMessage(1063351); // Your attacker pierced your armor!            
 
             if (Core.HS)
@@ -67,6 +69,7 @@ namespace Server.Items
                 _Table[defender] = Timer.DelayCall<Mobile>(TimeSpan.FromSeconds(3), RemoveEffects, defender);
             }
 
+            defender.PlaySound(0x28E);
             defender.FixedParticles(0x3728, 1, 26, 0x26D6, 0, 0, EffectLayer.Waist);
         }
 
@@ -74,6 +77,7 @@ namespace Server.Items
         {
             if (IsUnderEffects(m))
             {
+                m.SendLocalizedMessage(1153904); // Your armor has returned to normal.
                 _Table.Remove(m);
             }
         }

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -2560,6 +2560,8 @@ namespace Server.Items
 				false,
 				ranged ? Server.DamageType.Ranged : Server.DamageType.Melee);
 
+            DualWield.DoHit(attacker, defender, damage);
+
             if (sparks)
             {
                 int mana = attacker.Mana + damageGiven;

--- a/Scripts/Items/Resource/Bandage.cs
+++ b/Scripts/Items/Resource/Bandage.cs
@@ -23,11 +23,6 @@ namespace Server.Items
 
 		public override double DefaultWeight { get { return 0.1; } }
 
-		public static void Initialize()
-		{
-			EventSink.BandageTargetRequest += EventSink_BandageTargetRequest;
-		}
-
 		[Constructable]
 		public Bandage()
 			: this(1)
@@ -87,16 +82,10 @@ namespace Server.Items
 			}
 		}
 
-		private static void EventSink_BandageTargetRequest(BandageTargetRequestEventArgs e)
+        public static void BandageTargetRequest(Bandage b, Mobile from, Mobile target)
 		{
-			Bandage b = e.Bandage as Bandage;
-
-			if (b == null || b.Deleted)
-			{
-				return;
-			}
-
-			Mobile from = e.Mobile;
+            if (b.Deleted)
+                return;
 
 			if (from.InRange(b.GetWorldLocation(), Range))
 			{
@@ -109,10 +98,9 @@ namespace Server.Items
 				}
 
 				from.RevealingAction();
-
 				from.SendLocalizedMessage(500948); // Who will you use the bandages on?
 
-				new InternalTarget(b).Invoke(from, e.Target);
+                new InternalTarget(b).Invoke(from, target);
 			}
 			else
 			{

--- a/Scripts/Items/Tools/Clocks.cs
+++ b/Scripts/Items/Tools/Clocks.cs
@@ -59,6 +59,8 @@ namespace Server.Items
         public static void Initialize()
         {
             m_ServerStart = DateTime.UtcNow;
+
+            Timer.DelayCall(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2), new TimerCallback(ClockTime.Tick_Callback));
         }
 
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)
@@ -192,11 +194,6 @@ namespace Server.Items
     {
         private static List<ClockTime> _Instances = new List<ClockTime>();        
 
-        public static void Initialize()
-        {
-            Timer.DelayCall(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2), new TimerCallback(Tick_Callback));
-        }
-
         [Constructable]
         public ClockTime()
             : this(0x104B)
@@ -224,7 +221,7 @@ namespace Server.Items
             _Instances.Remove(this);
         }
 
-        private static void Tick_Callback()
+        public static void Tick_Callback()
         {
             foreach (var clock in _Instances.Where(p => p != null && !p.Deleted && p.IsLockedDown))
             {

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -681,9 +681,6 @@ namespace Server
 
                 value += HonorableExecution.GetSwingBonus(m);
 
-                if (DualWield.Registry.Contains(m))
-                    value += ((DualWield.DualWieldTimer)DualWield.Registry[m]).BonusSwingSpeed;
-
                 TransformContext context = TransformationSpellHelper.GetContext(m);
 
                 if (context != null && context.Spell is ReaperFormSpell)

--- a/Scripts/Services/ChampionSystem/ChampionSpawn.cs
+++ b/Scripts/Services/ChampionSystem/ChampionSpawn.cs
@@ -395,6 +395,9 @@ namespace Server.Engines.CannedEvil
                 Level = 1;
             else
                 Level = 0;
+
+            if (Level > 0)
+                AdvanceLevel();
         }
 
         public void Stop()

--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -335,8 +335,13 @@ namespace Server.Spells
 
 		public virtual bool OnCasterEquiping(Item item)
 		{
-			if (IsCasting)
+            if (IsCasting)
 			{
+                if ((item.Layer == Layer.OneHanded || item.Layer == Layer.TwoHanded) && item.AllowEquipedCast(Caster))
+                {
+                    return true;
+                }
+
 				Disturb(DisturbType.EquipRequest);
 			}
 

--- a/Server/ContextMenus/ContextMenu.cs
+++ b/Server/ContextMenus/ContextMenu.cs
@@ -120,6 +120,22 @@ namespace Server.ContextMenus
                 case 0x086: number = 3006111; break;    // Command: Kill
                 case 0x087: number = 3006114; break;    // Command: Stay
                 case 0x089: number = 3006112; break;    // Command: Stop
+                case 0x0140: number = 1113797; break;   // Enable PVP Warning TODO: Not Enabled
+                case 0x025A: number = 3006205; break;   // Release Co-Ownership TODO: Not Enabled
+                case 0x025C: number = 3006207; break;   // Leave House
+                case 0x0196: number = 3006156; break;   // Quest Conversation
+                case 0x0194: number = 3006154; break;   // View Quest Log
+                case 0x0195: number = 3006155; break;   // Cancel Quest
+                case 0x0321: number = 3006169; break;   // Toggle Quest Item
+                case 0x01A0: number = 1114299; break;   // Open Item Insurance Menu
+                case 0x01A2: number = 3006201; break;   // Toggle Item Insurance
+                case 0x0396: number = 1115022; break;   // Open Titles Menu
+                case 0x0393: number = 1049594; break;   // Loyalty Rating
+                case 0x0134: number = 3006157; break;   // Cancel Protection
+                case 0x03F2: number = 1152531; break;   // Void Pool
+                case 0x03F5: number = 1154112; break;   // Allow Trades
+                case 0x03F6: number = 1154113; break;   // Refuse Trades
+                case 0x0334: number = 3006168; break;   // Siege Bless Item
             }
 
             if (index >= 0x64)

--- a/Server/EventSink.cs
+++ b/Server/EventSink.cs
@@ -47,8 +47,6 @@ namespace Server
 
 	public delegate void CastSpellRequestEventHandler(CastSpellRequestEventArgs e);
 
-	public delegate void BandageTargetRequestEventHandler(BandageTargetRequestEventArgs e);
-
 	public delegate void AnimateRequestEventHandler(AnimateRequestEventArgs e);
 
 	public delegate void LogoutEventHandler(LogoutEventArgs e);
@@ -532,24 +530,6 @@ namespace Server
 			m_Mobile = m;
 			m_Spellbook = book;
 			m_SpellID = spellID;
-		}
-	}
-
-	public class BandageTargetRequestEventArgs : EventArgs
-	{
-		private readonly Mobile m_Mobile;
-		private readonly Item m_Bandage;
-		private readonly Mobile m_Target;
-
-		public Mobile Mobile { get { return m_Mobile; } }
-		public Item Bandage { get { return m_Bandage; } }
-		public Mobile Target { get { return m_Target; } }
-
-		public BandageTargetRequestEventArgs(Mobile m, Item bandage, Mobile target)
-		{
-			m_Mobile = m;
-			m_Bandage = bandage;
-			m_Target = target;
 		}
 	}
 
@@ -1255,7 +1235,6 @@ namespace Server
 		public static event StunRequestEventHandler StunRequest;
 		public static event OpenSpellbookRequestEventHandler OpenSpellbookRequest;
 		public static event CastSpellRequestEventHandler CastSpellRequest;
-		public static event BandageTargetRequestEventHandler BandageTargetRequest;
 		public static event AnimateRequestEventHandler AnimateRequest;
 		public static event LogoutEventHandler Logout;
 		public static event SocketConnectEventHandler SocketConnect;
@@ -1522,14 +1501,6 @@ namespace Server
 			if (CastSpellRequest != null)
 			{
 				CastSpellRequest(e);
-			}
-		}
-
-		public static void InvokeBandageTargetRequest(BandageTargetRequestEventArgs e)
-		{
-			if (BandageTargetRequest != null)
-			{
-				BandageTargetRequest(e);
 			}
 		}
 
@@ -1845,7 +1816,6 @@ namespace Server
 			StunRequest = null;
 			OpenSpellbookRequest = null;
 			CastSpellRequest = null;
-			BandageTargetRequest = null;
 			AnimateRequest = null;
 			Logout = null;
 			SocketConnect = null;

--- a/Server/Network/PacketHandlers.cs
+++ b/Server/Network/PacketHandlers.cs
@@ -157,7 +157,6 @@ namespace Server.Network
 			RegisterExtended(0x1A, true, StatLockChange);
 			RegisterExtended(0x1C, true, CastSpell);
 			RegisterExtended(0x24, false, UnhandledBF);
-			RegisterExtended(0x2C, true, BandageTarget);
 
 			#region Stygian Abyss
 			RegisterExtended(0x32, true, ToggleFlying);
@@ -1866,41 +1865,6 @@ namespace Server.Network
 			int spellID = pvSrc.ReadInt16() - 1;
 
 			EventSink.InvokeCastSpellRequest(new CastSpellRequestEventArgs(from, spellID, spellbook));
-		}
-
-		public static void BandageTarget(NetState state, PacketReader pvSrc)
-		{
-			Mobile from = state.Mobile;
-
-			if (from == null)
-			{
-				return;
-			}
-
-			if (from.IsStaff() || Core.TickCount - from.NextActionTime >= 0)
-			{
-				Item bandage = World.FindItem(pvSrc.ReadInt32());
-
-				if (bandage == null)
-				{
-					return;
-				}
-
-				Mobile target = World.FindMobile(pvSrc.ReadInt32());
-
-				if (target == null)
-				{
-					return;
-				}
-
-				EventSink.InvokeBandageTargetRequest(new BandageTargetRequestEventArgs(from, bandage, target));
-
-				from.NextActionTime = Core.TickCount + Mobile.ActionDelay;
-			}
-			else
-			{
-				from.SendActionMessage();
-			}
 		}
 
 		#region Stygain Abyss


### PR DESCRIPTION
- Fixed Auto Item Use/Target macro. New packet handlers conflicted with the old macros.  From what I see, this is only used with bandages.  I've removed all BandageSelf/Target macros and will use this from now on.
- Fixed Dual Wield, per EA
- Fixed Issue where champ spawns that spawn with 1+ candle will auto Revert
- Spell Channeling weapons/shields will no longer fizzle a spell while equipping
- Fixed minor messages with Armor Pierce
- Added more Enhanced Client context buttons