### PR TITLE
Bugfix in Infectious Strike

### DIFF
--- a/Scripts/Abilities/InfectiousStrike.cs
+++ b/Scripts/Abilities/InfectiousStrike.cs
@@ -4,7 +4,7 @@ namespace Server.Items
 {
     /// <summary>
     /// This special move represents a significant change to the use of poisons in Age of Shadows.
-    /// Now, only certain weapon types — those that have Infectious Strike as an available special move — will be able to be poisoned.
+    /// Now, only certain weapon types â€” those that have Infectious Strike as an available special move â€” will be able to be poisoned.
     /// Targets will no longer be poisoned at random when hit by poisoned weapons.
     /// Instead, the wielder must use this ability to deliver the venom.
     /// While no skill in Poisoning is directly required to use this ability, being knowledgeable in the application and use of toxins
@@ -25,7 +25,12 @@ namespace Server.Items
                 return 20;
             }
         }
-
+        
+        public override bool RequiresSecondarySkill(Mobile from)
+        {
+            return false;
+        }
+        
         public override SkillName GetSecondarySkill(Mobile from)
         {
             return SkillName.Poisoning;


### PR DESCRIPTION
Infectious Strike doesn't require secondary skill - characters able to use Infectious Strike without 70 or 90 poisoning as per OSI mechanics