### PR TITLE
Update TreasureMapChest.cs

### DIFF
--- a/Scripts/Items/Containers/TreasureMapChest.cs
+++ b/Scripts/Items/Containers/TreasureMapChest.cs
@@ -20,7 +20,7 @@ namespace Server.Items
             typeof(LunaLance), typeof(NightsKiss), typeof(NoxRangersHeavyCrossbow),
             typeof(PolarBearMask), typeof(VioletCourage), typeof(HeartOfTheLion),
             typeof(ColdBlood), typeof(AlchemistsBauble), typeof(CaptainQuacklebushsCutlass),
-			typeof(ForgedPardon), typeof(ShieldOfInvulnerability), typeof(AncientShipModelOfTheHMSCape),
+			typeof(ShieldOfInvulnerability), typeof(AncientShipModelOfTheHMSCape),
 			typeof(AdmiralsHeartyRum)
         };
 


### PR DESCRIPTION
Forged Pardons were spawning in the regular pink artifact bag. They should only have that once chance to spawn, which they do, in the LevelFiveToSeven type.