### PR TITLE
Bug Fixes

### DIFF
--- a/Data/Decoration/Stygian Abyss/Ter Mur/Underworld.cfg
+++ b/Data/Decoration/Stygian Abyss/Ter Mur/Underworld.cfg
@@ -61,12 +61,14 @@ SecretShadowWallNS 0x363A
 1136 1166 -12
 
 # Secret Passage: Stone stairs
-Static 0x0752 (Hue=2000)
+Static 0x3F0 (Hue=1945)
 1139 1165 -27
 1138 1166 -22
+1138 1165 -22
 1139 1166 -27
 1140 1165 -32
 1137 1166 -17
+1137 1165 -17
 
 # Secret Dungeon Wall
 SecretDungeonWallNS 0x0242

--- a/Scripts/Abilities/Bladeweave.cs
+++ b/Scripts/Abilities/Bladeweave.cs
@@ -87,7 +87,6 @@ namespace Server.Items
 
         public override void OnHit(Mobile attacker, Mobile defender, int damage)
         {
-            //Borno - Changed to false so we're not using double mana- the NewAbility will use mana instead
             if (CheckMana(attacker, false))
             {
                 BladeWeaveRedirect bwr;

--- a/Scripts/Abilities/DoubleShot.cs
+++ b/Scripts/Abilities/DoubleShot.cs
@@ -19,6 +19,16 @@ namespace Server.Items
             }
         }
 
+        public override bool OnBeforeDamage(Mobile attacker, Mobile defender)
+        {
+            BaseWeapon wep = attacker.Weapon as BaseWeapon;
+
+            if (wep != null)
+                wep.ProcessingMultipleHits = true;
+
+            return true;
+        }
+
         public override SkillName GetSecondarySkill(Mobile from)
         {
             return from.Skills[SkillName.Ninjitsu].Base > from.Skills[SkillName.Bushido].Base ? SkillName.Ninjitsu : SkillName.Bushido;
@@ -63,6 +73,9 @@ namespace Server.Items
             defender.FixedParticles(0x37B9, 1, 19, 0x251D, EffectLayer.Waist);
 
             attacker.Weapon.OnSwing(attacker, defender);
+
+            if (attacker.Weapon is BaseWeapon)
+                ((BaseWeapon)attacker.Weapon).ProcessingMultipleHits = false;
         }
     }
 }

--- a/Scripts/Abilities/DoubleStrike.cs
+++ b/Scripts/Abilities/DoubleStrike.cs
@@ -15,6 +15,16 @@ namespace Server.Items
 		public override int BaseMana { get { return 30; } }
 		public override double DamageScalar { get { return 0.9; } }
 
+        public override bool OnBeforeDamage(Mobile attacker, Mobile defender)
+        {
+            BaseWeapon wep = attacker.Weapon as BaseWeapon;
+
+            if (wep != null)
+                wep.ProcessingMultipleHits = true;
+
+            return true;
+        }
+
 		public override void OnHit(Mobile attacker, Mobile defender, int damage)
 		{
 			if (!Validate(attacker) || !CheckMana(attacker, true))
@@ -40,7 +50,7 @@ namespace Server.Items
 				return;
 			}
 
-			IWeapon weapon = attacker.Weapon;
+			BaseWeapon weapon = attacker.Weapon as BaseWeapon;
 
 			if (weapon == null)
 			{
@@ -54,10 +64,10 @@ namespace Server.Items
 
 			if (attacker.InLOS(defender))
 			{
-				BaseWeapon.InDoubleStrike = true;
+                weapon.InDoubleStrike = true;
 				attacker.RevealingAction();
 				attacker.NextCombatTime = Core.TickCount + (int)weapon.OnSwing(attacker, defender).TotalMilliseconds;
-				BaseWeapon.InDoubleStrike = false;
+                weapon.InDoubleStrike = false;
 			}
 		}
 	}

--- a/Scripts/Abilities/DualWield.cs
+++ b/Scripts/Abilities/DualWield.cs
@@ -74,6 +74,9 @@ namespace Server.Items
 
                 m_Registry[from].Stop();
                 m_Registry.Remove(from);
+
+                if(from.Weapon is BaseWeapon)
+                    ((BaseWeapon)from.Weapon).ProcessingMultipleHits = false;
             }
         }
 
@@ -87,11 +90,18 @@ namespace Server.Items
         {
             if (HasRegistry(attacker) && attacker.Weapon is BaseWeapon && m_Registry[attacker].DualHitChance > Utility.RandomDouble())
             {
+                BaseWeapon wep = (BaseWeapon)attacker.Weapon;
+
                 if (!m_Registry[attacker].SecondHit)
                 {
+                    wep.ProcessingMultipleHits = true;
                     m_Registry[attacker].SecondHit = true;
-                    ((BaseWeapon)attacker.Weapon).OnHit(attacker, defender, .6);
+                    wep.OnHit(attacker, defender, .6);
                     m_Registry[attacker].SecondHit = false;
+                }
+                else if (wep.ProcessingMultipleHits)
+                {
+                    wep.EndDualWield = true;
                 }
             }
         }

--- a/Scripts/Abilities/WhirlwindAttack.cs
+++ b/Scripts/Abilities/WhirlwindAttack.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using Server.Spells;
 
 namespace Server.Items
@@ -20,6 +20,17 @@ namespace Server.Items
                 return 15;
             }
         }
+
+        public override bool OnBeforeDamage(Mobile attacker, Mobile defender)
+        {
+            BaseWeapon wep = attacker.Weapon as BaseWeapon;
+
+            if (wep != null)
+                wep.ProcessingMultipleHits = true;
+
+            return true;
+        }
+
         public override void OnHit(Mobile attacker, Mobile defender, int damage)
         {
             if (!this.Validate(attacker))
@@ -43,17 +54,11 @@ namespace Server.Items
             attacker.FixedEffect(0x3728, 10, 15);
             attacker.PlaySound(0x2A1);
 
-            ArrayList list = new ArrayList();
+            List<Mobile> list = new List<Mobile>();
+            IPooledEnumerable eable = attacker.GetMobilesInRange(1);
 
-            foreach (Mobile m in attacker.GetMobilesInRange(1))
-                list.Add(m);
-
-            ArrayList targets = new ArrayList();
-
-            for (int i = 0; i < list.Count; ++i)
+            foreach (Mobile m in eable)
             {
-                Mobile m = (Mobile)list[i];
-
                 if (m != defender && m != attacker && SpellHelper.ValidIndirectTarget(attacker, m))
                 {
                     if (m == null || m.Deleted || m.Map != attacker.Map || !m.Alive || !attacker.CanSee(m) || !attacker.CanBeHarmful(m))
@@ -63,30 +68,36 @@ namespace Server.Items
                         continue;
 
                     if (attacker.InLOS(m))
-                        targets.Add(m);
+                        list.Add(m);
                 }
             }
 
-            if (targets.Count > 0)
+            eable.Free();
+
+            if (list.Count > 0)
             {
                 double bushido = attacker.Skills.Bushido.Value;
-                double damageBonus = 1.0 + Math.Pow((targets.Count * bushido) / 60, 2) / 100;
+                double damageBonus = 1.0 + Math.Pow((list.Count * bushido) / 60, 2) / 100;
 
                 if (damageBonus > 2.0)
                     damageBonus = 2.0;
 					
                 attacker.RevealingAction();
 
-                for (int i = 0; i < targets.Count; ++i)
+                for (int i = 0; i < list.Count; ++i)
                 {
-                    Mobile m = (Mobile)targets[i];
+                    Mobile m = list[i];
 
                     attacker.SendLocalizedMessage(1060161); // The whirling attack strikes a target!
                     m.SendLocalizedMessage(1060162); // You are struck by the whirling attack and take damage!
 
                     weapon.OnHit(attacker, m, damageBonus);
                 }
+
+                weapon.ProcessingMultipleHits = false;
             }
+
+            ColUtility.Free(list);
         }
     }
 }

