### PR TITLE
Revert "Bugfix - when multiple BODs are turned in at once, only one additional BOD is made available."

### DIFF
--- a/Scripts/Services/BulkOrders/BulkOrderSystem.cs
+++ b/Scripts/Services/BulkOrders/BulkOrderSystem.cs
@@ -238,7 +238,7 @@ namespace Server.Engines.BulkOrders
                 {
                     if (context.Entries.ContainsKey(type))
                     {
-                        context.Entries[type].LastBulkOrder = (context.Entries[type].LastBulkOrder + ts) - TimeSpan.FromHours(Delay);
+                        context.Entries[type].LastBulkOrder = (DateTime.UtcNow + ts) - TimeSpan.FromHours(Delay);
                     }
                 }
                 else if (context.Entries.ContainsKey(type))


### PR DESCRIPTION
Reverts ServUO/ServUO#3197

This needs to be reworked.  See this bug:
http://servuo.com/threads/bulkorder-crash.9106/