### PR TITLE
Update BaseClothing.cs

### DIFF
--- a/Scripts/Items/Equipment/Clothing/BaseClothing.cs
+++ b/Scripts/Items/Equipment/Clothing/BaseClothing.cs
@@ -1282,6 +1282,9 @@ namespace Server.Items
 
             if ((prop = m_AosAttributes.LowerRegCost) != 0)
                 list.Add(1060434, prop.ToString()); // lower reagent cost ~1_val~%
+            
+            if ((prop = m_AosAttributes.LowerAmmoCost) != 0)
+				list.Add(1075208, prop.ToString()); // Lower Ammo Cost ~1_Percentage~%
 
             if ((prop = m_AosClothingAttributes.LowerStatReq) != 0)
                 list.Add(1060435, prop.ToString()); // lower requirements ~1_val~%


### PR DESCRIPTION
Since LowerAmmoCost was added as a basic property it should appear in here too.

Currently if you were to put LowerAmmoCost on a piece of clothing it would not appear. Even though there are no LowerAmmoCost clothing items, yet, there are also no LowerAmmoCost weapons yet it correctly appears on those.