### PR TITLE
Bug Fixes

### DIFF
--- a/Data/Bulk Orders/Inscription/smalls.cfg
+++ b/Data/Bulk Orders/Inscription/smalls.cfg
@@ -32,7 +32,7 @@ WallOfStoneScroll,0x1F44
 
 # 4th Circle
 ArchCureScroll,0x1F45
-ArchProtectionScroll,0x1F45
+ArchProtectionScroll,0x1F46
 CurseScroll,0x1F47
 FireFieldScroll,0x1F48
 GreaterHealScroll,0x1F49

--- a/Data/Regions.xml
+++ b/Data/Regions.xml
@@ -624,20 +624,20 @@
         <logoutDelay active="false" />
       </region>
     </region>
-    <region type="TownRegion" priority="50" name="Magincia">
-      <rect x="3653" y="2046" width="27" height="48" />
-      <rect x="3752" y="2046" width="52" height="48" />
-      <rect x="3680" y="2045" width="72" height="49" />
-      <rect x="3652" y="2094" width="160" height="180" />
-      <rect x="3649" y="2256" width="54" height="47" />
-      <go x="3714" y="2220" z="20" />
-      <music name="Magincia" />
-      <region>
-        <rect x="3680" y="2152" width="24" height="8" />
-        <rect x="3720" y="2216" width="16" height="16" />
-        <logoutDelay active="false" />
-      </region>
-    </region>
+    <region type="NewMaginciaRegion" priority="50" name="Magincia">
+		<rect x="3632" y="2032" width="50" height="70" />
+		<rect x="3624" y="2162" width="95" height="70" />
+		<rect x="3752" y="2046" width="52" height="48" />
+		<rect x="3680" y="2045" width="72" height="49" />
+		<rect x="3652" y="2094" width="160" height="180" />
+		<rect x="3649" y="2256" width="54" height="47" />
+		<go x="3714" y="2220" z="20" />
+		<music name="Magincia" />
+		<region>
+			<rect x="3687" y="2246" width="12" height="16" />
+			<logoutDelay active="false" />
+		</region>
+	</region>
     <region type="TownRegion" priority="50" name="Buccaneer's Den">
       <rect x="2612" y="2057" width="164" height="210" />
       <rect x="2604" y="2065" width="8" height="189" zmin="0" />
@@ -1677,20 +1677,20 @@
         <logoutDelay active="false" />
       </region>
     </region>
-    <region priority="50" name="Magincia">
-      <rect x="3653" y="2046" width="27" height="48" />
-      <rect x="3752" y="2046" width="52" height="48" />
-      <rect x="3680" y="2045" width="72" height="49" />
-      <rect x="3652" y="2094" width="160" height="180" />
-      <rect x="3649" y="2256" width="54" height="47" />
-      <go x="3714" y="2220" z="20" />
-      <music name="Magincia" />
-      <region>
-        <rect x="3680" y="2152" width="24" height="8" />
-        <rect x="3720" y="2216" width="16" height="16" />
-        <logoutDelay active="false" />
-      </region>
-    </region>
+    <region type="NewMaginciaRegion" priority="50" name="Magincia">
+		<rect x="3632" y="2032" width="50" height="70" />
+		<rect x="3624" y="2162" width="95" height="70" />
+		<rect x="3752" y="2046" width="52" height="48" />
+		<rect x="3680" y="2045" width="72" height="49" />
+		<rect x="3652" y="2094" width="160" height="180" />
+		<rect x="3649" y="2256" width="54" height="47" />
+		<go x="3714" y="2220" z="20" />
+		<music name="Magincia" />
+		<region>
+			<rect x="3687" y="2246" width="12" height="16" />
+			<logoutDelay active="false" />
+		</region>
+	</region>
     <region type="TownRegion" priority="50" name="Buccaneer's Den">
       <rect x="2612" y="2057" width="164" height="210" />
       <rect x="2604" y="2065" width="8" height="189" zmin="0" />

--- a/Scripts/Items/Decorative/DamageableItem.cs
+++ b/Scripts/Items/Decorative/DamageableItem.cs
@@ -379,6 +379,9 @@ namespace Server.Items
                 else if (m_DestroyedID >= 0)
                 {
                     ItemID = m_DestroyedID;
+
+                    if (Spawner != null)
+                        Spawner.Remove(this);
                 }
 
                 Destroyed = true;

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -1886,6 +1886,7 @@ namespace Server.Items
             Layer.Pants,
             Layer.Shirt,
             Layer.Helm,
