### PR TITLE
Implementation of SHA512 for Passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ reportHistory.xml
 *.DotSettings.user
 *.log
 *.bin
+*.lock
+*.ide
+*.ide-shm
+*.ide-wal

--- a/Config/Accounts.cfg
+++ b/Config/Accounts.cfg
@@ -1,4 +1,3 @@
-
 # Number of accounts allowed to be created from a single IP address
 AccountsPerIp=1
 
@@ -19,6 +18,7 @@ DeleteDelay=07:00:00:00
 PasswordCommandEnabled=false
 
 # Account password protection level.
-# Default: NewCrypt
-# Options: None, Crypt, NewCrypt
-ProtectPasswords=NewCrypt
+# Default: NewSecureCrypt
+# Options: None, Crypt, NewCrypt, NewSecureCrypt (Recommended)
+# Explanation: Plain, MD5, SHA1, SHA512
+ProtectPasswords=NewSecureCrypt

--- a/Scripts/Accounting/Account.cs
+++ b/Scripts/Accounting/Account.cs
@@ -199,8 +199,9 @@ namespace Server.Accounting
 			var plainPassword = Utility.GetText(node["password"], null);
 			var MD5Password = Utility.GetText(node["cryptPassword"], null);
 			var SHA1Password = Utility.GetText(node["newCryptPassword"], null);
+            var SHA512Password = Utility.GetText(node["securenewCryptPassword"], null);
 
-			switch (AccountHandler.ProtectPasswords)
+            switch (AccountHandler.ProtectPasswords)
 			{
 				case PasswordProtection.None:
 				{
@@ -208,11 +209,15 @@ namespace Server.Accounting
 					{
 						SetPassword(plainPassword);
 					}
-					else if (SHA1Password != null)
+					else if (SHA512Password != null)
 					{
-						_SHA1Password = SHA1Password;
+						_SHA512Password = SHA512Password;
 					}
-					else if (MD5Password != null)
+                    else if (SHA1Password != null)
+                    {
+                        _SHA1Password = SHA1Password;
+                    }
+                    else if (MD5Password != null)
 					{
 						_MD5Password = MD5Password;
 					}
@@ -237,7 +242,11 @@ namespace Server.Accounting
 					{
 						_SHA1Password = SHA1Password;
 					}
-					else
+                    else if (SHA512Password != null)
+                    {
+                        _SHA512Password = SHA512Password;
+                    }
+                        else
 					{
 						SetPassword("empty");
 					}
@@ -389,11 +398,16 @@ namespace Server.Accounting
 		/// </summary>
 		public string _SHA1Password { get; set; }
 
-		/// <summary>
-		///     Internal bitfield of account flags. Consider using direct access properties (Banned, Young), or GetFlag/SetFlag
-		///     methods
-		/// </summary>
-		public int Flags { get; set; }
+        /// <summary>
+        ///     Account username and password hashed with SHA512. May be null.
+        /// </summary>
+        public string _SHA512Password { get; set; }
+
+        /// <summary>
+        ///     Internal bitfield of account flags. Consider using direct access properties (Banned, Young), or GetFlag/SetFlag
+        ///     methods
+        /// </summary>
+        public int Flags { get; set; }
 
 		/// <summary>
 		///     Gets or sets a flag indiciating if this account is banned.

--- a/Scripts/Accounting/Account.cs
+++ b/Scripts/Accounting/Account.cs
@@ -683,6 +683,7 @@ namespace Server.Accounting
 					PlainPassword = plainPassword;
 					_MD5Password = null;
 					_SHA1Password = null;
+					_SHA512Password = null;
 				}
 					break;
 				case PasswordProtection.Crypt:
@@ -690,6 +691,7 @@ namespace Server.Accounting
 					PlainPassword = null;
 					_MD5Password = HashMD5(plainPassword);
 					_SHA1Password = null;
+					_SHA512Password = null;
 				}
 					break;
                 case PasswordProtection.NewCrypt:
@@ -697,6 +699,7 @@ namespace Server.Accounting
                     PlainPassword = null;
                     _MD5Password = null;
                     _SHA1Password = HashSHA1(Username + plainPassword);
+					_SHA512Password = null;
                 }
                     break;
                 default: // PasswordProtection.NewSecureCrypt

--- a/Scripts/Accounting/Account.cs
+++ b/Scripts/Accounting/Account.cs
@@ -197,8 +197,8 @@ namespace Server.Accounting
 			Username = Utility.GetText(node["username"], "empty");
 
 			var plainPassword = Utility.GetText(node["password"], null);