--- a/Scripts/Gumps/BaseGump.cs
+++ b/Scripts/Gumps/BaseGump.cs
@@ -17,6 +17,8 @@ namespace Server.Gumps
         public PlayerMobile User { get; private set; }
         public bool Open { get; set; }
 
+        public virtual bool CloseOnMapChange { get { return false; } }
+
         public Gump Parent 
         {
             get { return _Parent; }
@@ -214,6 +216,55 @@ namespace Server.Gumps
             }
 
             AddItemProperty(mob.Serial);
+        }
+
+        public static List<T> GetGumps<T>(PlayerMobile pm) where T : BaseGump
+        {
+            var ns = pm.NetState;
+            List<T> list = new List<T>();
+
+            if (ns == null)
+                return list;
+
+            foreach (BaseGump gump in ns.Gumps.OfType<BaseGump>().Where(g => g.GetType() == typeof(T)))
+            {
+                list.Add(gump as T);
+            }
+
+            return list;
+        }
+
+        public static List<BaseGump> GetGumps(PlayerMobile pm, bool checkOpen = false)
+        {
+            var ns = pm.NetState;
+            List<BaseGump> list = new List<BaseGump>();
+
+            if (ns == null)
+                return list;
+
+            foreach (BaseGump gump in ns.Gumps.OfType<BaseGump>().Where(g => (!checkOpen || g.Open)))
+            {
+                list.Add(gump);
+            }
+
+            return list;
+        }
+
+        public static void CheckCloseGumps(PlayerMobile pm, bool checkOpen = false)
+        {
+            var ns = pm.NetState;
+
+            if (ns != null)
+            {
+                var gumps = GetGumps(pm, checkOpen);
+
+                foreach (BaseGump gump in gumps.Where(g => g.CloseOnMapChange))
+                {
+                    pm.CloseGump(gump.GetType());
+                }
+
+                ColUtility.Free(gumps);
+            }
         }
 
         #region Formatting

--- a/Scripts/Gumps/ConfirmCallbackGump.cs
+++ b/Scripts/Gumps/ConfirmCallbackGump.cs
@@ -89,8 +89,8 @@ namespace Server.Gumps
 			AddRadio( 25, 175, 0x25F8, 0x25FB, true, 1);
 			AddRadio( 25, 210, 0x25F8, 0x25FB, false, 2);
 
-            AddHtmlLocalized(60, 180, 280, 20, ConfirmLocalization, 0xFFFFFF, false, false);
-            AddHtmlLocalized(60, 215, 280, 20, CloseLocalization, 0xFFFFFF, false, false);
+            AddHtmlLocalized(60, 180, 280, 20, ConfirmLocalization, 0xFFFFFF, false, false); // Yes
+            AddHtmlLocalized(60, 215, 280, 20, CloseLocalization, 0xFFFFFF, false, false);   // No
 
             AddButton(265, 220, 0xF7, 0xF8, 1, GumpButtonType.Reply, 0);
 		}
@@ -113,4 +113,112 @@ namespace Server.Gumps
             }
         }
 	}
+
+    public class GenericConfirmCallbackGump<T> : BaseGump
+    {
+        public Action<Mobile, T> ConfirmCallback { get; set; }
+        public Action<Mobile, T> CloseCallback { get; set; }
+
+        public object Title { get; set; }
+        public object Body { get; set; }
+        public T State { get; set; }
+        public string Arguments { get; set; }
+
+        public int ConfirmLocalization { get; private set; }
+        public int CloseLocalization { get; private set; }
+
+        public GenericConfirmCallbackGump(
+            PlayerMobile user,
+            object title,
+            object body,
+            T state,
+            string args = null,
+            Action<Mobile, T> confirm = null,
+            Action<Mobile, T> close = null,
+            int x = 20,
+            int y = 20,
+            int confirmLoc = 1074976,
+            int closeLoc = 1074977)
+            : base(user, x, y)
+        {
+            Title = title;
+            Body = body;
+            State = state;
+            Arguments = args;
+
+            ConfirmCallback = confirm;
+            CloseCallback = close;
+
+            ConfirmLocalization = confirmLoc;
+            CloseLocalization = closeLoc;
+
+            if (!Open)
+                AddGumpLayout();
+        }
+
+        public override void AddGumpLayout()
+        {
+            AddImageTiled(0, 0, 348, 262, 0xA8E);
+            AddAlphaRegion(0, 0, 348, 262);
+            AddImage(0, 15, 0x27A8);
+            AddImageTiled(0, 30, 17, 200, 0x27A7);
+            AddImage(0, 230, 0x27AA);
+            AddImage(15, 0, 0x280C);
+            AddImageTiled(30, 0, 300, 17, 0x280A);
+            AddImage(315, 0, 0x280E);
+            AddImage(15, 244, 0x280C);
+            AddImageTiled(30, 244, 300, 17, 0x280A);
+            AddImage(315, 244, 0x280E);
+            AddImage(330, 15, 0x27A8);
+            AddImageTiled(330, 30, 17, 200, 0x27A7);
+            AddImage(330, 230, 0x27AA);
+            AddImage(333, 2, 0x2716);
+            AddImage(333, 248, 0x2716);
+            AddImage(2, 248, 0x2716);
+            AddImage(2, 2, 0x2716);
+
+            if (Title is int)
+                AddHtmlLocalized(25, 25, 200, 20, (int)Title, 0x7D00, false, false);
+            else if (Title is string)
+                AddHtml(25, 25, 200, 20, String.Format("<basefont color=#FF0000>{0}", (string)Title), false, false);
+
+            AddImage(25, 45, 0xBBF);
+
+            if (Body is int)
+            {
+                if (Arguments != null)
+                    AddHtmlLocalized(25, 55, 300, 120, (int)Body, Arguments, 0xFFFFFF, false, false);
+                else
+                    AddHtmlLocalized(25, 55, 300, 120, (int)Body, 0xFFFFFF, false, false);
+            }
+            else if (Body is string)
+                AddHtml(25, 55, 300, 120, String.Format("<BASEFONT COLOR=#FFFFFF>{0}</BASEFONT>", (string)Body), false, false);
+
+            AddRadio(25, 175, 0x25F8, 0x25FB, true, 1);
+            AddRadio(25, 210, 0x25F8, 0x25FB, false, 2);
+
+            AddHtmlLocalized(60, 180, 280, 20, ConfirmLocalization, 0xFFFFFF, false, false); // Yes
+            AddHtmlLocalized(60, 215, 280, 20, CloseLocalization, 0xFFFFFF, false, false);   // No
+
+            AddButton(265, 220, 0xF7, 0xF8, 1, GumpButtonType.Reply, 0);
+        }
+
+        public override void OnResponse(RelayInfo info)
+        {
+            if (info.ButtonID != 1)
+                return;
+
+            bool confirm = info.IsSwitched(1);
+
+            if (confirm)
+            {
+                if (ConfirmCallback != null)
+                    ConfirmCallback(User, State);
+            }
+            else if (CloseCallback != null)
+            {
+                CloseCallback(User, State);
+            }
+        }
+    }
 }

--- a/Scripts/Items/Containers/ParagonChest.cs
+++ b/Scripts/Items/Containers/ParagonChest.cs
@@ -19,9 +19,9 @@ namespace Server.Items
         public ParagonChest(string name, int level)
             : base(Utility.RandomList(m_ItemIDs))
         {
-            this.m_Name = name;
-            this.Hue = Utility.RandomList(m_Hues);
-            this.Fill(level);
+            m_Name = name;
+            Hue = Utility.RandomList(m_Hues);
+            Fill(level);
         }
 
         public ParagonChest(Serial serial)
