### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ reportHistory.xml
 .vs/
 drng64.dll
 drng32.dll
+libdrng.so

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ reportHistory.xml
 *.log
 *.bin
 .vs/
+drng64.dll
+drng32.dll


### PR DESCRIPTION
Excluded DLLs for Hardware Random Number Generator (drng32.dll & drng64.dll) until LICENSE is clear if this can be distributed with ServUO or not.