### PR TITLE
Update ResourceDrops.cs

### DIFF
--- a/Scripts/Skills/Imbuing/ResourceDrops.cs
+++ b/Scripts/Skills/Imbuing/ResourceDrops.cs
@@ -136,6 +136,9 @@ namespace Server.Items
 
         public static void CheckDrop(BaseCreature bc, Container c)
         {
+            if (bc.Controlled == true)
+				return;
+            
             if (m_IngredientTable != null)
             {
                 foreach (IngredientDropEntry entry in m_IngredientTable)


### PR DESCRIPTION
Fixes a nasty exploit where tamed, bonded, creatures can be brought into these regions and exploited non stop flooding the world with these resources.