### PR TITLE
Pet Training Fixes/Updates

### DIFF
--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -1653,14 +1653,14 @@ namespace Server.Items
 			double bushidoNonRacial = defender.Skills[SkillName.Bushido].NonRacialValue;
 			double bushido = defender.Skills[SkillName.Bushido].Value;
 
-			if (shield != null)
+			if (shield != null || !defender.Player)
 			{
 				double chance = (parry - bushidoNonRacial) / 400.0;
 					// As per OSI, no negitive effect from the Racial stuffs, ie, 120 parry and '0' bushido with humans
 
 				if (chance < 0) // chance shouldn't go below 0
 				{
-					chance = 0;
+					chance = defender.Player ? 0 : .1;
 				}
 
                 // Skill Masteries
@@ -1679,14 +1679,14 @@ namespace Server.Items
 				}
 
 				// Low dexterity lowers the chance.
-				if (defender.Dex < 80)
+				if (defender.Player && defender.Dex < 80)
 				{
 					chance = chance * (20 + defender.Dex) / 100;
 				}
 
 				return defender.CheckSkill(SkillName.Parry, chance);
 			}
-			else if (defender is BaseCreature || (!(defender.Weapon is Fists) && !(defender.Weapon is BaseRanged)))
+			else if (!(defender.Weapon is Fists) && !(defender.Weapon is BaseRanged))
 			{
 				BaseWeapon weapon = defender.Weapon as BaseWeapon;
 
@@ -1700,9 +1700,6 @@ namespace Server.Items
 				double chance = (parry * bushido) / divisor;
 
 				double aosChance = parry / 800.0;
-
-                if (parry == 0 && defender is BaseCreature)
-                    parry = 20.0;
 
 				// Parry or Bushido over 100 grant a 5% bonus.
 				if (parry >= 100.0)
@@ -1749,7 +1746,7 @@ namespace Server.Items
 
 			if (defender.Player || defender.Body.IsHuman || (defender is BaseCreature && 
                                                             ((BaseCreature)defender).Controlled &&
-                                                            defender.Skills[SkillName.Wrestling].Base > 100))
+                                                            defender.Skills[SkillName.Wrestling].Base >= 100))
 			{
 				blocked = CheckParry(defender);
                 BaseWeapon weapon = defender.Weapon as BaseWeapon;

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -319,32 +319,40 @@ namespace Server
                 }
             }
 
-            #region Pet Training
-            if (PetTrainingHelper.Enabled && (from is BaseCreature || m is BaseCreature))
-            {
-                SpecialAbility.CheckCombatTrigger(from, m, ref totalDamage, type);
-
-                if (from is BaseCreature && m is BaseCreature)
-                {
-                    var profile = PetTrainingHelper.GetTrainingProfile((BaseCreature)from);
-
-                    if (profile != null)
-                    {
-                        profile.CheckProgress((BaseCreature)m);
-                    }
-
-                    profile = PetTrainingHelper.GetTrainingProfile((BaseCreature)m);
-
-                    if (profile != null && 0.3 > Utility.RandomDouble())
-                    {
-                        profile.CheckProgress((BaseCreature)from);
-                    }
-                }
-            }
-            #endregion
-
             #region Skill Mastery
             SkillMasterySpell.OnDamage(m, from, type, ref totalDamage);
+            #endregion
+
+            #region Pet Training
+            if (PetTrainingHelper.Enabled)
+            {
+                if (from is BaseCreature || m is BaseCreature)
+                {
+                    SpecialAbility.CheckCombatTrigger(from, m, ref totalDamage, type);
+
+                    if (from is BaseCreature && m is BaseCreature)
+                    {
+                        var profile = PetTrainingHelper.GetTrainingProfile((BaseCreature)from);
+
+                        if (profile != null)
+                        {
+                            profile.CheckProgress((BaseCreature)m);
+                        }
+
+                        profile = PetTrainingHelper.GetTrainingProfile((BaseCreature)m);
+
+                        if (profile != null && 0.3 > Utility.RandomDouble())
+                        {
+                            profile.CheckProgress((BaseCreature)from);
+                        }
+                    }
+                }
+
+                if (from is BaseCreature && ((BaseCreature)from).Controlled && m.Player)
+                {
+                    totalDamage /= 2;
+                }
+            }
             #endregion
 
             if (keepAlive && totalDamage > m.Hits)

--- a/Scripts/Misc/SkillCheck.cs
+++ b/Scripts/Misc/SkillCheck.cs
@@ -266,7 +266,7 @@ namespace Server.Misc
             if (from is BaseCreature && ((BaseCreature)from).IsDeadPet)
                 return;
 
-            if (skill.SkillName == SkillName.Focus && from is BaseCreature)
+            if (!PetTrainingHelper.Enabled && skill.SkillName == SkillName.Focus && from is BaseCreature)
                 return;
 
             if (skill.Base < skill.Cap && skill.Lock == SkillLock.Up)