+            Layer.Arms,
             Layer.Gloves,
             Layer.Ring,
             Layer.Talisman,

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -1696,6 +1696,9 @@ namespace Server.Items
 					chance = 0;
 				}
 
+                // Skill Masteries
+                chance += HeightenedSensesSpell.GetParryBonus(defender);
+
 				// Parry/Bushido over 100 grants a 5% bonus.
 				if (parry >= 100.0 || bushido >= 100.0)
 				{
@@ -1810,8 +1813,8 @@ namespace Server.Items
 
 						double bushido = defender.Skills.Bushido.Value;
 
-						defender.Hits += Utility.RandomMinMax(1, (int)(bushido / 12));
-						defender.Stam += Utility.RandomMinMax(1, (int)(bushido / 5));
+                        defender.Hits += Utility.RandomMinMax(1, (int)(bushido / 12)) + MasteryInfo.AnticipateHitBonus(defender) / 10;
+                        defender.Stam += Utility.RandomMinMax(1, (int)(bushido / 5)) + MasteryInfo.AnticipateHitBonus(defender) / 10;
 					}
 
 					BaseShield shield = defender.FindItemOnLayer(Layer.TwoHanded) as BaseShield;
@@ -2546,7 +2549,6 @@ namespace Server.Items
                 damage += (int)((double)damage * ((double)MasteryInfo.GetKnockoutModifier(attacker, defender is PlayerMobile) / 100.0));
 
             SkillMasterySpell.OnHit(attacker, defender, ref damage);
-            BodyGuardSpell.CheckBodyGuard(attacker, defender, ref damage, phys, fire, cold, pois, nrgy);
 
             // Bane
             if (m_ExtendedWeaponAttributes.Bane > 0 && defender.Hits < defender.HitsMax / 2)

--- a/Scripts/Items/Tools/Dices.cs
+++ b/Scripts/Items/Tools/Dices.cs
@@ -1,15 +1,30 @@
 using System;
 using Server.Network;
+using Server.Gumps;
+using Server.Multis;
+using System.Collections.Generic;
+using Server.ContextMenus;
 
 namespace Server.Items
 {
-    public class Dices : Item, ITelekinesisable
+    public class Dices : Item, ITelekinesisable, ISecurable
     {
+        [CommandProperty(AccessLevel.GameMaster)]
+        public SecureLevel Level { get; set; }
+
         [Constructable]
         public Dices()
             : base(0xFA7)
         {
             Weight = 1.0;
+
+            Level = SecureLevel.Friends;
+        }
+
+        public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)
+        {
+            base.GetContextMenuEntries(from, list);
+            SetSecureLevelEntry.AddTo(from, this, list);
         }
 
         public Dices(Serial serial)
@@ -47,13 +62,24 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)0);
+            writer.Write((int)1);
+
+            writer.Write((int)Level);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            if (version > 0)
+            {
+                Level = (SecureLevel)reader.ReadInt();
+            }
+            else
+            {
+                Level = SecureLevel.Friends;
+            }
         }
     }
 }

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -226,20 +226,30 @@ namespace Server
 
                 /* Per EA's UO Herald Pub48 (ML):
                 * ((resist spellsx10)/20 + 10=percentage of damage resisted)
+                * 
+                * Tested 12/29/2017-
+                * No cap, also, above forumula is no longer in effect.
                 */
 
                 if (oath == m)
                 {
                     totalDamage = (int)(totalDamage * 1.1);
 
-                    if (totalDamage > 35 && from is PlayerMobile) /* capped @ 35, seems no expansion */
+                    if (!Core.TOL && totalDamage > 35 && from is PlayerMobile) /* capped @ 35, seems no expansion */
                     {
                         totalDamage = 35;
                     }
 
                     if (Core.ML)
                     {
-                        from.Damage((int)(totalDamage * (1 - (((from.Skills.MagicResist.Value * .5) + 10) / 100))), m);
+                        if (m is PlayerMobile)
+                        {
+                            from.Damage((int)(totalDamage * 1.20), m);
+                        }
+                        else
+                        {
+                            from.Damage((int)(totalDamage * (1 - (((from.Skills.MagicResist.Value * .5) + 10) / 100))), m);
+                        }
                     }
                     else
                     {
@@ -320,6 +330,7 @@ namespace Server
             }
 
             ManaShieldSpell.CheckManaShield(m, ref totalDamage);
+            BodyGuardSpell.CheckBodyGuard(from, m, type, ref totalDamage);
             SkillMasterySpell.OnDamaged(m, from, ref totalDamage);
             #endregion
 
@@ -333,7 +344,7 @@ namespace Server
             #endregion
 
             if (type == DamageType.Spell && m != null && Feint.Registry.ContainsKey(m) && Feint.Registry[m].Enemy == from)
-                damage -= (int)((double)damage * ((double)Feint.Registry[m].DamageReduction / 100));
+                totalDamage -= (int)((double)damage * ((double)Feint.Registry[m].DamageReduction / 100));
 
             if (m.Hidden && Core.ML && type >= DamageType.Spell)
             {

--- a/Scripts/Mobiles/NPCs/AnimalTrainer.cs
+++ b/Scripts/Mobiles/NPCs/AnimalTrainer.cs
@@ -428,10 +428,26 @@ namespace Server.Mobiles
 					Claim(e.Mobile);
 				}
 			}
