### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Addons/DolphinRug.cs
+++ b/Scripts/Items/Addons/DolphinRug.cs
@@ -122,7 +122,7 @@ namespace Server.Items
         {
             BaseHouse house = BaseHouse.FindHouseAt(from);
 
-            if (house != null && house.IsOwner(from))
+            if (house != null && (house.IsOwner(from) || (house.LockDowns.ContainsKey(this) && house.LockDowns[this] == from)))
             {
                 if (m_NextUse < DateTime.UtcNow)
                 {

--- a/Scripts/Items/Addons/RoseRug.cs
+++ b/Scripts/Items/Addons/RoseRug.cs
@@ -129,7 +129,7 @@ namespace Server.Items
         {
             BaseHouse house = BaseHouse.FindHouseAt(from);
 
-            if (house != null && house.IsOwner(from))
+            if (house != null && (house.IsOwner(from) || (house.LockDowns.ContainsKey(this) && house.LockDowns[this] == from)))
             {
                 if (m_NextUse < DateTime.UtcNow)
                 {

--- a/Scripts/Items/Addons/SkullRug.cs
+++ b/Scripts/Items/Addons/SkullRug.cs
@@ -122,7 +122,7 @@ namespace Server.Items
         {
             BaseHouse house = BaseHouse.FindHouseAt(from);
 
-            if (house != null && house.IsOwner(from))
+            if (house != null && (house.IsOwner(from) || (house.LockDowns.ContainsKey(this) && house.LockDowns[this] == from)))
             {
                 if (m_NextUse < DateTime.UtcNow)
                 {

--- a/Scripts/Items/Artifacts/Equipment/Armor/LordBlackthornsExemplar.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/LordBlackthornsExemplar.cs
@@ -9,8 +9,8 @@ namespace Server.Items
         public LordBlackthornsExemplar()
             : base()
         {
-            this.Hue = 0x501;
-            this.BlockRepair = true;
+            Hue = 0x501;
+            NegativeAttributes.NoRepair = 1;
         }
 
         public LordBlackthornsExemplar(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/SentinelsGuard.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/SentinelsGuard.cs
@@ -9,8 +9,8 @@ namespace Server.Items
         public SentinelsGuard()
             : base()
         {
-            this.Hue = 0x21;
-            BlockRepair = true;
+            Hue = 0x21;
+            NegativeAttributes.NoRepair = 1;
         }
 
         public SentinelsGuard(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/DragonsEnd.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/DragonsEnd.cs
@@ -9,15 +9,15 @@ namespace Server.Items
         public DragonsEnd()
             : base()
         {
-            this.Hue = 0x554;
+            Hue = 0x554;
 
-            this.Slayer = SlayerName.DragonSlaying;
+            Slayer = SlayerName.DragonSlaying;
 
-            this.Attributes.AttackChance = 10;
-            this.Attributes.WeaponDamage = 60;
+            Attributes.AttackChance = 10;
+            Attributes.WeaponDamage = 60;
 
-            this.WeaponAttributes.ResistFireBonus = 20;
-            this.BlockRepair = true;
+            WeaponAttributes.ResistFireBonus = 20;
+            NegativeAttributes.NoRepair = 1;
         }
 
         public DragonsEnd(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/JaanasStaff.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/JaanasStaff.cs
@@ -9,14 +9,14 @@ namespace Server.Items
         public JaanasStaff()
             : base()
         {
-            this.Hue = 0x58C;
+            Hue = 0x58C;
 
-            this.WeaponAttributes.MageWeapon = 10;
+            WeaponAttributes.MageWeapon = 10;
 
-            this.Attributes.SpellChanneling = 1;
-            this.Attributes.Luck = 220;
-            this.Attributes.DefendChance = 15;
-            this.BlockRepair = true;
+            Attributes.SpellChanneling = 1;
+            Attributes.Luck = 220;
+            Attributes.DefendChance = 15;
+            NegativeAttributes.NoRepair = 1;
         }
 
         public JaanasStaff(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/KatrinasCrook.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/KatrinasCrook.cs
@@ -9,13 +9,14 @@ namespace Server.Items
         public KatrinasCrook()
             : base()
         {
-            this.WeaponAttributes.HitLeechStam = 40;
-            this.WeaponAttributes.HitLeechMana = 55;
-            this.WeaponAttributes.HitLeechHits = 55;
+            WeaponAttributes.HitLeechStam = 40;
+            WeaponAttributes.HitLeechMana = 55;
+            WeaponAttributes.HitLeechHits = 55;
 
-            this.Attributes.WeaponDamage = 60;
-            this.Attributes.DefendChance = 15;
-            this.BlockRepair = true;
+            Attributes.WeaponDamage = 60;
+            Attributes.DefendChance = 15;
+
+            NegativeAttributes.NoRepair = 1;
         }
 
         public KatrinasCrook(Serial serial)

--- a/Scripts/Items/Consumables/TreasureMap.cs
+++ b/Scripts/Items/Consumables/TreasureMap.cs
@@ -322,8 +322,7 @@ namespace Server.Items
 
             AddWorldPin(m_Location.X, m_Location.Y);
 
-            if (map != Map.Trammel && map != Map.Felucca)
-                m_NextReset = DateTime.UtcNow + ResetTime;
+            m_NextReset = DateTime.UtcNow + ResetTime;
         }
 
         public Map GetRandomMap()
@@ -786,6 +785,7 @@ namespace Server.Items
                 m_Decoder = null;
                 GetRandomLocation(Facet);
                 InvalidateProperties();
+                m_NextReset = DateTime.UtcNow + ResetTime;
             }
         }
 
@@ -966,6 +966,11 @@ namespace Server.Items
             if (Core.AOS && m_Decoder != null && LootType == LootType.Regular)
             {
                 LootType = LootType.Blessed;
+            }
+
+            if (m_NextReset == DateTime.MinValue)
+            {
+                m_NextReset = DateTime.UtcNow + ResetTime;
             }
         }
 

--- a/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
+++ b/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
@@ -41,7 +41,6 @@ namespace Server.Items
         #endregion
 
         #region Runic Reforging
-        private bool m_BlockRepair;
         private ItemPower m_ItemPower;
         private ReforgedPrefix m_ReforgedPrefix;
         private ReforgedSuffix m_ReforgedSuffix;
@@ -317,13 +316,6 @@ namespace Server.Items
         { 
             get { return m_ReforgedSuffix; } 
             set { m_ReforgedSuffix = value; InvalidateProperties(); }
-        }
-
-        [CommandProperty(AccessLevel.GameMaster)]
-        public bool BlockRepair
-        {
-            get { return m_BlockRepair; }
-            set { m_BlockRepair = value; InvalidateProperties(); }
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -1000,7 +992,9 @@ namespace Server.Items
         {
             base.Serialize(writer);
 
-            writer.Write(11); // version
+            writer.Write(12); // version
+
+            // Version 12 - removed VvV Item (handled in VvV System) and BlockRepair (Handled as negative attribute)
 
             writer.Write(m_SetPhysicalBonus);
             writer.Write(m_SetFireBonus);
@@ -1012,7 +1006,6 @@ namespace Server.Items
 
             m_TalismanProtection.Serialize(writer);
 
-            writer.Write(_VvVItem);
             writer.Write(_Owner);
             writer.Write(_OwnerName);
 
@@ -1027,7 +1020,6 @@ namespace Server.Items
             writer.Write((int)m_ReforgedPrefix);
             writer.Write((int)m_ReforgedSuffix);
             writer.Write((int)m_ItemPower);
-            writer.Write(m_BlockRepair);
             #endregion
 
             #region Stygian Abyss
@@ -1071,6 +1063,7 @@ namespace Server.Items
 
             switch (version)
             {
+                case 12:
                 case 11:
                     {
                         m_SetPhysicalBonus = reader.ReadInt();
@@ -1092,7 +1085,8 @@ namespace Server.Items
                     }
                 case 8:
                     {
-                        _VvVItem = reader.ReadBool();
+                        if (version == 11)
+                            reader.ReadBool();
                         _Owner = reader.ReadMobile();
                         _OwnerName = reader.ReadString();
                         goto case 7;
@@ -1113,7 +1107,8 @@ namespace Server.Items
                         m_ReforgedPrefix = (ReforgedPrefix)reader.ReadInt();
                         m_ReforgedSuffix = (ReforgedSuffix)reader.ReadInt();
                         m_ItemPower = (ItemPower)reader.ReadInt();
-                        m_BlockRepair = reader.ReadBool();
+                        if(version == 11 && reader.ReadBool())
+                            m_NegativeAttributes.NoRepair = 1;
                         #endregion
 
                         #region Stygian Abyss

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -199,7 +199,6 @@ namespace Server.Items
         #endregion
 
         #region Runic Reforging
-        private bool m_BlockRepair;
         private ItemPower m_ItemPower;
         private ReforgedPrefix m_ReforgedPrefix;
         private ReforgedSuffix m_ReforgedSuffix;
@@ -708,12 +707,6 @@ namespace Server.Items
         #endregion
 
         #region Runic Reforging
-        [CommandProperty(AccessLevel.GameMaster)]
-        public bool BlockRepair
-        {
-            get { return m_BlockRepair; }
-            set { m_BlockRepair = value; }
-        }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public ItemPower ItemPower
@@ -3866,12 +3859,13 @@ namespace Server.Items
 		{
 			base.Serialize(writer);
 
-			writer.Write(17); // version
+			writer.Write(18); // version
+
+            // Version 18 - removed VvV Item (handled in VvV System) and BlockRepair (Handled as negative attribute)
 
             writer.Write(m_UsesRemaining);
             writer.Write(m_ShowUsesRemaining);
 
-            writer.Write(_VvVItem);
             writer.Write(_Owner);
             writer.Write(_OwnerName);
 
@@ -3887,7 +3881,6 @@ namespace Server.Items
             writer.Write((int)m_ReforgedPrefix);
             writer.Write((int)m_ReforgedSuffix);
             writer.Write((int)m_ItemPower);
-            writer.Write(m_BlockRepair);
             #endregion
 
             #region Stygian Abyss
@@ -4269,6 +4262,7 @@ namespace Server.Items
 
 			switch (version)
 			{
+                case 18:
                 case 17:
                     {
                         m_UsesRemaining = reader.ReadInt();
@@ -4295,7 +4289,13 @@ namespace Server.Items
                         m_ReforgedPrefix = (ReforgedPrefix)reader.ReadInt();
                         m_ReforgedSuffix = (ReforgedSuffix)reader.ReadInt();
                         m_ItemPower = (ItemPower)reader.ReadInt();
-                        m_BlockRepair = reader.ReadBool();
+                        if (version == 17 && reader.ReadBool())
+                        {
+                            Timer.DelayCall(TimeSpan.FromSeconds(1), () =>
+                            {
+                                m_NegativeAttributes.NoRepair = 1;
+                            });
+                        }
                         #endregion
 
                         #region Stygian Abyss

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -3013,6 +3013,9 @@ namespace Server
 
         public void GetProperties(ObjectPropertyList list, Item item)
         {
+            if (NoRepair > 0)
+                list.Add(1151782);
+
             if (Brittle > 0 ||
                 item is BaseWeapon && ((BaseWeapon)item).Attributes.Brittle > 0 ||
                 item is BaseArmor && ((BaseArmor)item).Attributes.Brittle > 0 ||
@@ -3031,9 +3034,6 @@ namespace Server
 
             if (Antique > 0)
                 list.Add(1076187);
-
-            if (NoRepair > 0)
-                list.Add(1151782);
         }
 
         public const double CombatDecayChance = 0.02;

--- a/Scripts/Mobiles/Normal/CorrosiveSlime.cs
+++ b/Scripts/Mobiles/Normal/CorrosiveSlime.cs
@@ -78,8 +78,6 @@ namespace Server.Mobiles
         }
         public override void OnDeath(Container c)
         {
-            base.OnDeath(c);
-
             if (!Controlled && Map != null && Map != Map.TerMur && Utility.Random(10) == 0)
             {
                 Item item = null;
@@ -94,6 +92,8 @@ namespace Server.Mobiles
 				if (item != null)
 					c.DropItem(item);
             }
+
+            base.OnDeath(c);
         }
         public override void Serialize(GenericWriter writer)
         {

--- a/Scripts/Services/City Loyalty System/CityLoyaltyEntry.cs
+++ b/Scripts/Services/City Loyalty System/CityLoyaltyEntry.cs
@@ -126,6 +126,7 @@ namespace Server.Engines.CityLoyalty
 			writer.Write(Love);
 			writer.Write(Hate);
 			writer.Write(Neutrality);
+
 			writer.Write((int)Titles);
             writer.Write(TradeDealExpires);
             writer.Write(_Utilizing);

--- a/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
+++ b/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
@@ -211,6 +211,8 @@ namespace Server.Engines.CityLoyalty
         [CommandProperty(AccessLevel.GameMaster)]
         public DateTime PostedOn { get; set; }
 
+        private Dictionary<Mobile, DateTime> CitizenWait { get; set; }
+
 		public CityLoyaltySystem(City city)
 		{
             City = city;
@@ -219,6 +221,7 @@ namespace Server.Engines.CityLoyalty
                 Cities = new List<CityLoyaltySystem>();
 
             Election = new CityElection(this);
+            CitizenWait = new Dictionary<Mobile, DateTime>();
 
 			Cities.Add(this);
 		}
@@ -287,7 +290,7 @@ namespace Server.Engines.CityLoyalty
                         Stone.InvalidateProperties();
                 }
 
-                _CitizenWait[from] = DateTime.UtcNow + TimeSpan.FromDays(CitizenJoinWait);
+                CitizenWait[from] = DateTime.UtcNow + TimeSpan.FromDays(CitizenJoinWait);
             }
 		}
 		
@@ -568,13 +571,55 @@ namespace Server.Engines.CityLoyalty
                 to.SendLocalizedMessage(message);
         }
 
+        public bool CanAdd(Mobile from)
+        {
+            if (CitizenWait.ContainsKey(from))
+            {
+                if (CitizenWait[from] < DateTime.UtcNow)
+                {
+                    RemoveWaitTime(from);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public int NextJoin(Mobile from)
+        {
+            if (CitizenWait.ContainsKey(from))
+            {
+                return (int)(CitizenWait[from] - DateTime.UtcNow).TotalDays;
+            }
+
+            return 0;
+        }
+
+        public void RemoveWaitTime(Mobile from)
+        {
+            if (CitizenWait.ContainsKey(from))
+            {
+                CitizenWait.Remove(from);
+            }
+        }
+
         public static void Initialize()
         {
             EventSink.Login += OnLogin;
-            _CitizenWait = new Dictionary<Mobile, DateTime>();
+            Timer.DelayCall(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), OnTick);
 
             CommandSystem.Register("ElectionStartTime", AccessLevel.Administrator, e => e.Mobile.SendGump(new ElectionStartTimeGump(e.Mobile as PlayerMobile)));
-           
+            CommandSystem.Register("RemoveWait", AccessLevel.Administrator, e =>
+                {
+                    foreach (var city in Cities)
+                    {
+                        city.RemoveWaitTime(e.Mobile);
+                    }
+                });
+
             CommandSystem.Register("SystemInfo", AccessLevel.Administrator, e => 
             {
                 e.Mobile.CloseGump(typeof(SystemInfoGump));
@@ -583,7 +628,6 @@ namespace Server.Engines.CityLoyalty
         }
 
 		private static DateTime _NextAtrophy;
-		private static Dictionary<Mobile, DateTime> _CitizenWait;
 		
 		public static List<CityLoyaltySystem> Cities { get; private set; }
 
@@ -651,41 +695,45 @@ namespace Server.Engines.CityLoyalty
                 });
         }
 
-        public static bool CanAddCitizen(Mobile from, out int days)
+        public static bool CanAddCitizen(Mobile from)
         {
-            if (_CitizenWait.ContainsKey(from))
+            foreach (var city in Cities)
             {
-                if (_CitizenWait[from] < DateTime.UtcNow)
-                {
-                    RemoveWaitTime(from);
-                }
-                else
-                {
-                    days = (int)(_CitizenWait[from] - DateTime.UtcNow).TotalDays;
+                if (!city.CanAdd(from))
                     return false;
+            }
+            return true;
+        }
+
+        public static int NextJoinCity(Mobile from)
+        {
+            foreach (var city in Cities)
+            {
+                if (!city.CanAdd(from))
+                {
+                    return city.NextJoin(from);
                 }
             }
-            days = 0;
-            return true;
+
+            return 0;
         }
 
         public static void OnTick()
         {
-            List<PlayerMobile> list = new List<PlayerMobile>(_CitizenWait.Keys.OfType<PlayerMobile>());
-
-            foreach (PlayerMobile pm in list)
+            foreach (var sys in Cities)
             {
-                if (_CitizenWait[pm] < DateTime.UtcNow)
+                List<Mobile> list = new List<Mobile>(sys.CitizenWait.Keys);
+
+                foreach (var m in list)
                 {
-                    RemoveWaitTime(pm);
+                    if (sys.CitizenWait[m] < DateTime.UtcNow)
+                    {
+                        sys.RemoveWaitTime(m);
+                    }
                 }
-            }
 
-            list.Clear();
-            list.TrimExcess();
+                ColUtility.Free(list);
 
-            Cities.ForEach(sys =>
-            {
                 if (DateTime.UtcNow > _NextAtrophy)
                 {
                     sys.PlayerTable.ForEach(t =>
@@ -726,18 +774,10 @@ namespace Server.Engines.CityLoyalty
                 }
                 else
                     sys.Election = new CityElection(sys);
-            });
+            }
 
             CityTradeSystem.OnTick();
         }
-		
-		public static void RemoveWaitTime(Mobile from)
-		{
-			if(_CitizenWait.ContainsKey(from))
-			{
-				_CitizenWait.Remove(from);
-			}
-		}
 		
 		public static bool HasCitizenship(Mobile from)
 		{
@@ -1053,8 +1093,15 @@ namespace Server.Engines.CityLoyalty
             writer.Write((int)City);
 
 			base.Serialize(writer);
-			writer.Write(0);
-			
+			writer.Write(1);
+
+            writer.Write(CitizenWait.Count);
+            foreach (var kvp in CitizenWait)
+            {
+                writer.Write(kvp.Key);
+                writer.Write(kvp.Value);
+            }
+
 			writer.Write(CompletedTrades);
             writer.Write(Governor);
             writer.Write(GovernorElect);
@@ -1076,16 +1123,6 @@ namespace Server.Engines.CityLoyalty
             }
             else
                 writer.Write(1);
-
-            if (this.City == City.Britain)
-            {
-                writer.Write(_CitizenWait.Count);
-                foreach (KeyValuePair<Mobile, DateTime> kvp in _CitizenWait)
-                {
-                    writer.Write(kvp.Key);
-                    writer.Write(kvp.Value);
-                }
-            }
 		}
 		
 		public override void Deserialize(GenericReader reader)
@@ -1094,30 +1131,48 @@ namespace Server.Engines.CityLoyalty
 
 			base.Deserialize(reader);
 			int version = reader.ReadInt();
-			
-			CompletedTrades = reader.ReadInt();
-            Governor = reader.ReadMobile();
-            GovernorElect = reader.ReadMobile();
-            PendingGovernor = reader.ReadBool();
-            Treasury = reader.ReadLong();
-            ActiveTradeDeal = (TradeDeal)reader.ReadInt();
-            TradeDealStart = reader.ReadDateTime();
-            NextTradeDealCheck = reader.ReadDateTime();
-            CanUtilize = reader.ReadBool();
 
-            Headline = reader.ReadString();
-            Body = reader.ReadString();
-            PostedOn = reader.ReadDateTime();
-
-            if (reader.ReadInt() == 0)
-                Election = new CityElection(this, reader);
-            else
-                Election = new CityElection(this);
-
-            if (this.City == City.Britain)
+            switch (version)
             {
-                _CitizenWait = new Dictionary<Mobile, DateTime>();
+                case 1:
+                    {
+                        int count = reader.ReadInt();
+                        for (int i = 0; i < count; i++)
+                        {
+                            Mobile m = reader.ReadMobile();
+                            DateTime dt = reader.ReadDateTime();
 
+                            if (m != null && dt > DateTime.UtcNow)
+                                CitizenWait[m] = dt;
+                        }
+                    }
+                    goto case 0;
+                case 0:
+                    {
+                        CompletedTrades = reader.ReadInt();
+                        Governor = reader.ReadMobile();
+                        GovernorElect = reader.ReadMobile();
+                        PendingGovernor = reader.ReadBool();
+                        Treasury = reader.ReadLong();
+                        ActiveTradeDeal = (TradeDeal)reader.ReadInt();
+                        TradeDealStart = reader.ReadDateTime();
+                        NextTradeDealCheck = reader.ReadDateTime();
+                        CanUtilize = reader.ReadBool();
+
+                        Headline = reader.ReadString();
+                        Body = reader.ReadString();
+                        PostedOn = reader.ReadDateTime();
+
+                        if (reader.ReadInt() == 0)
+                            Election = new CityElection(this, reader);
+                        else
+                            Election = new CityElection(this);
+                    }
+                    break;
+            }
+
+            if (version == 0 && this.City == City.Britain)
+            {
                 int count = reader.ReadInt();
                 for (int i = 0; i < count; i++)
                 {
@@ -1125,10 +1180,8 @@ namespace Server.Engines.CityLoyalty
                     DateTime dt = reader.ReadDateTime();
 
                     if (m != null && dt > DateTime.UtcNow)
-                        _CitizenWait[m] = dt;
+                        CitizenWait[m] = dt;
                 }
-
-                Timer.DelayCall(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), OnTick);
             }
 		}
 	}

--- a/Scripts/Services/City Loyalty System/Election.cs
+++ b/Scripts/Services/City Loyalty System/Election.cs
@@ -293,7 +293,7 @@ namespace Server.Engines.CityLoyalty
                 }
             }
 
-            if (City.Governor == null && AutoPickGovernor != DateTime.MinValue && DateTime.UtcNow > AutoPickGovernor)
+            if (City.Governor == null && AutoPickGovernor != DateTime.MinValue && DateTime.Now > AutoPickGovernor)
             {
                 if (City.GovernorElect != null)
                 {
@@ -321,7 +321,7 @@ namespace Server.Engines.CityLoyalty
             {
                 Candidates.ForEach(entry =>
                     {
-                        if (entry.TimeOfNomination + TimeSpan.FromHours(NominationDeadline) < DateTime.UtcNow && entry.Endorsements.Count == 0)
+                        if (entry.TimeOfNomination + TimeSpan.FromHours(NominationDeadline) < DateTime.Now && entry.Endorsements.Count == 0)
                             Candidates.Remove(entry);
                     });
             }
@@ -485,13 +485,13 @@ namespace Server.Engines.CityLoyalty
                 Candidates.Sort();
                 City.GovernorElect = Candidates[0].Player;
 
-                AutoPickGovernor = DateTime.UtcNow + TimeSpan.FromDays(7);
+                AutoPickGovernor = DateTime.Now + TimeSpan.FromDays(7);
             }
 
             if (City.GovernorElect == null)
             {
                 City.PendingGovernor = true;
-                AutoPickGovernor = DateTime.UtcNow + TimeSpan.FromDays(Utility.RandomMinMax(2, 4));
+                AutoPickGovernor = DateTime.Now + TimeSpan.FromDays(Utility.RandomMinMax(2, 4));
 
                 if (City.Stone != null)
                     City.Stone.InvalidateProperties();
@@ -516,7 +516,7 @@ namespace Server.Engines.CityLoyalty
             if (entry != null)
                 Candidates.Remove(entry);
 
-            AutoPickGovernor = DateTime.UtcNow + TimeSpan.FromDays(Utility.RandomMinMax(2, 4));
+            AutoPickGovernor = DateTime.Now + TimeSpan.FromDays(Utility.RandomMinMax(2, 4));
         }
 
         public void Serialize(GenericWriter writer)
@@ -580,7 +580,7 @@ namespace Server.Engines.CityLoyalty
         public BallotEntry(PlayerMobile pm, int love, int hate)
         {
             Player = pm;
-            TimeOfNomination = DateTime.UtcNow;
+            TimeOfNomination = DateTime.Now;
 
             Love = love;
             Hate = hate;

--- a/Scripts/Services/City Loyalty System/Gumps.cs
+++ b/Scripts/Services/City Loyalty System/Gumps.cs
@@ -65,9 +65,8 @@ namespace Server.Engines.CityLoyalty
             for (int i = 0; i < CityLoyaltySystem.Cities.Count; i++)
             {
                 CityLoyaltySystem city = CityLoyaltySystem.Cities[i];
-                int days = 0;
 
-                if (city.CanUtilize && Citizenship == null && CityLoyaltySystem.CanAddCitizen(User, out days))
+                if (city.CanUtilize && Citizenship == null && CityLoyaltySystem.CanAddCitizen(User))
                     AddButton(30, y + 3, 2103, 2104, 100 + i, GumpButtonType.Reply, 0);
 
                 AddHtmlLocalized(50, y, 200, 16, CityLoyaltySystem.CityLocalization(city.City), false, false);
@@ -99,8 +98,7 @@ namespace Server.Engines.CityLoyalty
             }
             else
             {
-                int days = 0;
-                if (CityLoyaltySystem.CanAddCitizen(User, out days))
+                if (CityLoyaltySystem.CanAddCitizen(User))
                 {
                     AddHtmlLocalized(30, y, 280, 90, 1152885, false, false);
                     /*Click the gem next to the name of a city to declare your 
@@ -109,7 +107,7 @@ namespace Server.Engines.CityLoyalty
                 }
                 else
                 {
-                    AddHtmlLocalized(30, y, 285, 80, 1152886, days.ToString(), 0, false, false);
+                    AddHtmlLocalized(30, y, 285, 80, 1152886, CityLoyaltySystem.NextJoinCity(User).ToString(), 0, false, false);
                     /*You recently renounced citizenship, so you must wait ~1_COUNT~ 
                      * more days before you may declare citizenship again.*/
                 }
@@ -184,9 +182,7 @@ namespace Server.Engines.CityLoyalty
 
             if(info.ButtonID == 1 && City != null)
             {
-                int i = 0;
-
-                if (CityLoyaltySystem.CanAddCitizen(User, out i))
+                if (CityLoyaltySystem.CanAddCitizen(User))
                 {
                     City.DeclareCitizen(User);
                 }
@@ -232,9 +228,7 @@ namespace Server.Engines.CityLoyalty
 
             if (info.ButtonID == 1 && Citizenship != null)
             {
-                int i = 0;
-
-                if (CityLoyaltySystem.CanAddCitizen(User, out i))
+                if (CityLoyaltySystem.CanAddCitizen(User))
                 {
                     Citizenship.RenounceCitizenship(User);
                     User.SendMessage("You renounce your citizenship to {0}!", Citizenship.Definition.Name);

--- a/Scripts/Services/Craft/Core/Repair.cs
+++ b/Scripts/Services/Craft/Core/Repair.cs
@@ -199,7 +199,7 @@ namespace Server.Engines.Craft
                             {
                                 number = 1044278; // That item has been repaired many times, and will break if repairs are attempted again.
                             }
-                            else if (weapon.BlockRepair || weapon.NegativeAttributes.NoRepair > 0)
+                            else if (weapon.NegativeAttributes.NoRepair > 0)
                             {
                                 number = 1044277; // That item cannot be repaired.
                             }
@@ -264,7 +264,7 @@ namespace Server.Engines.Craft
                             {
                                 number = 1044278; // That item has been repaired many times, and will break if repairs are attempted again.
                             }
-                            else if (armor.BlockRepair || armor.NegativeAttributes.NoRepair > 0)
+                            else if (armor.NegativeAttributes.NoRepair > 0)
                             {
                                 number = 1044277; // That item cannot be repaired.
                             }
@@ -329,7 +329,7 @@ namespace Server.Engines.Craft
                             {
                                 number = 1044278; // That item has been repaired many times, and will break if repairs are attempted again.
                             }
-                            else if (jewel.BlockRepair || jewel.NegativeAttributes.NoRepair > 0)
+                            else if (jewel.NegativeAttributes.NoRepair > 0)
                             {
                                 number = 1044277; // That item cannot be repaired.
                             }
@@ -394,7 +394,7 @@ namespace Server.Engines.Craft
                             {
                                 number = 1044278; // That item has been repaired many times, and will break if repairs are attempted again.
                             }
-                            else if (clothing.BlockRepair || clothing.NegativeAttributes.NoRepair > 0)// quick fix
+                            else if (clothing.NegativeAttributes.NoRepair > 0)// quick fix
                             {
                                 number = 1044277; // That item cannot be repaired.
                             }

--- a/Scripts/Services/Craft/DefCarpentry.cs
+++ b/Scripts/Services/Craft/DefCarpentry.cs
@@ -261,7 +261,7 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(ChickenCoop), 1044294, 1112570, 90.0, 115.0, typeof(Board), 1044041, 150, 1044351);
                 SetNeededExpansion(index, Expansion.SA);
 
-                index = AddCraft(typeof(ExodusSummoningAlter), 1044294, 1153502, 95.0, 120.0, typeof(Log), 1044041, 100, 1044351);
+                index = AddCraft(typeof(ExodusSummoningAlter), 1044294, 1153502, 95.0, 120.0, typeof(Board), 1044041, 100, 1044351);
                 AddSkill(index, SkillName.Magery, 75.0, 120.0);
                 AddRes(index, typeof(Granite), 1044607, 10, 1044253);
                 AddRes(index, typeof(SmallPieceofBlackrock), 1150016, 10, 1044253);
@@ -272,12 +272,12 @@ namespace Server.Engines.Craft
             #region TOL
             if (Core.TOL)
             {
-                index = AddCraft(typeof(CraftableHouseItem), 1044294, 1155849, 42.1, 77.7, typeof(Log), 1044041, 5, 1044351);
+                index = AddCraft(typeof(CraftableHouseItem), 1044294, 1155849, 42.1, 77.7, typeof(Board), 1044041, 5, 1044351);
                 SetData(index, CraftableItemType.DarkWoodenSignHanger);
                 SetDisplayID(index, 2967);
                 SetNeededExpansion(index, Expansion.TOL);
 
-                index = AddCraft(typeof(CraftableHouseItem), 1044294, 1155850, 42.1, 77.7, typeof(Log), 1044041, 5, 1044351);
+                index = AddCraft(typeof(CraftableHouseItem), 1044294, 1155850, 42.1, 77.7, typeof(Board), 1044041, 5, 1044351);
                 SetData(index, CraftableItemType.LightWoodenSignHanger);
                 SetDisplayID(index, 2969);
                 SetNeededExpansion(index, Expansion.TOL);
@@ -840,10 +840,10 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(GargishCouchSouthDeed), 1044290, 1111775, 90.0, 115.0, typeof(Board), 1044041, 75, 1044351);
                 SetNeededExpansion(index, Expansion.SA);
 
-                index = AddCraft(typeof(LongTableSouthDeed), 1044290, 1111781, 90.0, 115.0, typeof(Log), 1044041, 80, 1044351);
+                index = AddCraft(typeof(LongTableSouthDeed), 1044290, 1111781, 90.0, 115.0, typeof(Board), 1044041, 80, 1044351);
                 SetNeededExpansion(index, Expansion.SA);
 
-                index = AddCraft(typeof(LongTableEastDeed), 1044290, 1111782, 90.0, 115.0, typeof(Log), 1044041, 80, 1044351);
+                index = AddCraft(typeof(LongTableEastDeed), 1044290, 1111782, 90.0, 115.0, typeof(Board), 1044041, 80, 1044351);
                 SetNeededExpansion(index, Expansion.SA);
            
                 index = AddCraft(typeof(TerMurDresserEastDeed), 1044290, 1111784, 90.0, 115.0, typeof(Board), 1044041, 60, 1044351);

--- a/Scripts/Services/Factions/Core/Faction.cs
+++ b/Scripts/Services/Factions/Core/Faction.cs
@@ -960,7 +960,7 @@ namespace Server.Factions
 
         #region Skill Loss
         public const double SkillLossFactor = 1.0 / 3;
-        public static readonly TimeSpan SkillLossPeriod = TimeSpan.FromMinutes(20.0);
+        public static TimeSpan SkillLossPeriod { get { return Core.SA ? TimeSpan.FromMinutes(5) : TimeSpan.FromMinutes(20.0); } }
 
         private static readonly Dictionary<Mobile, SkillLossContext> m_SkillLoss = new Dictionary<Mobile, SkillLossContext>();
 

--- a/Scripts/Services/RunicReforging/Gumps.cs
+++ b/Scripts/Services/RunicReforging/Gumps.cs
@@ -298,6 +298,9 @@ namespace Server.Gumps
 
                             if ((m_Options & ReforgingOption.GrandArtifice) != 0)
                             {
+                                if (0.8 > Utility.RandomDouble())
+                                    maxprops++;
+
                                 // choosing name 1
                                 if ((m_Options & ReforgingOption.InspiredArtifice) != 0)
                                 {
@@ -354,11 +357,21 @@ namespace Server.Gumps
                                 }
                             }
 
+                            // 50% chance to switch prefix/suffix around
+                            if ((prefix != ReforgedPrefix.None || suffix != ReforgedSuffix.None) && 0.5 > Utility.RandomDouble())
+                            {
+                                int pre = (int)prefix;
+                                int suf = (int)suffix;
+
+                                prefix = (ReforgedPrefix)suf;
+                                suffix = (ReforgedSuffix)pre;
+                            }
+
                             RunicReforging.ApplyReforgedProperties(m_ToReforge, prefix, suffix, true, budget, min, max, maxprops, 0, m_Tool, m_Options);
 
                             OnAfterReforged(m_ToReforge);
                             from.SendLocalizedMessage(1152286); // You re-forge the item!
-                            from.FixedParticles(0x374A, 10, 30, 5021, EffectLayer.Head);
+                            //from.FixedParticles(0x374A, 10, 30, 5021, EffectLayer.Head);
                             from.PlaySound(0x665);
 
                             m_Tool.UsesRemaining -= totalCharges;
@@ -453,18 +466,14 @@ namespace Server.Gumps
             if ((m_Options & ReforgingOption.Fundamental) != 0)
                 budget += 100;
 
-            if (((m_Options & ReforgingOption.Powerful) != 0 && (m_Options & ReforgingOption.Structural) != 0) || (m_Options & ReforgingOption.Fundamental) != 0)
-                maxprops++;
-
-            if (maxprops <= 6 && budget >= 650 && 0.10 > Utility.RandomDouble())
-                maxprops = 7;
-
             return budget;
         }
 
         public void OnAfterReforged(Item item)
         {
-            AosAttributes attr = null;
+            AosAttributes attr = RunicReforging.GetAosAttributes(item);
+            NegativeAttributes neg = RunicReforging.GetNegativeAttributes(item);
+
             int durability = 0;
 
             if (item is BaseWeapon)
@@ -475,16 +484,23 @@ namespace Server.Gumps
 
             if (attr != null && (m_Options & ReforgingOption.Structural) != 0)
             {
-                attr.Brittle = 1;
+                if(neg != null)
+                    neg.Brittle = 1;
 
                 if ((m_Options & ReforgingOption.Fortified) != 0)
                     durability = 150;
+
+                item.Hue = 2500;
             }
 
             if ((m_Options & ReforgingOption.Fundamental) != 0)
             {
-                RunicReforging.SetBlockRepair(item);
+                if (neg != null)
+                    neg.NoRepair = 1;
+
                 durability = (m_Options & ReforgingOption.Integral) != 0 ? 255 : 200;
+
+                item.Hue = 2500;
             }
 
             if (durability > 0 && item is IDurability)

--- a/Scripts/Services/Vendor Searching/VendorSearch.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearch.cs
@@ -372,22 +372,7 @@ namespace Server.Engines.VendorSearching
         {
             NegativeAttributes neg = RunicReforging.GetNegativeAttributes(item);
 
-            if (neg != null && neg.NoRepair != 0)
-                return false;
-
-            if (item is BaseWeapon && ((BaseWeapon)item).BlockRepair)
-                return false;
-
-            if (item is BaseArmor && ((BaseArmor)item).BlockRepair)
-                return false;
-
-            if (item is BaseJewel && ((BaseJewel)item).BlockRepair)
-                return false;
-
-            if (item is BaseClothing && ((BaseClothing)item).BlockRepair)
-                return false;
-
-            return true;
+            return neg != null && neg.NoRepair != 0;
         }
 
         private static bool CheckKeyword(string searchstring, Item item)

--- a/Scripts/Services/ViceVsVirtue/Items/VvVAltar.cs
+++ b/Scripts/Services/ViceVsVirtue/Items/VvVAltar.cs
@@ -140,7 +140,11 @@ namespace Server.Engines.VvV
 
         public void Complete(Guild g)
         {
-            Timer.DelayCall<Guild>(TimeSpan.FromSeconds(5), Battle.OccupyAltar, g);
+            if (g != null)
+            {
+                Timer.DelayCall<Guild>(TimeSpan.FromSeconds(5), Battle.OccupyAltar, g);
+            }
+
             Timer.DelayCall(TimeSpan.FromSeconds(2), DoFireworks);
             IsActive = false;
 

--- a/Scripts/Skills/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Skills/Imbuing/Core/Imbuing.cs
@@ -218,7 +218,7 @@ namespace Server.SkillHandlers
 
         private static Type[] _SpecialImbuable =
         {
-            typeof(ClockworkLeggings), typeof(GargishClockworkLeggings)
+            typeof(ClockworkLeggings), typeof(GargishClockworkLeggings), typeof(OrcishKinMask), typeof(SavageMask)
         };
 
         private static Type[] _NonCraftables =


### PR DESCRIPTION
Runic Reforging
- fixed but where resists weren't being applied to Armor
- name#1 and name#2 now appear randomly as the prefix/suffix
- updated prefix/suffix specific property count
- Random properties (not from prefix/suffix) are now randomly chosen from pool of unused prefix/suffix lists. It used to use standard RunicProperty. We need to check how standard loot is handled
- Fundamental and/or Structural options now hue the item
- Removed BlockRepair from BaseArmor/BaseWeapon/BaseJewel/BaseClothing as negative attribute NoBlock made this redundant

Bug Fixes
- All t-maps now reset, regardless of Facet
- Added lockdown owner to access of rug resources
- Corrosive slimes should now drop the prop peerless keys
- Change City Loyalty Electoin DateTime.UtcNow to DateTime.Now so election times conincside with server time
- Added Savage Mask and Orcish Kin Mask to imbue list
- Reduced VvV Statloss to 5 minutes