### PR TITLE
Update for pets skill decrease on res

### DIFF
--- a/Scripts/Gumps/PetResurrectGump.cs
+++ b/Scripts/Gumps/PetResurrectGump.cs
@@ -65,7 +65,7 @@ namespace Server.Gumps
 
                 double decreaseAmount;
 
-                if (from == this.m_Pet.ControlMaster)
+                if (from is PlayerMobile)
                     decreaseAmount = 0.1;
                 else
                     decreaseAmount = 0.2;


### PR DESCRIPTION
Pets lose 0.1% of each skill when resurrected by any player, not only ControlMaster. 0.2% when resurrected by NPC