### PR TITLE
[Hotfix] Update Main.cs and ScriptCompiler.cs for MONO5

### DIFF
--- a/Server/Main.cs
+++ b/Server/Main.cs
@@ -35,7 +35,7 @@ namespace Server
 
 			GlobalMaxUpdateRange = 24;
 			GlobalUpdateRange = 18;
-            		GlobalRadarRange = 37;
+            GlobalRadarRange = 37;
 		}
 
 		private static bool _Crashed;
@@ -561,7 +561,7 @@ namespace Server
                         dotnet = "4.7.1";
             #endif
 
-	    #if MONO
+			#if MONO
 			Type mono = Type.GetType("Mono.Runtime");
 			if (mono != null)
 			{	
@@ -572,7 +572,7 @@ namespace Server
 					Unix = true;
 				}
 			}
-	    #endif
+			#endif
 
             
 	    if (String.IsNullOrEmpty(dotnet))
@@ -582,7 +582,7 @@ namespace Server
             Console.WriteLine("Core: Compiled for " + (Unix ? "MONO " : ".NET ") + "{0}", dotnet);
             Utility.PopColor();
 
-	    int platform = (int)Environment.OSVersion.Platform;
+			int platform = (int)Environment.OSVersion.Platform;
 
 			if (platform == 4 || platform == 128)
 			{

--- a/Server/Main.cs
+++ b/Server/Main.cs
@@ -35,7 +35,7 @@ namespace Server
 
 			GlobalMaxUpdateRange = 24;
 			GlobalUpdateRange = 18;
-            GlobalRadarRange = 37;
+            		GlobalRadarRange = 37;
 		}
 
 		private static bool _Crashed;
@@ -89,7 +89,7 @@ namespace Server
 
 		public static bool Service { get; private set; }
 
-        public static bool NoConsole { get; private set; }
+		public static bool NoConsole { get; private set; }
 		public static bool Debug { get; private set; }
 
 		public static bool HaltOnWarning { get; private set; }
@@ -561,14 +561,28 @@ namespace Server
                         dotnet = "4.7.1";
             #endif
 
-            if (String.IsNullOrEmpty(dotnet))
+	    #if MONO
+			Type mono = Type.GetType("Mono.Runtime");
+			if (mono != null)
+			{	
+				MethodInfo displayName = mono.GetMethod("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static);
+				if (displayName != null)
+				{
+					dotnet = displayName.Invoke(null, null).ToString();
+					Unix = true;
+				}
+			}
+	    #endif
+
+            
+	    if (String.IsNullOrEmpty(dotnet))
                 dotnet = "MONO/CSC/Unknown";
             
             Utility.PushColor(ConsoleColor.Green);
-            Console.WriteLine("Core: Compiled for .NET {0}", dotnet);
+            Console.WriteLine("Core: Compiled for " + (Unix ? "MONO " : ".NET ") + "{0}", dotnet);
             Utility.PopColor();
 
-            int platform = (int)Environment.OSVersion.Platform;
+	    int platform = (int)Environment.OSVersion.Platform;
 
 			if (platform == 4 || platform == 128)
 			{

--- a/Server/ScriptCompiler.cs
+++ b/Server/ScriptCompiler.cs
@@ -229,13 +229,12 @@ namespace Server
 				{
 					parms.WarningLevel = 4;
 				}
+				
+				if (Core.Unix)				
+					parms.CompilerOptions = String.Format( "{0} /nowarn:169,219,414 /recurse:Scripts/*.cs", parms.CompilerOptions );
 
-#if !MONO
-				CompilerResults results = provider.CompileAssemblyFromFile(parms, files);
-#else
-				parms.CompilerOptions = String.Format( "{0} /nowarn:169,219,414 /recurse:Scripts/*.cs", parms.CompilerOptions );
-				CompilerResults results = provider.CompileAssemblyFromFile( parms, "" );
-                #endif
+				CompilerResults results = provider.CompileAssemblyFromFile( parms, files );
+				
 				m_AdditionalReferences.Add(path);
 
 				Display(results);


### PR DESCRIPTION
Updated for compatibility with MONO5.
Checked with Mono 3.2.8 and Mono 5.10.0

Changes in Main.cs
      + Checking for Mono Version #if Mono and Code is a double check right now
Changes in ScriptCompiler.cs
       + Changed file encoding (^M) to be inline with others
       + Changed lines 233 to 236 to resolve errors with Mono 5