### PR TITLE
Update CombatTraining.cs

### DIFF
--- a/Scripts/Spells/Skill Masteries/CombatTraining.cs
+++ b/Scripts/Spells/Skill Masteries/CombatTraining.cs
@@ -281,6 +281,7 @@ namespace Server.Spells.SkillMasteries
                     from.CheckTargetSkill(SkillName.AnimalTaming, (BaseCreature)targeted, taming - 25, taming + 25);
                     from.CheckTargetSkill(SkillName.AnimalLore, (BaseCreature)targeted, lore - 25, lore + 25);
 
+                    from.CloseGump(typeof(ChooseTrainingGump));
                     from.SendGump(new ChooseTrainingGump(from, (BaseCreature)targeted, Spell));
                 }
             }


### PR DESCRIPTION
Players who keep the gump up but keep targeting their pets will end up with an unlimited number of these gumps to close. 

This simply makes it so there is ever only 1 gump to close.

Tested and confirmed it works on newest SVN.