### PR TITLE
Various Bug Fixes

### DIFF
--- a/Scripts/Abilities/BleedAttack.cs
+++ b/Scripts/Abilities/BleedAttack.cs
@@ -156,7 +156,7 @@ namespace Server.Items
                 Priority = TimerPriority.TwoFiftyMS;
 				m_BloodDrinker = blooddrinker;
 
-                m_MaxCount = Spells.SkillMasteries.BardSpell.GetSpellForParty(m, typeof(Spells.SkillMasteries.ResilienceSpell)) != null ? 3 : 5;
+                m_MaxCount = Spells.SkillMasteries.SkillMasterySpell.UnderPartyEffects(m, typeof(Spells.SkillMasteries.ResilienceSpell)) ? 3 : 5;
 			}
 
             protected override void OnTick()

--- a/Scripts/Abilities/MortalStrike.cs
+++ b/Scripts/Abilities/MortalStrike.cs
@@ -101,7 +101,7 @@ namespace Server.Items
             // Do not reset timer if one is already in place.
             if (Core.HS || !IsWounded(defender))
             {
-                if (Spells.SkillMasteries.BardSpell.GetSpellForParty(defender, typeof(Spells.SkillMasteries.ResilienceSpell)) != null)//Halves time
+                if (Spells.SkillMasteries.SkillMasterySpell.UnderPartyEffects(defender, typeof(Spells.SkillMasteries.ResilienceSpell))) //Halves time
                     BeginWound(defender, defender.Player ? TimeSpan.FromSeconds(3.0) : TimeSpan.FromSeconds(6));
                 else
                     BeginWound(defender, defender.Player ? PlayerDuration : NPCDuration);

--- a/Scripts/Items/Containers/Container.cs
+++ b/Scripts/Items/Containers/Container.cs
@@ -258,10 +258,15 @@ namespace Server.Items
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (from.IsStaff() || from.InRange(GetWorldLocation(), 2) || RootParent is PlayerVendor)
+            if (from.IsStaff() || RootParent is PlayerVendor ||
+                (from.InRange(GetWorldLocation(), 2) && (Parent != null || (Z >= from.Z - 8 && Z <= from.Z + 16))))
+            {
                 Open(from);
+            }
             else
+            {
                 from.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1019045); // I can't reach that.
+            }
         }
 
 		public override void AddNameProperty(ObjectPropertyList list)

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -1886,6 +1886,7 @@ namespace Server.Items
             Layer.Pants,
             Layer.Shirt,
             Layer.Helm,
+            Layer.Arms,
             Layer.Gloves,
             Layer.Ring,
             Layer.Talisman,

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -228,32 +228,26 @@ namespace Server
                 * ((resist spellsx10)/20 + 10=percentage of damage resisted)
                 * 
                 * Tested 12/29/2017-
-                * No cap, also, above forumula is no longer in effect.
+                * No cap, also, above forumula is only in effect vs. creatures
                 */
 
                 if (oath == m)
                 {
-                    totalDamage = (int)(totalDamage * 1.1);
+                    int originalDamage = totalDamage;
+                    totalDamage = (int)(totalDamage * 1.2);
 
                     if (!Core.TOL && totalDamage > 35 && from is PlayerMobile) /* capped @ 35, seems no expansion */
                     {
                         totalDamage = 35;
                     }
 
-                    if (Core.ML)
+                    if (Core.ML && m is BaseCreature)
                     {
-                        if (m is PlayerMobile)
-                        {
-                            from.Damage((int)(totalDamage * 1.20), m);
-                        }
-                        else
-                        {
-                            from.Damage((int)(totalDamage * (1 - (((from.Skills.MagicResist.Value * .5) + 10) / 100))), m);
-                        }
+                        from.Damage((int)(originalDamage * (1 - (((from.Skills.MagicResist.Value * .5) + 10) / 100))), m);
                     }
                     else
                     {
-                        from.Damage(totalDamage, m);
+                        from.Damage(originalDamage, m);
                     }
                 }
                 else if (!ignoreArmor)
@@ -316,22 +310,7 @@ namespace Server
             #endregion
 
             #region Skill Mastery
