### PR TITLE
Update Kraken.cs

### DIFF
--- a/Scripts/Mobiles/Normal/Kraken.cs
+++ b/Scripts/Mobiles/Normal/Kraken.cs
@@ -57,24 +57,6 @@ namespace Server.Mobiles
             }                       
         }
 
-        public override void OnDeath(Container c)
-        {
-            if (CheckLocation() && .1 >= Utility.RandomDouble())
-                c.DropItem(new MessageInABottle());
-
-            base.OnDeath(c);
-        }
-
-        private bool CheckLocation()
-        {
-            Region r = this.Region;
-
-            if (r is Server.Regions.DungeonRegion || Server.Spells.SpellHelper.IsFeluccaWind(Map, Location) || Server.Spells.SpellHelper.IsTrammelWind(Map, Location))
-                return false;
-
-            return true;
-        }
-
         public Kraken(Serial serial)
             : base(serial)
         {


### PR DESCRIPTION
Currently on ServUO krakens spawn in the open ocean. They should not.

On top of that the Kraken that is "fished up" is the only one the drops MIBS. The few that spawn in dungeons 100% do not.

Since SpecialFishingNet.cs already determines the chance for a fished up one to get a MIB there is no need for the repeat method on the Kraken itself. On top of that the "check" for its location is also not needed since the ones that spawn in dungeons do not drop MIBS and the current ServUO repo is wrong with having them spawn in the wild, open oceans, without having to be fished up with fishing nets.

Tested and confirmed on EA.