### PR TITLE
Block spaces in usernames

### DIFF
--- a/Scripts/Accounting/AccountHandler.cs
+++ b/Scripts/Accounting/AccountHandler.cs
@@ -71,7 +71,7 @@ namespace Server.Misc
 
         private static readonly char[] m_ForbiddenChars = new char[]
         {
-            '<', '>', ':', '"', '/', '\\', '|', '?', '*'
+            '<', '>', ':', '"', '/', '\\', '|', '?', '*', ' '
         };
 
         private static AccessLevel m_LockdownLevel;


### PR DESCRIPTION
Add space character to the list of forbidden characters, Will only apply to new accounts.
Solves #3202 