-            SkillMasterySpell spell = SkillMasterySpell.GetSpellForParty(m, typeof(PerseveranceSpell));
-
-            if (spell != null)
-                spell.AbsorbDamage(ref totalDamage);
-
-            if (type >= DamageType.Spell)
-            {
-                spell = SkillMasterySpell.GetHarmfulSpell(from, typeof(TribulationSpell));
-
-                if (spell != null)
-                    spell.AbsorbDamage(ref damage);
-            }
-
-            ManaShieldSpell.CheckManaShield(m, ref totalDamage);
-            BodyGuardSpell.CheckBodyGuard(from, m, type, ref totalDamage);
-            SkillMasterySpell.OnDamaged(m, from, ref totalDamage);
+            SkillMasterySpell.OnDamage(m, from, type, ref totalDamage);
             #endregion
 
             if (keepAlive && totalDamage > m.Hits)
@@ -358,7 +337,6 @@ namespace Server
             }
 
             m.Damage(totalDamage, from, true, false);
-
             SpiritSpeak.CheckDisrupt(m);
 
             #region Stygian Abyss

--- a/Scripts/Mobiles/NPCs/Naturalist.cs
+++ b/Scripts/Mobiles/NPCs/Naturalist.cs
@@ -120,7 +120,21 @@ namespace Server.Engines.Quests.Naturalist
 
                             if (study.StudiedSpecialNest)
                             {
-                                reward = new Seed(type, PlantHue.FireRed, false);
+                                PlantHue hue;
+                                switch (Utility.Random(3))
+                                {
+                                    case 0: 
+                                        hue = PlantHue.FireRed; 
+                                        break;
+                                    case 1: 
+                                        hue = PlantHue.White; 
+                                        break;
+                                    default:
+                                        hue = PlantHue.Black;
+                                        break;
+                                }
+
+                                reward = new Seed(type, hue, false);
                             }
                             else
                             {

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -2003,13 +2003,6 @@ namespace Server.Mobiles
             }
             #endregion
 
-            #region Skill Mastery
-            SkillMasterySpell spell = SkillMasterySpell.GetHarmfulSpell(this, typeof(TribulationSpell));
-
-            if (spell != null)
-                spell.DoDamage(this, amount);
-            #endregion
-
             base.OnDamage(amount, from, willKill);
         }
 

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -4079,16 +4079,6 @@ namespace Server.Mobiles
 			SendToStaffMessage(from, String.Format(format, args));
 		}
 
-        public override void Damage(int amount, Mobile from)
-        {
-            Damage(amount, from, false, false);
-        }
-
-        public override void Damage(int amount, Mobile from, bool informMount)
-        {
-            Damage(amount, from, informMount, false);
-        }
-
         #region Poison
         public override void OnCured(Mobile from, Poison oldPoison)
         {
@@ -4103,7 +4093,7 @@ namespace Server.Mobiles
 			}
 
             //Skill Masteries
-            if (SkillMasterySpell.GetSpellForParty(this, typeof(Spells.SkillMasteries.ResilienceSpell)) != null && 0.25 > Utility.RandomDouble())
+            if (SkillMasterySpell.UnderPartyEffects(this, typeof(Spells.SkillMasteries.ResilienceSpell)) && 0.25 > Utility.RandomDouble())
             {
                 return ApplyPoisonResult.Immune;
             }

--- a/Scripts/Services/Craft/DefBlacksmithy.cs
+++ b/Scripts/Services/Craft/DefBlacksmithy.cs
@@ -91,9 +91,14 @@ namespace Server.Engines.Craft
             return 0.0; // 0%
         }
 
+        private System.Collections.Generic.List<Type> _NoConsumeOnFail = new System.Collections.Generic.List<Type>
+        {
+            typeof(LeggingsOfBane), typeof(GauntletsOfNobility)
+        };
+
         public override bool ConsumeOnFailure(Mobile from, Type resourceType, CraftItem craftItem)
         {
-            if (resourceType == typeof(LeggingsOfBane) || resourceType == typeof(GauntletsOfNobility))
+            if (_NoConsumeOnFail.Contains(resourceType))
                 return false;
 
             return base.ConsumeOnFailure(from, resourceType, craftItem);

--- a/Scripts/Services/Craft/DefCarpentry.cs
+++ b/Scripts/Services/Craft/DefCarpentry.cs
@@ -133,9 +133,14 @@ namespace Server.Engines.Craft
             }
         }
 
