### PR TITLE
Crash fix for BOD / Bugfix for turning in multiple BODs at once yields only one to be available

### DIFF
--- a/Scripts/Services/BulkOrders/BulkOrderSystem.cs
+++ b/Scripts/Services/BulkOrders/BulkOrderSystem.cs
@@ -238,7 +238,10 @@ namespace Server.Engines.BulkOrders
                 {
                     if (context.Entries.ContainsKey(type))
                     {
-                        context.Entries[type].LastBulkOrder = (DateTime.UtcNow + ts) - TimeSpan.FromHours(Delay);
+                        if (context.Entries[type].LastBulkOrder < DateTime.UtcNow - TimeSpan.FromHours(Delay * MaxCachedDeeds))
+                            context.Entries[type].LastBulkOrder = DateTime.UtcNow - TimeSpan.FromHours(Delay * MaxCachedDeeds);
+                        else
+                            context.Entries[type].LastBulkOrder = (context.Entries[type].LastBulkOrder + ts) - TimeSpan.FromHours(Delay);
                     }
                 }
                 else if (context.Entries.ContainsKey(type))


### PR DESCRIPTION
- Pull request 3211
- Pull request 3197

Verified the crash - occurred on character that hadn't gotten any BODs before turning one in.

Verified the fix in the same scenario