@@ -31,31 +31,31 @@ namespace Server.Items
 
         public override void OnSingleClick(Mobile from)
         {
-            this.LabelTo(from, 1063449, this.m_Name);
+            LabelTo(from, 1063449, m_Name);
         }
 
         public override void GetProperties(ObjectPropertyList list)
         {
             base.GetProperties(list);
 
-            list.Add(1063449, this.m_Name);
+            list.Add(1063449, m_Name);
         }
 
         public void Flip()
         {
-            switch ( this.ItemID )
+            switch ( ItemID )
             {
                 case 0x9AB :
-                    this.ItemID = 0xE7C;
+                    ItemID = 0xE7C;
                     break;
                 case 0xE7C :
-                    this.ItemID = 0x9AB;
+                    ItemID = 0x9AB;
                     break;
                 case 0xE40 :
-                    this.ItemID = 0xE41;
+                    ItemID = 0xE41;
                     break;
                 case 0xE41 :
-                    this.ItemID = 0xE40;
+                    ItemID = 0xE40;
                     break;
             }
         }
@@ -66,7 +66,7 @@ namespace Server.Items
 
             writer.Write((int)0); // version
 
-            writer.Write(this.m_Name);
+            writer.Write(m_Name);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -75,7 +75,7 @@ namespace Server.Items
 
             int version = reader.ReadInt();
 
-            this.m_Name = Utility.Intern(reader.ReadString());
+            m_Name = Utility.Intern(reader.ReadString());
         }
 
         private static void GetRandomAOSStats(out int attributeCount, out int min, out int max)
@@ -116,40 +116,40 @@ namespace Server.Items
 
         private void Fill(int level)
         {
-            this.TrapType = TrapType.ExplosionTrap;
-            this.TrapPower = level * 25;
-            this.TrapLevel = level;
-            this.Locked = true;
+            TrapType = TrapType.ExplosionTrap;
+            TrapPower = level * 25;
+            TrapLevel = level;
+            Locked = true;
 
             switch ( level )
             {
                 case 1:
-                    this.RequiredSkill = 36;
+                    RequiredSkill = 36;
                     break;
                 case 2:
-                    this.RequiredSkill = 76;
+                    RequiredSkill = 76;
                     break;
                 case 3:
-                    this.RequiredSkill = 84;
+                    RequiredSkill = 84;
                     break;
                 case 4:
-                    this.RequiredSkill = 92;
+                    RequiredSkill = 92;
                     break;
                 case 5:
-                    this.RequiredSkill = 100;
+                    RequiredSkill = 100;
                     break;
                 case 6:
-                    this.RequiredSkill = 100;
+                    RequiredSkill = 100;
                     break;
             }
 
-            this.LockLevel = this.RequiredSkill - 10;
-            this.MaxLockLevel = this.RequiredSkill + 40;
+            LockLevel = RequiredSkill - 10;
+            MaxLockLevel = RequiredSkill + 40;
 
-            this.DropItem(new Gold(level * 200));
+            DropItem(new Gold(level * 200));
 
             for (int i = 0; i < level; ++i)
-                this.DropItem(Loot.RandomScroll(0, 63, SpellbookType.Regular));
+                DropItem(Loot.RandomScroll(0, 63, SpellbookType.Regular));
 
             for (int i = 0; i < level * 2; ++i)
             {
@@ -191,7 +191,7 @@ namespace Server.Items
                         weapon.DurabilityLevel = (WeaponDurabilityLevel)Utility.Random(6);
                     }
 
-                    this.DropItem(item);
+                    DropItem(item);
                 }
                 else if (item is BaseArmor)
                 {
@@ -212,7 +212,7 @@ namespace Server.Items
                         armor.Durability = (ArmorDurabilityLevel)Utility.Random(6);
                     }
 
-                    this.DropItem(item);
+                    DropItem(item);
                 }
                 else if (item is BaseHat)
                 {
@@ -228,7 +228,7 @@ namespace Server.Items
                         BaseRunicTool.ApplyAttributesTo(hat, attributeCount, min, max);
                     }
 
-                    this.DropItem(item);
+                    DropItem(item);
                 }
                 else if (item is BaseJewel)
                 {
@@ -239,7 +239,7 @@ namespace Server.Items
 
                     BaseRunicTool.ApplyAttributesTo((BaseJewel)item, attributeCount, min, max);
 
-                    this.DropItem(item);
+                    DropItem(item);
                 }
             }
 
@@ -247,16 +247,16 @@ namespace Server.Items
             {
                 Item item = Loot.RandomPossibleReagent();
                 item.Amount = Utility.RandomMinMax(40, 60);
-                this.DropItem(item);
+                DropItem(item);
             }
 
             for (int i = 0; i < level; i++)
             {
                 Item item = Loot.RandomGem();
-                this.DropItem(item);
+                DropItem(item);
             }
 
-            this.DropItem(new TreasureMap(level + 1, (Utility.RandomBool() ? Map.Felucca : Map.Trammel)));
+            DropItem(new TreasureMap(level + 1, (Siege.SiegeShard ?  Map.Felucca : Utility.RandomBool() ? Map.Felucca : Map.Trammel)));
         }
     }
 }

--- a/Scripts/Items/Containers/TrashChest.cs
+++ b/Scripts/Items/Containers/TrashChest.cs
@@ -105,7 +105,13 @@ namespace Server.Items
                         continue;
 
                     ConfirmCleanupItem(items[i]);
-                    items[i].Delete();
+
+                    #region SA
+                    if (.01 > Utility.RandomDouble())
+                        TrashBarrel.DropToCavernOfDiscarded(items[i]);
+                    else
+                        items[i].Delete();
+                    #endregion
                 }
 
                 if (this.m_Cleanup.Any(x => x.mobiles != null))

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -2063,9 +2063,37 @@ namespace Server.Items
 			return 0;
 		}
 
-		private static bool m_InDoubleStrike;
-		public static bool InDoubleStrike { get { return m_InDoubleStrike; } set { m_InDoubleStrike = value; } }
+		private bool m_InDoubleStrike;
+        private bool m_ProcessingMultipleHits;
 
+		public bool InDoubleStrike 
+        {
+            get { return m_InDoubleStrike; }
+            set
+            { 
+                m_InDoubleStrike = value;
+
+                if (m_InDoubleStrike)
+                    ProcessingMultipleHits = true;
+                else
+                    ProcessingMultipleHits = false;
+            } 
+        }
+
+        public bool ProcessingMultipleHits
+        {
+            get { return m_ProcessingMultipleHits; }
+            set
+            {
+                m_ProcessingMultipleHits = value;
+
+                if (!m_ProcessingMultipleHits)
+                    BlockHitEffects = false;
+            }
+        }
+
+        public bool EndDualWield { get; set; }
+        public bool BlockHitEffects { get; set; }
         public DateTime NextSelfRepair { get; set; }
 
 		public void OnHit(Mobile attacker, IDamageable damageable)
@@ -2075,6 +2103,12 @@ namespace Server.Items
 
         public virtual void OnHit(Mobile attacker, IDamageable damageable, double damageBonus)
 		{
+            if (EndDualWield)
+            {
+                ProcessingMultipleHits = false;
+                EndDualWield = false;
+            }
+
             Mobile defender = damageable as Mobile;
             Clone clone = null;
 
@@ -2712,7 +2746,7 @@ namespace Server.Items
 				}
 			}
 
-			if (Core.AOS)
+			if (Core.AOS && !BlockHitEffects)
 			{
 				int physChance = (int)(AosWeaponAttributes.GetValue(attacker, AosWeaponAttribute.HitPhysicalArea) * propertyBonus);
 				int fireChance = (int)(AosWeaponAttributes.GetValue(attacker, AosWeaponAttribute.HitFireArea) * propertyBonus);
@@ -2951,6 +2985,9 @@ namespace Server.Items
 			attacker.PlaySound(0x1E5);
 
 			SpellHelper.Damage(TimeSpan.FromSeconds(1.0), defender, attacker, damage, 0, 100, 0, 0, 0);
+
+            if (ProcessingMultipleHits)
+                BlockHitEffects = true;
 		}
 
 		public virtual void DoHarm(Mobile attacker, Mobile defender)
@@ -2977,6 +3014,9 @@ namespace Server.Items
 			defender.PlaySound(0x0FC);
 
 			SpellHelper.Damage(TimeSpan.Zero, defender, attacker, damage, 0, 0, 100, 0, 0);