-			else
-			{
-				base.OnSpeech(e);
-			}
+            else if (!e.Handled && e.Speech.ToLower().IndexOf("stablecount") >= 0)
+            {
+                IPooledEnumerable eable = e.Mobile.Map.GetMobilesInRange(e.Mobile.Location, 8);
+                e.Handled = true;
+
+                foreach (Mobile m in eable)
+                {
+                    if (m is AnimalTrainer)
+                    {
+                        e.Mobile.SendLocalizedMessage(1071250, String.Format("{0}\t{1}", e.Mobile.Stabled.Count.ToString(), GetMaxStabled(e.Mobile).ToString())); // ~1_USED~/~2_MAX~ stable stalls used.
+                        break;
+                    }
+                }
+
+                eable.Free();
+            }
+            else
+            {
+                base.OnSpeech(e);
+            }
 		}
 
 		public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -2430,13 +2430,13 @@ namespace Server.Mobiles
 
                     if (!Deleted && ar != null && armor.IsChildOf(m.Backpack) && CanConvertArmor(m, ar))
                     {
-                        if (!Banker.Withdraw(m, 250000, true))
-                        {
-                            m.SendLocalizedMessage(1019022); // You do not have enough gold.
-                        }
-                        else if (!InRange(m.Location, 3))
+                        if (!InRange(m.Location, 3))
                         {
                             m.SendLocalizedMessage(1149654); // You are too far away.
+                        }
+                        else if (!Banker.Withdraw(m, 250000, true))
+                        {
+                            m.SendLocalizedMessage(1019022); // You do not have enough gold.
                         }
                         else
                         {

--- a/Scripts/Mobiles/Normal/FireSteed.cs
+++ b/Scripts/Mobiles/Normal/FireSteed.cs
@@ -16,36 +16,39 @@ namespace Server.Mobiles
         public FireSteed(string name)
             : base(name, 0xBE, 0x3E9E, AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.BaseSoundID = 0xA8;
-            this.Hue = 1161;
+            BaseSoundID = 0xA8;
+            Hue = 1161;
 
-            this.SetStr(376, 400);
-            this.SetDex(91, 120);
-            this.SetInt(291, 300);
+            SetStr(376, 400);
+            SetDex(91, 120);
+            SetInt(291, 300);
 
-            this.SetHits(226, 240);
+            SetHits(226, 240);
 
-            this.SetDamage(11, 30);
+            SetDamage(11, 30);
 
-            this.SetDamageType(ResistanceType.Physical, 20);
-            this.SetDamageType(ResistanceType.Fire, 80);
+            SetDamageType(ResistanceType.Physical, 20);
+            SetDamageType(ResistanceType.Fire, 80);
 
-            this.SetResistance(ResistanceType.Physical, 30, 40);
-            this.SetResistance(ResistanceType.Fire, 70, 80);
-            this.SetResistance(ResistanceType.Cold, 20, 30);
-            this.SetResistance(ResistanceType.Poison, 30, 40);
-            this.SetResistance(ResistanceType.Energy, 30, 40);
+            SetResistance(ResistanceType.Physical, 30, 40);
+            SetResistance(ResistanceType.Fire, 70, 80);
+            SetResistance(ResistanceType.Cold, 20, 30);
+            SetResistance(ResistanceType.Poison, 30, 40);
+            SetResistance(ResistanceType.Energy, 30, 40);
 
-            this.SetSkill(SkillName.MagicResist, 100.0, 120.0);
-            this.SetSkill(SkillName.Tactics, 100.0);
-            this.SetSkill(SkillName.Wrestling, 100.0);
+            SetSkill(SkillName.MagicResist, 100.0, 120.0);
+            SetSkill(SkillName.Tactics, 100.0);
+            SetSkill(SkillName.Wrestling, 100.0);
 
-            this.Fame = 20000;
-            this.Karma = -20000;
+            Fame = 20000;
+            Karma = -20000;
 
-            this.Tamable = true;
-            this.ControlSlots = 2;
-            this.MinTameSkill = 106.0;
+            Tamable = true;
+            ControlSlots = 2;
+            MinTameSkill = 106.0;
+
+            PackItem(new SulfurousAsh(Utility.RandomMinMax(151, 300)));
+            PackItem(new Ruby(Utility.RandomMinMax(16, 30)));
         }
 
         public FireSteed(Serial serial)
@@ -74,11 +77,6 @@ namespace Server.Mobiles
                 return PackInstinct.Daemon | PackInstinct.Equine;
             }
         }
