### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Gumps/BaseRewardGump.cs
+++ b/Scripts/Gumps/BaseRewardGump.cs
@@ -18,13 +18,7 @@ namespace Server.Gumps
         public double Points { get; protected set; }
         public List<CollectionItem> Collection { get; protected set; }
 
-        public virtual int YDist 
-        { 
-            get 
-            {
-                return 10;
-            }
-        }
+        public virtual int YDist  {  get  { return 10; } }
 
         public BaseRewardGump(Mobile owner, PlayerMobile user, List<CollectionItem> col, int title, double points = -1.0)
             : base(50, 50)

--- a/Scripts/Items/Equipment/Armor/GargishLeatherArms.cs
+++ b/Scripts/Items/Equipment/Armor/GargishLeatherArms.cs
@@ -44,29 +44,6 @@ namespace Server.Items
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }
 
-        public override int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, ITool tool, CraftItem craftItem, int resHue)
-        {
-            Quality = (ItemQuality)quality;
-
-            if (makersMark)
-                Crafter = from;
-
-            Type resourceType = typeRes;
-
-            if (resourceType == null)
-                resourceType = craftItem.Resources.GetAt(0).ItemType;
-
-            Resource = CraftResources.GetFromType(resourceType);
-
-            PlayerConstructed = true;
-
-            CraftContext context = craftSystem.GetContext(from);
-
-            Hue = CraftResources.GetHue(Resource);
-
-            return quality;
-        }
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishLeatherChest.cs
+++ b/Scripts/Items/Equipment/Armor/GargishLeatherChest.cs
@@ -43,29 +43,6 @@ namespace Server.Items
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }
 
-        public override int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, ITool tool, CraftItem craftItem, int resHue)
-        {
-            Quality = (ItemQuality)quality;
-
-            if (makersMark)
-                Crafter = from;
-
-            Type resourceType = typeRes;
-
-            if (resourceType == null)
-                resourceType = craftItem.Resources.GetAt(0).ItemType;
-
-            Resource = CraftResources.GetFromType(resourceType);
-
-            PlayerConstructed = true;
-
-            CraftContext context = craftSystem.GetContext(from);
-
-            Hue = CraftResources.GetHue(Resource);
-
-            return quality;
-        }
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishLeatherKilt.cs
+++ b/Scripts/Items/Equipment/Armor/GargishLeatherKilt.cs
@@ -44,29 +44,6 @@ namespace Server.Items
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }
 
-        public override int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, ITool tool, CraftItem craftItem, int resHue)
-        {
-            Quality = (ItemQuality)quality;
-
-            if (makersMark)
-                Crafter = from;
-
-            Type resourceType = typeRes;
-
-            if (resourceType == null)
-                resourceType = craftItem.Resources.GetAt(0).ItemType;
-
-            Resource = CraftResources.GetFromType(resourceType);
-
-            PlayerConstructed = true;
-
-            CraftContext context = craftSystem.GetContext(from);
-
-            Hue = CraftResources.GetHue(Resource);
-
-            return quality;
-        }
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Items/Equipment/Armor/GargishLeatherLegs.cs
+++ b/Scripts/Items/Equipment/Armor/GargishLeatherLegs.cs
@@ -43,29 +43,6 @@ namespace Server.Items
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }
 
-        public override int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, ITool tool, CraftItem craftItem, int resHue)
-        {
-            Quality = (ItemQuality)quality;
-
-            if (makersMark)
-                Crafter = from;
-
-            Type resourceType = typeRes;
-
-            if (resourceType == null)
-                resourceType = craftItem.Resources.GetAt(0).ItemType;
-
-            Resource = CraftResources.GetFromType(resourceType);
-
-            PlayerConstructed = true;
-
-            CraftContext context = craftSystem.GetContext(from);
-
-            Hue = CraftResources.GetHue(Resource);
-
-            return quality;
-        }
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -6831,7 +6831,7 @@ namespace Server.Mobiles
 
         public bool IsHealing { get { return (m_HealTimer != null); } }
 
-        public virtual void CheckHeal()
+        public virtual bool CheckHeal()
         {
             long tc = Core.TickCount;
 
@@ -6843,15 +6843,20 @@ namespace Server.Mobiles
                     owner.Map == Map && InRange(owner, HealStartRange) && InLOS(owner) && owner.Hits < HealOwnerTrigger * owner.HitsMax)
                 {
                     HealStart(owner);
-
                     m_NextHealOwnerTime = tc + (int)TimeSpan.FromSeconds(HealOwnerInterval).TotalMilliseconds;
+
+                    return true;
                 }
                 else if (tc >= m_NextHealTime && CanBeBeneficial(this) && (Hits < HealTrigger * HitsMax || Poisoned))
                 {
                     HealStart(this);
                     m_NextHealTime = tc + (int)TimeSpan.FromSeconds(HealInterval).TotalMilliseconds;
+
+                    return true;
                 }
             }
