### PR TITLE
Bug fixes *Needs Core Recompile*

### DIFF
--- a/Scripts/Gumps/Properties/PropsGump.cs
+++ b/Scripts/Gumps/Properties/PropsGump.cs
@@ -449,7 +449,7 @@ namespace Server.Gumps
 
 						var type = prop.PropertyType;
 
-						if (IsType(type, _TypeOfMobile) || IsType(type, _TypeOfItem))
+                        if (IsType(type, _TypeOfMobile) || IsType(type, _TypeOfItem) || type.IsAssignableFrom(typeof(IDamageable)))
 						{
 							from.SendGump(new SetObjectGump(prop, from, m_Object, m_Stack, type, m_Page, m_List));
 						}

--- a/Scripts/Items/Addons/ParrotPerchAddon.cs
+++ b/Scripts/Items/Addons/ParrotPerchAddon.cs
@@ -14,9 +14,9 @@ namespace Server.Items
 
         public ParrotPerchAddon(PetParrot parrot)
         {
-            this.AddComponent(new AddonComponent(0x2FB6), 0, 0, 0);
+            AddComponent(new AddonComponent(0x2FB6), 0, 0, 0);
 			
-            this.m_Parrot = parrot;
+            m_Parrot = parrot;
         }
 
         public ParrotPerchAddon(Serial serial)
@@ -28,7 +28,7 @@ namespace Server.Items
         {
             get
             {
-                return new ParrotPerchAddonDeed(this.m_Parrot);
+                return new ParrotPerchAddonDeed(m_Parrot);
             }
         }
         public override bool RetainDeedHue
@@ -43,35 +43,35 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Parrot;
+                return m_Parrot;
             }
             set
             {
-                this.m_Parrot = value;
+                m_Parrot = value;
             }
         }
         public override void OnLocationChange(Point3D oldLocation)
         {
             base.OnLocationChange(oldLocation);
 			
-            if (this.m_Parrot != null)
-                this.m_Parrot.Location = new Point3D(this.X, this.Y, this.Z + 12);
+            if (m_Parrot != null)
+                m_Parrot.Location = new Point3D(X, Y, Z + 12);
         }
 
         public override void OnMapChange()
         {
             base.OnMapChange();
 			
-            if (this.m_Parrot != null)
-                this.m_Parrot.Map = this.Map;
+            if (m_Parrot != null)
+                m_Parrot.Map = Map;
         }
 
         public override void OnAfterDelete()
         {
             base.OnAfterDelete();
 			
-            if (this.m_Parrot != null)
-                this.m_Parrot.Internalize();
+            if (m_Parrot != null)
+                m_Parrot.Internalize();
         }
 
         public override void Serialize(GenericWriter writer)
@@ -80,7 +80,7 @@ namespace Server.Items
 
             writer.Write((int)0); //  version
 			
-            writer.Write((Mobile)this.m_Parrot);
+            writer.Write((Mobile)m_Parrot);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -89,7 +89,7 @@ namespace Server.Items
 
             int version = reader.ReadInt();
 			
-            this.m_Parrot = reader.ReadMobile() as PetParrot;
+            m_Parrot = reader.ReadMobile() as PetParrot;
         }
     }
 
@@ -105,9 +105,9 @@ namespace Server.Items
 
         public ParrotPerchAddonDeed(PetParrot parrot)
         {
-            this.LootType = LootType.Blessed;
+            LootType = LootType.Blessed;
 		
-            this.m_Parrot = parrot;
+            m_Parrot = parrot;
         }
 
         public ParrotPerchAddonDeed(Serial serial)
@@ -126,7 +126,7 @@ namespace Server.Items
         {
             get
             {
-                return new ParrotPerchAddon(this.m_Parrot);
+                return new ParrotPerchAddon(m_Parrot);
             }
         }
         [CommandProperty(AccessLevel.GameMaster)]