-        public override void GenerateLoot()
-        {
-            this.PackItem(new SulfurousAsh(Utility.RandomMinMax(151, 300)));
-            this.PackItem(new Ruby(Utility.RandomMinMax(16, 30)));
-        }
 
         public override void Serialize(GenericWriter writer)
         {
@@ -93,18 +91,18 @@ namespace Server.Mobiles
 
             int version = reader.ReadInt();
 
-            if (this.BaseSoundID <= 0)
-                this.BaseSoundID = 0xA8;
+            if (BaseSoundID <= 0)
+                BaseSoundID = 0xA8;
 
             if (version < 1)
             {
-                for (int i = 0; i < this.Skills.Length; ++i)
+                for (int i = 0; i < Skills.Length; ++i)
                 {
-                    this.Skills[i].Cap = Math.Max(100.0, this.Skills[i].Cap * 0.9);
+                    Skills[i].Cap = Math.Max(100.0, Skills[i].Cap * 0.9);
 
-                    if (this.Skills[i].Base > this.Skills[i].Cap)
+                    if (Skills[i].Base > Skills[i].Cap)
                     {
-                        this.Skills[i].Base = this.Skills[i].Cap;
+                        Skills[i].Base = Skills[i].Cap;
                     }
                 }
             }

--- a/Scripts/Mobiles/Normal/Revenant.cs
+++ b/Scripts/Mobiles/Normal/Revenant.cs
@@ -24,7 +24,6 @@ namespace Server.Mobiles
 			Name = "a revenant";
 			Body = 400;
 			Hue = 1;
-			// TODO: Sound values?
 
 			double scalar = caster.Skills[SkillName.SpiritSpeak].Value * 0.01;
 
@@ -60,20 +59,16 @@ namespace Server.Mobiles
 
 			VirtualArmor = 32;
 
-			Item shroud = new DeathShroud();
-
+			Item shroud = new Robe();
+            shroud.ItemID = 0x2683;
 			shroud.Hue = 0x455;
-
 			shroud.Movable = false;
-
-			AddItem(shroud);
+			SetWearable(shroud);
 
 			Halberd weapon = new Halberd();
-
 			weapon.Hue = 1;
 			weapon.Movable = false;
-
-			AddItem(weapon);
+            SetWearable(weapon);
 		}
 
 		public Revenant(Serial serial)

--- a/Scripts/Multis/BaseHouse.cs
+++ b/Scripts/Multis/BaseHouse.cs
@@ -1252,7 +1252,7 @@ namespace Server.Multis
             if (from.AccessLevel >= AccessLevel.GameMaster || !IsLockedDown(item))
                 return true;
 
-            // ISecureable will set its own rules
+            // ISecurable will set its own rules
             if (item is ISecurable)
                 return HasSecureAccess(from, ((ISecurable)item).Level);
 

