### PR TITLE
Update Champions.cfg

### DIFF
--- a/Config/Champions.cfg
+++ b/Config/Champions.cfg
@@ -11,10 +11,10 @@ RotateDelay=01:00:00:00
 GoldPiles=50
 
 # The minimum amount of gold in a pile for the gold shower
-GoldMin=2500
+GoldMin=4000
 
 # The maximum amount of gold in a pile for the gold shower
-GoldMax=7500
+GoldMax=5500
 
 # The number of gold piles to spawn for the harrower gold shower
 HarrowerGoldPiles=75


### PR DESCRIPTION
https://www.servuo.com/threads/champion-spawn-gold-shower-is-slightly-off.8773/

With the current code - Min is 125,000gp and Max is 375,000gp.
Orig Code
m_GoldShowerPiles = Config.Get("Champions.GoldPiles", 50);
m_GoldShowerMinAmount = Config.Get("Champions.GoldMin", 2500);
m_GoldShowerMaxAmount = Config.Get("Champions.GoldMax", 7500);

According to Official UO

"the rewards for killing a Champion are different depending on which facet you are on. The deaths of all champions, with the exception of Meraktus the Tormented Minotaur are accompanied by a shower of gold totaling approximately 200,000 – 275,000gp "

With these changes you would never get less than 200,000gp and never more than 275,000gp per real UO.