@@ -134,26 +134,26 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Parrot;
+                return m_Parrot;
             }
             set
             {
-                this.m_Parrot = value;
-                this.InvalidateProperties();
+                m_Parrot = value;
+                InvalidateProperties();
             }
         }
         public override void GetProperties(ObjectPropertyList list)
         {
             base.GetProperties(list);
 			
-            if (this.m_Parrot != null)
+            if (m_Parrot != null)
             {
-                if (this.m_Parrot.Name != null)
-                    list.Add(1072624, this.m_Parrot.Name); // Includes a pet Parrot named ~1_NAME~
+                if (m_Parrot.Name != null)
+                    list.Add(1072624, m_Parrot.Name); // Includes a pet Parrot named ~1_NAME~
                 else
                     list.Add(1072620); // Includes a pet Parrot
 					
-                int weeks = PetParrot.GetWeeks(this.m_Parrot.Birth);
+                int weeks = PetParrot.GetWeeks(m_Parrot.Birth);
 				
                 if (weeks == 1)
                     list.Add(1072626); // 1 week old
@@ -164,7 +164,7 @@ namespace Server.Items
 
         public override void DeleteDeed()
         {
-            this.m_Safety = true;
+            m_Safety = true;
 			
             base.DeleteDeed();
         }
@@ -173,10 +173,10 @@ namespace Server.Items
         { 
             base.OnAfterDelete();
 			
-            if (!this.m_Safety && this.m_Parrot != null)
-                this.m_Parrot.Delete();
+            if (!m_Safety && m_Parrot != null)
+                m_Parrot.Delete();
 				
-            this.m_Safety = false;
+            m_Safety = false;
         }
 
         public override void Serialize(GenericWriter writer)
@@ -185,7 +185,7 @@ namespace Server.Items
 
             writer.Write((int)1); //  version
 			
-            writer.Write((Mobile)this.m_Parrot);
+            writer.Write((Mobile)m_Parrot);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -197,7 +197,7 @@ namespace Server.Items
             switch ( version )
             {
                 case 1:
-                    this.m_Parrot = reader.ReadMobile() as PetParrot;
+                    m_Parrot = reader.ReadMobile() as PetParrot;
 					
                     break;
                 case 0: 

--- a/Scripts/Items/Decorative/DamageableItem.cs
+++ b/Scripts/Items/Decorative/DamageableItem.cs
@@ -328,7 +328,7 @@ namespace Server.Items
 
             if (amount > 0 && theirState != null)
             {
-                theirState.Send(Packet.Acquire(new DamagePacket(this, amount)));
+                theirState.Send(new DamagePacket(this, amount));
             }
 
 			OnDamage(amount, from, Hits < 0);

--- a/Scripts/Items/Resource/Bandage.cs
+++ b/Scripts/Items/Resource/Bandage.cs
@@ -13,6 +13,7 @@ using Server.Gumps;
 using Server.Mobiles;
 using Server.Targeting;
 using Server.Network;
+using Server.Engines.Despise;
 #endregion
 
 namespace Server.Items
@@ -233,8 +234,13 @@ namespace Server.Items
 			return bc;
 		}
 
-		public static SkillName GetPrimarySkill(Mobile m)
+		public static SkillName GetPrimarySkill(Mobile healer, Mobile m)
 		{
+            if (m is DespiseCreature)
+            {
+                return healer.Skills[SkillName.Healing].Value > healer.Skills[SkillName.Veterinary].Value ? SkillName.Healing : SkillName.Veterinary;
+            }
+
 			if (!m.Player && (m.Body.IsMonster || m.Body.IsAnimal))
 			{
 				return SkillName.Veterinary;
@@ -245,8 +251,13 @@ namespace Server.Items
 			}
 		}
 
-		public static SkillName GetSecondarySkill(Mobile m)
+        public static SkillName GetSecondarySkill(Mobile healer, Mobile m)
 		{
+            if (m is DespiseCreature)
+            {
+                return healer.Skills[SkillName.Healing].Value > healer.Skills[SkillName.Veterinary].Value ? SkillName.Anatomy : SkillName.AnimalLore;
+            }
+
 			if (!m.Player && (m.Body.IsMonster || m.Body.IsAnimal))
 			{
 				return SkillName.AnimalLore;
@@ -303,8 +314,8 @@ namespace Server.Items
             bool playSound = true;
             bool checkSkills = false;
 
-            SkillName primarySkill = GetPrimarySkill(m_Patient);
-            SkillName secondarySkill = GetSecondarySkill(m_Patient);
+            SkillName primarySkill = GetPrimarySkill(m_Healer, m_Patient);
+            SkillName secondarySkill = GetSecondarySkill(m_Healer, m_Patient);
 
             BaseCreature petPatient = m_Patient as BaseCreature;
 
@@ -671,7 +682,7 @@ namespace Server.Items
                 }
                 else
                 {
-                    if (Core.AOS && GetPrimarySkill(patient) == SkillName.Veterinary)
+                    if (Core.AOS && GetPrimarySkill(healer, patient) == SkillName.Veterinary)
                     {
                         seconds = 2.0;
                     }

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -454,9 +454,9 @@ namespace Server
                 case 13: return Math.Min(4, AosAttributes.GetValue(from, AosAttribute.CastSpeed));
                 case 14: return Math.Min(40, AosAttributes.GetValue(from, AosAttribute.LowerManaCost)) + BaseArmor.GetInherentLowerManaCost(from);
                 
-                case 15: return GetManaRegen(from); // HP   REGEN
-                case 16: return GetStamRegen(from); // Stam REGEN
-                case 17: return GetManaRegen(from); // MANA REGEN
+                case 15: return RegenRates.HitPointRegen(from); // HP   REGEN
+                case 16: return RegenRates.StamRegen(from); // Stam REGEN
+                case 17: return RegenRates.ManaRegen(from); // MANA REGEN
                 case 18: return Math.Min(105, AosAttributes.GetValue(from, AosAttribute.ReflectPhysical)); // reflect phys
                 case 19: return Math.Min(50, AosAttributes.GetValue(from, AosAttribute.EnhancePotions)); // enhance pots
 
@@ -473,57 +473,6 @@ namespace Server
                 case 28: return AosAttributes.GetValue(from, AosAttribute.BonusMana); // mana inc
 				default: return 0;
 			}
-        }
-
-        private static int GetHitsRegen(Mobile m)
-        {
-            int regen = AosAttributes.GetValue(m, AosAttribute.RegenHits);
-
-            if (RegenRates.CheckAnimal(m, typeof(Dog)) || RegenRates.CheckAnimal(m, typeof(Cat)))
-                regen += m.Skills[SkillName.Ninjitsu].Fixed / 30;
-
-            if (RegenRates.CheckTransform(m, typeof(HorrificBeastSpell)))
-                regen += 20;
-
-            regen += RampageSpell.GetBonus(m, RampageSpell.BonusType.HitPointRegen);
-            regen += CombatTrainingSpell.RegenBonus(m);
-            regen += BarrabHemolymphConcentrate.HPRegenBonus(m);
-
-            if (m.Race == Race.Human)
-                regen += 2;
-
-            return Math.Min(18, regen);
-        }
-
-        private static int GetStamRegen(Mobile m)
-        {
-            int regen = AosAttributes.GetValue(m, AosAttribute.RegenStam);
-
-            if (RegenRates.CheckTransform(m, typeof(VampiricEmbraceSpell)))
-                regen += 15;
-
-            if (RegenRates.CheckAnimal(m, typeof(Kirin)))
-                regen += 20;
-
-            regen += RampageSpell.GetBonus(m, RampageSpell.BonusType.StamRegen);
-
-            return regen;
-        }
-
-        private static int GetManaRegen(Mobile m)
-        {
-            int regen = AosAttributes.GetValue(m, AosAttribute.RegenMana);
-
-            if (RegenRates.CheckTransform(m, typeof(VampiricEmbraceSpell)))
-                regen += 3;
-
-            if (RegenRates.CheckTransform(m, typeof(LichFormSpell)))
-                regen += 13;
-
-            if (m.Race == Race.Gargoyle)
-                regen += 2;
-
-            return Math.Min(30, regen);
         }
         #endregion
     }

--- a/Scripts/Misc/RegenRates.cs
+++ b/Scripts/Misc/RegenRates.cs
@@ -76,36 +76,7 @@ namespace Server.Misc
 
         private static TimeSpan Mobile_HitsRegenRate(Mobile from)
         {
-            int points = AosAttributes.GetValue(from, AosAttribute.RegenHits);
-
-            if (from is BaseCreature)
-                points += ((BaseCreature)from).DefaultHitsRegen;
-
-            if (Core.ML && from.Race == Race.Human)	//Is this affected by the cap?
-                points += 2;
-           
-            if (points < 0)
-                points = 0;
-
-            if (Core.ML && from is PlayerMobile)	//does racial bonus go before/after?
-                points = Math.Min(points, 18);
-
-            if (CheckTransform(from, typeof(HorrificBeastSpell)))
-                points += 20;
-
-            if (CheckAnimal(from, typeof(Dog)) || CheckAnimal(from, typeof(Cat)))
-                points += from.Skills[SkillName.Ninjitsu].Fixed / 30;
-
-            // Skill Masteries
-            points += RampageSpell.GetBonus(from, RampageSpell.BonusType.HitPointRegen);
-            points += CombatTrainingSpell.RegenBonus(from);
-            points += BarrabHemolymphConcentrate.HPRegenBonus(from);
-
-            if (Core.AOS)
-                foreach (RegenBonusHandler handler in HitsBonusHandlers)
-                    points += handler(from);
-
-            return TimeSpan.FromSeconds(1.0 / (0.1 * (1 + points)));
+            return TimeSpan.FromSeconds(1.0 / (0.1 * (1 + HitPointRegen(from))));
         }
 
         private static TimeSpan Mobile_StamRegenRate(Mobile from)
@@ -116,32 +87,7 @@ namespace Server.Misc
             CheckBonusSkill(from, from.Stam, from.StamMax, SkillName.Focus);
 
             int points = (int)(from.Skills[SkillName.Focus].Value * 0.1);
-
-            int cappedPoints = AosAttributes.GetValue(from, AosAttribute.RegenStam);
-
-            if (from is BaseCreature)
-                points += ((BaseCreature)from).DefaultStamRegen;
-
-            if (CheckTransform(from, typeof(VampiricEmbraceSpell)))
-                cappedPoints += 15;
-
-            if (CheckAnimal(from, typeof(Kirin)))
-                cappedPoints += 20;
-
-            if (Core.ML && from is PlayerMobile)
-                cappedPoints = Math.Min(cappedPoints, 24);
-
-            points += cappedPoints;
-
-            // Skill Masteries
-            points += RampageSpell.GetBonus(from, RampageSpell.BonusType.StamRegen); // After the cap???
-
-            if (points < -1)
-                points = -1;
-
-            if (Core.AOS)
-                foreach (RegenBonusHandler handler in StamBonusHandlers)
-                    points += handler(from);
+            points += StamRegen(from);
 
             return TimeSpan.FromSeconds(1.0 / (0.1 * (2 + points)));
         }
@@ -172,32 +118,13 @@ namespace Server.Misc
 
                 double totalPoints = focusPoints + medPoints + (from.Meditating ? (medPoints > 13.0 ? 13.0 : medPoints) : 0.0);
 
-                int cappedPoints = AosAttributes.GetValue(from, AosAttribute.RegenMana);
-
-                if (from is BaseCreature)
-                    totalPoints += ((BaseCreature)from).DefaultManaRegen;
-
-                if (CheckTransform(from, typeof(VampiricEmbraceSpell)))
-                    cappedPoints += 3;
-                else if (CheckTransform(from, typeof(LichFormSpell)))
-                    cappedPoints += 13;
-
-                if (Core.ML && from is PlayerMobile)
-                    cappedPoints = Math.Min(cappedPoints, 18);
-
-                totalPoints += cappedPoints;
-
-				if (from is PlayerMobile && ((PlayerMobile)from).Race == Race.Gargoyle)
-					totalPoints += 2;
+                totalPoints += ManaRegen(from);
 
                 if (totalPoints < -1)
                     totalPoints = -1;
 
                 if (Core.ML)
                     totalPoints = Math.Floor(totalPoints);
-
-                foreach (RegenBonusHandler handler in ManaBonusHandlers)
-                    totalPoints += handler(from);
 
                 rate = 1.0 / (0.1 * (2 + totalPoints));
             }
@@ -226,6 +153,95 @@ namespace Server.Misc
             }
 
             return TimeSpan.FromSeconds(rate);