--- a/Scripts/Quests/Sacred Quest/ShrineOfSingularity.cs
+++ b/Scripts/Quests/Sacred Quest/ShrineOfSingularity.cs
@@ -8,7 +8,7 @@ namespace Server.Items
 {
     public class ShrineOfSingularity : Item
     {
-        private static readonly TimeSpan FailDelay = TimeSpan.FromHours(24);
+        private static readonly TimeSpan FailDelay = TimeSpan.FromHours(2);
 
         [Constructable]
         public ShrineOfSingularity() : base(0x48A8)

--- a/Scripts/Services/CleanUpBritannia/Items/Mailbox.cs
+++ b/Scripts/Services/CleanUpBritannia/Items/Mailbox.cs
@@ -86,20 +86,17 @@ namespace Server.Items
                 return false;
             }
 
-            DropItem(dropped);
-
-            if (house != null)
+            if (house != null && IsLockedDown)
             {
-                if (IsLockedDown)
+                if (!house.CheckAccessibility(this, from))
                 {
-                    if (!house.CheckAccessibility(this, from))
-                    {
-                        this.PrivateOverheadMessage(MessageType.Regular, 0x21, 1061637, from.NetState); // You are not allowed to access this!
-                        from.SendLocalizedMessage(501727); // You cannot lock that down!
-                        return false;
-                    }
+                    this.PrivateOverheadMessage(MessageType.Regular, 0x21, 1061637, from.NetState); // You are not allowed to access this!
+                    from.SendLocalizedMessage(501727); // You cannot lock that down!
+                    return false;
                 }
             }
+
+            DropItem(dropped);
 
             if (house != null && !IsLockedDown)
             {
@@ -111,10 +108,7 @@ namespace Server.Items
 
         public override bool IsAccessibleTo(Mobile m)
         {
-            if (!BaseHouse.CheckAccessible(m, this))
-                return false;
-
-            return base.IsAccessibleTo(m);
+            return true;
         }
 
         public override void SendFullItemsMessage(Mobile to, Item item) // That mailbox is completely full.

--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -413,6 +413,15 @@ namespace Server.Engines.Craft
             #endregion
 		};
 
+        private static readonly Type[] m_ClothColoredItemTable = new[]
+        {
+            typeof( GozaMatSouthDeed ), typeof( GozaMatEastDeed ),
+			typeof( SquareGozaMatSouthDeed ), typeof( SquareGozaMatEastDeed ),
+			typeof( BrocadeGozaMatSouthDeed ), typeof( BrocadeGozaMatEastDeed ),
+			typeof( BrocadeSquareGozaMatSouthDeed ), typeof( BrocadeSquareGozaMatEastDeed ),
+            typeof( Tessen )
+        };
+
 		private static readonly Type[] m_ColoredResourceTable = new[]
 		{
 			#region Mondain's Legacy
@@ -515,6 +524,19 @@ namespace Server.Engines.Craft
 
 			return (inItemTable && inResourceTable);
 		}
+
+        public bool RetainsColorFromCloth(Item item)
+        {
+            Type t = item.GetType();
+
+            foreach (var type in m_ClothColoredItemTable)
+            {
+                if (type == t)
+                    return true;
+            }
+
+            return false;
+        }
 
 		public bool Find(Mobile from, int[] itemIDs)
 		{
@@ -1147,6 +1169,7 @@ namespace Server.Engines.Craft
 		}
 
 		private int m_ResHue;
+        private int m_ClothHue;
 		private int m_ResAmount;
 		private CraftSystem m_System;
 
@@ -1172,6 +1195,11 @@ namespace Server.Engines.Craft
 			{
 				return;
 			}
+
+            if (item is Cloth || item is UncutCloth || item is AbyssalCloth)
+            {
+                m_ClothHue = item.Hue;
+            }
 
             if (amount >= m_ResAmount)
 			{
@@ -1695,6 +1723,11 @@ namespace Server.Engines.Craft
 					{
 						item.Hue = resHue;
 					}
+
+                    if (item.Hue == 0 && RetainsColorFromCloth(item) && m_ClothHue != 0)
+                    {
+                        item.Hue = m_ClothHue;
+                    }
 
 					if (maxAmount > 0)
 					{

--- a/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Creatures/Undead.cs
+++ b/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Creatures/Undead.cs
@@ -159,14 +159,16 @@ namespace Server.Mobiles
 			Body = 400;
             Hue = 0x847E;
 
-            var shroud = new Server.Items.HoodedShroudOfShadows();
+            var shroud = new Server.Items.Robe();
+            shroud.ItemID = 0x2683;
+            shroud.Hue = 0x455;
             shroud.Movable = false;
-            AddItem(shroud);
+            SetWearable(shroud);
 
             var boots = new Server.Items.Boots();
             boots.Hue = 1;
             boots.Movable = false;
-            AddItem(boots);
+            SetWearable(boots);
 		}
 		
 		[Constructable]

--- a/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Gumps.cs
+++ b/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Gumps.cs
@@ -20,11 +20,6 @@ namespace Server.Engines.VoidPool
 
 	public class VoidPoolGump : Gump
 	{
-        public static void Initialize()
-        {
-            CommandSystem.Register("VoidPool", AccessLevel.Player, SendGump_OnCommand);
-        }
-
         public static readonly int Red = 0x4800;
         public static readonly int Orange = 0xB104;
 	
@@ -105,18 +100,6 @@ namespace Server.Engines.VoidPool
                     break;
 			}
 		}
-
-        [Usage("VoidPool")]
-        [Description("Sends Void Pool Gump to player.")]
-        public static void SendGump_OnCommand(CommandEventArgs e)
-        {
-            Mobile from = e.Mobile;
-
-            if (VoidPoolController.InstanceTram != null || VoidPoolController.InstanceFel != null)
-            {
-                e.Mobile.SendGump(new VoidPoolGump(from.Map == Map.Trammel ? VoidPoolController.InstanceTram : VoidPoolController.InstanceFel, from as PlayerMobile));
-            }
-        }
 	}
 
     public class ScoresGump : Gump

