### PR TITLE
Salvage bag fix

### DIFF
--- a/Scripts/Items/Containers/SalvageBag.cs
+++ b/Scripts/Items/Containers/SalvageBag.cs
@@ -71,25 +71,7 @@ namespace Server.Items
 		
         private bool Scissorables() //Where context menu checks for Leather items and cloth items
         {
-            foreach (Item i in this.Items)
-            {
-                if (i != null && !i.Deleted)
-                {
-                    if (i is IScissorable)
-                    {
-                        if (i is BaseClothing)
-                            return true;
-                        if (i is BaseArmor)
-                        {
-                            if (CraftResources.GetType(((BaseArmor)i).Resource) == CraftResourceType.Leather)
-                                return true;
-                        }
-                        if ((i is Cloth) || (i is BoltOfCloth) || (i is Hides) || (i is BonePile))
-                            return true;
-                    }
-                }
-            }
-            return false;
+            return Items.Any(i => (i != null) && (!i.Deleted) && (i is IScissorable) && (i is Item));
         }
 
         #endregion	


### PR DESCRIPTION
Since the salvage method itself just looks for items that are IScissorable, the additonal checks to determine if there are anything to salvage just prevent starting salvaging when there are only items that don't meet them - specifically things like Oil Cloth.

This change allows the salvage cloth option to be present when there are any IScissorable items in the salvage bag.


```
        private void SalvageCloth(Mobile from)
        {
               .....

                Item item = Scissorables[i];
                if (item is IScissorable)
                {
                    if (((IScissorable)item).Scissor(from, scissors))
                    {
                        salvaged++;
                    }
```