--- a/Scripts/Mobiles/AI/Magical AI/PaladinAI.cs
+++ b/Scripts/Mobiles/AI/Magical AI/PaladinAI.cs
@@ -43,11 +43,15 @@ namespace Server.Mobiles
             if(mana >= 15)
                 select = 3;
 
+            if (mana >= 20 && !EnemyOfOneSpell.UnderEffect(m_Mobile))
+                select = 4;
+
             switch (Utility.Random(select))
             {
                 case 0: return new RemoveCurseSpell(m_Mobile, null);
                 case 1: return new DivineFurySpell(m_Mobile, null);
                 case 2: return new ConsecrateWeaponSpell(m_Mobile, null);
+                case 3: return new EnemyOfOneSpell(m_Mobile, null);
             }
 
             return new ConsecrateWeaponSpell(m_Mobile, null);

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -3004,6 +3004,12 @@ namespace Server.Mobiles
             else if(Tamable)
             {
                 CalculateSlots();
+
+                if (m_iControlSlots < ControlSlotsMin)
+                {
+                    ControlSlotsMin = m_iControlSlots;
+                }
+
                 ControlSlots = ControlSlotsMin;
             }
 
@@ -5177,7 +5183,7 @@ namespace Server.Mobiles
                 Skills[name].Cap = Skills[name].Base;
             }
 
-            if (name == SkillName.Poisoning && Skills[name].Base > 0)
+            if (name == SkillName.Poisoning && Skills[name].Base > 0 && !PetTrainingHelper.ValidateTrainingPoint(this, MagicalAbility.Poisoning))
             {
                 SetMagicalAbility(MagicalAbility.Poisoning);
             }

--- a/Scripts/Mobiles/Normal/Kepetch.cs
+++ b/Scripts/Mobiles/Normal/Kepetch.cs
@@ -14,29 +14,29 @@ namespace Server.Mobiles
         public Kepetch()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a kepetch";
-            this.Body = 726;
+            Name = "a kepetch";
+            Body = 726;
 
-            this.SetStr(337, 354);
-            this.SetDex(184, 194);
-            this.SetInt(32, 37);
+            SetStr(337, 354);
+            SetDex(184, 194);
+            SetInt(32, 37);
 
-            this.SetHits(308, 366);
+            SetHits(308, 366);
 
-            this.SetDamage(7, 17);
+            SetDamage(7, 17);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 55, 65);
-            this.SetResistance(ResistanceType.Fire, 40, 45);
-            this.SetResistance(ResistanceType.Cold, 45, 55);
-            this.SetResistance(ResistanceType.Poison, 55, 65);
-            this.SetResistance(ResistanceType.Energy, 65, 75);
+            SetResistance(ResistanceType.Physical, 55, 65);
+            SetResistance(ResistanceType.Fire, 40, 45);
+            SetResistance(ResistanceType.Cold, 45, 55);
+            SetResistance(ResistanceType.Poison, 55, 65);
+            SetResistance(ResistanceType.Energy, 65, 75);
 
-            this.SetSkill(SkillName.Anatomy, 119.7, 124.1);
-            this.SetSkill(SkillName.MagicResist, 89.9, 97.4);
-            this.SetSkill(SkillName.Tactics, 117.4, 123.5);
-            this.SetSkill(SkillName.Wrestling, 107.7, 113.9);
+            SetSkill(SkillName.Anatomy, 119.7, 124.1);
+            SetSkill(SkillName.MagicResist, 89.9, 97.4);
+            SetSkill(SkillName.Tactics, 117.4, 123.5);
+            SetSkill(SkillName.Wrestling, 107.7, 113.9);
         }
 
         public Kepetch(Serial serial)
@@ -110,7 +110,7 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Average, 2);
+            AddLoot(LootPack.Average, 2);
         }
 
         public override int GetIdleSound()

