### PR TITLE
Hotfix/Crashfix - Update ServUO.exe.config

### DIFF
--- a/ServUO.exe.config
+++ b/ServUO.exe.config
@@ -7,7 +7,9 @@
   <runtime>
     <gcServer enabled="false" />
   </runtime>
-  <dllmap dll="libz"   target="libz.so.1" />
-  <dllmap dll="drng32" target="libdrng.so" />
-  <dllmap dll="drng64" target="libdrng.so" />
+  <!-- UNCOMMENT ON UNIX for NOW -->
+  <!--
+  <dllmap os="!windows" dll="libz"   target="libz.so.1" />
+  <dllmap os="!windows" dll="drng32" target="libdrng.so" />
+  <dllmap os="!windows" dll="drng64" target="libdrng.so" /> -->
 </configuration>


### PR DESCRIPTION
dllmap will not work on windows, this will result in a crash for Release Builds *not* Debug.

I'll push a automatic "uncomment" via ServUO.sh for linux tomorrow.

Windows Users: Delete file or comment out dllmap until merged.

Sry about that.