+        private System.Collections.Generic.List<Type> _NoConsumeOfFailure = new System.Collections.Generic.List<Type>
+        {
+            typeof(StaffOfTheMagi), typeof(BlackrockMoonstone)
+        };
+
         public override bool ConsumeOnFailure(Mobile from, Type resourceType, CraftItem craftItem)
         {
-            if (resourceType == typeof(StaffOfTheMagi))
+            if (_NoConsumeOfFailure.Contains(resourceType))
                 return false;
 
             return base.ConsumeOnFailure(from, resourceType, craftItem);

--- a/Scripts/Services/Craft/DefTinkering.cs
+++ b/Scripts/Services/Craft/DefTinkering.cs
@@ -167,9 +167,15 @@ namespace Server.Engines.Craft
             }
         }
 
+        private System.Collections.Generic.List<Type> _NoConsumeOnFailure = new System.Collections.Generic.List<Type>
+        {
+            typeof(Silver), typeof(RingOfTheElements), typeof(HatOfTheMagi), typeof(AutomatonActuator),
+            typeof(BlackrockMoonstone)
+        };
+
         public override bool ConsumeOnFailure(Mobile from, Type resourceType, CraftItem craftItem)
         {
-            if (resourceType == typeof(Silver) || resourceType == typeof(RingOfTheElements) || resourceType == typeof(HatOfTheMagi) || resourceType == typeof(AutomatonActuator))
+            if (_NoConsumeOnFailure.Contains(resourceType))
                 return false;
 
             return base.ConsumeOnFailure(from, resourceType, craftItem);

--- a/Scripts/Services/TreasuresOfKotlCity/Items/PowerCoreDockingStations.cs
+++ b/Scripts/Services/TreasuresOfKotlCity/Items/PowerCoreDockingStations.cs
@@ -178,6 +178,8 @@ namespace Server.Engines.TreasuresOfKotlCity
 
             foreach (Item item in delete)
                 item.Delete();
+
+            _Active = false;
         }
 
         private void AddComplexComponent(int item, int xoffset, int yoffset, int zoffset, int hue, int localization = 0)

--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -287,7 +287,9 @@ namespace Server.Spells
                 #endregion
 
                 if (disturb)
+                {
                     Disturb(DisturbType.Hurt, false, true);
+                }
             }
         }
 

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -390,7 +390,7 @@ namespace Server.Spells
             {
                 int span = (((6 * caster.Skills.EvalInt.Fixed) / 50) + 1);
 
-                if (caster.Spell is CurseSpell && SkillMasterySpell.GetSpellForParty(target, typeof(ResilienceSpell)) != null)
+                if (caster.Spell is CurseSpell && SkillMasterySpell.UnderPartyEffects(target, typeof(ResilienceSpell)))
                     span /= 2;
 
                 return TimeSpan.FromSeconds(span);

--- a/Scripts/Spells/Skill Masteries/BardSpells/Perseverance.cs
+++ b/Scripts/Spells/Skill Masteries/BardSpells/Perseverance.cs
@@ -57,8 +57,7 @@ namespace Server.Spells.SkillMasteries
                     BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.Perseverance, 1115615, 1115732, args.ToString()));
                 }
 
-                list.Clear();
-                list.TrimExcess();
+                ColUtility.Free(list);
 
 				BeginTimer();
 			}
@@ -80,7 +79,7 @@ namespace Server.Spells.SkillMasteries
         }
 		
 		/// <summary>
-		/// Called in AOS.cs - Defense Chance Bonus
+		/// Defense Chance Bonus
 		/// </summary>
 		/// <returns>Defense Chance Bonus</returns>
 		public override int PropertyBonus()