+        }
+
+        public static int HitPointRegen(Mobile from)
+        {
+            int points = AosAttributes.GetValue(from, AosAttribute.RegenHits);
+
+            if (from is BaseCreature)
+                points += ((BaseCreature)from).DefaultHitsRegen;
+
+            if (Core.ML && from is PlayerMobile && from.Race == Race.Human)	//Is this affected by the cap?
+                points += 2;
+
+            if (points < 0)
+                points = 0;
+
+            if (Core.ML && from is PlayerMobile)	//does racial bonus go before/after?
+                points = Math.Min(points, 18);
+
+            if (CheckTransform(from, typeof(HorrificBeastSpell)))
+                points += 20;
+
+            if (CheckAnimal(from, typeof(Dog)) || CheckAnimal(from, typeof(Cat)))
+                points += from.Skills[SkillName.Ninjitsu].Fixed / 30;
+
+            // Skill Masteries - goes after cap
+            points += RampageSpell.GetBonus(from, RampageSpell.BonusType.HitPointRegen);
+            points += CombatTrainingSpell.RegenBonus(from);
+            points += BarrabHemolymphConcentrate.HPRegenBonus(from);
+
+            if (Core.AOS)
+                foreach (RegenBonusHandler handler in HitsBonusHandlers)
+                    points += handler(from);
+
+            return points;
+        }
+
+        public static int StamRegen(Mobile from)
+        {
+            int cappedPoints = AosAttributes.GetValue(from, AosAttribute.RegenStam);
+
+            if (from is BaseCreature)
+                points += ((BaseCreature)from).DefaultStamRegen;
+
+            if (CheckTransform(from, typeof(VampiricEmbraceSpell)))
+                cappedPoints += 15;
+
+            if (CheckAnimal(from, typeof(Kirin)))
+                cappedPoints += 20;
+
+            if (Core.ML && from is PlayerMobile)
+                cappedPoints = Math.Min(cappedPoints, 24);
+
+            points += cappedPoints;
+
+            // Skill Masteries - goes after cap
+            points += RampageSpell.GetBonus(from, RampageSpell.BonusType.StamRegen);
+
+            if (points < -1)
+                points = -1;
+
+            if (Core.AOS)
+                foreach (RegenBonusHandler handler in StamBonusHandlers)
+                    points += handler(from);
+
+            return points;
+        }
+
+        public static int ManaRegen(Mobile from)
+        {
+            int points = AosAttributes.GetValue(from, AosAttribute.RegenMana);
+
+            if (from is BaseCreature)
+                points += ((BaseCreature)from).DefaultManaRegen;
+
+            if (CheckTransform(from, typeof(VampiricEmbraceSpell)))
+                points += 3;
+            else if (CheckTransform(from, typeof(LichFormSpell)))
+                points += 13;
+
+            if (from is PlayerMobile && from.Race == Race.Gargoyle)
+                points += 2;
+
+            if (Core.ML && from is PlayerMobile)
+                points = Math.Min(points, 18);
+
+            foreach (RegenBonusHandler handler in ManaBonusHandlers)
+                points += handler(from);
+
+            return points;
         }
 
         private static double GetArmorMeditationValue(BaseArmor ar)

--- a/Scripts/Misc/RegenRates.cs
+++ b/Scripts/Misc/RegenRates.cs
@@ -191,21 +191,19 @@ namespace Server.Misc
 
         public static int StamRegen(Mobile from)
         {
-            int cappedPoints = AosAttributes.GetValue(from, AosAttribute.RegenStam);
+            int points = AosAttributes.GetValue(from, AosAttribute.RegenStam);
 
             if (from is BaseCreature)
                 points += ((BaseCreature)from).DefaultStamRegen;
 
             if (CheckTransform(from, typeof(VampiricEmbraceSpell)))
-                cappedPoints += 15;
+                points += 15;
 
             if (CheckAnimal(from, typeof(Kirin)))
-                cappedPoints += 20;
+                points += 20;
 
             if (Core.ML && from is PlayerMobile)
-                cappedPoints = Math.Min(cappedPoints, 24);
-
-            points += cappedPoints;
+                points = Math.Min(points, 24);
 
             // Skill Masteries - goes after cap
             points += RampageSpell.GetBonus(from, RampageSpell.BonusType.StamRegen);

--- a/Scripts/Misc/SkillCheck.cs
+++ b/Scripts/Misc/SkillCheck.cs
@@ -337,9 +337,9 @@ namespace Server.Misc
                     CheckReduceSkill((PlayerMobile)from, skills, toGain, skill);
                 }
 
-                if (skills.Total + toGain <= skills.Cap)
+                if (!from.Player || (skills.Total + toGain <= skills.Cap))
                 {
-                    skill.BaseFixedPoint += toGain;
+                    skill.BaseFixedPoint = Math.Min(skill.CapFixedPoint, skill.BaseFixedPoint + toGain);
 
                     if(from is PlayerMobile)
                         UpdateGGS(from, skill);

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -639,14 +639,15 @@ namespace Server.Mobiles
             return _SlotLowerables.Any(t => t == GetType());
         }
 
-        public void CalculateSlots()
+        public void CalculateSlots(int slots)
         {
             var def = PetTrainingHelper.GetTrainingDefinition(this);
 
             if (def == null)
             {
-                ControlSlotsMin = ControlSlots;
-                ControlSlotsMax = ControlSlots;
+                ControlSlotsMin = slots;
+                ControlSlotsMax = slots;
+                return;
             }
             else
             {
@@ -3063,7 +3064,7 @@ namespace Server.Mobiles
             {
                 if (Tamable)
                 {
-                    CalculateSlots();
+                    CalculateSlots(m_iControlSlots);
 
                     if (m_iControlSlots < ControlSlotsMin)
                     {
@@ -3866,7 +3867,7 @@ namespace Server.Mobiles
             {
                 if (PetTrainingHelper.Enabled && ControlSlotsMin == 0 && ControlSlotsMax == 0)
                 {
-                    CalculateSlots();
+                    CalculateSlots(value);
                     m_iControlSlots = ControlSlotsMin;
                 }
                 else

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -5251,7 +5251,9 @@ namespace Server.Mobiles
                 Skills[name].Cap = Skills[name].Base;
             }
 
-            if (name == SkillName.Poisoning && Skills[name].Base > 0 && !PetTrainingHelper.ValidateTrainingPoint(this, MagicalAbility.Poisoning))
+            if (name == SkillName.Poisoning && Skills[name].Base > 0 && 
+                !Controlled &&
+                !PetTrainingHelper.ValidateTrainingPoint(this, MagicalAbility.Poisoning))
             {
                 SetMagicalAbility(MagicalAbility.Poisoning);
             }

--- a/Scripts/Mobiles/Normal/BaseMount.cs
+++ b/Scripts/Mobiles/Normal/BaseMount.cs
@@ -323,28 +323,32 @@ namespace Server.Mobiles
             if (type == BlockMountType.None)
                 return true;
 
-            if (message)
+            if (message && mob.NetState != null)
             {
                 switch (type)
                 {
                     case BlockMountType.Dazed:
                         {
-                            mob.SendLocalizedMessage(flying ? 1112457 : 1040024); // You are still too dazed from being knocked off your mount to ride!
+                            mob.PrivateOverheadMessage(MessageType.Regular, 0x3B2, flying ? 1112457 : 1040024, mob.NetState);
+                            // You are still too dazed from being knocked off your mount to ride!
                             break;
                         }
                     case BlockMountType.BolaRecovery:
                         {
-                            mob.SendLocalizedMessage(flying ? 1112455 : 1062910); // You cannot mount while recovering from a bola throw.
+                            mob.PrivateOverheadMessage(MessageType.Regular, 0x3B2, flying ? 1112455 : 1062910, mob.NetState);
+                            // You cannot mount while recovering from a bola throw.
                             break;
                         }
                     case BlockMountType.RidingSwipe:
                         {
-                            mob.SendLocalizedMessage(1075636); // You cannot mount.
+                            mob.PrivateOverheadMessage(MessageType.Regular, 0x3B2, flying ? 1112454 : 1062934, mob.NetState);
+                            // You must heal your mount before riding it.
                             break;
                         }
                     case BlockMountType.DismountRecovery:
                         {
-                            mob.SendLocalizedMessage(flying ? 1112456 : 1070859); // You cannot mount while recovering from a dismount special maneuver.
+                            mob.PrivateOverheadMessage(MessageType.Regular, 0x3B2, flying ? 1112456 : 1070859, mob.NetState);
+                            // You cannot mount while recovering from a dismount special maneuver.
                             break;
                         }
                 }

--- a/Scripts/Mobiles/Normal/ClockworkScorpion.cs
+++ b/Scripts/Mobiles/Normal/ClockworkScorpion.cs
@@ -11,35 +11,35 @@ namespace Server.Mobiles
         public ClockworkScorpion()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.4, 0.8)
         {
-            this.Name = "a clockwork scorpion";
-            this.Body = 717;
+            Name = "a clockwork scorpion";
+            Body = 717;
 
-            this.SetStr(225, 245);
-            this.SetDex(80, 100);
-            this.SetInt(30, 40);
+            SetStr(225, 245);
+            SetDex(80, 100);
+            SetInt(30, 40);
 
-            this.SetHits(151, 210);
+            SetHits(151, 210);
 
-            this.SetDamage(5, 10);
+            SetDamage(5, 10);
 
-            this.SetDamageType(ResistanceType.Physical, 60);
-            this.SetDamageType(ResistanceType.Poison, 40);
+            SetDamageType(ResistanceType.Physical, 60);
+            SetDamageType(ResistanceType.Poison, 40);
 
-            this.SetResistance(ResistanceType.Physical, 80, 100);
-            this.SetResistance(ResistanceType.Fire, 20, 30);
-            this.SetResistance(ResistanceType.Cold, 60, 80);
-            this.SetResistance(ResistanceType.Poison, 100);
-            this.SetResistance(ResistanceType.Energy, 10, 25);
+            SetResistance(ResistanceType.Physical, 80, 100);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 60, 80);
+            SetResistance(ResistanceType.Poison, 100);
+            SetResistance(ResistanceType.Energy, 10, 25);
 
-            this.SetSkill(SkillName.MagicResist, 30.1, 50.0);
-            this.SetSkill(SkillName.Poisoning, 95.1, 100.0);
-            this.SetSkill(SkillName.Tactics, 70.1, 90.0);
-            this.SetSkill(SkillName.Wrestling, 50.1, 80.0);
+            SetSkill(SkillName.MagicResist, 30.1, 50.0);
+            SetSkill(SkillName.Poisoning, 95.1, 100.0);
+            SetSkill(SkillName.Tactics, 70.1, 90.0);
+            SetSkill(SkillName.Wrestling, 50.1, 80.0);
 
-            this.Fame = 3500;
-            this.Karma = -3500;
+            Fame = 3500;
+            Karma = -3500;
 
-            this.ControlSlots = 1;
+            ControlSlots = 1;
         }
 
         public ClockworkScorpion(Serial serial)
@@ -79,7 +79,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return !this.Controlled;
+                return !Controlled;
             }
         }
         public override bool BleedImmune
@@ -100,7 +100,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return !Core.AOS || this.Controlled;
+                return !Core.AOS || Controlled;
             }
         }
         public override Poison PoisonImmune