+
+            return false;
         }
 
         public virtual void HealStart(Mobile patient)

--- a/Scripts/Services/ChampionSystem/ChampionSpawn.cs
+++ b/Scripts/Services/ChampionSystem/ChampionSpawn.cs
@@ -1542,7 +1542,7 @@ namespace Server.Engines.CannedEvil
 
         public override bool OnMoveInto(Mobile m, Direction d, Point3D newLocation, Point3D oldLocation)
         {
-            if (m is PlayerMobile && !m.Alive && (m.Corpse == null || m.Corpse.Deleted))
+            if (m is PlayerMobile && !m.Alive && (m.Corpse == null || m.Corpse.Deleted) && Map == Map.Felucca)
             {
                 return false;
             }
@@ -1554,7 +1554,7 @@ namespace Server.Engines.CannedEvil
         {
             Mobile m = e.Mobile;
 
-            if (m is PlayerMobile && m.Region.IsPartOf<ChampionSpawnRegion>() && m.AccessLevel == AccessLevel.Player)
+            if (m is PlayerMobile && m.Region.IsPartOf<ChampionSpawnRegion>() && m.AccessLevel == AccessLevel.Player && m.Map == Map.Felucca)
             {
                 if (m.Alive && m.Backpack != null)
                 {
@@ -1592,7 +1592,7 @@ namespace Server.Engines.CannedEvil
         {
             Mobile m = e.Mobile;
 
-            if (m is PlayerMobile && !m.Alive && (m.Corpse == null || m.Corpse.Deleted) && m.Region.IsPartOf<ChampionSpawnRegion>())
+            if (m is PlayerMobile && !m.Alive && (m.Corpse == null || m.Corpse.Deleted) && m.Region.IsPartOf<ChampionSpawnRegion>() && m.Map == Map.Felucca)
             {
                 Map map = m.Map;
                 Point3D loc = ExorcismSpell.GetNearestShrine(m, ref map);

--- a/Scripts/Services/HuntmasterChallenge/HuntingSystem.cs
+++ b/Scripts/Services/HuntmasterChallenge/HuntingSystem.cs
@@ -65,7 +65,7 @@ namespace Server.Engines.HuntsmasterChallenge
 
             m_SeasonBegins = DateTime.Now;
             DateTime ends = DateTime.Now + TimeSpan.FromDays(30);
-            m_SeasonEnds = new DateTime(ends.Year, ends.Month, ends.Day, 8, 0, 0);
+            m_SeasonEnds = new DateTime(ends.Year, ends.Month, 1, 0, 0, 0);
             m_NextHint = DateTime.UtcNow;
             m_NextBonusIndex = DateTime.UtcNow;
 
@@ -264,7 +264,7 @@ namespace Server.Engines.HuntsmasterChallenge
 			
 			m_SeasonBegins = DateTime.Now;
             DateTime ends = DateTime.Now + TimeSpan.FromDays(30);
-			m_SeasonEnds = new DateTime(ends.Year, ends.Month, ends.Day, 8, 0, 0);
+			m_SeasonEnds = new DateTime(ends.Year, ends.Month, 1, 0, 0, 0);
 
             HuntingDisplayTrophy.InvalidateDisplayTrophies();
 		}

--- a/Scripts/Services/Pet Training/SpecialAbility.cs
+++ b/Scripts/Services/Pet Training/SpecialAbility.cs
@@ -1557,6 +1557,21 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool Trigger(BaseCreature creature, Mobile defender, ref int damage)
+        {
+            if (CheckMana(creature) && Validate(creature, defender) && TriggerChance >= Utility.RandomDouble())
+            {
+                if (creature.CheckHeal())
+                {
+                    creature.Mana -= ManaCost;
+                    AddToCooldown(creature);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public override void DoEffects(BaseCreature creature, Mobile target, ref int damage)
         {
             creature.CheckHeal();

--- a/Scripts/Services/PointsSystems/KotlCityData.cs
+++ b/Scripts/Services/PointsSystems/KotlCityData.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Server.Items;
 using Server.Mobiles;
 using Server.Commands;
+using Server.Engines.TreasuresOfKotlCity;
 
 namespace Server.Engines.Points
 {
@@ -43,6 +44,11 @@ namespace Server.Engines.Points
 
                 int fame = victim.Fame / 2;
                 int luck = Math.Max(0, ((PlayerMobile)damager).RealLuck);
+
+                if (victim.Spawner is KotlBattleSimulator)
+                {
+                    fame *= 2;
+                }
 
                 DungeonPoints[damager] += (int)(fame * (1 + Math.Sqrt(luck) / 100));
 

--- a/Scripts/Services/TreasuresOfKotlCity/Items/KotlBattleSimulator.cs
+++ b/Scripts/Services/TreasuresOfKotlCity/Items/KotlBattleSimulator.cs
@@ -123,6 +123,7 @@ namespace Server.Engines.TreasuresOfKotlCity
             int oldMaxCount = SpawnPerWave;
 
             Level++;
+            Kills = 0;
 
             int inc = SpawnPerWave - oldMaxCount;
 
@@ -248,6 +249,39 @@ namespace Server.Engines.TreasuresOfKotlCity
                         Spawn = new List<ISpawnable>();
 
                     Spawn.Add(bc);
+                }
+            }
+
+            if (_Active)
+            {
+                StartTimer();
+
+                if (Spawn == null || Spawn.Count == 0)
+                {
+                    if (Spawn == null)
+                        Spawn = new List<ISpawnable>();
+
+                    if (Level >= Levels)
+                    {
+                        EndSimulation();
+                        return;
+                    }
+                    else
+                    {
+                        IncreaseLevel();
+                    }
+                }
+                else
+                {
+                    int toSpawn = Math.Max(0, SpawnPerWave - (Spawn.Count + Kills));
+
+                    if (toSpawn > 0)
+                    {
+                        for (int i = 0; i < toSpawn; i++)
+                        {
+                            Timer.DelayCall(NextSpawnDuration, DoSpawn);
+                        }
+                    }
                 }
             }
 

--- a/Scripts/Services/TreasuresOfKotlCity/RewardGump.cs
+++ b/Scripts/Services/TreasuresOfKotlCity/RewardGump.cs
@@ -12,6 +12,8 @@ namespace Server.Engines.TreasuresOfKotlCity
 {
     public class KotlCityRewardGump : BaseRewardGump
     {
+        public override int YDist { get { return 15; } }
+
         public KotlCityRewardGump(Mobile owner, PlayerMobile user)
             : base(owner, user, KotlCityRewards.Rewards, 1156988)
         {

--- a/Scripts/Services/ViceVsVirtue/ViceVsVirtueSystem.cs
+++ b/Scripts/Services/ViceVsVirtue/ViceVsVirtueSystem.cs
@@ -133,7 +133,8 @@ namespace Server.Engines.VvV
             Guild g = pm.Guild as Guild;
             VvVPlayerEntry entry = GetEntry(pm, true) as VvVPlayerEntry;
 
-            entry.Active = true;
+            if (!entry.Active)
+                entry.Active = true;
 
             pm.SendLocalizedMessage(1155564); // You have joined Vice vs Virtue!
             pm.SendLocalizedMessage(1063156, g.Name); // The guild information for ~1_val~ has been updated.
@@ -773,7 +774,7 @@ namespace Server.Engines.VvV
             {
                 if (!_Active && value)
                 {
-                    Points = ViceVsVirtueSystem.StartSilver;
+                    Points = 0;
                 }
 
                 _Active = value;
@@ -786,7 +787,8 @@ namespace Server.Engines.VvV
         public VvVPlayerEntry(PlayerMobile pm)
             : base(pm)
         {
-            Active = true;
+            _Active = true;
+            Points = ViceVsVirtueSystem.StartSilver;
         }
 
         public override void Serialize(GenericWriter writer)


### PR DESCRIPTION
- Spaced out Kotl Reward items in gump
- Gargish leather armor should now apply proper exceptional, resource and armslore bonus to resistances
- Creatures should no longer use  mana when heal check fails
- Ghost restrictions at champion spawns no longer apply in non-fel facets. This should remove the issue where ghosts could not leave twisted wield dungeon.
- Huntsmaster challenge should now end/start on the first of every month. The system will need to complete the current season before this kicks in.
- Kotl Battle Simulator spawner should now restart after a shard restart, which was preventing it from ever starting again. For existing issues, simply set the KotlBattleSimulator Active property to false, then back to true
- Subsequent VvV joining should reset silver to 0