--- a/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/VoidPoolController.cs
+++ b/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/VoidPoolController.cs
@@ -138,6 +138,7 @@ namespace Server.Engines.VoidPool
         [CommandProperty(AccessLevel.GameMaster)]
         public int RespawnMax { get; set; }
 
+        [CommandProperty(AccessLevel.GameMaster)]
         public Level3Spawner Level3Spawner { get; set; }
 
         public VoidPoolController(Map map)
@@ -177,8 +178,8 @@ namespace Server.Engines.VoidPool
 
             ClearSpawners();
 			Active = true;
-            
-            Level3Spawner = new Level3Spawner(this);
+
+            ResetLevel3Spawners();
 		}
 
         public override void OnDoubleClick(Mobile from)
@@ -608,9 +609,17 @@ namespace Server.Engines.VoidPool
 		public override void Serialize(GenericWriter writer)
 		{
 			base.Serialize(writer);
-			writer.Write((int)1);
+			writer.Write((int)2);
 
-            Level3Spawner.Serialize(writer);
+            if (Level3Spawner != null)
+            {
+                writer.Write(0);
+                Level3Spawner.Serialize(writer);
+            }
+            else
+            {
+                writer.Write(1);
+            }
 
             writer.Write(RespawnMin);
             writer.Write(RespawnMax);
@@ -630,8 +639,12 @@ namespace Server.Engines.VoidPool
 
             switch (version)
             {
+                case 2:
                 case 1:
-                    Level3Spawner = new Level3Spawner(reader, this);
+                    if (version == 1 || reader.ReadInt() == 0)
+                    {
+                        Level3Spawner = new Level3Spawner(reader, this);
+                    }
                     goto case 0;
                 case 0:
                     if (version == 0)

--- a/Scripts/Services/Revamped Dungeons/DespiseRevamped/AI.cs
+++ b/Scripts/Services/Revamped Dungeons/DespiseRevamped/AI.cs
@@ -126,6 +126,59 @@ namespace Server.Engines.Despise
             return true;
         }
 
+        public override bool DoOrderGuard()
+        {
+            if (m_Creature.Orb == null || !m_Creature.Controlled)
+                return base.DoOrderGuard();
+
+            switch (m_Creature.Orb.Aggression)
+            {
+                case Aggression.Following:
+                    return base.DoOrderGuard();
+                case Aggression.Defensive:
+                    {
+                        int length = m_Creature.GetLeashLength();
+                        IPoint3D p = m_Creature.Orb.Anchor as IPoint3D;
+
+                        if (p == null)
+                            p = m_Creature;
+
+                        Mobile combatant = m_Creature.Combatant != null ? m_Creature.Combatant as Mobile : m_Creature.ControlMaster != null ? m_Creature.ControlMaster.Combatant as Mobile : null;
+
+                        if (combatant != null && combatant.GetDistanceToSqrt(p) <= length)
+                        {
+                            if (m_Creature.Debug)
+                                m_Creature.DebugSay("I have detected {0} as an aggressor, attacking", m_Creature.FocusMob.Name);
+
+                            m_Creature.Combatant = combatant;
+                            m_Creature.ControlTarget = combatant;
+                            m_Creature.ControlOrder = OrderType.Attack;
+                            Action = ActionType.Combat;
+                        }
+                        else
+                            return base.DoOrderNone();
+                    }
+                    break;
+                case Aggression.Aggressive:
+                    {
+                        if (AcquireFocusMob(m_Creature.GetLeashLength(), m_Creature.FightMode, false, false, true))
+                        {
+                            if (m_Creature.Debug)
+                                m_Creature.DebugSay("I have detected {0}, attacking", m_Creature.FocusMob.Name);
+
+                            m_Creature.Combatant = m_Creature.FocusMob;
+                            m_Creature.ControlTarget = m_Creature.FocusMob;
+                            m_Creature.ControlOrder = OrderType.Attack;
+                            Action = ActionType.Combat;
+                        }
+                        else
+                            return base.DoOrderNone();
+                    }
+                    break;
+            }
+            return true;
+        }
+
         public override bool DoOrderNone()
         {
             if (m_Creature.Orb == null || !m_Creature.Controlled)
@@ -442,6 +495,59 @@ namespace Server.Engines.Despise
             if (!fighting)
                 return base.DoOrderFollow();
 
+            return true;
+        }
+
+        public override bool DoOrderGuard()
+        {
+            if (m_Creature.Orb == null || !m_Creature.Controlled)
+                return base.DoOrderGuard();
+
+            switch (m_Creature.Orb.Aggression)
+            {
+                case Aggression.Following:
+                    return base.DoOrderGuard();
+                case Aggression.Defensive:
+                    {
+                        int length = m_Creature.GetLeashLength();
+                        IPoint3D p = m_Creature.Orb.Anchor as IPoint3D;
+
+                        if (p == null)
+                            p = m_Creature;
+
+                        Mobile combatant = m_Creature.Combatant != null ? m_Creature.Combatant as Mobile : m_Creature.ControlMaster != null ? m_Creature.ControlMaster.Combatant as Mobile : null;
+
+                        if (combatant != null && combatant.GetDistanceToSqrt(p) <= length)
+                        {
+                            if (m_Creature.Debug)
+                                m_Creature.DebugSay("I have detected {0} as an aggressor, attacking", m_Creature.FocusMob.Name);
+
+                            m_Creature.Combatant = combatant;
+                            m_Creature.ControlTarget = combatant;
+                            m_Creature.ControlOrder = OrderType.Attack;
+                            Action = ActionType.Combat;
+                        }
+                        else
+                            return base.DoOrderNone();
+                    }
+                    break;
+                case Aggression.Aggressive:
+                    {
+                        if (AcquireFocusMob(m_Creature.GetLeashLength(), m_Creature.FightMode, false, false, true))
+                        {
+                            if (m_Creature.Debug)
+                                m_Creature.DebugSay("I have detected {0}, attacking", m_Creature.FocusMob.Name);
+
+                            m_Creature.Combatant = m_Creature.FocusMob;
+                            m_Creature.ControlTarget = m_Creature.FocusMob;
+                            m_Creature.ControlOrder = OrderType.Attack;
+                            Action = ActionType.Combat;
+                        }
+                        else
+                            return base.DoOrderNone();
+                    }
+                    break;
+            }
             return true;
         }
 

--- a/Scripts/Spells/Skill Masteries/BodyGuard.cs
+++ b/Scripts/Spells/Skill Masteries/BodyGuard.cs
@@ -20,7 +20,7 @@ namespace Server.Spells.SkillMasteries
                 9002
             );
  