--- a/Scripts/Mobiles/Normal/LesserHiryu.cs
+++ b/Scripts/Mobiles/Normal/LesserHiryu.cs
@@ -137,6 +137,16 @@ namespace Server.Mobiles
 
         public override double GetControlChance(Mobile m, bool useBaseSkill)
         {
+            if (PetTrainingHelper.Enabled)
+            {
+                var profile = PetTrainingHelper.GetAbilityProfile(this);
+
+                if (profile != null && profile.HasCustomized())
+                {
+                    return base.GetControlChance(m, useBaseSkill);
+                }
+            }
+
             double tamingChance = base.GetControlChance(m, useBaseSkill);
 
             if (tamingChance >= 0.95)

--- a/Scripts/Mobiles/Normal/SabertoothedTiger.cs
+++ b/Scripts/Mobiles/Normal/SabertoothedTiger.cs
@@ -14,11 +14,11 @@ namespace Server.Mobiles
             Body = 0x588;
             Female = true;
 
-            SetStr(521);
-            SetDex(403);
-            SetInt(448);
+            SetStr(496, 523);
+            SetDex(386, 403);
+            SetInt(443, 469);
 
-            SetHits(404);
+            SetHits(362, 423);
 
             SetDamage(21, 28);
 

--- a/Scripts/Mobiles/Normal/Triceratops.cs
+++ b/Scripts/Mobiles/Normal/Triceratops.cs
@@ -10,36 +10,36 @@ namespace Server.Mobiles
         public Triceratops()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "Triceratops";
-            this.Body = 0x587;
-            this.Female = true;
+            Name = "Triceratops";
+            Body = 0x587;
+            Female = true;
 
-            this.SetStr(1100, 1300);
-            this.SetDex(150, 170);
-            this.SetInt(280, 310);
+            SetStr(1100, 1300);
+            SetDex(150, 170);
+            SetInt(280, 310);
 
-            this.SetHits(1100 , 1200);
+            SetHits(1100 , 1200);
 
-            this.SetDamage(21, 28);
+            SetDamage(21, 28);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 70, 80);
-            this.SetResistance(ResistanceType.Fire, 40, 50);
-            this.SetResistance(ResistanceType.Cold, 40, 50);
-            this.SetResistance(ResistanceType.Poison, 30, 40);
-            this.SetResistance(ResistanceType.Energy, 40, 50);
+            SetResistance(ResistanceType.Physical, 70, 80);
+            SetResistance(ResistanceType.Fire, 40, 50);
+            SetResistance(ResistanceType.Cold, 40, 50);
+            SetResistance(ResistanceType.Poison, 30, 40);
+            SetResistance(ResistanceType.Energy, 40, 50);
 
-            this.SetSkill(SkillName.Anatomy, 65.0, 75.0);
-            this.SetSkill(SkillName.Tactics, 90.0, 100.0);
-            this.SetSkill(SkillName.Wrestling, 95.0, 105.0);
-            this.SetSkill(SkillName.DetectHidden, 75.0);
-            this.SetSkill(SkillName.Focus, 95.0, 105.0);
-            this.SetSkill(SkillName.Parry, 0.0, 105.0);
+            SetSkill(SkillName.Anatomy, 65.0, 75.0);
+            SetSkill(SkillName.Tactics, 90.0, 100.0);
+            SetSkill(SkillName.Wrestling, 95.0, 105.0);
+            SetSkill(SkillName.DetectHidden, 75.0);
+            SetSkill(SkillName.Focus, 95.0, 105.0);
+            SetSkill(SkillName.Parry, 0.0, 105.0);
 
-            this.Tamable = true;
-            this.ControlSlots = 3;
-            this.MinTameSkill = 102.0;
+            Tamable = true;
+            ControlSlots = 3;
+            MinTameSkill = 102.0;
 
             SetMagicalAbility(MagicalAbility.Piercing);
         }

--- a/Scripts/Services/Expansions/Time Of Legends/Mobiles/Dimetrosaur.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Mobiles/Dimetrosaur.cs
@@ -84,6 +84,11 @@ namespace Server.Mobiles
             SetHits(360, 380);
         }
 
+        public override void OnAfterTame(Mobile tamer)
+        {
+            SetHits(HitsMax / 4);
+        }
+
         public override bool CanAngerOnTame { get { return true; } }
         public override bool StatLossAfterTame { get { return true; } }
         public override int Meat { get { return 1; } }