-			var cryptPassword = Utility.GetText(node["cryptPassword"], null);
-			var newCryptPassword = Utility.GetText(node["newCryptPassword"], null);
+			var MD5Password = Utility.GetText(node["cryptPassword"], null);
+			var SHA1Password = Utility.GetText(node["newCryptPassword"], null);
 
 			switch (AccountHandler.ProtectPasswords)
 			{
@@ -208,13 +208,13 @@ namespace Server.Accounting
 					{
 						SetPassword(plainPassword);
 					}
-					else if (newCryptPassword != null)
+					else if (SHA1Password != null)
 					{
-						NewCryptPassword = newCryptPassword;
+						_SHA1Password = SHA1Password;
 					}
-					else if (cryptPassword != null)
+					else if (MD5Password != null)
 					{
-						CryptPassword = cryptPassword;
+						_MD5Password = MD5Password;
 					}
 					else
 					{
@@ -225,17 +225,17 @@ namespace Server.Accounting
 				}
 				case PasswordProtection.Crypt:
 				{
-					if (cryptPassword != null)
+					if (MD5Password != null)
 					{
-						CryptPassword = cryptPassword;
+						_MD5Password = MD5Password;
 					}
 					else if (plainPassword != null)
 					{
 						SetPassword(plainPassword);
 					}
-					else if (newCryptPassword != null)
+					else if (SHA1Password != null)
 					{
-						NewCryptPassword = newCryptPassword;
+						_SHA1Password = SHA1Password;
 					}
 					else
 					{
@@ -246,17 +246,17 @@ namespace Server.Accounting
 				}
 				default: // PasswordProtection.NewCrypt
 				{
-					if (newCryptPassword != null)
+					if (SHA1Password != null)
 					{
-						NewCryptPassword = newCryptPassword;
+						_SHA1Password = SHA1Password;
 					}
 					else if (plainPassword != null)
 					{
 						SetPassword(plainPassword);
 					}
-					else if (cryptPassword != null)
+					else if (MD5Password != null)
 					{
-						CryptPassword = cryptPassword;
+						_MD5Password = MD5Password;
 					}
 					else
 					{
@@ -382,12 +382,12 @@ namespace Server.Accounting
 		/// <summary>
 		///     Account password. Hashed with MD5. May be null.
 		/// </summary>
-		public string CryptPassword { get; set; }
+		public string _MD5Password { get; set; }
 
 		/// <summary>
 		///     Account username and password hashed with SHA1. May be null.
 		/// </summary>
-		public string NewCryptPassword { get; set; }
+		public string _SHA1Password { get; set; }
 
 		/// <summary>
 		///     Internal bitfield of account flags. Consider using direct access properties (Banned, Young), or GetFlag/SetFlag
@@ -637,22 +637,22 @@ namespace Server.Accounting
 				case PasswordProtection.None:
 				{
 					PlainPassword = plainPassword;
-					CryptPassword = null;
-					NewCryptPassword = null;
+					_MD5Password = null;
+					_SHA1Password = null;
 				}
 					break;
 				case PasswordProtection.Crypt:
 				{
 					PlainPassword = null;
-					CryptPassword = HashMD5(plainPassword);
-					NewCryptPassword = null;
+					_MD5Password = HashMD5(plainPassword);
+					_SHA1Password = null;
 				}
 					break;
 				default: // PasswordProtection.NewCrypt
 				{
 					PlainPassword = null;
-					CryptPassword = null;
-					NewCryptPassword = HashSHA1(Username + plainPassword);
+					_MD5Password = null;
+					_SHA1Password = HashSHA1(Username + plainPassword);
 				}
 					break;
 			}
@@ -668,14 +668,14 @@ namespace Server.Accounting
 				ok = (PlainPassword == plainPassword);
 				curProt = PasswordProtection.None;
 			}
-			else if (CryptPassword != null)
+			else if (_MD5Password != null)
 			{
-				ok = (CryptPassword == HashMD5(plainPassword));
+				ok = (_MD5Password == HashMD5(plainPassword));
 				curProt = PasswordProtection.Crypt;
 			}
 			else
 			{
-				ok = (NewCryptPassword == HashSHA1(Username + plainPassword));
+				ok = (_SHA1Password == HashSHA1(Username + plainPassword));
 				curProt = PasswordProtection.NewCrypt;
 			}
 
@@ -1255,17 +1255,17 @@ namespace Server.Accounting
 				xml.WriteEndElement();
 			}
 
-			if (CryptPassword != null)
+			if (_MD5Password != null)
 			{
 				xml.WriteStartElement("cryptPassword");
-				xml.WriteString(CryptPassword);
+				xml.WriteString(_MD5Password);
 				xml.WriteEndElement();
 			}
 
-			if (NewCryptPassword != null)
+			if (_SHA1Password != null)
 			{
 				xml.WriteStartElement("newCryptPassword");
-				xml.WriteString(NewCryptPassword);
+				xml.WriteString(_SHA1Password);
 				xml.WriteEndElement();
 			}
 

--- a/Scripts/Accounting/AccountHandler.cs
+++ b/Scripts/Accounting/AccountHandler.cs
@@ -15,14 +15,15 @@ namespace Server.Misc
     {
         None,
         Crypt,
-        NewCrypt
+        NewCrypt,
+        NewSecureCrypt
     }
 
     public class AccountHandler
     {
 	    public static PasswordProtection ProtectPasswords = Config.GetEnum(
 		    "Accounts.ProtectPasswords",
-			PasswordProtection.NewCrypt);
+			PasswordProtection.NewSecureCrypt);
 
         private static readonly int MaxAccountsPerIP = Config.Get("Accounts.AccountsPerIp", 1);
         private static readonly bool AutoAccountCreation = Config.Get("Accounts.AutoCreateAccounts", true);


### PR DESCRIPTION
SHA512 support

Password-System requires complete rework (I will do this) for proper salting (generating 'random' salt on first run) and better readability. Passwords are automatically converted from SHA1 to SHA512 after logon and next save.

NOTICE: SHA512 is the new default if you replace Config/Accounts.cfg. Change it back to NewCrypt (SHA1) in Accounts.cfg if you're in need of SHA1.

However keep in mind Server <-> Client communication stays unencrypted and is absolutely vulnerable to man in the middle attacks as client encryption is removed. It only protects if data gets stolen.


MD5 is no go and SHA1 is known to be vulnerable to collisions.

Cheers 