### PR TITLE
Change Bulk Order Turn in delay from 10 seconds to 2 seconds.

### DIFF
--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -1271,7 +1271,7 @@ namespace Server.Mobiles
 
 				if (Core.ML && pm != null)
 				{
-					pm.NextBODTurnInTime = DateTime.UtcNow + TimeSpan.FromSeconds(10.0);
+					pm.NextBODTurnInTime = DateTime.UtcNow + TimeSpan.FromSeconds(2.0);
 				}
 
 				dropped.Delete();


### PR DESCRIPTION
When a player goes to turn in a bulk order they have to wait 10 seconds before turning in another one. A player reported this was wrong and since they just came over from real UO we tested it. After testing I could not get the message "You'll have to wait a few seconds while I inspect the last order." to come up at all. It takes a few clicks but I can get one bod banked and the next one dropped in about 2 - 3 seconds. Please watch the attached video and you will see.

I have sent a PR requesting the timer change from 10 seconds to 2 seconds.

@Dexter_Lexia I .rar'ed an MP4 video showing me on real UO turning in bulk orders 1 after another.

- Taken From ServUO Bug Reports.