### PR TITLE
CharacterCreation.cs code cleanup

### DIFF
--- a/Scripts/Misc/CharacterCreation.cs
+++ b/Scripts/Misc/CharacterCreation.cs
@@ -1,6 +1,5 @@
 using System;
 using Server.Accounting;
-using Server.Engines.XmlSpawner2;
 using Server.Items;
 using Server.Mobiles;
 using Server.Network;


### PR DESCRIPTION
In the spirit of code cleanup!

Removed using Server.Engines.XmlSpawner2;

Before CharacterCreation used to attach the XMLPoints but that was removed a while ago.