### PR TITLE
Update RewardSystem.cs

### DIFF
--- a/Scripts/Services/VeteranRewards/RewardSystem.cs
+++ b/Scripts/Services/VeteranRewards/RewardSystem.cs
@@ -444,7 +444,6 @@ namespace Server.Engines.VeteranRewards
                     new RewardEntry(monsterStatues, 1155748, typeof(MonsterStatuette), MonsterStatuetteType.DarkFather),
                     new RewardEntry(monsterStatues, 1157079, typeof(MonsterStatuette), Expansion.TOL, MonsterStatuetteType.Zipactriotal),
 
-                    new RewardEntry(etherealSteeds, 1006019, typeof(EtherealHorse)),
                     new RewardEntry(etherealSteeds, 1006051, typeof(EtherealLlama)),
                     new RewardEntry(etherealSteeds, 1006050, typeof(EtherealOstard)),
 
@@ -571,8 +570,6 @@ namespace Server.Engines.VeteranRewards
                     new RewardEntry(houseAddOns,    1150121, typeof(RoseRugAddonDeed), Expansion.SA),
                     new RewardEntry(houseAddOns,    1150122, typeof(DolphinRugAddonDeed), Expansion.SA),
                     new RewardEntry(houseAddOns,    1157996, typeof(KoiPondDeed), Expansion.TOL),
-
-                    new RewardEntry( miscellaneous, 1150424, typeof(ChestOfSending), Expansion.SA),
                 }),
                 new RewardList(RewardInterval, 11, new RewardEntry[]
                 {


### PR DESCRIPTION
Chest of Sending is part of the Gothic theme pack, not the Veteran Reward System.
http://www.uoguide.com/Chest_of_Sending

Ethereal Horse was moved on real UO from a 3rd year reward to a 1st year reward. On ServUO it is correctly located under 1st year rewards, but whoever moved it forgot to remove it from 3rd year rewards also. It appears twice.