--- a/Scripts/Services/Expansions/Time Of Legends/Mobiles/Najasaurus.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Mobiles/Najasaurus.cs
@@ -12,38 +12,38 @@ namespace Server.Mobiles
         public Najasaurus()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, .2, .4)
         {
-            this.Name = "a najasaurus";
-            this.Body = 1289;
-            this.BaseSoundID = 219;
+            Name = "a najasaurus";
+            Body = 1289;
+            BaseSoundID = 219;
 
-            this.SetStr(160, 300);
-            this.SetDex(160, 300);
-            this.SetInt(20, 40);
+            SetStr(162, 346);
+            SetDex(151, 218);
+            SetInt(21, 40);
 
-            this.SetDamage(13, 24);
-            this.SetHits(700, 900);
+            SetDamage(13, 24);
+            SetHits(746, 844);
 
-            this.SetDamageType(ResistanceType.Physical, 50);
-            this.SetDamageType(ResistanceType.Poison, 50);
+            SetDamageType(ResistanceType.Physical, 50);
+            SetDamageType(ResistanceType.Poison, 50);
 
-            this.SetResistance(ResistanceType.Physical, 45, 55);
-            this.SetResistance(ResistanceType.Fire, 50, 60);
-            this.SetResistance(ResistanceType.Cold, 45, 55);
-            this.SetResistance(ResistanceType.Poison, 100);
-            this.SetResistance(ResistanceType.Energy, 35, 45);
+            SetResistance(ResistanceType.Physical, 45, 55);
+            SetResistance(ResistanceType.Fire, 50, 60);
+            SetResistance(ResistanceType.Cold, 45, 55);
+            SetResistance(ResistanceType.Poison, 100);
+            SetResistance(ResistanceType.Energy, 35, 45);
 
-            this.SetSkill(SkillName.MagicResist, 150.0, 190.0);
-            this.SetSkill(SkillName.Tactics, 80.0, 95.0);
-            this.SetSkill(SkillName.Wrestling, 80.0, 100.0);
-            this.SetSkill(SkillName.Poisoning, 90.0, 100.0);
-            this.SetSkill(SkillName.DetectHidden, 45.0, 55.0);
+            SetSkill(SkillName.MagicResist, 150.0, 190.0);
+            SetSkill(SkillName.Tactics, 80.0, 95.0);
+            SetSkill(SkillName.Wrestling, 80.0, 100.0);
+            SetSkill(SkillName.Poisoning, 90.0, 100.0);
+            SetSkill(SkillName.DetectHidden, 45.0, 55.0);
 
-            this.Fame = 17000;
-            this.Karma = -17000;
+            Fame = 17000;
+            Karma = -17000;
 
-            this.Tamable = true;
-            this.ControlSlots = 2;
-            this.MinTameSkill = 102.0;
+            Tamable = true;
+            ControlSlots = 2;
+            MinTameSkill = 102.0;
         }
 
         public override Poison HitPoison { get { return Poison.Lethal; } }
@@ -53,7 +53,7 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.FilthyRich);
+            AddLoot(LootPack.FilthyRich);
         }
 
         public Najasaurus(Serial serial)

--- a/Scripts/Services/Pet Training/AreaEffects.cs
+++ b/Scripts/Services/Pet Training/AreaEffects.cs
@@ -247,6 +247,7 @@ namespace Server.Mobiles
         public override TimeSpan CooldownDuration { get { return TimeSpan.FromSeconds(40 + Utility.RandomDouble() * 30); } }
         public override int MaxRange { get { return 4; } }
         public override int EffectRange { get { return 4; } }
+        public override int ManaCost { get { return 100; } }
 
         public static Dictionary<Mobile, Timer> _Table;
 