@@ -89,7 +88,7 @@ namespace Server.Spells.SkillMasteries
 		}
 
         /// <summary>
-        /// Called in AOS.cs - Casting Focus
+        /// Casting Focus
         /// </summary>
         /// <returns>Casting Focus</returns>
 		public override int PropertyBonus2()
@@ -98,10 +97,10 @@ namespace Server.Spells.SkillMasteries
 		}
 		
 		/// <summary>
-		/// Called in AOS.cs, modifies total damage dealt
+		/// modifies total damage dealt
 		/// </summary>
 		/// <param name="damage"></param>
-		public override void AbsorbDamage(ref int damage)
+		public void AbsorbDamage(ref int damage)
 		{
 			damage -= (int)(damage * m_DamageMod);
 		}

--- a/Scripts/Spells/Skill Masteries/BardSpells/Tribulation.cs
+++ b/Scripts/Spells/Skill Masteries/BardSpells/Tribulation.cs
@@ -142,7 +142,7 @@ namespace Server.Spells.SkillMasteries
             BuffInfo.RemoveBuff(Caster, BuffIcon.TribulationCaster);
         }
 		
-        public override void OnTargetDamaged(Mobile attacker, Mobile victim, int damageTaken)
+        public override void OnTargetDamaged(Mobile attacker, Mobile victim, DamageType type, ref int damageTaken)
 		{
 			if(m_NextDamage > DateTime.UtcNow)
 				return;

--- a/Scripts/Spells/Skill Masteries/BodyGuard.cs
+++ b/Scripts/Spells/Skill Masteries/BodyGuard.cs
@@ -173,14 +173,12 @@ namespace Server.Spells.SkillMasteries
             RemoveGumpTimer(protectee, Caster);
             FinishSequence();
         }
-		
-		public static void CheckBodyGuard(Mobile attacker, Mobile defender, DamageType type, ref int damage)
+
+        public override void OnTargetDamaged(Mobile attacker, Mobile defender, DamageType type, ref int damage)
 		{
-			BodyGuardSpell spell = GetSpell(s => s.GetType() == typeof(BodyGuardSpell) && s.Target == defender) as BodyGuardSpell;
-			
-			if(spell != null && spell.Caster.InRange(spell.Target, 2))
+            if (defender == Target && Caster.InRange(defender, 2))
 			{
-				double mod = (double)spell.PropertyBonus() / 100.0;
+				double mod = (double)PropertyBonus() / 100.0;
 				
 				damage = damage - (int)((double)damage * mod);
                 int casterDamage = damage - (int)((double)damage * (mod - .05));
@@ -188,7 +186,7 @@ namespace Server.Spells.SkillMasteries
                 if (type >= DamageType.Spell)
                     casterDamage /= 2;
 
-                spell.Caster.Damage(casterDamage, attacker);
+                Caster.Damage(casterDamage, attacker);
 			}
 		}
 

--- a/Scripts/Spells/Skill Masteries/Core/SkillMasteryMove.cs
+++ b/Scripts/Spells/Skill Masteries/Core/SkillMasteryMove.cs
@@ -94,7 +94,7 @@ namespace Server.Spells.SkillMasteries
         {
         }
 
-        public virtual void OnDamaged(Mobile attacker, Mobile defender, int damage)
+        public virtual void OnDamaged(Mobile attacker, Mobile defender, DamageType type, ref int damage)
         {
         }
     }

--- a/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
+++ b/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
@@ -226,10 +226,10 @@ namespace Server.Spells.SkillMasteries
 		{
 			return 0;
 		}
-		
-		public virtual void AbsorbDamage(ref int damage)
-		{
-		}
+
+        public virtual void OnDamaged(Mobile attacker, Mobile defender, DamageType type, ref int damage)
+        {
+        }
 		
 		public virtual void DoDamage(Mobile victim, int damageTaken)
 		{
@@ -259,11 +259,7 @@ namespace Server.Spells.SkillMasteries
         {
         }
 
-        public virtual void OnDamaged(Mobile attacker, Mobile victim, int damage)
-        {
-        }
-
-        public virtual void OnTargetDamaged(Mobile attacker, Mobile victim, int damage)
+        public virtual void OnTargetDamaged(Mobile attacker, Mobile victim, DamageType type, ref int damage)
         {
         }
 
@@ -517,6 +513,11 @@ namespace Server.Spells.SkillMasteries
             return false;
         }
 
