### PR TITLE
Fixes Crash from Void Pool Context Menu

### DIFF
--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -43,6 +43,7 @@ using Server.Spells.Sixth;
 using Server.Spells.Spellweaving;
 using Server.Targeting;
 using System.Linq;
+using Server.Engines.VoidPool;
 using Server.Spells.SkillMasteries;
 
 using RankDefinition = Server.Guilds.RankDefinition;
@@ -2251,7 +2252,10 @@ namespace Server.Mobiles
                 Region r = Region.Find(Location, Map);
 
                 #region Void Pool
-                list.Add(new Server.Engines.Points.VoidPoolInfo(this));
+                var controller = Map == Map.Trammel ? VoidPoolController.InstanceTram : VoidPoolController.InstanceFel;
+
+                if (controller != null)
+                    list.Add(new Server.Engines.Points.VoidPoolInfo(this));
                 #endregion
 
                 #region TOL Shadowguard

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -10029,6 +10029,7 @@
     <Compile Include="Services\Revamped Dungeons\WrongDungeon\Items\MysteriousTunnel.cs" />
     <Compile Include="Services\Revamped Dungeons\WrongDungeon\Items\WrongMazeWall.cs" />
     <Compile Include="Services\RunicReforging\ReforgingContext.cs" />
+    <Compile Include="Services\Spawner\SpawnObject.cs" />
     <Compile Include="Services\Tomb of Kings\Arisen Invasion\ArisenController.cs" />
     <Compile Include="Services\Tomb of Kings\Chambers\Chamber.cs" />
     <Compile Include="Services\Tomb of Kings\Chambers\ChamberBarrier.cs" />


### PR DESCRIPTION
If the controller was not created by generating the Covetous Dungeon, then players could click the context menu and cause a null reference to the missing controller. Resolves #2866 

Also resolves a file missing from the project.