@@ -333,6 +334,8 @@ namespace Server.Mobiles
 
     public class ExplosiveGoo : AreaEffect
     {
+        public override int ManaCost { get { return 30; } }
+
         public ExplosiveGoo()
         {
         }
@@ -388,6 +391,7 @@ namespace Server.Mobiles
         public override double TriggerChance { get { return 0.4; } }
         public override int EffectRange { get { return 10; } }
         public override MagicalAbility RequiredSchool { get { return MagicalAbility.Poisoning; } }
+        public override int ManaCost { get { return 50; } }
 
         public PoisonBreath()
         {

--- a/Scripts/Services/Pet Training/Gumps.cs
+++ b/Scripts/Services/Pet Training/Gumps.cs
@@ -186,31 +186,31 @@ namespace Server.Mobiles
             AddHtmlLocalized(47, 74, 160, 18, 3001030, 0xC8, false, false); // Combat Ratings
 
             AddHtmlLocalized(53, 92, 160, 18, 1044103, _Label, false, false); // Wrestling
-            AddHtml(180, 92, 35, 18, FormatSkill(Creature, SkillName.Wrestling), false, false);
+            AddHtml(180, 92, 75, 18, FormatSkill(Creature, SkillName.Wrestling), false, false);
 
             AddHtmlLocalized(53, 110, 160, 18, 1044087, _Label, false, false); // Tactics
-            AddHtml(180, 110, 35, 18, FormatSkill(Creature, SkillName.Tactics), false, false);
+            AddHtml(180, 110, 75, 18, FormatSkill(Creature, SkillName.Tactics), false, false);
 
             AddHtmlLocalized(53, 128, 160, 18, 1044086, _Label, false, false); // Magic Resistance
-            AddHtml(180, 128, 35, 18, FormatSkill(Creature, SkillName.MagicResist), false, false);
+            AddHtml(180, 128, 75, 18, FormatSkill(Creature, SkillName.MagicResist), false, false);
 
             AddHtmlLocalized(53, 146, 160, 18, 1044061, _Label, false, false); // Anatomy
-            AddHtml(180, 146, 35, 18, FormatSkill(Creature, SkillName.Anatomy), false, false);
+            AddHtml(180, 146, 75, 18, FormatSkill(Creature, SkillName.Anatomy), false, false);
 
             AddHtmlLocalized(53, 164, 160, 18, 1002082, _Label, false, false); // Healing
-            AddHtml(180, 164, 35, 18, FormatSkill(Creature, SkillName.Healing), false, false);
+            AddHtml(180, 164, 75, 18, FormatSkill(Creature, SkillName.Healing), false, false);
 
             AddHtmlLocalized(53, 182, 160, 18, 1002122, _Label, false, false); // Poisoning
-            AddHtml(180, 182, 35, 18, FormatSkill(Creature, SkillName.Poisoning), false, false);
+            AddHtml(180, 182, 75, 18, FormatSkill(Creature, SkillName.Poisoning), false, false);
 
             AddHtmlLocalized(53, 200, 160, 18, 1044074, _Label, false, false); // Detect Hidden
-            AddHtml(180, 200, 35, 18, FormatSkill(Creature, SkillName.DetectHidden), false, false);
+            AddHtml(180, 200, 75, 18, FormatSkill(Creature, SkillName.DetectHidden), false, false);
 
             AddHtmlLocalized(53, 218, 160, 18, 1002088, _Label, false, false); // Hiding
-            AddHtml(180, 218, 35, 18, FormatSkill(Creature, SkillName.Hiding), false, false);
+            AddHtml(180, 218, 75, 18, FormatSkill(Creature, SkillName.Hiding), false, false);
 
             AddHtmlLocalized(53, 236, 160, 18, 1002118, _Label, false, false); // Parrying
-            AddHtml(180, 236, 35, 18, FormatSkill(Creature, SkillName.Parry), false, false);
+            AddHtml(180, 236, 75, 18, FormatSkill(Creature, SkillName.Parry), false, false);
 
             AddButton(240, 328, 0x15E1, 0x15E5, 0, GumpButtonType.Page, 6);
             AddButton(217, 328, 0x15E3, 0x15E7, 0, GumpButtonType.Page, 4);
@@ -222,31 +222,31 @@ namespace Server.Mobiles
             AddHtmlLocalized(47, 74, 160, 18, 3001032, 0xC8, false, false); // Lore & Knowledge
 
             AddHtmlLocalized(53, 92, 160, 18, 1044085, _Label, false, false); // Magery
-            AddHtml(180, 92, 35, 18, FormatSkill(Creature, SkillName.Magery), false, false);
+            AddHtml(180, 92, 75, 18, FormatSkill(Creature, SkillName.Magery), false, false);
 
             AddHtmlLocalized(53, 110, 160, 18, 1044076, _Label, false, false); // Eval Int
-            AddHtml(180, 110, 35, 18, FormatSkill(Creature, SkillName.EvalInt), false, false);
+            AddHtml(180, 110, 75, 18, FormatSkill(Creature, SkillName.EvalInt), false, false);
 
             AddHtmlLocalized(53, 128, 160, 18, 1044106, _Label, false, false); // Meditation
-            AddHtml(180, 128, 35, 18, FormatSkill(Creature, SkillName.Meditation), false, false);
+            AddHtml(180, 128, 75, 18, FormatSkill(Creature, SkillName.Meditation), false, false);
 
             AddHtmlLocalized(53, 146, 160, 18, 1044109, _Label, false, false); // Necromancy
-            AddHtml(180, 146, 35, 18, FormatSkill(Creature, SkillName.Necromancy), false, false);
+            AddHtml(180, 146, 75, 18, FormatSkill(Creature, SkillName.Necromancy), false, false);
 
             AddHtmlLocalized(53, 164, 160, 18, 1002140, _Label, false, false); // Spirit Speak
-            AddHtml(180, 164, 35, 18, FormatSkill(Creature, SkillName.SpiritSpeak), false, false);
+            AddHtml(180, 164, 75, 18, FormatSkill(Creature, SkillName.SpiritSpeak), false, false);
 
             AddHtmlLocalized(53, 182, 160, 18, 1044115, _Label, false, false); // Mysticism
-            AddHtml(180, 182, 35, 18, FormatSkill(Creature, SkillName.Mysticism), false, false);
+            AddHtml(180, 182, 75, 18, FormatSkill(Creature, SkillName.Mysticism), false, false);
 
             AddHtmlLocalized(53, 200, 160, 18, 1044110, _Label, false, false); // Focus
-            AddHtml(180, 200, 35, 18, FormatSkill(Creature, SkillName.Focus), false, false);
+            AddHtml(180, 200, 75, 18, FormatSkill(Creature, SkillName.Focus), false, false);
 
             AddHtmlLocalized(53, 218, 160, 18, 1044114, _Label, false, false); // Spellweaving
-            AddHtml(180, 218, 35, 18, FormatSkill(Creature, SkillName.Spellweaving), false, false);
+            AddHtml(180, 218, 75, 18, FormatSkill(Creature, SkillName.Spellweaving), false, false);
 
             AddHtmlLocalized(53, 236, 160, 18, 1044075, _Label, false, false); // Discordance
-            AddHtml(180, 236, 35, 18, FormatSkill(Creature, SkillName.Discordance), false, false);
+            AddHtml(180, 236, 75, 18, FormatSkill(Creature, SkillName.Discordance), false, false);
 
             AddButton(240, 328, 0x15E1, 0x15E5, 0, GumpButtonType.Page, 7);
             AddButton(217, 328, 0x15E3, 0x15E7, 0, GumpButtonType.Page, 5);
@@ -258,13 +258,13 @@ namespace Server.Mobiles
             AddHtmlLocalized(47, 74, 160, 18, 3001032, 0xC8, false, false); // Lore & Knowledge
 
             AddHtmlLocalized(53, 92, 160, 18, 1044112, _Label, false, false); // Bushido
-            AddHtml(180, 92, 35, 18, FormatSkill(Creature, SkillName.Bushido), false, false);
+            AddHtml(180, 92, 75, 18, FormatSkill(Creature, SkillName.Bushido), false, false);
 
             AddHtmlLocalized(53, 110, 160, 18, 1044113, _Label, false, false); // Ninjitsu
-            AddHtml(180, 110, 35, 18, FormatSkill(Creature, SkillName.Ninjitsu), false, false);
+            AddHtml(180, 110, 75, 18, FormatSkill(Creature, SkillName.Ninjitsu), false, false);
 
             AddHtmlLocalized(53, 128, 160, 18, 1044111, _Label, false, false); // Chivalry
-            AddHtml(180, 128, 35, 18, FormatSkill(Creature, SkillName.Chivalry), false, false);
+            AddHtml(180, 128, 75, 18, FormatSkill(Creature, SkillName.Chivalry), false, false);
 
             AddImage(28, 146, 0x826);
 
@@ -371,17 +371,23 @@ namespace Server.Mobiles
 
                     AddHtmlLocalized(47, 74, 160, 18, 1157505, 0xC8, false, false); // Pet Advancements
 
-                    for (int i = 0; i < profile.History.Count; i++)
+                    for (int i = profile.History.Count - 1; i >= 0; i--)
                     {
                         var loc = PetTrainingHelper.GetLocalization(profile.History[i]);
+                        bool skill = profile.History[i] is SkillName; // ? "#228B22" : "#FF4500";
 
                         if (loc[0].Number > 0)
                         {
-                            AddHtmlLocalized(53, y, 180, 18, loc[0], C32216(0xFF4500), false, false);
+                            AddHtmlLocalized(53, y, 180, 18, loc[0], C32216(skill ? 0x008000 : 0xFF4500), false, false);
+
+                            if (skill)
+                            {
+                                AddHtml(180, y, 75, 18, String.Format("<div align=right>{0:F1}</div>", Creature.Skills[(SkillName)profile.History[i]].Cap), false, false);
+                            }
                         }
                         else if (loc[0].String != null)
                         {
-                            AddHtml(53, y, 180, 18, Color("#FF4500", loc[0]), false, false);
+                            AddHtml(53, y, 180, 18, Color(skill ? "#008000" : "#FF4500", loc[0]), false, false);
                         }
 
                         AddTooltip(PetTrainingHelper.GetCategoryLocalization(profile.History[i]));
@@ -563,14 +569,16 @@ namespace Server.Mobiles
 
         public override void AddGumpLayout()
         {
-            List<BaseCreature> pets = new List<BaseCreature>(User.AllFollowers.OfType<BaseCreature>().Where(p => p.TrainingProfile != null && p.TrainingProfile.HasBegunTraining));
+            List<BaseCreature> pets = new List<BaseCreature>(User.AllFollowers.OfType<BaseCreature>().Where(p => 
+                p.TrainingProfile != null &&
+                p.TrainingProfile.HasBegunTraining &&
+                p.Map == User.Map));
 
             if (pets == null || pets.Count == 0)
             {
                 AddBackground(0, 24, 254, 170, 0x24A4);
                 return;
             }
-
 
             if (pets.Contains(Creature) && pets[0] != Creature)
             {
@@ -860,7 +868,7 @@ namespace Server.Mobiles
 
                 if ((abil == MagicalAbility.Chivalry && Creature.Karma < 0) ||
                     (abil == MagicalAbility.Necromancy && Creature.Karma > 0) ||
-                    (abil == MagicalAbility.Necromancy && Creature.Karma > 0))
+                    (abil == MagicalAbility.Necromage && Creature.Karma > 0))
                 {
                     continue;
                 }
@@ -1223,13 +1231,25 @@ namespace Server.Mobiles
             if (Value > TrainingPoint.GetMax(Creature))
                 Value = TrainingPoint.GetMax(Creature);
 
+            int cost = PetTrainingHelper.GetTotalCost(TrainingPoint, Creature, Value, StartValue);
             double weight = TrainingPoint.Weight;
+
+            if (CanAdjust())
+            {
+                if (cost > profile.TrainingPoints)
+                {
+                    double dif = cost - profile.TrainingPoints;
+                    Value -= (int)Math.Ceiling((dif / weight));
+                }
+            }
 
             if (StartValue > 0)
             {
                 double valueWeight = (int)((double)Value * weight);
                 double maxWeight = TrainingPoint.GetMax(Creature) * weight;
                 double nonAdjustedWeight = (Value - StartValue) * weight;
+
+                double originalValueWeight = valueWeight;
 
                 if (TrainingPoint.TrainPoint is PetStat && (PetStat)TrainingPoint.TrainPoint <= PetStat.Mana)
                 {
@@ -1268,8 +1288,14 @@ namespace Server.Mobiles
                     valueWeight = maxWeight;
                 }
 
-                Value = (int)(valueWeight / weight);
+                if (originalValueWeight != valueWeight)
+                {
+                    Value = Math.Max(StartValue, (int)(valueWeight / weight));
+                }
             }
+
+            cost = PetTrainingHelper.GetTotalCost(TrainingPoint, Creature, Value, StartValue);
+            int avail = profile.TrainingPoints - cost;
 
             AddHtmlLocalized(35, 205, 245, 20, CenterLoc, "#1157493", 0, false, false); // REQUIREMENTS
 
@@ -1315,14 +1341,11 @@ namespace Server.Mobiles
                 AddHtmlLocalized(45, 225, 225, 60, cliloc, String.Format("#{0}", TrainingPoint.Name.Number), 0, false, false);
             }
 
-            int cost = PetTrainingHelper.GetTotalCost(TrainingPoint, Creature, Value, StartValue);
-            int avail = profile.TrainingPoints - cost;
-
             AddHtmlLocalized(305, 225, 145, 18, 1157490, false, false); // Avail. Training Points:
             AddLabel(455, 225, 0, avail.ToString());
 
             AddHtmlLocalized(305, 245, 145, 18, 1113646, false, false); // Total Property Weight:
-            AddLabel(455, 245, 0, String.Format("{0}/{1}", (Value * weight).ToString(), (TrainingPoint.GetMax(Creature) * weight).ToString()));
+            AddLabel(455, 245, 0, String.Format("{0}/{1}", ((int)(Value * weight)).ToString(), (TrainingPoint.GetMax(Creature) * weight).ToString()));
 
             if (TrainingPoint.Name.Number > 0)
                 AddHtmlLocalized(305, 265, 145, 18, TrainingPoint.Name.Number, false, false);
@@ -1339,7 +1362,7 @@ namespace Server.Mobiles
             }
 
             AddHtmlLocalized(230, 352, 150, 18, 1113586, false, false); // Property Weight:
-            AddHtml(267, 373, 35, 18, Center((Value * weight).ToString()), false, false);
+            AddHtml(267, 373, 75, 18, Center(((int)(Value * weight)).ToString()), false, false);
 
             if (CanAdjust())
             {
@@ -1438,7 +1461,7 @@ namespace Server.Mobiles
                         }
                         else
                         {
-                            Value = Math.Max(TrainingPoint.Start, Value -= (TrainingPoint.GetMax(Creature) / 10));
+                            Value = Value - (TrainingPoint.GetMax(Creature) / 10);
                         }
                     }
                     Refresh();
@@ -1452,8 +1475,14 @@ namespace Server.Mobiles
                         }
                         else
                         {
-                            Value--;
-                            Value = Math.Max(TrainingPoint.Start, Value);
+                            if (TrainingPoint.Weight < 1.0)
+                            {
+                                Value -= (int)(TrainingPoint.Weight * 100);
+                            }
+                            else
+                            {
+                                Value--;
+                            }
                         }
                     }
                     Refresh();