@@ -112,7 +112,7 @@ namespace Server.Mobiles
         }
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager, 2);
+            AddLoot(LootPack.Meager, 2);
         }
 
         public override int GetAngerSound()
@@ -122,7 +122,7 @@ namespace Server.Mobiles
 
         public override int GetIdleSound()
         {
-            if (!this.Controlled)
+            if (!Controlled)
                 return 542;
 
             return base.GetIdleSound();
@@ -130,7 +130,7 @@ namespace Server.Mobiles
 
         public override int GetDeathSound()
         {
-            if (!this.Controlled)
+            if (!Controlled)
                 return 545;
 
             return base.GetDeathSound();
@@ -143,7 +143,7 @@ namespace Server.Mobiles
 
         public override int GetHurtSound()
         {
-            if (this.Controlled)
+            if (Controlled)
                 return 320;
 
             return base.GetHurtSound();
@@ -151,9 +151,9 @@ namespace Server.Mobiles
   
         public override void OnDamage(int amount, Mobile from, bool willKill)
         {
-            Mobile master = this.GetMaster();
+            Mobile master = GetMaster();
 
-            if (master != null && master.Player && master.Map == this.Map && master.InRange(this.Location, 20))
+            if (master != null && master.Player && master.Map == Map && master.InRange(Location, 20))
             {
                 if (master.Mana >= amount)
                 {
@@ -173,13 +173,18 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            if (version == 0 && (AbilityProfile == null || AbilityProfile.MagicalAbility == MagicalAbility.None))
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
+            }
         }
     }
 }

--- a/Scripts/Mobiles/Normal/CoralSnake.cs
+++ b/Scripts/Mobiles/Normal/CoralSnake.cs
@@ -76,15 +76,18 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
-            writer.Write(0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
+            int version = reader.ReadInt();
 
-            var version = reader.ReadInt();
+            if (version == 0 && (AbilityProfile == null || AbilityProfile.MagicalAbility == MagicalAbility.None))
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
+            }
         }
     }
 }

--- a/Scripts/Mobiles/Normal/CorrosiveSlime.cs
+++ b/Scripts/Mobiles/Normal/CorrosiveSlime.cs
@@ -95,16 +95,22 @@ namespace Server.Mobiles
 
             base.OnDeath(c);
         }
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            if (version == 0 && (AbilityProfile == null || AbilityProfile.MagicalAbility == MagicalAbility.None))
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
+            }
         }
     }
 }

--- a/Scripts/Mobiles/Normal/DreadSpider.cs
+++ b/Scripts/Mobiles/Normal/DreadSpider.cs
@@ -72,13 +72,18 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            if (version == 0 && (AbilityProfile == null || AbilityProfile.MagicalAbility == MagicalAbility.None))
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
+            }
         }
     }
 }

--- a/Scripts/Mobiles/Normal/FrostMite.cs
+++ b/Scripts/Mobiles/Normal/FrostMite.cs
@@ -1,46 +1,47 @@
 using System;
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
     [CorpseName("a beetle corpse")]
     public class FrostMite : BaseCreature
     {
-        private static readonly Dictionary<Mobile, ExpireTimer> m_Table = new Dictionary<Mobile, ExpireTimer>();
-
         [Constructable]
         public FrostMite() : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "Frost Mite";
-            this.Body = 0x590;
-            this.Female = true;
+            Name = "Frost Mite";
+            Body = 0x590;
+            Female = true;
 
-            this.SetStr(1017);
-            this.SetDex(164);
-            this.SetInt(283);
+            SetStr(1017);
+            SetDex(164);
+            SetInt(283);
 
-            this.SetHits(862);
+            SetHits(862);
 
-            this.SetDamage(21, 28);
+            SetDamage(21, 28);
 
-            this.SetDamageType(ResistanceType.Physical, 0);
-            this.SetDamageType(ResistanceType.Cold, 100);
+            SetDamageType(ResistanceType.Physical, 0);
+            SetDamageType(ResistanceType.Cold, 100);
 
-            this.SetResistance(ResistanceType.Physical, 60, 70);
-            this.SetResistance(ResistanceType.Fire, 15, 25);
-            this.SetResistance(ResistanceType.Cold, 90, 100);
-            this.SetResistance(ResistanceType.Poison, 50, 70);
-            this.SetResistance(ResistanceType.Energy, 40, 45);
+            SetResistance(ResistanceType.Physical, 60, 70);
+            SetResistance(ResistanceType.Fire, 15, 25);
+            SetResistance(ResistanceType.Cold, 90, 100);
+            SetResistance(ResistanceType.Poison, 50, 70);
+            SetResistance(ResistanceType.Energy, 40, 45);
 
-            this.SetSkill(SkillName.MagicResist, 50.0, 85.0);
-            this.SetSkill(SkillName.Tactics, 70.0, 105.0);
-            this.SetSkill(SkillName.Wrestling, 70.0, 110.0);
-            this.SetSkill(SkillName.DetectHidden, 60.0, 80.0);
-            this.SetSkill(SkillName.Focus, 100.0, 115.0);
+            SetSkill(SkillName.MagicResist, 50.0, 85.0);
+            SetSkill(SkillName.Tactics, 70.0, 105.0);
+            SetSkill(SkillName.Wrestling, 70.0, 110.0);
+            SetSkill(SkillName.DetectHidden, 60.0, 80.0);
+            SetSkill(SkillName.Focus, 100.0, 115.0);
 
-            this.Tamable = true;
-            this.ControlSlots = 3;
-            this.MinTameSkill = 102.0;
+            Tamable = true;
+            ControlSlots = 3;
+            MinTameSkill = 102.0;
+
+            SetWeaponAbility(WeaponAbility.ColdWind);
         }
 
         public override int GetAngerSound()
@@ -70,7 +71,7 @@ namespace Server.Mobiles
 
         public override int Meat { get { return 5; } }
         public override FoodType FavoriteFood { get { return FoodType.Meat; } }
-        public override bool HasAura { get { return !this.Controlled; } }
+        public override bool HasAura { get { return !Controlled; } }
         public override int AuraRange { get { return 2; } }
         public override int AuraBaseDamage { get { return 15; } }
         public override int AuraFireDamage { get { return 0; } }
@@ -80,68 +81,7 @@ namespace Server.Mobiles
 
         public override void AuraEffect(Mobile m)
         {
-            m.SendLocalizedMessage(1008111, false, this.Name); //  : The intense cold is damaging you!
-        }
-
-        public override void OnGaveMeleeAttack(Mobile defender)
-        {
-            base.OnGaveMeleeAttack(defender);
-
-            if (0.1 > Utility.RandomDouble())
-            {
-                if (m_Table.ContainsKey(defender))
-                {
-                    m_Table[defender].DoExpire();
-                    defender.SendLocalizedMessage(1070831); // The freezing wind continues to blow!
-                }
-                else
-                {
-                    defender.SendLocalizedMessage(1070832); // An icy wind surrounds you, freezing your lungs as you breathe!
-                }
-
-                ExpireTimer timer = new ExpireTimer(defender, this);
-                timer.Start();
-                m_Table[defender] = timer;
-            }
-        }
-
-        private class ExpireTimer : Timer
-        {
-            private readonly Mobile m_Mobile;
-            private readonly Mobile m_From;
-            private int m_Count;
-            public ExpireTimer(Mobile m, Mobile from)
-                : base(TimeSpan.FromSeconds(1.0), TimeSpan.FromSeconds(1.0))
-            {
-                this.m_Mobile = m;
-                this.m_From = from;
-                this.Priority = TimerPriority.TwoFiftyMS;
-            }
-
-            public void DoExpire()
-            {
-                this.Stop();
-                m_Table.Remove(this.m_Mobile);
-            }
-
-            public void DrainLife()
-            {
-                if (this.m_Mobile.Alive)
-                    this.m_Mobile.Damage(2, this.m_From);
-                else
-                    this.DoExpire();
-            }
-
-            protected override void OnTick()
-            {
-                this.DrainLife();
-
-                if (++this.m_Count >= 5)
-                {
-                    this.DoExpire();
-                    this.m_Mobile.SendLocalizedMessage(1070830); // The icy wind dissipates.
-                }
-            }
+            m.SendLocalizedMessage(1008111, false, Name); //  : The intense cold is damaging you!
         }
 
         public FrostMite(Serial serial) : base(serial)

