### PR TITLE
Hardcoded max skills cap generating wrong reports 

### DIFF
--- a/Scripts/Services/Reports/Reports.cs
+++ b/Scripts/Services/Reports/Reports.cs
@@ -154,7 +154,7 @@ namespace Server.Engines.Reports
 
             foreach (Mobile mob in World.Mobiles.Values)
             {
-                if (mob.SkillsTotal >= 1500 && mob.SkillsTotal <= 7200 && mob is PlayerMobile)
+                if (mob.SkillsTotal >= 1500 && mob.SkillsTotal <= (Config.Get("PlayerCaps.TotalSkillCap", 7000)+200) && mob is PlayerMobile)
                 {
                     Skills skills = mob.Skills;
 


### PR DESCRIPTION
Hardcoded max skills cap generating wrong reports when shard have more than 7000 max skills cap -> changed to get the Config value