@@ -1467,8 +1496,14 @@ namespace Server.Mobiles
                         }
                         else
                         {
-                            Value++;
-                            Value = Math.Min(TrainingPoint.GetMax(Creature), Value);
+                            if (TrainingPoint.Weight < 1.0)
+                            {
+                                Value += (int)(TrainingPoint.Weight * 100);
+                            }
+                            else
+                            {
+                                Value++;
+                            }
                         }
                     }
                     Refresh();
@@ -1483,7 +1518,6 @@ namespace Server.Mobiles
                         else
                         {
                             Value += (TrainingPoint.GetMax(Creature) / 10);
-                            Value = Math.Min(TrainingPoint.GetMax(Creature), Value);
                         }
                     }
                     Refresh();
@@ -1511,7 +1545,7 @@ namespace Server.Mobiles
                         User.SendLocalizedMessage(1153204); // The pet is too far away from you!
                     }
                     else if (Server.Spells.SpellHelper.CheckCombat(User) || Server.Spells.SpellHelper.CheckCombat(Creature) ||
-                        Creature.Aggressors.Count > 0 || Creature.Aggressed.Count > 0)
+                        Creature.Aggressed.Count > 0)
                     {
                         User.SendLocalizedMessage(1156876); // Since you have been in combat recently you may not use this feature.
                     }