--- a/Scripts/Mobiles/Normal/GiantSpider.cs
+++ b/Scripts/Mobiles/Normal/GiantSpider.cs
@@ -10,39 +10,39 @@ namespace Server.Mobiles
         public GiantSpider()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
-            this.Name = "a giant spider";
-            this.Body = 28;
-            this.BaseSoundID = 0x388;
+            Name = "a giant spider";
+            Body = 28;
+            BaseSoundID = 0x388;
 
-            this.SetStr(76, 100);
-            this.SetDex(76, 95);
-            this.SetInt(36, 60);
+            SetStr(76, 100);
+            SetDex(76, 95);
+            SetInt(36, 60);
 
-            this.SetHits(46, 60);
-            this.SetMana(0);
+            SetHits(46, 60);
+            SetMana(0);
 
-            this.SetDamage(5, 13);
+            SetDamage(5, 13);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 15, 20);
-            this.SetResistance(ResistanceType.Poison, 25, 35);
+            SetResistance(ResistanceType.Physical, 15, 20);
+            SetResistance(ResistanceType.Poison, 25, 35);
 
-            this.SetSkill(SkillName.Poisoning, 60.1, 80.0);
-            this.SetSkill(SkillName.MagicResist, 25.1, 40.0);
-            this.SetSkill(SkillName.Tactics, 35.1, 50.0);
-            this.SetSkill(SkillName.Wrestling, 50.1, 65.0);
+            SetSkill(SkillName.Poisoning, 60.1, 80.0);
+            SetSkill(SkillName.MagicResist, 25.1, 40.0);
+            SetSkill(SkillName.Tactics, 35.1, 50.0);
+            SetSkill(SkillName.Wrestling, 50.1, 65.0);
 
-            this.Fame = 600;
-            this.Karma = -600;
+            Fame = 600;
+            Karma = -600;
 
-            this.VirtualArmor = 16;
+            VirtualArmor = 16;
 
-            this.Tamable = true;
-            this.ControlSlots = 1;
-            this.MinTameSkill = 59.1;
+            Tamable = true;
+            ControlSlots = 1;
+            MinTameSkill = 59.1;
 
-            this.PackItem(new SpidersSilk(5));
+            PackItem(new SpidersSilk(5));
         }
 
         public GiantSpider(Serial serial)
@@ -80,19 +80,24 @@ namespace Server.Mobiles
         }
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Poor);
+            AddLoot(LootPack.Poor);
         }
 
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            if (version == 0 && (AbilityProfile == null || AbilityProfile.MagicalAbility == MagicalAbility.None))
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
+            }
         }
     }
 }

--- a/Scripts/Mobiles/Normal/LadyOfTheSnow.cs
+++ b/Scripts/Mobiles/Normal/LadyOfTheSnow.cs
@@ -7,7 +7,6 @@ namespace Server.Mobiles
     [CorpseName("a lady of the snow corpse")]
     public class LadyOfTheSnow : BaseCreature
     {
-        private static readonly Hashtable m_Table = new Hashtable();
         [Constructable]
         public LadyOfTheSnow()
             : base(AIType.AI_NecroMage, FightMode.Closest, 10, 1, 0.2, 0.4)
@@ -48,6 +47,8 @@ namespace Server.Mobiles
 
             if (0.25 > Utility.RandomDouble())
                 PackItem(Engines.Plants.Seed.RandomBonsaiSeed());
+
+            SetWeaponAbility(WeaponAbility.ColdWind);
         }
 
         public LadyOfTheSnow(Serial serial)
@@ -87,36 +88,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.Rich);
         }
 
-        // TODO: Snowball
-        public override void OnGaveMeleeAttack(Mobile defender)
-        {
-            base.OnGaveMeleeAttack(defender);
-
-            if (0.1 > Utility.RandomDouble())
-            {
-                /* Cold Wind
-                * Graphics: Message - Type: "3" From: "0x57D4F5B" To: "0x0" ItemId: "0x37B9" ItemIdName: "glow" FromLocation: "(928 164, 34)" ToLocation: "(928 164, 34)" Speed: "10" Duration: "5" FixedDirection: "True" Explode: "False"
-                * Start cliloc: 1070832
-                * Damage: 1hp per second for 5 seconds
-                * End cliloc: 1070830
-                * Reset cliloc: 1070831
-                */
-                ExpireTimer timer = (ExpireTimer)m_Table[defender];
-
-                if (timer != null)
-                {
-                    timer.DoExpire();
-                    defender.SendLocalizedMessage(1070831); // The freezing wind continues to blow!
-                }
-                else
-                    defender.SendLocalizedMessage(1070832); // An icy wind surrounds you, freezing your lungs as you breathe!
-
-                timer = new ExpireTimer(defender, this);
-                timer.Start();
-                m_Table[defender] = timer;
-            }
-        }
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
@@ -129,45 +100,6 @@ namespace Server.Mobiles
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
-        }
-
-        private class ExpireTimer : Timer
-        {
-            private readonly Mobile m_Mobile;
-            private readonly Mobile m_From;
-            private int m_Count;
-            public ExpireTimer(Mobile m, Mobile from)
-                : base(TimeSpan.FromSeconds(1.0), TimeSpan.FromSeconds(1.0))
-            {
-                m_Mobile = m;
-                m_From = from;
-                Priority = TimerPriority.TwoFiftyMS;
-            }
-
-            public void DoExpire()
-            {
-                Stop();
-                m_Table.Remove(m_Mobile);
-            }
-
-            public void DrainLife()
-            {
-                if (m_Mobile.Alive)
-                    m_Mobile.Damage(2, m_From);
-                else
-                    DoExpire();
-            }
-
-            protected override void OnTick()
-            {
-                DrainLife();
-
-                if (++m_Count >= 5)
-                {
-                    DoExpire();
-                    m_Mobile.SendLocalizedMessage(1070830); // The icy wind dissipates.
-                }
-            }
         }
     }
 }

--- a/Scripts/Mobiles/Normal/RuneBeetle.cs
+++ b/Scripts/Mobiles/Normal/RuneBeetle.cs
@@ -125,7 +125,7 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)2);
+            writer.Write((int)3);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -146,10 +146,18 @@ namespace Server.Mobiles
                 }
             }
 
-            if (version == 1)
+            if (version < 3)
             {
-                SetSpecialAbility(SpecialAbility.RuneCorruption);
-                SetWeaponAbility(WeaponAbility.BleedAttack);
+                if (AbilityProfile == null || AbilityProfile.MagicalAbility == MagicalAbility.None)
+                {
+                    SetMagicalAbility(MagicalAbility.Poisoning);
+                }
+
+                if (version == 1)
+                {
+                    SetSpecialAbility(SpecialAbility.RuneCorruption);
+                    SetWeaponAbility(WeaponAbility.BleedAttack);
+                }
             }
         }
     }

--- a/Scripts/Mobiles/Normal/Scorpion.cs
+++ b/Scripts/Mobiles/Normal/Scorpion.cs
@@ -97,13 +97,18 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            if (version == 0 && (AbilityProfile == null || AbilityProfile.MagicalAbility == MagicalAbility.None))
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
+            }
         }
     }
 }

--- a/Scripts/Mobiles/Normal/Slime.cs
+++ b/Scripts/Mobiles/Normal/Slime.cs
@@ -78,13 +78,18 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            if (version == 0 && (AbilityProfile == null || AbilityProfile.MagicalAbility == MagicalAbility.None))
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
+            }
         }
     }
 }

--- a/Scripts/Mobiles/Normal/Snake.cs
+++ b/Scripts/Mobiles/Normal/Snake.cs
@@ -83,18 +83,22 @@ namespace Server.Mobiles
                 return FoodType.Eggs;
             }
         }
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
-            writer.Write((int)0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
+
+            if (version == 0 && (AbilityProfile == null || AbilityProfile.MagicalAbility == MagicalAbility.None))
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
+            }
         }
     }
 }