+
+            if (ProcessingMultipleHits)
+                BlockHitEffects = true;
 		}
 
 		public virtual void DoFireball(Mobile attacker, Mobile defender)
@@ -2994,6 +3034,9 @@ namespace Server.Items
 			attacker.PlaySound(0x15E);
 
 			SpellHelper.Damage(TimeSpan.FromSeconds(1.0), defender, attacker, damage, 0, 100, 0, 0, 0);
+
+            if (ProcessingMultipleHits)
+                BlockHitEffects = true;
 		}
 
 		public virtual void DoLightning(Mobile attacker, Mobile defender)
@@ -3010,6 +3053,9 @@ namespace Server.Items
 			defender.BoltEffect(0);
 
 			SpellHelper.Damage(TimeSpan.Zero, defender, attacker, damage, 0, 0, 0, 0, 100);
+
+            if (ProcessingMultipleHits)
+                BlockHitEffects = true;
 		}
 
 		public virtual void DoDispel(Mobile attacker, Mobile defender)
@@ -3071,6 +3117,9 @@ namespace Server.Items
 
             Server.Spells.Fourth.CurseSpell.AddEffect(defender, duration, 10, 10, 10);
             BuffInfo.AddBuff(defender, new BuffInfo(BuffIcon.Curse, 1075835, 1075836, duration, defender, args));
+
+            if (ProcessingMultipleHits)
+                BlockHitEffects = true;
 		}
 
 		public virtual void DoFatigue(Mobile attacker, Mobile defender, int damagegiven)
@@ -3078,6 +3127,9 @@ namespace Server.Items
 			// Message?
 			// Effects?
 			defender.Stam -= (damagegiven * (100 - m_AosWeaponAttributes.HitFatigue)) / 100;
+
+            if (ProcessingMultipleHits)
+                BlockHitEffects = true;
 		}
 
 		public virtual void DoManaDrain(Mobile attacker, Mobile defender, int damagegiven)
@@ -3086,6 +3138,9 @@ namespace Server.Items
 			defender.FixedParticles(0x3789, 10, 25, 5032, EffectLayer.Head);
 			defender.PlaySound(0x1F8);
 			defender.Mana -= (damagegiven * (100 - m_AosWeaponAttributes.HitManaDrain)) / 100;
+
+            if (ProcessingMultipleHits)
+                BlockHitEffects = true;
 		}
 		#endregion
 
@@ -3140,6 +3195,9 @@ namespace Server.Items
                     AOS.Damage(m, from, (int)(damageGiven / 2), phys, fire, cold, pois, nrgy, Server.DamageType.SpellAOE);
                 }
             }
+
+            if (ProcessingMultipleHits)
+                BlockHitEffects = true;
 
             ColUtility.Free(list);
 		}

--- a/Scripts/Items/Functional/ChickenCoop.cs
+++ b/Scripts/Items/Functional/ChickenCoop.cs
@@ -498,7 +498,11 @@ namespace Server.Items
                     Mobile chicken = reader.ReadMobile();
 
                     if (chicken != null && chicken is BaseCreature)
-                        list.Add(chicken as BaseCreature);
+                    {
+                        var bc = chicken as BaseCreature;
+                        bc.IsStabled = true;
+                        list.Add(bc);
+                    }
                 }
 
                 if (owner != null && list.Count > 0)

--- a/Scripts/Items/Quest/TyballsShadow.cs
+++ b/Scripts/Items/Quest/TyballsShadow.cs
@@ -11,40 +11,40 @@ namespace Server.Mobiles
         public TyballsShadow()
             : base(AIType.AI_Mage, FightMode.Closest, 10, 1, 0.15, 0.4)
         {
-            this.Body = 0x190;
-            this.Hue = 0x4001;
-            this.Female = false;
-            this.Name = "Tyball's Shadow";
-           
-            this.AddItem(new Robe(2406));
-                                
-            this.SetStr(400, 450);
-            this.SetDex(210, 250);
-            this.SetInt(310, 330);
+            Body = 0x190;
+            Hue = 0x4001;
+            Female = false;
+            Name = "Tyball's Shadow";
+                            
+            SetStr(400, 450);
+            SetDex(210, 250);
+            SetInt(310, 330);
 
-            this.SetHits(2800, 3000);
+            SetHits(2800, 3000);
 
-            this.SetDamage(20, 25);
+            SetDamage(20, 25);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
-            this.SetDamageType(ResistanceType.Energy, 25);
-            this.SetDamageType(ResistanceType.Poison, 20);
-            this.SetDamageType(ResistanceType.Energy, 20);
+            SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Energy, 25);
+            SetDamageType(ResistanceType.Poison, 20);
+            SetDamageType(ResistanceType.Energy, 20);
 
-            this.SetResistance(ResistanceType.Physical, 70);
-            this.SetResistance(ResistanceType.Fire, 70);
-            this.SetResistance(ResistanceType.Cold, 70);
-            this.SetResistance(ResistanceType.Poison, 70);
-            this.SetResistance(ResistanceType.Energy, 70);
+            SetResistance(ResistanceType.Physical, 70);
+            SetResistance(ResistanceType.Fire, 70);
+            SetResistance(ResistanceType.Cold, 70);
+            SetResistance(ResistanceType.Poison, 70);
+            SetResistance(ResistanceType.Energy, 70);
 
-            this.SetSkill(SkillName.Magery, 100.0);
-            this.SetSkill(SkillName.MagicResist, 120.0);
-            this.SetSkill(SkillName.Tactics, 100.0);
-            this.SetSkill(SkillName.Wrestling, 100.0);
+            SetSkill(SkillName.Magery, 100.0);
+            SetSkill(SkillName.MagicResist, 120.0);
+            SetSkill(SkillName.Tactics, 100.0);
+            SetSkill(SkillName.Wrestling, 100.0);
 
-            this.Fame = 20000; 
-            this.Karma = -20000;
-            this.VirtualArmor = 65;
+            SetWearable(new ShroudOfTheCondemned(), -1, 0.1);
+
+            Fame = 20000; 
+            Karma = -20000;
+            VirtualArmor = 65;
         }
 
         public TyballsShadow(Serial serial)
@@ -82,12 +82,12 @@ namespace Server.Mobiles
         }
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.FilthyRich, 3);
+            AddLoot(LootPack.FilthyRich, 3);
         }
 
         public override void OnDeath(Container c)
         {
-            if (this.Map == Map.TerMur)
+            if (Map == Map.TerMur)
             {
                 List<DamageStore> rights = GetLootingRights();
                 List<Mobile> toGive = new List<Mobile>();
@@ -101,12 +101,6 @@ namespace Server.Mobiles
 
                 if (toGive.Count > 0)
                     toGive[Utility.Random(toGive.Count)].AddToBackpack(new YellowKey1());
-
-                /*else
-                c.DropItem(new YellowKey1());*/
-
-                if (Utility.RandomDouble() < 0.10)
-                    c.DropItem(new ShroudOfTheCondemned());
             }
             base.OnDeath(c);
         }

--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -3044,10 +3044,6 @@ namespace Server.Mobiles
 			m_Timer.Start();
 		}
 
-		private long m_NextDetectHidden;
-
-		public virtual bool CanDetectHidden { get { return m_Mobile.Skills[SkillName.DetectHidden].Value > 0; } }
-
         public virtual void AfterThink()
         {
         }
@@ -3065,8 +3061,6 @@ namespace Server.Mobiles
 					TimeSpan.FromSeconds(Utility.RandomDouble()), TimeSpan.FromSeconds(Math.Max(0.0, owner.m_Mobile.CurrentSpeed)))
 			{
 				m_Owner = owner;
-
-				m_Owner.m_NextDetectHidden = Core.TickCount;
 
 				Priority = TimerPriority.FiftyMS;
 			}

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -32,6 +32,7 @@ using Server.Targeting;
 using System.Linq;
 using Server.Spells.SkillMasteries;
 using Server.Prompts;
+using Server.Engines.VvV;
 #endregion
 
 namespace Server.Mobiles
