### PR TITLE
Pet training Bug Fixes

### DIFF
--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -3001,6 +3001,11 @@ namespace Server.Mobiles
                     _TrainingProfile = new TrainingProfile(this, reader);
                 }
             }
+            else if(Tamable)
+            {
+                CalculateSlots();
+                ControlSlots = ControlSlotsMin;
+            }
 
             if (version <= 14 && m_Paragon && Hue == 0x31)
             {
@@ -7452,7 +7457,7 @@ namespace Server.Mobiles
         {
             long tc = Core.TickCount;
 
-            if (HasAura && tc >= m_NextAura)
+            if (Combatant != null && HasAura && tc >= m_NextAura)
             {
                 AuraDamage();
                 m_NextAura = tc + (int)AuraInterval.TotalMilliseconds;

--- a/Scripts/Mobiles/Normal/Mongbat.cs
+++ b/Scripts/Mobiles/Normal/Mongbat.cs
@@ -9,35 +9,35 @@ namespace Server.Mobiles
         public Mongbat()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a mongbat";
-            this.Body = 39;
-            this.BaseSoundID = 422;
+            Name = "a mongbat";
+            Body = 39;
+            BaseSoundID = 422;
 
-            this.SetStr(6, 10);
-            this.SetDex(26, 38);
-            this.SetInt(6, 14);
+            SetStr(6, 10);
+            SetDex(26, 38);
+            SetInt(6, 14);
 
-            this.SetHits(4, 6);
-            this.SetMana(0);
+            SetHits(4, 6);
+            SetMana(0);
 
-            this.SetDamage(1, 2);
+            SetDamage(1, 2);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 5, 10);
+            SetResistance(ResistanceType.Physical, 5, 10);
 
-            this.SetSkill(SkillName.MagicResist, 5.1, 14.0);
-            this.SetSkill(SkillName.Tactics, 5.1, 10.0);
-            this.SetSkill(SkillName.Wrestling, 5.1, 10.0);
+            SetSkill(SkillName.MagicResist, 5.1, 14.0);
+            SetSkill(SkillName.Tactics, 5.1, 10.0);
+            SetSkill(SkillName.Wrestling, 5.1, 10.0);
 
-            this.Fame = 150;
-            this.Karma = -150;
+            Fame = 150;
+            Karma = -150;
 
-            this.VirtualArmor = 10;
+            VirtualArmor = 10;
 
-            this.Tamable = true;
-            this.ControlSlots = 1;
-            this.MinTameSkill = -18.9;
+            Tamable = true;
+            ControlSlots = 1;
+            MinTameSkill = -18.9;
         }
 
         public Mongbat(Serial serial)
@@ -70,7 +70,7 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Poor);
+            AddLoot(LootPack.Poor);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Services/Pet Training/AbilityProfile.cs
+++ b/Scripts/Services/Pet Training/AbilityProfile.cs
@@ -378,7 +378,11 @@ namespace Server.Mobiles
         {
             if (MagicalAbility != MagicalAbility.None)
             {
-                yield return MagicalAbility;
+                foreach (var abil in PetTrainingHelper.MagicalAbilities)
+                {
+                    if ((MagicalAbility & abil) != 0)
+                        yield return abil;
+                }
             }
 
             if (SpecialAbilities != null)

--- a/Scripts/Services/Pet Training/PetTrainingGate.cs
+++ b/Scripts/Services/Pet Training/PetTrainingGate.cs
@@ -1,6 +1,7 @@
 using Server;
 using System;
 using Server.Mobiles;
+using Server.Gumps;
 
 namespace Server.Items
 {
@@ -36,6 +37,16 @@ namespace Server.Items
                 {
                     profile.TrainingProgress = profile.TrainingProgressMax;
                     bc.FixedEffect(0x375A, 10, 30);
+
+                    if (bc.ControlMaster is PlayerMobile)
+                    {
+                        var gump = bc.ControlMaster.FindGump<NewAnimalLoreGump>();
+
+                        if (gump != null)
+                            gump.Refresh();
+                        else
+                            BaseGump.SendGump(new NewAnimalLoreGump((PlayerMobile)bc.ControlMaster, bc));
+                    }
                 }
             }
 


### PR DESCRIPTION
- pre-patch pets will not be alloted the proper min/max control slots so they can be trained
- Fixed crash when loring certain creatures, ie rune beetles
- Fixed issue with capped training attributes to stats and resists formulas
- Fixed stam/mana regen being switch when trained
- Fixed double anatomy cliloc, it should now show Parry instead
- Fixed occurance where damage per second would be applied past its cap in a particular round of Training
- Fixed powerscroll requirement display
- Adding str/dex/int will no longer effect hits/stam/Mana
- Common skills, even if skill level is zero, can have a powerscroll trained, ie resist spells, anatomy, tactics, parry (wrestle 100+)
- Using Training Gate will now refresh animal lore Gumps
- Creature Damage Aura no longer triggers when creature is not in Combat