@@ -1561,26 +1595,14 @@ namespace Server.Mobiles
 
                                     profile.OnTrain(User, cost);
 
-                                    if (profile.HasBegunTraining)
-                                    {
-                                        Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
-                                        {
-                                            ResendGumps();
-                                        });
-                                    }
+                                    ResendGumps(profile.HasBegunTraining);
 
                                     Server.Engines.Quests.TeachingSomethingNewQuest.CheckComplete(User);
                                 }
                             },
                             () =>
                             {
-                                if (profile.HasBegunTraining)
-                                {
-                                    Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
-                                    {
-                                        ResendGumps();
-                                    });
-                                }
+                                ResendGumps(profile.HasBegunTraining);
                             }));
                     }
                     break;
@@ -1619,7 +1641,7 @@ namespace Server.Mobiles
             }
         }
 
-        private void ResendGumps()
+        private void ResendGumps(bool sendOptions)
         {
             Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
             {
@@ -1634,15 +1656,18 @@ namespace Server.Mobiles
                     BaseGump.SendGump(new NewAnimalLoreGump(User, Creature));
                 }
 
-                gump = User.FindGump<PetTrainingOptionsGump>();
+                if (sendOptions)
+                {
+                    gump = User.FindGump<PetTrainingOptionsGump>();
 
-                if (gump != null)
-                {
-                    gump.Refresh();
-                }
-                else
-                {
-                    BaseGump.SendGump(new PetTrainingOptionsGump(User, Creature));
+                    if (gump != null)
+                    {
+                        gump.Refresh();
+                    }
+                    else
+                    {
+                        BaseGump.SendGump(new PetTrainingOptionsGump(User, Creature));
+                    }
                 }
             });
         }