@@ -1002,7 +1003,8 @@ namespace Server.Mobiles
         {
             List<Mobile> list = new List<Mobile>();
 
-            foreach (Mobile m in this.GetMobilesInRange(2))
+            IPooledEnumerable eable = GetMobilesInRange(2);
+            foreach (Mobile m in eable)
             {
                 if (m == this || !CanBeHarmful(m))
                     continue;
@@ -1012,6 +1014,8 @@ namespace Server.Mobiles
                 else if (m.Player)
                     list.Add(m);
             }
+
+            eable.Free();
 
             foreach (Mobile m in list)
             {
@@ -1036,6 +1040,8 @@ namespace Server.Mobiles
                 Hits += toDrain;
                 m.Damage(toDrain, this);
             }
+
+            ColUtility.Free(list);
         }
         #endregion
 
@@ -3725,7 +3731,8 @@ namespace Server.Mobiles
         {
             int iCount = 0;
 
-            foreach (Mobile m in GetMobilesInRange(iRange))
+            IPooledEnumerable eable = GetMobilesInRange(iRange);
+            foreach (Mobile m in eable)
             {
                 if (m is BaseCreature)
                 {
@@ -3744,6 +3751,8 @@ namespace Server.Mobiles
                     }
                 }
             }
+
+            eable.Free();
 
             return iCount;
         }
@@ -4281,6 +4290,21 @@ namespace Server.Mobiles
             if (master != null)
             {
                 target.OnHarmfulAction(master, target.IsHarmfulCriminal(master));
+            }
+
+            if (ViceVsVirtueSystem.Enabled && Map == Faction.Facet)
+            {
+                ViceVsVirtueSystem.CheckHarmful(this, target);
+            }
+        }
+
+        public override void DoBeneficial(Mobile target)
+        {
+            base.DoBeneficial(target);
+
+            if (ViceVsVirtueSystem.Enabled && Map == Faction.Facet && target != null)
+            {
+                ViceVsVirtueSystem.CheckBeneficial(this, target);
             }
         }
 
@@ -6448,20 +6472,15 @@ namespace Server.Mobiles
 
             if (Map != null)
             {
-                foreach (Mobile m in GetMobilesInRange(AreaDamageRange))
+                IPooledEnumerable eable = GetMobilesInRange(AreaDamageRange);
+                foreach (Mobile m in eable)
                 {
-                    if (this != m && SpellHelper.ValidIndirectTarget(this, m) && CanBeHarmful(m, false) && (!Core.AOS || InLOS(m)))
+                    if (m != this && SpellHelper.ValidIndirectTarget(this, m) && CanBeHarmful(m, false) && (!Core.AOS || InLOS(m)))
                     {
-                        if (m is BaseCreature && ((BaseCreature)m).Controlled)
-                        {
-                            targets.Add(m);
-                        }
-                        else if (m.Player)
-                        {
-                            targets.Add(m);
-                        }
+                        targets.Add(m);
                     }
                 }
+                eable.Free();
             }
 
             for (int i = 0; i < targets.Count; ++i)
@@ -6475,6 +6494,7 @@ namespace Server.Mobiles
                 Effects.PlaySound(m.Location, m.Map, 0x229);
             }
 
+            ColUtility.Free(targets);
             m_NextAreaPoison = DateTime.UtcNow + AreaPoisonDelay;
         }
         #endregion
@@ -6500,20 +6520,15 @@ namespace Server.Mobiles
 
             if (Map != null)
             {
-                foreach (Mobile m in GetMobilesInRange(AreaDamageRange))
+                IPooledEnumerable eable = GetMobilesInRange(AreaDamageRange);
+                foreach (Mobile m in eable)
                 {
                     if (this != m && SpellHelper.ValidIndirectTarget(this, m) && CanBeHarmful(m, false) && (!Core.AOS || InLOS(m)))
                     {
-                        if (m is BaseCreature && ((BaseCreature)m).Controlled)
-                        {
-                            targets.Add(m);
-                        }
-                        else if (m.Player)
-                        {
-                            targets.Add(m);
-                        }
+                        targets.Add(m);
                     }
                 }
+                eable.Free();
             }
 
             for (int i = 0; i < targets.Count; ++i)
@@ -6563,6 +6578,7 @@ namespace Server.Mobiles
                     AreaEnergyDamage);
             }
 
+            ColUtility.Free(targets);
             m_NextAreaDamage = DateTime.UtcNow + AreaDamageDelay;
         }
 
@@ -6748,27 +6764,17 @@ namespace Server.Mobiles
 
             var list = new List<Mobile>();
 
-            foreach (Mobile m in GetMobilesInRange(AuraRange))
+            IPooledEnumerable eable = GetMobilesInRange(AuraRange);
+
+            foreach (Mobile m in eable)
             {
-                if (m == this || !CanBeHarmful(m, false) || (Core.AOS && !InLOS(m)))
-                {
-                    continue;
-                }
-
-                if (m is BaseCreature)
-                {
-                    BaseCreature bc = (BaseCreature)m;
-
-                    if (bc.Controlled || bc.Summoned || bc.Team != Team)
-                    {
-                        list.Add(m);
-                    }
-                }
-                else if (m.Player && m.AccessLevel == AccessLevel.Player)
+                if (m != this && SpellHelper.ValidIndirectTarget(this, m) && CanBeHarmful(m, false) && (!Core.AOS || InLOS(m)))
                 {
                     list.Add(m);
                 }
             }
+
+            eable.Free();
 
             foreach (Mobile m in list)
             {
@@ -6790,6 +6796,8 @@ namespace Server.Mobiles
                 m.RevealingAction();
                 AuraEffect(m);
             }
+
+            ColUtility.Free(list);
         }
 
         public virtual void AuraEffect(Mobile m)
@@ -7062,8 +7070,7 @@ namespace Server.Mobiles
             if (possibles.Count > 0)
                 t = possibles[Utility.Random(possibles.Count)];
 
-            possibles.Clear();
-            possibles.TrimExcess();
+            ColUtility.Free(possibles);
 
             return t;
         }
@@ -7166,11 +7173,12 @@ namespace Server.Mobiles
             if (list.Count > 0)
                 mob = list[Utility.Random(list.Count)];
 
-            list.Clear();
+            ColUtility.Free(list);
             return mob;
         }
         #endregion
 
+        #region Detect Hidden
         private long m_NextFindPlayer;
 
         public virtual bool CanDetectHidden { get { return Skills[SkillName.DetectHidden].Value > 0; } }
@@ -7228,6 +7236,7 @@ namespace Server.Mobiles
 
             eable.Free();
         }
+        #endregion
 
         public virtual void OnThink()
         {
@@ -7548,7 +7557,8 @@ namespace Server.Mobiles
         {
             var move = new List<Mobile>();
 
-            foreach (Mobile m in master.GetMobilesInRange(3))
+            IPooledEnumerable eable = master.GetMobilesInRange(3);
+            foreach (Mobile m in eable)
             {
                 if (m is BaseCreature)
                 {
@@ -7568,10 +7578,14 @@ namespace Server.Mobiles
                 }
             }
 
+            eable.Free();
+
             foreach (Mobile m in move)
             {
                 m.MoveToWorld(loc, map);
             }
+
+            ColUtility.Free(move);
         }
 
         public virtual void ResurrectPet()

--- a/Scripts/Mobiles/Normal/DarkGuardian.cs
+++ b/Scripts/Mobiles/Normal/DarkGuardian.cs
@@ -46,7 +46,6 @@ namespace Server.Mobiles
 
             VirtualArmor = 50;
             PackNecroReg(15, 25);
-            PackItem(new DaemonBone(30));
         }
 
         public DarkGuardian(Serial serial)

--- a/Scripts/Mobiles/Normal/DespiseGoodCreatures.cs
+++ b/Scripts/Mobiles/Normal/DespiseGoodCreatures.cs
@@ -204,6 +204,8 @@ namespace Server.Engines.Despise
             AddItem(new Bow());
             PackItem(new Arrow(Utility.RandomMinMax(5, 10)));
             Power = powerLevel;