-        public override int RequiredMana { get { return 40; } } // TODO: How much?
+        public override int RequiredMana { get { return 40; } }
         public override int DisruptMessage { get { return 1156103; } } // Bodyguard has expired.
         public override bool BlocksMovement { get { return false; } }
         public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds(1.0); } }
@@ -126,8 +126,8 @@ namespace Server.Spells.SkillMasteries
                 Caster.SendLocalizedMessage(1049452, "\t" + toGuard.Name); // You are now protecting ~2_NAME~.
                 toGuard.SendLocalizedMessage(1049451, Caster.Name); // You are now being protected by ~1_NAME~.
 
-                BuffInfo.AddBuff(Caster, new BuffInfo(BuffIcon.Bodyguard, 1155924, 1156061, TimeSpan.FromSeconds(90), Caster, String.Format("{0}\t{1}\t{2}\t{2}", Caster.Name, (_Block + 5).ToString(), toGuard.Name, _Block.ToString())));
-                BuffInfo.AddBuff(toGuard, new BuffInfo(BuffIcon.Bodyguard, 1155924, 1156061, TimeSpan.FromSeconds(90), toGuard, String.Format("{0}\t{1}\t{2}\t{2}", Caster.Name, (_Block + 5).ToString(), toGuard.Name, _Block.ToString())));
+                BuffInfo.AddBuff(Caster, new BuffInfo(BuffIcon.Bodyguard, 1155924, 1156061, TimeSpan.FromSeconds(90), Caster, String.Format("{0}\t{1}\t{2}\t{3}", Caster.Name, (_Block + 5).ToString(), toGuard.Name, _Block.ToString())));
+                BuffInfo.AddBuff(toGuard, new BuffInfo(BuffIcon.Bodyguard, 1155924, 1156061, TimeSpan.FromSeconds(90), toGuard, String.Format("{0}\t{1}\t{2}\t{3}", Caster.Name, (_Block + 5).ToString(), toGuard.Name, _Block.ToString())));
                 //~1_NAME~ receives ~2_DAMAGE~% of all damage dealt to ~3_NAME~. All damage dealt to ~3_NAME~ will be reduced by ~4_DAMAGE~%. Body guard must be within 2 tiles. 
 			}
 
