### PR TITLE
Update ChampionSystem.cs

### DIFF
--- a/Scripts/Services/ChampionSystem/ChampionSystem.cs
+++ b/Scripts/Services/ChampionSystem/ChampionSystem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -71,8 +71,8 @@ namespace Server.Engines.CannedEvil
 			m_Enabled = Config.Get("Champions.Enabled", true);
 			m_RotateDelay = Config.Get("Champions.RotateDelay", TimeSpan.FromDays(1.0d));
 			m_GoldShowerPiles = Config.Get("Champions.GoldPiles", 50);
-			m_GoldShowerMinAmount = Config.Get("Champions.GoldMin", 2500);
-			m_GoldShowerMaxAmount = Config.Get("Champions.GoldMax", 7500);
+			m_GoldShowerMinAmount = Config.Get("Champions.GoldMin", 4000);
+			m_GoldShowerMaxAmount = Config.Get("Champions.GoldMax", 5500);
 			m_HarrowerGoldPiles = Config.Get("Champions.HarrowerGoldPiles", 75);
 			m_HarrowerGoldMinAmount = Config.Get("Champions.HarrowerGoldMin", 5000);
 			m_HarrowerGoldMaxAmount = Config.Get("Champions.HarrowerGoldMax", 10000);


### PR DESCRIPTION
https://www.servuo.com/threads/champion-spawn-gold-shower-is-slightly-off.8773/

With the current code - Min is 125,000gp and Max is 375,000gp.
Orig Code
m_GoldShowerPiles = Config.Get("Champions.GoldPiles", 50);
m_GoldShowerMinAmount = Config.Get("Champions.GoldMin", 2500);
m_GoldShowerMaxAmount = Config.Get("Champions.GoldMax", 7500);

According to Official UO

"the rewards for killing a Champion are different depending on which facet you are on. The deaths of all champions, with the exception of Meraktus the Tormented Minotaur are accompanied by a shower of gold totaling approximately 200,000 – 275,000gp "

With these changes you would never get less than 200,000gp and never more than 275,000gp per real UO.