### PR TITLE
Update EngravingTools.cs

### DIFF
--- a/Scripts/Items/Consumables/EngravingTools.cs
+++ b/Scripts/Items/Consumables/EngravingTools.cs
@@ -360,7 +360,7 @@ namespace Server.Items
                     typeof(RedArmoire), typeof(CherryArmoire), typeof(MapleArmoire),
                     typeof(ElegantArmoire), typeof(Keg), typeof(SimpleElvenArmoire),
                     typeof(DecorativeBox), typeof(FancyElvenArmoire), typeof(RarewoodChest),
-                    typeof(RewardSign)
+                    typeof(RewardSign), typeof(GargoyleWoodenChest)
                 };
             }
         }


### PR DESCRIPTION
The Gargoyle Wooden Chest was never added to the wooden container engraving tool menu when it was scripted in. This as a container that is crafted by carpenters at the cost of 30 logs or boards.

Originally reported here - http://trueuo.com/index.php?threads/possible-bug-gargish-chest.186/