### PR TITLE
Added SHA512 Support

### DIFF
--- a/Config/Accounts.cfg
+++ b/Config/Accounts.cfg
@@ -1,4 +1,3 @@
-
 # Number of accounts allowed to be created from a single IP address
 AccountsPerIp=1
 
@@ -19,6 +18,7 @@ DeleteDelay=07:00:00:00
 PasswordCommandEnabled=false
 
 # Account password protection level.
-# Default: NewCrypt
-# Options: None, Crypt, NewCrypt
-ProtectPasswords=NewCrypt
+# Default: NewSecureCrypt
+# Options: None, Crypt, NewCrypt, NewSecureCrypt (Recommended)
+# Explanation: Plain, MD5, SHA1, SHA512
+ProtectPasswords=NewSecureCrypt

--- a/Config/Accounts.cfg
+++ b/Config/Accounts.cfg
@@ -18,7 +18,7 @@ DeleteDelay=07:00:00:00
 PasswordCommandEnabled=false
 
 # Account password protection level.
-# Default: NewSecureCrypt
-# Options: None, Crypt, NewCrypt, NewSecureCrypt (Recommended)
+# Default: NewCrypt
+# Options: None, Crypt, NewCrypt (Default), NewSecureCrypt (Recommended)
 # Explanation: Plain, MD5, SHA1, SHA512
-ProtectPasswords=NewSecureCrypt
+ProtectPasswords=NewCrypt

--- a/Scripts/Accounting/AccountHandler.cs
+++ b/Scripts/Accounting/AccountHandler.cs
@@ -15,14 +15,15 @@ namespace Server.Misc
     {
         None,
         Crypt,
-        NewCrypt
+        NewCrypt,
+        NewSecureCrypt
     }
 
     public class AccountHandler
     {
 	    public static PasswordProtection ProtectPasswords = Config.GetEnum(
 		    "Accounts.ProtectPasswords",
-			PasswordProtection.NewCrypt);
+			PasswordProtection.NewSecureCrypt);
 
         private static readonly int MaxAccountsPerIP = Config.Get("Accounts.AccountsPerIp", 1);
         private static readonly bool AutoAccountCreation = Config.Get("Accounts.AutoCreateAccounts", true);


### PR DESCRIPTION
SHA512 support

Password-System requires complete rework (I will do this) for proper salting (generating 'random' salt on first run) and better readability. Passwords are automatically converted from SHA1 to SHA512 after logon and next save.

NOTICE: SHA512 is the new default if you replace Config/Accounts.cfg. Change it back to NewCrypt (SHA1) in Accounts.cfg if you're in need of SHA1.

However keep in mind Server <-> Client communication stays unencrypted and is absolutely vulnerable to man in the middle attacks as client encryption is removed. It only protects if data gets stolen.

MD5 and SHA1 are known to be vulnerable to collisions and not safe.

Cheers