+        public static bool UnderPartyEffects(Mobile from, Type type)
+        {
+            return GetSpellForParty(from, type) != null;
+        }
+
         public static SkillMasterySpell GetSpellForParty(Mobile from, Type type)
         {
             CheckTable(from);
@@ -667,7 +668,7 @@ namespace Server.Spells.SkillMasteries
         /// <param name="victim"></param>
         /// <param name="damager"></param>
         /// <param name="damage"></param>
-		public static void OnDamaged(Mobile victim, Mobile damager, ref int damage)
+		public static void OnDamage(Mobile victim, Mobile damager, DamageType type, ref int damage)
 		{
 			if(victim == null)
 				return;
@@ -679,20 +680,20 @@ namespace Server.Spells.SkillMasteries
                 if (sp.DamageCanDisrupt && damage > sp.DamageThreshold)
                     sp.Expire(true);
 
-                sp.OnDamaged(damager, victim, damage);
+                sp.OnDamaged(damager, victim, type, ref damage);
             }
 
             foreach (SkillMasterySpell sp in GetSpells(s => s.Target == victim))
             {
-                sp.OnTargetDamaged(damager, victim, damage);
+                sp.OnTargetDamaged(damager, victim, type, ref damage);
             }
 
             SkillMasteryMove move = SpecialMove.GetCurrentMove(victim) as SkillMasteryMove;
 
             if (move != null)
-                move.OnDamaged(damager, victim, damage);
+                move.OnDamaged(damager, victim, type, ref damage);
 
-            SkillMasterySpell spell = SkillMasterySpell.GetSpellForParty(victim, typeof(PerseveranceSpell));
+            PerseveranceSpell spell = SkillMasterySpell.GetSpellForParty(victim, typeof(PerseveranceSpell)) as PerseveranceSpell;
 
             if (spell != null)
                 spell.AbsorbDamage(ref damage);

--- a/Scripts/Spells/Skill Masteries/FistsOfFury.cs
+++ b/Scripts/Spells/Skill Masteries/FistsOfFury.cs
@@ -66,7 +66,7 @@ namespace Server.Spells.SkillMasteries
                 });
         }
 
-        public override void OnDamaged(Mobile attacker, Mobile defender, int damage)
+        public override void OnDamaged(Mobile attacker, Mobile defender, DamageType type, ref int damage)
         {
             BaseWeapon wep = defender.Weapon as BaseWeapon;
 

--- a/Scripts/Spells/Skill Masteries/ManaShield.cs
+++ b/Scripts/Spells/Skill Masteries/ManaShield.cs
@@ -81,26 +81,22 @@ namespace Server.Spells.SkillMasteries
             BuffInfo.RemoveBuff(Caster, BuffIcon.ManaShield);
         }
 