+
+            RangeFight = 8;
         }
 
         protected override BaseAI ForcedAI { get { return new DespiseMeleeAI(this); } }

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -45,6 +45,7 @@ using Server.Targeting;
 using System.Linq;
 using Server.Engines.VoidPool;
 using Server.Spells.SkillMasteries;
+using Server.Engines.VvV;
 
 using RankDefinition = Server.Guilds.RankDefinition;
 #endregion
@@ -1672,6 +1673,27 @@ namespace Server.Mobiles
 			}
 		}
 
+        public override void DoHarmful(IDamageable damageable, bool indirect)
+        {
+            base.DoHarmful(damageable, indirect);
+
+            if (ViceVsVirtueSystem.Enabled && Map == Faction.Facet && damageable is Mobile)
+            {
+                ViceVsVirtueSystem.CheckHarmful(this, (Mobile)damageable);
+            }
+        }
+
+        public override void DoBeneficial(Mobile target)
+        {
+            Console.WriteLine("Doing BENE");
+            base.DoBeneficial(target);
+
+            if (ViceVsVirtueSystem.Enabled && Map == Faction.Facet && target != null)
+            {
+                ViceVsVirtueSystem.CheckBeneficial(this, target);
+            }
+        }
+
 		public override bool CanBeHarmful(IDamageable damageable, bool message, bool ignoreOurBlessedness)
 		{
             Mobile target = damageable as Mobile;
@@ -3120,7 +3142,7 @@ namespace Server.Mobiles
 
 		private static int CheckContentForTrade(Item item)
 		{
-			if (item is TrapableContainer && ((TrapableContainer)item).TrapType != TrapType.None)
+			if (item is TrapableContainer && ((TrapableContainer)item).TrapType != Server.Items.TrapType.None)
 			{
 				return 1004044; // You may not trade trapped items.
 			}
@@ -3273,6 +3295,8 @@ namespace Server.Mobiles
 			{
 				InvalidateProperties();
 			}
+
+            BaseGump.CheckCloseGumps(this);
 
 			#region Dueling
 			if (m_DuelContext != null)

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -1685,7 +1685,6 @@ namespace Server.Mobiles
 
         public override void DoBeneficial(Mobile target)
         {
-            Console.WriteLine("Doing BENE");
             base.DoBeneficial(target);
 
             if (ViceVsVirtueSystem.Enabled && Map == Faction.Facet && target != null)

--- a/Scripts/Quests/TheSummoning/TheSummoningQuest.cs
+++ b/Scripts/Quests/TheSummoning/TheSummoningQuest.cs
@@ -116,6 +116,9 @@ namespace Server.Engines.Quests.Doom
             if (creature == null || creature.Controlled || creature.Summoned)
                 return 0;
 
+            if (creature is DarkGuardian)
+                return 30;
+
             int fame = creature.Fame;
 
             if (fame < 1500)

--- a/Scripts/Services/BasketWeaving/NaturalDye.cs
+++ b/Scripts/Services/BasketWeaving/NaturalDye.cs
@@ -149,7 +149,7 @@ namespace Server.Items
                                   item is BaseBook || item is BaseClothing ||
                                   item is BaseJewel || item is BaseStatuette ||
                                   item is BaseWeapon || item is Runebook ||
-                                  item is Spellbook);
+                                  item is Spellbook || item.IsArtifact || BasePigmentsOfTokuno.IsValidItem(item));
 
                     if (!valid && item is BaseArmor)
                     {

--- a/Scripts/Services/Doom/GuardianRoom.cs
+++ b/Scripts/Services/Doom/GuardianRoom.cs
@@ -126,7 +126,7 @@ namespace Server.Engines.Doom
                     count++;
             }
 
-            count = Math.Min(1, count * 2);
+            count = Math.Max(1, count * 2);
 
 			for(int i = 0; i < count; i++)
 			{

--- a/Scripts/Services/Harvest/HarvestSystem.cs
+++ b/Scripts/Services/Harvest/HarvestSystem.cs
@@ -226,7 +226,7 @@ namespace Server.Engines.Harvest
 								}
 								else
 								{
-									item.Delete();
+                                    bonusItem.Delete();
 								}
 							}
                         }
@@ -316,7 +316,7 @@ namespace Server.Engines.Harvest
 
             Map map = m.Map;
 
-            if (map == null)
+            if (map == null || map == Map.Internal)
                 return false;
 
             List<Item> atFeet = new List<Item>();

--- a/Scripts/Services/PVP Arena System/ArenaDuel.cs
+++ b/Scripts/Services/PVP Arena System/ArenaDuel.cs
@@ -6,6 +6,7 @@ using Server.Mobiles;
 using System.Linq;
 using Server.Network;
 using Server.Gumps;
+using Server.Spells;
 
 namespace Server.Engines.ArenaSystem
 {
@@ -377,6 +378,13 @@ namespace Server.Engines.ArenaSystem
 
             BaseCreature.TeleportPets(pm, p, map);
             pm.MoveToWorld(p, Arena.Definition.Map);
+
+            if (pm.Spell is Spell)
+            {
+                ((Spell)pm.Spell).Disturb(DisturbType.Hurt);
+            }
+
+            Server.Targeting.Target.Cancel(pm);
 
             bool allin = true;
 

--- a/Scripts/Services/PVP Arena System/Gumps.cs
+++ b/Scripts/Services/PVP Arena System/Gumps.cs
@@ -14,6 +14,8 @@ namespace Server.Engines.ArenaSystem
 
         public PVPArena Arena { get; private set; }
 
+        public override bool CloseOnMapChange { get { return true; } }
+
         public BaseArenaGump(PlayerMobile pm, PVPArena arena)
             : base(pm, 30, 30)
         {
@@ -143,6 +145,11 @@ namespace Server.Engines.ArenaSystem
 
         public override void OnResponse(RelayInfo info)
         {
+            if (Arena.Stone != null && !User.InRange(Arena.Stone.Location, 15))
+            {
+                return;
+            }
+
             switch (info.ButtonID)
             {
                 case 1: // host

--- a/Scripts/Services/PVP Arena System/Region.cs
+++ b/Scripts/Services/PVP Arena System/Region.cs
@@ -59,6 +59,11 @@ namespace Server.Engines.ArenaSystem
                 return false;
             }
 
+            if (o is BraceletOfBinding)
+            {
+                return false;
+            }
+
             return base.OnDoubleClick(m, o);
         }
 

--- a/Scripts/Services/Underworld/Maze of Death/GoldenCompass.cs
+++ b/Scripts/Services/Underworld/Maze of Death/GoldenCompass.cs
@@ -76,6 +76,11 @@ namespace Server.Items
 			base.Deserialize(reader);
 			int v = reader.ReadInt();
 			m_Span = reader.ReadInt();
+
+            if(m_Span > 0)
+            {
+                StartTimer();
+            }
 		}
 	}
 }

--- a/Scripts/Services/Underworld/Maze of Death/Region.cs
+++ b/Scripts/Services/Underworld/Maze of Death/Region.cs
@@ -240,14 +240,19 @@ namespace Server.Regions
 			if(m.Backpack == null)
 				return;
 
-            m.SendLocalizedMessage(1113580); // You are filled with a sense of dread and impending doom!
-			
-			if(m.Backpack.FindItemByType(typeof(GoldenCompass)) != null)
-			{
-				m.CloseGump(typeof(CompassDirectionGump));
-				m.SendGump(new CompassDirectionGump(m));
-			}
-			
+            if (m.NetState != null)
+            {
+                m.Paralyze(TimeSpan.FromSeconds(2));
+                m.PrivateOverheadMessage(Server.Network.MessageType.Regular, 33, 1113580, m.NetState); // You are filled with a sense of dread and impending doom!
+                m.PrivateOverheadMessage(Server.Network.MessageType.Regular, 0x3B2, 1113581, m.NetState); // I might need something to help me navigate through this.
+
+                if (m.Backpack.FindItemByType(typeof(GoldenCompass)) != null)
+                {
+                    m.CloseGump(typeof(CompassDirectionGump));
+                    m.SendGump(new CompassDirectionGump(m));
+                }
+            }
+
 			base.OnEnter(m);
 		}
 		

