### PR TITLE
Make the timespan for vendor bribe multiplier decay configurable

### DIFF
--- a/Config/Vendors.cfg
+++ b/Config/Vendors.cfg
@@ -16,3 +16,7 @@ SellItemChange=1000
 
 # this determines the amount of stacked economy items are stocked
 EconomyStockAmount=500
+
+# these settings are the min and max timeframe (in days) for the bribe multiplier to decay
+BribeDecayMinTime=25
+BribeDecayMaxTime=30

--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -1358,6 +1358,15 @@ namespace Server.Mobiles
 
         public Dictionary<Mobile, PendingBribe> Bribes { get; set; }
 
+        private void CheckNextMultiplierDecay(bool force = true)
+        {
+            int minDays = Config.Get("Vendors.BribeDecayMinTime", 25);
+            int maxDays = Config.Get("Vendors.BribeDecayMaxTime", 30);
+
+            if (force || (NextMultiplierDecay > DateTime.UtcNow + TimeSpan.FromDays(maxDays)))
+                NextMultiplierDecay = DateTime.UtcNow + TimeSpan.FromDays(Utility.RandomMinMax(minDays, maxDays));
+        }
+
         public void TryBribe(Mobile m)
         {
             if (UnderWatch)
@@ -1365,6 +1374,7 @@ namespace Server.Mobiles
                 if (WatchEnds < DateTime.UtcNow)
                 {
                     WatchEnds = DateTime.MinValue;
+                    RecentBribes = 0;
                 }
                 else
                 {
@@ -1431,7 +1441,7 @@ namespace Server.Mobiles
             }
 
             BribeMultiplier++;
-            NextMultiplierDecay = DateTime.UtcNow + TimeSpan.FromDays(Utility.RandomMinMax(25, 30));
+            CheckNextMultiplierDecay();
         }
 
         #endregion
@@ -2286,7 +2296,7 @@ namespace Server.Mobiles
                         if (BribeMultiplier > 0)
                             BribeMultiplier /= 2;
 
-                        NextMultiplierDecay = DateTime.UtcNow + TimeSpan.FromDays(Utility.RandomMinMax(25, 30));
+                        CheckNextMultiplierDecay();
                     });
             }
 		}
@@ -2307,6 +2317,7 @@ namespace Server.Mobiles
                 case 2:
                     BribeMultiplier = reader.ReadInt();
                     NextMultiplierDecay = reader.ReadDateTime();
+                    CheckNextMultiplierDecay(false);  // Reset NextMultiplierDecay if it is out of range of the config
                     RecentBribes = reader.ReadInt();
                     goto case 1;
 				case 1:


### PR DESCRIPTION
Setup configuration in vendor.cfg to change the min and max vendor bribe decay period.

Check the config on load and reset the timer if the config max is lower than the current time

Reset the RecentBribes when no longer under watch, so that the next bribe doesn't automatically trigger a watch

Since prior to this change, RecentBribes was always incremented, and never reset or decremented - after there have been 5 bribes, the vendor would always be under watch after each bribe.  Since this state is maintained over saves, the only time the vendor would not be under watch would be at the beginning of a shard - so this seems like a bug to me.


```
        public void DoBribe(Mobile m, IBOD bod)
        {
            BulkOrderSystem.MutateBOD(bod);

            RecentBribes++;

            if (RecentBribes >= 3 && Utility.Random(6) < RecentBribes)
            {
                WatchEnds = DateTime.UtcNow + TimeSpan.FromMinutes(Utility.RandomMinMax(120, 180));
            }
```