@@ -174,17 +174,21 @@ namespace Server.Spells.SkillMasteries
             FinishSequence();
         }
 		
-		public static void CheckBodyGuard(Mobile attacker, Mobile defender, ref int damage, int phys, int fire, int cold, int pois, int nrgy)
+		public static void CheckBodyGuard(Mobile attacker, Mobile defender, DamageType type, ref int damage)
 		{
 			BodyGuardSpell spell = GetSpell(s => s.GetType() == typeof(BodyGuardSpell) && s.Target == defender) as BodyGuardSpell;
 			
 			if(spell != null && spell.Caster.InRange(spell.Target, 2))
 			{
 				double mod = (double)spell.PropertyBonus() / 100.0;
-				int casterDamage = damage - (int)((double)damage * (mod + .05));
+				
 				damage = damage - (int)((double)damage * mod);
+                int casterDamage = damage - (int)((double)damage * (mod - .05));
 
-                AOS.Damage(spell.Caster, attacker, casterDamage, phys, fire, cold, pois, nrgy);
+                if (type >= DamageType.Spell)
+                    casterDamage /= 2;
+
+                spell.Caster.Damage(casterDamage, attacker);
 			}
 		}
 

--- a/Scripts/Spells/Skill Masteries/Core/MasteryInfo.cs
+++ b/Scripts/Spells/Skill Masteries/Core/MasteryInfo.cs
@@ -460,7 +460,7 @@ namespace Server.Spells.SkillMasteries
         {
             if (IsActivePassive(m, PassiveSpell.AnticipateHit))
             {
-                return (int)(m.Skills[SkillName.Bushido].Value / 2);
+                return (int)(m.Skills[SkillName.Bushido].Value * .67);
             }
 
             return 0;


### PR DESCRIPTION
- Fixed Insciption Bug with arch cure scrolls
- Added new magincia regions for proper house placement
- Heightened Senses now applied the correct parry Bonus
- Dice can now have security level Set
- Blood Oath no longer factors resist spells in PVP, per EA
- Added 'stablecount' command to animal trainers
- Fixed 2x loot for fire steeds
- Revenants and Covetous Revenants should now be wearing hooded robes!
- Shrine of Singluarity quest (on fail) is now 2 real hours, 24 UO hours
- Fixed assessibility issue with mailboxes
- Goza mats and tessens now retain the color of the cloth uses to craft them with
- Removed [voidpool command as it is not needed
- Despise pets should now attack opposite aligned creatures, as well as the bosses properly
- Anticipate his should now function properly when using confidence
- Body guard should be block/transfer the proper amount of damage
- Fixed Body Guard buff icons