--- a/Scripts/Services/VeteranRewards/CrystalPortals/CorruptedCrystalPortal.cs
+++ b/Scripts/Services/VeteranRewards/CrystalPortals/CorruptedCrystalPortal.cs
@@ -170,7 +170,7 @@ namespace Server.Items
 
 			ResolveDest(e.Mobile, e.Speech.Trim(), ref loc, ref map);
 
-			if (loc == Point3D.Zero || map == null || map == Map.Internal)
+            if (loc == Point3D.Zero || map == null || map == Map.Internal || (Siege.SiegeShard && map == Map.Trammel))
 			{
 				return;
 			}

--- a/Scripts/Services/VeteranRewards/CrystalPortals/CrystalPortal.cs
+++ b/Scripts/Services/VeteranRewards/CrystalPortals/CrystalPortal.cs
@@ -169,7 +169,7 @@ namespace Server.Items
 
 			ResolveDest(e.Speech.Trim(), ref loc, ref map);
 
-			if (loc == Point3D.Zero || map == null || map == Map.Internal)
+			if (loc == Point3D.Zero || map == null || map == Map.Internal || (Siege.SiegeShard && map == Map.Trammel))
 			{
 				return;
 			}

--- a/Scripts/Services/ViceVsVirtue/Gumps/BattleWarningGump.cs
+++ b/Scripts/Services/ViceVsVirtue/Gumps/BattleWarningGump.cs
@@ -12,6 +12,7 @@ namespace Server.Engines.VvV
     public class BattleWarningGump : Gump
     {
         public PlayerMobile User { get; set; }
+        public Timer Timer { get; set; }
 
         public BattleWarningGump(PlayerMobile pm)
             : base(50, 50)
@@ -25,10 +26,22 @@ namespace Server.Engines.VvV
 
             AddButton(463, 168, 4005, 4007, 1, GumpButtonType.Reply, 0);
             AddHtmlLocalized(250, 171, 250, 20, 1155647, 0xFFFF, false, false); // Teleport to nearest Moongate?
+
+            Timer = Timer.DelayCall(TimeSpan.FromMinutes(1), () =>
+                {
+                    User.CloseGump(typeof(BattleWarningGump));
+                    ViceVsVirtueSystem.AddTempParticipant(User);
+                });
         }
 
         public override void OnResponse(NetState state, RelayInfo info)
         {
+            if (Timer != null)
+            {
+                Timer.Stop();
+                Timer = null;
+            }
+
             if (info.ButtonID == 1)
             {
                 PublicMoongate closestGate = null;
@@ -63,11 +76,13 @@ namespace Server.Engines.VvV
                 else
                 {
                     User.SendLocalizedMessage(1155584); // You are now open to attack!
+                    ViceVsVirtueSystem.AddTempParticipant(User);
                 }
             }
             else
             {
                 User.SendLocalizedMessage(1155584); // You are now open to attack!
+                ViceVsVirtueSystem.AddTempParticipant(User);
             }
         }
     }

--- a/Scripts/Services/ViceVsVirtue/VvVBattle.cs
+++ b/Scripts/Services/ViceVsVirtue/VvVBattle.cs
@@ -28,7 +28,7 @@ namespace Server.Engines.VvV
     [PropertyObject]
     public class VvVBattle
     {
-        public static readonly int Duration = 05;
+        public static readonly int Duration = 30;
         public static readonly int Cooldown = 5;
         public static readonly int Announcement = 2;
         public static readonly int KillCooldownDuration = 5;
@@ -357,8 +357,6 @@ namespace Server.Engines.VvV
                 }
             }
 