-        public static void CheckManaShield(Mobile m, ref int damage)
+        public override void OnDamaged(Mobile attacker, Mobile defender, DamageType type, ref int damage)
         {
-            ManaShieldSpell spell = GetSpell<ManaShieldSpell>(m);
-
-            if (spell != null)
+            Console.WriteLine("Chance for {0} is {1}", defender.Name, Chance);
+            if (Chance >= Utility.RandomDouble())
             {
-                if (spell.Chance >= Utility.RandomDouble())
-                {
-                    int toShield = damage / 2;
+                int toShield = damage / 2;
 
-                    if (m.Mana >= toShield)
-                    {
-                        m.Mana -= toShield;
-                        damage -= toShield;
-                    }
-                    else
-                    {
-                        damage -= m.Mana;
-                        m.Mana = 0;
-                    }
+                if (defender.Mana >= toShield)
+                {
+                    defender.Mana -= toShield;
+                    damage -= toShield;
+                }
+                else
+                {
+                    damage -= defender.Mana;
+                    defender.Mana = 0;
                 }
             }
         }

--- a/Scripts/Spells/Skill Masteries/ManaShield.cs
+++ b/Scripts/Spells/Skill Masteries/ManaShield.cs
@@ -83,7 +83,6 @@ namespace Server.Spells.SkillMasteries
 
         public override void OnDamaged(Mobile attacker, Mobile defender, DamageType type, ref int damage)
         {
-            Console.WriteLine("Chance for {0} is {1}", defender.Name, Chance);
             if (Chance >= Utility.RandomDouble())
             {
                 int toShield = damage / 2;

--- a/Scripts/Spells/Skill Masteries/PlayingTheOdds.cs
+++ b/Scripts/Spells/Skill Masteries/PlayingTheOdds.cs
@@ -53,9 +53,7 @@ namespace Server.Spells.SkillMasteries
                 return false;
             }
 
-            PlayingTheOddsSpell spell = GetSpellForParty(Caster, typeof(PlayingTheOddsSpell)) as PlayingTheOddsSpell;
-
-            if (spell != null)
+            if (SkillMasterySpell.UnderPartyEffects(Caster, typeof(PlayingTheOddsSpell)))
             {
                 Caster.SendLocalizedMessage(1062945); // That ability is already in effect.
                 return false;

--- a/Scripts/Spells/Skill Masteries/Warcry.cs
+++ b/Scripts/Spells/Skill Masteries/Warcry.cs
@@ -36,7 +36,7 @@ namespace Server.Spells.SkillMasteries
                 _Radius = skill / 40;
                 _DamageMalus = (int)((double)skill / 2.4);
 
-                Caster.PrivateOverheadMessage(MessageType.Regular, 1150, false, "Prepare Yourself!", Caster.NetState);
+                Caster.PublicOverheadMessage(MessageType.Regular, Caster.SpeechHue, false, "Prepare Yourself!");
                 Caster.PlaySound(Caster.Female ? 0x338 : 0x44A);
                 TimeSpan d;
 
@@ -49,21 +49,25 @@ namespace Server.Spells.SkillMasteries
 
                 Expires = DateTime.UtcNow + TimeSpan.FromSeconds(10);
                 BeginTimer();
+
+                BuffInfo.AddBuff(Caster, new BuffInfo(BuffIcon.Warcry, 1155906, 1156058, TimeSpan.FromSeconds(10), Caster, String.Format("{0}\t{1}", _Radius.ToString(), _DamageMalus.ToString())));
+                //Reduces all incoming attack damage from opponents who hear the war cry within ~1_RANGE~ tiles by ~2_val~%.
             }
 
             FinishSequence();
         }
 
-        public override void OnGotHit(Mobile attacker, ref int damage)
+        //public override void OnGotHit(Mobile attacker, ref int damage)
+        public override void OnDamaged(Mobile attacker, Mobile victim, DamageType type, ref int damage)
         {
             if (attacker.InRange(Caster, _Radius))
             {
                 damage -= (int)((double)damage * ((double)_DamageMalus / 100.00));
 
                 Caster.PlaySound(attacker.Female ? 0x338 : 0x44A);
-                Caster.FixedEffect(0x3779, 10, 20, 1372, 0);
+                Caster.FixedEffect(0x3779, 10, 20, 1372, 4);
 
-                Caster.SendLocalizedMessage(1156161, attacker.Name); // ~1_NAME~ attacks you for 50% damage.
+                //Caster.SendLocalizedMessage(1156161, attacker.Name); // ~1_NAME~ attacks you for 50% damage.
             }
         }
     }


### PR DESCRIPTION
- Consolidated functions so they aren't so spread out within the various scripts
- Warcry now is triggered on all damage types
- Warcry now shows proper buff icons
- Bodyguard reflect damage will now disrupts spells. This is due to another bug that previously only effected pre-aos shards. It has been fixed
- Naturalist now has a chance to reward white/black seeds along with blaze seeds
- Artifact ingredients no longer delete on fail, only raw resources
- Opening containers now restricted to the player being within 8 to 16 tiles of the z axis of the container
- Blood Oath should now apply the increased damage to the correct mobile