### PR TITLE
Update PetBondingPotion.cs

### DIFF
--- a/Scripts/Items/Tools/PetBondingPotion.cs
+++ b/Scripts/Items/Tools/PetBondingPotion.cs
@@ -57,7 +57,7 @@ namespace Server.Items
 
         protected override void OnTarget(Mobile from, object target)
         {
-            if (m_Potion == null || m_Potion.Deleted)
+            if (m_Potion == null || m_Potion.Deleted || !m_Potion.IsChildOf(from.Backpack))
                     return;
                     
             if (target is BaseCreature)

--- a/Scripts/Items/Tools/PetBondingPotion.cs
+++ b/Scripts/Items/Tools/PetBondingPotion.cs
@@ -57,6 +57,9 @@ namespace Server.Items
 
         protected override void OnTarget(Mobile from, object target)
         {
+            if (m_Potion == null || m_Potion.Deleted)
+                    return;
+                    
             if (target is BaseCreature)
             {
                 BaseCreature t = (BaseCreature)target;


### PR DESCRIPTION
Pet Bonding Potion was missing checks to make sure the item was not already used or in a players backpack prior to being used.

This could result in a player selling the potion and then using it right away, if they still have the cursor up.