--- a/Scripts/Mobiles/Normal/Wight.cs
+++ b/Scripts/Mobiles/Normal/Wight.cs
@@ -45,7 +45,9 @@ namespace Server.Mobiles
             Karma = -1500;
 
             VirtualArmor = 19;
+
             SetWeaponAbility(WeaponAbility.MortalStrike);
+            SetWeaponAbility(WeaponAbility.ColdWind);
         }
 
         public Wight(Serial serial)

--- a/Scripts/Mobiles/Normal/WolfSpider.cs
+++ b/Scripts/Mobiles/Normal/WolfSpider.cs
@@ -120,7 +120,7 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)1);
+            writer.Write((int)2);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -132,6 +132,11 @@ namespace Server.Mobiles
             {
                 Hue = 0;
                 Body = 736;
+            }
+
+            if (version == 1 && (AbilityProfile == null || AbilityProfile.MagicalAbility == MagicalAbility.None))
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
             }
         }
     }

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -134,29 +134,37 @@ namespace Server.Mobiles
 		#endregion
 
 		#region Stygian Abyss
-		public override void ToggleFlying()
-		{
-			if (Race != Race.Gargoyle)
-				return;
+        public override void ToggleFlying()
+        {
+            if (Race != Race.Gargoyle)
+                return;
+
+            if (Frozen)
+            {
+                SendLocalizedMessage(1060170); // You cannot use this ability while frozen.
+                return;
+            }
 
             if (!Flying)
             {
-                if (Spell == null)
-                {
-                    Spell spell = new FlySpell(this);
+                if (this.Spell is Spell)
+                    ((Spell)this.Spell).Disturb(DisturbType.Unspecified, false, false);
 
-                    spell.Cast();
-                }
+                Spell spell = new FlySpell(this);
+                spell.Cast();
             }
             else if (IsValidLandLocation(Location, Map))
             {
+                if (this.Spell is Spell)
+                    ((Spell)this.Spell).Disturb(DisturbType.Unspecified, false, false);
+
                 Animate(AnimationType.Land, 0);
                 Flying = false;
                 BuffInfo.RemoveBuff(this, BuffIcon.Fly);
             }
             else
                 LocalOverheadMessage(MessageType.Regular, 0x3B2, 1113081); // You may not land here.
-		}
+        }
 
         public static bool IsValidLandLocation(Point3D p, Map map)
         {

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -4997,6 +4997,15 @@ namespace Server.Mobiles
 			{
 				return false;
 			}
+            else if (AccessLevel == AccessLevel.Player)
+            {
+                Region r = item.GetRegion();
+
+                if (r is BaseRegion && !((BaseRegion)r).CanSee(this, item))
+                {
+                    return false;
+                }
+            }
 
 			return base.CanSee(item);
 		}

--- a/Scripts/Multis/BaseHouse.cs
+++ b/Scripts/Multis/BaseHouse.cs
@@ -3229,6 +3229,11 @@ namespace Server.Multis
 
                 m_Addons[item] = Owner;
             }
+
+            foreach (var item in Region.GetEnumeratedItems().Where(i => i is AddonComponent && ((AddonComponent)i).Addon == null))
+            {
+                item.Delete();
+            }
         }
 
         private void FixLockdowns_Sandbox()

--- a/Scripts/Quests/Eodon/MyrmidexThreat/Mobiles/Questers.cs
+++ b/Scripts/Quests/Eodon/MyrmidexThreat/Mobiles/Questers.cs
@@ -242,7 +242,7 @@ namespace Server.Mobiles
 			{
 				public InternalBuyInfo(BaseVendor owner)
 				{  
-					Add( new GenericBuyInfo( "Stasis Chamber Power Core", typeof( StasisChamberPowerCore ), 101250, 500, 40155, 0 ) ); // TODO: Get itemid
+					Add( new GenericBuyInfo( "Stasis Chamber Power Core", typeof( StasisChamberPowerCore ), 101250, 500, 40155, 0 ) );
 				}
 			}
 

--- a/Scripts/Regions/BaseRegion.cs
+++ b/Scripts/Regions/BaseRegion.cs
@@ -598,5 +598,10 @@ namespace Server.Regions
         {
             return true;
         }
+
+        public virtual bool CanSee(Mobile m, IEntity e)
+        {
+            return true;
+        }
     }
 }

--- a/Scripts/Services/Expansions/Time Of Legends/Mobiles/Dimetrosaur.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Mobiles/Dimetrosaur.cs
@@ -115,7 +115,7 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(1);
+            writer.Write(3);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -133,6 +133,11 @@ namespace Server.Mobiles
                 SetAreaEffect(AreaEffect.PoisonBreath);
                 SetWeaponAbility(WeaponAbility.MortalStrike);
                 SetWeaponAbility(WeaponAbility.Dismount);
+            }
+
+            if (version < 2)
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
             }
         }
     }

--- a/Scripts/Services/Expansions/Time Of Legends/Mobiles/Dimetrosaur.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Mobiles/Dimetrosaur.cs
@@ -115,7 +115,7 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(3);
+            writer.Write(2);
         }
 
         public override void Deserialize(GenericReader reader)

--- a/Scripts/Services/Expansions/Time Of Legends/Mobiles/Najasaurus.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Mobiles/Najasaurus.cs
@@ -63,13 +63,18 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(0);
+            writer.Write(1);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            if (version == 0)
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
+            }
         }
     }
 }

--- a/Scripts/Services/Pet Training/AreaEffects.cs
+++ b/Scripts/Services/Pet Training/AreaEffects.cs
@@ -425,7 +425,7 @@ namespace Server.Mobiles
             {
                 var profile = PetTrainingHelper.GetAbilityProfile(creature);
 
-                if (profile.HasAbility(MagicalAbility.Poisoning))
+                if (profile != null && profile.HasAbility(MagicalAbility.Poisoning))
                     creature.CheckSkill(SkillName.Poisoning, 0, creature.Skills[SkillName.Poisoning].Cap);
             }
         }

--- a/Scripts/Services/Pet Training/Gumps.cs
+++ b/Scripts/Services/Pet Training/Gumps.cs
@@ -5,6 +5,7 @@ using Server.Items;
 using Server.SkillHandlers;
 using System.Collections.Generic;
 using System.Linq;
+using Server.Misc;
 
 namespace Server.Mobiles
 {
@@ -118,13 +119,13 @@ namespace Server.Mobiles
             AddHtmlLocalized(47, 74, 160, 18, 1049593, 0xC8, false, false); // Attributes
 
             AddHtmlLocalized(53, 92, 160, 18, 1075627, _Label, false, false); // Hit Point Regeneration
-            AddHtml(180, 92, 75, 18, FormatStat(profile == null ? 0 : profile.RegenHits), false, false);
+            AddHtml(180, 92, 75, 18, FormatStat(RegenRates.HitPointRegen(Creature)), false, false);
 
             AddHtmlLocalized(53, 110, 160, 18, 1079411, _Label, false, false); // Stamina Regeneration
-            AddHtml(180, 110, 75, 18, FormatStat(profile == null ? 0 : profile.RegenStam), false, false);
+            AddHtml(180, 110, 75, 18, FormatStat(RegenRates.StamRegen(Creature)), false, false);
 
             AddHtmlLocalized(53, 128, 160, 18, 1079410, _Label, false, false); // Mana Regeneration
-            AddHtml(180, 128, 75, 18, FormatStat(profile == null ? 0 : profile.RegenMana), false, false);
+            AddHtml(180, 128, 75, 18, FormatStat(RegenRates.ManaRegen(Creature)), false, false);
 
             AddButton(240, 328, 0x15E1, 0x15E5, 0, GumpButtonType.Page, 3);
             AddButton(217, 328, 0x15E3, 0x15E7, 0, GumpButtonType.Page, 1);

--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -319,7 +319,7 @@ namespace Server.Mobiles
 
         public static WeaponAbility[] WepAbility2 =
         {
-            WeaponAbility.ArmorIgnore, WeaponAbility.Bladeweave, WeaponAbility.BleedAttack, WeaponAbility.ColdWind, WeaponAbility.ConcussionBlow,
+            WeaponAbility.ArmorIgnore, WeaponAbility.ArmorPierce, WeaponAbility.Bladeweave, WeaponAbility.BleedAttack, WeaponAbility.ColdWind, WeaponAbility.ConcussionBlow,
             WeaponAbility.CrushingBlow, WeaponAbility.Dismount, WeaponAbility.Feint, WeaponAbility.ForceOfNature, WeaponAbility.FrenziedWhirlwind,
             WeaponAbility.MortalStrike, WeaponAbility.NerveStrike, WeaponAbility.ParalyzingBlow, WeaponAbility.PsychicAttack, WeaponAbility.TalonStrike
         };

--- a/Scripts/Services/XmlSpawner/XmlSpawner Core/XmlUtils/XmlFind.cs
+++ b/Scripts/Services/XmlSpawner/XmlSpawner Core/XmlUtils/XmlFind.cs
@@ -387,7 +387,7 @@ namespace Server.Mobiles
 
 				if (m.Map != Map.Internal || m.Account != null ||
 					(m is IMount && ((IMount)m).Rider != null) ||
-                    (m is GalleonPilot) ||
+                    (m is GalleonPilot) || m is PetParrot ||
                     (GenericBuyInfo.IsDisplayCache(m)) ||
 					(m is BaseCreature && ((BaseCreature)m).IsStabled))
 					return true;
@@ -399,11 +399,8 @@ namespace Server.Mobiles
 					Item i = (Item)o;
 
 					// note, in order to test for a vendors display container that contains valid internal map items 
-					// we need to see if we have a DisplayCache type container.  Unfortunately, DisplayCache
-					// is a private class declared in GenericBuyInfo and so cannot be tested for here. 
-					// To get around that we just check the declaring type.
 					if (i.Map != Map.Internal || i.Parent != null || i is Fists || i is MountItem || i is EffectItem || i.HeldBy != null ||
-						i is MovingCrate || i is SpawnPersistence || (i.GetType().DeclaringType == typeof(GenericBuyInfo)))
+                        i is MovingCrate || i is SpawnPersistence || GenericBuyInfo.IsDisplayCache(i))
 						return true;
 
                     // boat stuffs