--- a/Scripts/Services/Pet Training/PetTrainingGate.cs
+++ b/Scripts/Services/Pet Training/PetTrainingGate.cs
@@ -53,7 +53,8 @@ namespace Server.Items
             return true;
         }
 
-        public PetTrainingGate(Serial serial)
+        public PetTrainingGate(Serial serial) 
+            : base(serial)
         {
         }
 
@@ -109,6 +110,7 @@ namespace Server.Items
         }
 
         public PetBondRemoveGate(Serial serial)
+            : base(serial)
         {
         }
 
@@ -165,6 +167,7 @@ namespace Server.Items
         }
 
         public PowerScrollGiver(Serial serial)
+            : base(serial)
         {
         }
 

--- a/Scripts/Services/Pet Training/SpecialAbility.cs
+++ b/Scripts/Services/Pet Training/SpecialAbility.cs
@@ -1317,7 +1317,7 @@ namespace Server.Mobiles
 	
 	public class LifeLeech : SpecialAbility
 	{
-		public override int ManaCost { get { return 15;  } }
+		public override int ManaCost { get { return 5;  } }
 		public override TimeSpan CooldownDuration { get { return TimeSpan.FromSeconds(Utility.Random(10, 20)); } }
         public override bool TriggerOnDoMeleeDamage { get { return true; } }
 
@@ -1561,7 +1561,7 @@ namespace Server.Mobiles
         public override bool TriggerOnThink { get { return true; } }
         public override double TriggerChance { get { return 1.0; } }
         public override bool RequiresCombatant { get { return false; } }
-        public override int ManaCost { get { return 0; } }
+        public override int ManaCost { get { return 15; } }
         public override TimeSpan CooldownDuration { get { return TimeSpan.MinValue; } }
         public override bool NaturalAbility { get { return true; } }
 

--- a/Scripts/Spells/Chivalry/EnemyOfOne.cs
+++ b/Scripts/Spells/Chivalry/EnemyOfOne.cs
@@ -89,7 +89,7 @@ namespace Server.Spells.Chivalry
             return m_Table[m];
         }
 
-        private static bool UnderEffect(Mobile m)
+        public static bool UnderEffect(Mobile m)
         {
             return m_Table.ContainsKey(m);
         }


### PR DESCRIPTION
- Creatures will now gain in parry with gm+ wrestling
- Damage to players from controlled pets have been halved, per EA
- Creatures will now gain Focus
- Added Enemy of One to Paladin AI
- Pre-Patch creatures will retain their lower control slots, ie dragons
- Dimetrosaur hits have been adjusted on Tame, per EA
- Minor tweaks to select creature stats
- Training damage per second should now work properly
- Updated various Area Effect and Special Ability mana costs
- Pet Training/bond gate and PS giver no longer bugs out
- Pets will only gain progress so much from individual targets
- Added pet power hour, pet EA
- Minor adjustments to new animal lore Gump
- fixed issues where training GUI would go over cap
- Fixed issue where single increment wouldn't work