### PR TITLE
Update DespiseEvilCreatures.cs

### DIFF
--- a/Scripts/Mobiles/Normal/DespiseEvilCreatures.cs
+++ b/Scripts/Mobiles/Normal/DespiseEvilCreatures.cs
@@ -241,7 +241,7 @@ namespace Server.Engines.Despise
         public Hellion(int powerLevel) : base(AIType.AI_Melee, FightMode.Good)
         {
             Name = "Hellion";
-            Body = 130;
+            Body = 4;
             BaseSoundID = 0x174;
             Hue = 2671;
 


### PR DESCRIPTION
I am going through using this walkthrough Goober did on EA to make Despise spawns non- randomized and noticed that the Hellion has the wrong body value. He uses the original body value of the Gargoyle.

http://trueuo.com/index.php?threads/spawners-in-tram-despise.84/

The walkthrough is at the provided link just go to 3:50 seconds into it.