@@ -429,7 +426,7 @@ namespace Server.Mobiles
                         return true;
 
                     if (i is ArisenController)
-                        return true;
+                        return true; 
 				}
 
 			return false;

--- a/Scripts/Skills/Fishing.cs
+++ b/Scripts/Skills/Fishing.cs
@@ -258,7 +258,7 @@ namespace Server.Engines.Harvest
             if (FishInfo.IsRareFish(type))
                 return type;
 
-            bool deepWater = Items.SpecialFishingNet.ValidateDeepWater(map, loc.X, loc.Y);
+            bool deepWater = IsDeepWater(loc, map);
             bool junkproof = HasTypeHook(tool, HookType.JunkProof); 
 
             double skillBase = from.Skills[SkillName.Fishing].Base;
@@ -290,6 +290,11 @@ namespace Server.Engines.Harvest
             }
 
             return type;
+        }
+
+        private bool IsDeepWater(Point3D p, Map map)
+        {
+            return Items.SpecialFishingNet.ValidateDeepWater(map, p.X, p.Y) && (map == Map.Trammel || map == Map.Felucca || map == Map.Tokuno);
         }
 
         public override bool CheckResources(Mobile from, Item tool, HarvestDefinition def, Map map, Point3D loc, bool timed)
@@ -1012,7 +1017,7 @@ namespace Server.Engines.Harvest
 
         public override bool CheckHarvestSkill(Map map, Point3D loc, Mobile from, HarvestResource res, HarvestDefinition def)
         {
-            bool deepWater = SpecialFishingNet.ValidateDeepWater(map, loc.X, loc.Y);
+            bool deepWater = IsDeepWater(loc, map);
             double value = from.Skills[SkillName.Fishing].Value;
 
             if (deepWater && value < 75.0) // can't fish here yet

--- a/Scripts/Skills/Stealth.cs
+++ b/Scripts/Skills/Stealth.cs
@@ -73,6 +73,12 @@ namespace Server.SkillHandlers
             {
                 m.SendLocalizedMessage(502725); // You must hide first
             }
+            else if (m.Flying)
+            {
+                m.SendLocalizedMessage(1113415); // You cannot use this ability while flying.
+                m.RevealingAction();
+                BuffInfo.RemoveBuff(m, BuffIcon.HidingAndOrStealth);
+            }
             else if (m.Skills[SkillName.Hiding].Base < HidingRequirement)
             {
                 m.SendLocalizedMessage(502726); // You are not hidden well enough.  Become better at hiding.

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -1081,7 +1081,7 @@ namespace Server.Spells
             if (map == Map.Felucca && loc.X >= 6975 && loc.X <= 7042 && loc.Y >= 2048 && loc.Y <= 2115)
                 return true;
 
-            return map == Map.TerMur && loc.X >= 64 && loc.X <= 1015 && loc.Y >= 1344 && loc.Y <= 2239;
+            return map == Map.TerMur && loc.X >= 64 && loc.X <= 1087 && loc.Y >= 1344 && loc.Y <= 2495;
         }
 
         public static bool IsNewDungeon(Map map, Point3D loc)

--- a/Scripts/Spells/Gargoyle/SpellDefinitions/FlySpell.cs
+++ b/Scripts/Spells/Gargoyle/SpellDefinitions/FlySpell.cs
@@ -16,7 +16,7 @@ namespace Server.Spells
         public override bool ClearHandsOnCast { get { return false; } }
         public override bool RevealOnCast { get { return false; } }
         public override double CastDelayFastScalar { get { return 0; } }
-        public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds(1.0); } }
+        public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds(2.0); } }
         public override TimeSpan GetCastRecovery() { return TimeSpan.Zero; }
         public override int GetMana() { return 0; }
         public override bool ConsumeReagents() { return true; }

--- a/Scripts/Spells/Ninjitsu/MirrorImage.cs
+++ b/Scripts/Spells/Ninjitsu/MirrorImage.cs
@@ -96,6 +96,11 @@ namespace Server.Spells.Ninjitsu
                 Caster.SendLocalizedMessage(1061091); // You cannot cast that spell in this form.
                 return false;
             }
+            else if (Caster.Flying)
+            {
+                Caster.SendLocalizedMessage(1113415); // You cannot use this ability while flying.
+                return false;
+            }
 
             return base.CheckCast();
         }

--- a/Scripts/Spells/Skill Masteries/BardSpells/Perseverance.cs
+++ b/Scripts/Spells/Skill Masteries/BardSpells/Perseverance.cs
@@ -46,18 +46,14 @@ namespace Server.Spells.SkillMasteries
                 m_PropertyBonus2 = (int)((BaseSkillBonus * 4) + (CollectiveBonus * 2));
                 m_DamageMod = ((BaseSkillBonus * 16) + (CollectiveBonus * 6)) / 100;
 
-                System.Collections.Generic.List<Mobile> list = GetParty();
-
-                foreach (Mobile m in list)
+                foreach (Mobile m in GetParty())
                 {
                     m.FixedParticles(0x373A, 10, 15, 5018, EffectLayer.Waist);
                     m.SendLocalizedMessage(1115739); // The bard's spellsong fills you with a feeling of invincibility.
 
-                    string args = String.Format("{0}\t{1}\t{2}", m_PropertyBonus, m_DamageMod, m_PropertyBonus2);
+                    string args = String.Format("{0}\t{1}\t{2}", m_PropertyBonus, (int)(m_DamageMod * 100), m_PropertyBonus2);
                     BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.Perseverance, 1115615, 1115732, args.ToString()));
                 }
-
-                ColUtility.Free(list);
 
 				BeginTimer();
 			}

--- a/Scripts/Spells/Skill Masteries/BardSpells/Resilience.cs
+++ b/Scripts/Spells/Skill Masteries/BardSpells/Resilience.cs
@@ -41,9 +41,8 @@ namespace Server.Spells.SkillMasteries
 			else if ( CheckSequence() )
 			{
                 m_PropertyBonus = (int)((BaseSkillBonus * 8) + (CollectiveBonus * 3));
-                System.Collections.Generic.List<Mobile> list = GetParty();
 
-                foreach (Mobile m in list)
+                foreach (Mobile m in GetParty())
                 {
                     m.FixedParticles(0x373A, 10, 15, 5018, EffectLayer.Waist);
                     m.SendLocalizedMessage(1115738); // The bard's spellsong fills you with a feeling of resilience.
@@ -51,9 +50,6 @@ namespace Server.Spells.SkillMasteries
                     string args = String.Format("{0}\t{1}\t{2}", m_PropertyBonus, m_PropertyBonus, m_PropertyBonus);
                     BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.Resilience, 1115614, 1115731, args.ToString()));
                 }
-
-                list.Clear();
-                list.TrimExcess();
 
 				BeginTimer();
 			}

--- a/Scripts/Spells/Skill Masteries/BardSpells/inspire.cs
+++ b/Scripts/Spells/Skill Masteries/BardSpells/inspire.cs
@@ -44,9 +44,7 @@ namespace Server.Spells.SkillMasteries
                 m_PropertyBonus = (int)((BaseSkillBonus * 12) + (CollectiveBonus * 3));
                 m_DamageBonus = (int)Math.Min(40, ((BaseSkillBonus * 30) + (CollectiveBonus * 10)));
 
