### PR TITLE
Update RunicAtlas.cs

### DIFF
--- a/Scripts/Items/Books/RunicAtlas.cs
+++ b/Scripts/Items/Books/RunicAtlas.cs
@@ -305,6 +305,10 @@ namespace Server.Items
                 Atlas.OnTravel();
                 new RecallSpell(User, null, e, null).Cast();
             }
+            else
+            {
+                User.SendLocalizedMessage(500015); // You do not have that spell!
+            }
 
             Atlas.Openers.Remove(User);
         }


### PR DESCRIPTION
The runebook will tell you if you try to recall but you do not have the recall spell.

The Runic Atlas was not doing that. It would just do nothing leaving the user confused, until they realized they did not have a sellbook with that spell on them. I have fixed it here.