### PR TITLE
Validate vendor search use upon gump response

### DIFF
--- a/Scripts/Services/Vendor Searching/VendorSearchGump.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearchGump.cs
@@ -152,6 +152,13 @@ namespace Server.Engines.VendorSearching
         {
             if (info.ButtonID != 0)
             {
+                if (!VendorSearch.CanSearch(User))
+                {
+                    User.CloseGump(typeof(VendorSearchGump));
+                    User.SendLocalizedMessage(1154680); //Before using vendor search, you must be in a justice region or a safe log-out location (such as an inn or a house which has you on its Owner, Co-owner, or Friends list). 
+                    return;
+                }
+                
                 TextRelay searchname = info.GetTextEntry(0);
 
                 if (searchname != null && !String.IsNullOrEmpty(searchname.Text))


### PR DESCRIPTION
Add a new validation check in the gump response handler for any button but exit. not OSI perfect as gump stays open when you leave a safe area, but solves the exploit potential re #3204 