### PR TITLE
Update TsukiWolf.cs

### DIFF
--- a/Scripts/Mobiles/Normal/TsukiWolf.cs
+++ b/Scripts/Mobiles/Normal/TsukiWolf.cs
@@ -79,8 +79,7 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            AddLoot(LootPack.Average);
-            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.FilthyRich);
         }
 
         public override void OnGaveMeleeAttack(Mobile defender)


### PR DESCRIPTION
http://www.trueuo.com/index.php?threads/tsuki-wolfs.225/

In here are two links that show why the change.

The Tsuki Wolf had his gold increase dropped. Removing the Average pack and upgrading from Rich to Filthy Rich seems to bridge that gap a little better, when you account for luck ect.

As it stands they have stats in line with a dragon (which has a loot pack of filthyrich x2)

https://stratics.com/w/index.php?title=UO:Tsuki_Wolf
http://www.uoguide.com/Tsuki_Wolf