-            CooldownEnds = DateTime.UtcNow + TimeSpan.FromMinutes(Cooldown);
-
             foreach (VvVAltar altar in Altars)
             {
                 if(!altar.Deleted)
@@ -430,6 +428,8 @@ namespace Server.Engines.VvV
             NextAltarActivate = DateTime.MinValue;
             ManaSpikeEndEffects = DateTime.MinValue;
             NextManaSpike = DateTime.MinValue;
+
+            CooldownEnds = DateTime.UtcNow + TimeSpan.FromMinutes(Cooldown);
 
             Timer.DelayCall(TimeSpan.FromMinutes(Cooldown), () =>
                 {

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -1431,8 +1431,6 @@ namespace Server.Spells
 
                 if (realAmount > 0 && target != from && from is PlayerMobile && target is PlayerMobile)
                     SpiritualityVirtue.OnHeal(from, realAmount);
-
-                SpiritualityVirtue.OnHeal(from, realAmount);
             }
 
             target.Heal(amount, from, message);

--- a/Scripts/Spells/Fifth/PoisonField.cs
+++ b/Scripts/Spells/Fifth/PoisonField.cs
@@ -294,7 +294,7 @@ namespace Server.Spells.Fifth
         {
             private readonly PoisonFieldSpell m_Owner;
             public InternalTarget(PoisonFieldSpell owner)
-                : base(Core.ML ? 10 : 12, true, TargetFlags.None)
+                : base(Core.TOL ? 15 : Core.ML ? 10 : 12, true, TargetFlags.None)
             {
                 m_Owner = owner;
             }

--- a/Scripts/Spells/Fourth/FireField.cs
+++ b/Scripts/Spells/Fourth/FireField.cs
@@ -310,7 +310,7 @@ namespace Server.Spells.Fourth
         {
             private readonly FireFieldSpell m_Owner;
             public InternalTarget(FireFieldSpell owner)
-                : base(Core.ML ? 10 : 12, true, TargetFlags.None)
+                : base(Core.TOL ? 15 : Core.ML ? 10 : 12, true, TargetFlags.None)
             {
                 m_Owner = owner;
             }

--- a/Scripts/Spells/Ninjitsu/MirrorImage.cs
+++ b/Scripts/Spells/Ninjitsu/MirrorImage.cs
@@ -254,6 +254,9 @@ namespace Server.Mobiles
                 return new CloneAI(this);
             }
         }
+
+        public override bool CanDetectHidden { get { return false; } }
+
         public override bool IsHumanInTown()
         {
             return false;
@@ -323,13 +326,6 @@ namespace Server.Mobiles
             m.CurrentSpeed = m.ActiveSpeed;
         }
 
-        public override bool CanDetectHidden
-        {
-            get
-            {
-                return false;
-            }
-        }
         public override bool Think()
         {
             // Clones only follow their owners

--- a/Scripts/Spells/Seventh/EnergyField.cs
+++ b/Scripts/Spells/Seventh/EnergyField.cs
@@ -205,7 +205,7 @@ namespace Server.Spells.Seventh
             private readonly EnergyFieldSpell m_Owner;
 
             public InternalTarget(EnergyFieldSpell owner)
-                : base(Core.ML ? 10 : 12, true, TargetFlags.None)
+                : base(Core.TOL ? 15 : Core.ML ? 10 : 12, true, TargetFlags.None)
             {
                 m_Owner = owner;
             }

--- a/Scripts/Spells/Sixth/ParalyzeField.cs
+++ b/Scripts/Spells/Sixth/ParalyzeField.cs
@@ -231,7 +231,7 @@ namespace Server.Spells.Sixth
         {
             private readonly ParalyzeFieldSpell m_Owner;
             public InternalTarget(ParalyzeFieldSpell owner)
-                : base(Core.ML ? 10 : 12, true, TargetFlags.None)
+                : base(Core.TOL ? 15 : Core.ML ? 10 : 12, true, TargetFlags.None)
             {
                 m_Owner = owner;
             }

--- a/Scripts/Spells/Skill Masteries/ManaShield.cs
+++ b/Scripts/Spells/Skill Masteries/ManaShield.cs
@@ -19,6 +19,7 @@ namespace Server.Spells.SkillMasteries
         public override double UpKeep { get { return 0; } }
         public override int RequiredMana { get { return 40; } }
         public override bool PartyEffects { get { return false; } }
+        public override bool RevealOnTick { get { return true; } }
 
         public override SkillName CastSkill { get { return SkillName.Spellweaving; } }
         public override SkillName DamageSkill { get { return SkillName.Meditation; } }

--- a/Scripts/Spells/Skill Masteries/ManaShield.cs
+++ b/Scripts/Spells/Skill Masteries/ManaShield.cs
@@ -19,7 +19,7 @@ namespace Server.Spells.SkillMasteries
         public override double UpKeep { get { return 0; } }
         public override int RequiredMana { get { return 40; } }
         public override bool PartyEffects { get { return false; } }
-        public override bool RevealOnTick { get { return true; } }
+        public override bool RevealOnTick { get { return false; } }
 
         public override SkillName CastSkill { get { return SkillName.Spellweaving; } }
         public override SkillName DamageSkill { get { return SkillName.Meditation; } }

--- a/Scripts/Spells/Spellweaving/ArcaneCircle.cs
+++ b/Scripts/Spells/Spellweaving/ArcaneCircle.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using Server.Items;
 using Server.Mobiles;
+using Server.Spells.SkillMasteries;
+using System.Linq;
 
 namespace Server.Spells.Spellweaving
 {
@@ -44,15 +46,15 @@ namespace Server.Spells.Spellweaving
 
         public override bool CheckCast()
         {
-            if (!IsValidLocation(this.Caster.Location, this.Caster.Map))
+            if (!IsValidLocation(Caster.Location, Caster.Map))
             {
-                this.Caster.SendLocalizedMessage(1072705); // You must be standing on an arcane circle, pentagram or abbatoir to use this spell.
+                Caster.SendLocalizedMessage(1072705); // You must be standing on an arcane circle, pentagram or abbatoir to use this spell.
                 return false;
             }
 
-            if (this.GetArcanists().Count < 2)
+            if (GetArcanists().Count < 2)
             {
-                this.Caster.SendLocalizedMessage(1080452); //There are not enough spellweavers present to create an Arcane Focus.
+                Caster.SendLocalizedMessage(1080452); //There are not enough spellweavers present to create an Arcane Focus.
                 return false;
             }
 
@@ -61,24 +63,26 @@ namespace Server.Spells.Spellweaving
 
         public override void OnCast()
         {
-            if (this.CheckSequence())
+            if (CheckSequence())
             {
-                this.Caster.FixedParticles(0x3779, 10, 20, 0x0, EffectLayer.Waist);
-                this.Caster.PlaySound(0x5C0);
+                Caster.FixedParticles(0x3779, 10, 20, 0x0, EffectLayer.Waist);
+                Caster.PlaySound(0x5C0);
 
-                List<Mobile> Arcanists = this.GetArcanists();
+                List<Mobile> Arcanists = GetArcanists();
 
-                TimeSpan duration = TimeSpan.FromHours(Math.Max(1, (int)(this.Caster.Skills.Spellweaving.Value / 24)));
+                TimeSpan duration = TimeSpan.FromHours(Math.Max(1, (int)(Caster.Skills.Spellweaving.Value / 24)));
 
                 duration += TimeSpan.FromHours(Math.Min(5, Arcanists.Count));
 
-                int strengthBonus = Math.Min(Arcanists.Count, IsBonus(this.Caster.Location, this.Caster.Map) ? 6 : 5);	//The Sanctuary is a special, single location place
+                int strengthBonus = Math.Min(IsBonus(Caster.Location, Caster.Map) ? 6 : 5, Arcanists.Sum(m => GetStrength(m))); // Math.Min(Arcanists.Count, IsBonus(Caster.Location, Caster.Map) ? 6 : 5);	//The Sanctuary is a special, single location place
 
                 for (int i = 0; i < Arcanists.Count; i++)
-                    this.GiveArcaneFocus(Arcanists[i], duration, strengthBonus);
+                {
+                    GiveArcaneFocus(Arcanists[i], duration, strengthBonus);
+                }
             }
 
-            this.FinishSequence();
+            FinishSequence();
         }
 
         private static bool IsBonus(Point3D p, Map m)
@@ -87,6 +91,11 @@ namespace Server.Spells.Spellweaving
                 (p.X == 6267 && p.Y == 131) ||
                 (p.X == 6589 && p.Y == 178) ||
                 (p.X == 1431 && p.Y == 1696); // new brit bank
+        }
+
+        private static int GetStrength(Mobile m)
+        {
+            return Math.Max(1, MasteryInfo.GetMasteryLevel(m, SkillName.Spellweaving));
         }
 
         private static bool IsValidLocation(Point3D location, Map map)
@@ -134,12 +143,12 @@ namespace Server.Spells.Spellweaving
         {
             List<Mobile> weavers = new List<Mobile>();
 
-            weavers.Add(this.Caster);
+            weavers.Add(Caster);
 
             //OSI Verified: Even enemies/combatants count
-            foreach (Mobile m in this.Caster.GetMobilesInRange(1))	//Range verified as 1
+            foreach (Mobile m in Caster.GetMobilesInRange(1))	//Range verified as 1
             {
-                if (m != this.Caster && m is PlayerMobile && this.Caster.CanBeBeneficial(m, false) && Math.Abs(this.Caster.Skills.Spellweaving.Value - m.Skills.Spellweaving.Value) <= 20 && !(m is Clone))
+                if (m != Caster && m is PlayerMobile && Caster.CanBeBeneficial(m, false) && Math.Abs(Caster.Skills.Spellweaving.Value - m.Skills.Spellweaving.Value) <= 20 && !(m is Clone))
                 {
                     weavers.Add(m);
                 }

--- a/Scripts/Spells/Third/WallOfStone.cs
+++ b/Scripts/Spells/Third/WallOfStone.cs
@@ -205,7 +205,7 @@ namespace Server.Spells.Third
         {
             private readonly WallOfStoneSpell m_Owner;
             public InternalTarget(WallOfStoneSpell owner)
-                : base(Core.ML ? 10 : 12, true, TargetFlags.None)
+                : base(Core.TOL ? 15 : Core.ML ? 10 : 12, true, TargetFlags.None)
             {
                 m_Owner = owner;
             }


### PR DESCRIPTION
- Fixed Underworld stairs for new worlds. Existing will need to change it themselves.
- Special Moves that call BaseWeapon OnHit method will only trigger hit effects once, either it be the initial hit, or the subsequent hit if the intial hit fails.
- Arena Stone gumps now close on facet Change
- Paragon chests no longer spawn trammel t-maps on siege rulesets
- Crystal portals no longer send folks to trammel
- Trash barrel and chests now have a 1% chance to drop items to cavern of discarded
- Fixed bug where chicken coops weren't setting creatures IsStabled to true upon server Load
- Tyballs Shadow now spawns wearing SHroud of the Condemned
- Vice Vs Virtue has some combat changes, per EA.  If a non-VvV player does a beneficial or aggressive action on a VvV player (in fel), they become a VvV combatant (orange) for 30 minutes. Also, if they don't leave the VvV battle zone after a minute, or close the gump without teleporting to a moongate, they become flagged for 30 minutes.
- VvV battle changed to 30 mintes
- Fixed an issue where VvV battles didn't auto Reset
- Fixed an issue where Dard Guardian Room wan't spawning the proper a
- Dark guardians now drop the proper amount of daemon bones
- Fixed Bonus Resources leaking to internal map
- Magincia Housing Lotto now checks (server start) for offending plots not converted to public house placement
- Spells/Targets are canceled prior to Arena Duels beginning
- Added [ResetArenaStats command. Target a arena stone to reset the arena stats
- Fixed issue where golden compase wouldn't decay after server is restarted
- Players are now paralyzed for 2 seconds and given a strict warning before entering the hallway of death
- Fixed issue where players were getting spirituality when not healing (ie hits were already at max)
- Field spells and wall of stone cast range increased to 15 (TOL Check)
- Mana shield no longer reveals every tick
- Arcane circle strength now depends on Spellweaving mastery level, per EA
- Summon Reaper now per EA