-                System.Collections.Generic.List<Mobile> list = GetParty();
-
-                foreach (Mobile m in list)
+                foreach (Mobile m in GetParty())
                 {
                     m.FixedParticles(0x373A, 10, 15, 5018, EffectLayer.Waist);
                     m.SendLocalizedMessage(1115736); // You feel inspired by the bard's spellsong.
@@ -54,9 +52,6 @@ namespace Server.Spells.SkillMasteries
                     string args = String.Format("{0}\t{1}\t{2}", m_PropertyBonus, m_PropertyBonus, m_DamageBonus);
                     BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.Inspire, 1115683, 1115729, args.ToString()));
                 }
-
-                list.Clear();
-                list.TrimExcess();
 
 				BeginTimer();
 			}

--- a/Scripts/Spells/Skill Masteries/PlayingTheOdds.cs
+++ b/Scripts/Spells/Skill Masteries/PlayingTheOdds.cs
@@ -77,9 +77,7 @@ namespace Server.Spells.SkillMasteries
                 BuffInfo.AddBuff(Caster, new BuffInfo(BuffIcon.PlayingTheOddsDebuff, 1155913, 1156091, duration, Caster));
                 //Your bow range has been reduced as you play the odds.
 
-                List<Mobile> list = GetParty();
-
-                foreach (Mobile m in list.Where(mob => mob is PlayerMobile))
+                foreach (Mobile m in GetParty().Where(mob => mob is PlayerMobile))
                 {
                     m.PlaySound(0x101);
                     m.FixedEffect(0x13B2, 10, 20, 2728, 5);
@@ -89,8 +87,6 @@ namespace Server.Spells.SkillMasteries
                         BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.PlayingTheOdds, 1155913, 1155998, duration, m, args));
                         //~1_NAME~ grants you the following:<br>+~2_VAl~% Hit Chance Increase.<br>+~3_VAL~% Swing Speed Increase.
                 }
-
-                ColUtility.Free(list);
 
                 Caster.SendLocalizedMessage(1156091); // Your bow range has been reduced as you play the odds.
 

--- a/Scripts/Spells/Spellweaving/ArcanistSpell.cs
+++ b/Scripts/Spells/Spellweaving/ArcanistSpell.cs
@@ -35,6 +35,11 @@ namespace Server.Spells.Spellweaving
 
 			if (focus == null || focus.Deleted)
 			{
+                if (Core.TOL && from is BaseCreature && from.Skills[SkillName.Spellweaving].Value > 0)
+                {
+                    return (int)Math.Max(1, Math.Min(6, from.Skills[SkillName.Spellweaving].Value / 20));
+                }
+
 				return 0;
 			}
 

--- a/Scripts/VendorInfo/GenericBuy.cs
+++ b/Scripts/VendorInfo/GenericBuy.cs
@@ -391,9 +391,14 @@ namespace Server.Mobiles
             }
         }
 
-        public static bool IsDisplayCache(Mobile m)
+        public static bool IsDisplayCache(IEntity e)
         {
-            return DisplayCache.Cache != null && DisplayCache.Cache.Mobiles != null && DisplayCache.Cache.Mobiles.Contains(m);
+            if (e is Mobile)
+            {
+                return DisplayCache.Cache.Mobiles != null && DisplayCache.Cache.Mobiles.Contains((Mobile)e);
+            }
+
+            return DisplayCache.Cache.Table != null && DisplayCache.Cache.Table.ContainsValue(e);
         }
 
         private class DisplayCache : Container
@@ -403,6 +408,7 @@ namespace Server.Mobiles
             private List<Mobile> m_Mobiles;
 
             public List<Mobile> Mobiles { get { return m_Mobiles; } }
+            public Dictionary<Type, IEntity> Table { get { return m_Table; } }
 
             public DisplayCache()
                 : base(0)

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -5559,80 +5559,7 @@ namespace Server
 
 				Paralyzed = false;
 
-				switch (m_VisibleDamageType)
-				{
-					case VisibleDamageType.Related:
-						{
-							NetState ourState = m_NetState, theirState = (from == null ? null : from.m_NetState);
-
-							if (ourState == null)
-							{
-								Mobile master = GetDamageMaster(from);
-
-								if (master != null)
-								{
-									ourState = master.m_NetState;
-								}
-							}
-
-							if (theirState == null && from != null)
-							{
-								Mobile master = from.GetDamageMaster(this);
-
-								if (master != null)
-								{
-									theirState = master.m_NetState;
-								}
-							}
-
-							if (amount > 0 && (ourState != null || theirState != null))
-							{
-								Packet p = null; // = new DamagePacket( this, amount );
-
-								if (ourState != null)
-								{
-									if (ourState.DamagePacket)
-									{
-										p = Packet.Acquire(new DamagePacket(this, amount));
-									}
-									else
-									{
-										p = Packet.Acquire(new DamagePacketOld(this, amount));
-									}
-
-									ourState.Send(p);
-								}
-
-								if (theirState != null && theirState != ourState)
-								{
-									bool newPacket = theirState.DamagePacket;
-
-									if (newPacket && (p == null || !(p is DamagePacket)))
-									{
-										Packet.Release(p);
-										p = Packet.Acquire(new DamagePacket(this, amount));
-									}
-									else if (!newPacket && (p == null || !(p is DamagePacketOld)))
-									{
-										Packet.Release(p);
-										p = Packet.Acquire(new DamagePacketOld(this, amount));
-									}
-
-									theirState.Send(p);
-								}
-
-								Packet.Release(p);
-							}
-
-							break;
-						}
-					case VisibleDamageType.Everyone:
-						{
-							SendDamageToAll(amount);
-							break;
-						}
-				}
-
+                SendDamagePacket(from, amount);
 				OnDamage(amount, from, newHits < 0);
 
 				IMount m = Mount;
@@ -5658,6 +5585,83 @@ namespace Server
 				}
 			}
 		}
+
+        public virtual void SendDamagePacket(Mobile from, int amount)
+        {
+            switch (m_VisibleDamageType)
+            {
+                case VisibleDamageType.Related:
+                    {
+                        NetState ourState = m_NetState, theirState = (from == null ? null : from.m_NetState);
+
+                        if (ourState == null)
+                        {
+                            Mobile master = GetDamageMaster(from);
+
+                            if (master != null)
+                            {
+                                ourState = master.m_NetState;
+                            }
+                        }
+
+                        if (theirState == null && from != null)
+                        {
+                            Mobile master = from.GetDamageMaster(this);
+
+                            if (master != null)
+                            {
+                                theirState = master.m_NetState;
+                            }
+                        }
+
+                        if (amount > 0 && (ourState != null || theirState != null))
+                        {
+                            Packet p = null; // = new DamagePacket( this, amount );
+
+                            if (ourState != null)
+                            {
+                                if (ourState.DamagePacket)
+                                {
+                                    p = Packet.Acquire(new DamagePacket(this, amount));
+                                }
+                                else
+                                {
+                                    p = Packet.Acquire(new DamagePacketOld(this, amount));
+                                }
+
+                                ourState.Send(p);
+                            }
+
+                            if (theirState != null && theirState != ourState)
+                            {
+                                bool newPacket = theirState.DamagePacket;
+
+                                if (newPacket && (p == null || !(p is DamagePacket)))
+                                {
+                                    Packet.Release(p);
+                                    p = Packet.Acquire(new DamagePacket(this, amount));
+                                }
+                                else if (!newPacket && (p == null || !(p is DamagePacketOld)))
+                                {
+                                    Packet.Release(p);
+                                    p = Packet.Acquire(new DamagePacketOld(this, amount));
+                                }
+
+                                theirState.Send(p);
+                            }
+
+                            Packet.Release(p);
+                        }
+
+                        break;
+                    }
+                case VisibleDamageType.Everyone:
+                    {
+                        SendDamageToAll(amount);
+                        break;
+                    }
+            }
+        }
 
 		public virtual void SendDamageToAll(int amount)
 		{


### PR DESCRIPTION
- Combatant no works via props Gump
- Fixed valid items showing on invalid internal map
- Healing with bandages (not vet) can now be used on Despise Creatures
- Animal Lore now shows the proper regen rates, as well as EC character sheet
- Pets now gain skill above the total skill cap
- Summons now use the proper control slots
- Deepwater fishing removed from TerMur
- Creatures that naturally poisons now start with poisoning magical ability
- Added Armor Pierce weapon ability to various creatures that was erroneously omitted
- Bard songs no longer flag the caster for criminal beneficial actions
- Bard songs no longer give beneficial actions that would otherwise flag the caster criminal
- Fixed Combat Training
- Spellweaving creatures now have a natural arcane circle, giving it +1 strength per 20 spellweaving Skill
- AddonComponents with null addon should now delete when a house is demolished
- Separated Damage Packet from Mobile.cs to a separate method. This was needed and provides more flexibility as to how damage can be shown.