### PR TITLE
Update BlackthornData.cs

### DIFF
--- a/Scripts/Services/PointsSystems/BlackthornData.cs
+++ b/Scripts/Services/PointsSystems/BlackthornData.cs
@@ -29,7 +29,7 @@ namespace Server.Engines.Points
 
         public override void ProcessKill(BaseCreature victim, Mobile damager, int index)
         {
-            if (victim.Controlled || victim.Owners.Count > 0 || victim.Fame <= 0)
+            if (victim.Controlled == true || victim.Owners.Count > 0 || victim.Fame <= 0)
                 return;
         
             Region r = victim.Region;

--- a/Scripts/Services/PointsSystems/BlackthornData.cs
+++ b/Scripts/Services/PointsSystems/BlackthornData.cs
@@ -29,6 +29,9 @@ namespace Server.Engines.Points
 
         public override void ProcessKill(BaseCreature victim, Mobile damager, int index)
         {
+            if (victim.Controlled || victim.Owners.Count > 0 || victim.Fame <= 0)
+                return;
+        
             Region r = victim.Region;
 
             if (damager is PlayerMobile && r.IsPartOf("BlackthornDungeon"))


### PR DESCRIPTION
Fixes an exploit where players can bring a bonded pet into Blackthorns dungeon and kill / rez it over and over, very quickly, to farm blackthorn artifacts,