### PR TITLE
Missing Cloaks of Life, Death, and Power

### DIFF
--- a/Scripts/Items/Artifacts/Equipment/Clothing/CloakOfDeath.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/CloakOfDeath.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Server.Items
+{
+    [Flipable(0x2FB9, 0x3173)]
+    public class CloakOfDeath : BaseOuterTorso
+    {
+        [Constructable]
+        public CloakOfDeath()
+            : base(0x2FB9)
+        {
+            Weight = 2.0;
+			Hue = 0x966;
+			Attributes.DefendChance = 3;
+			Attributes.AttackChance = 3;
+			Attributes.SpellDamage = 3;
+        }
+
+        public CloakOfDeath(Serial serial)
+            : base(serial)
+        {
+        }
+		
+		public override int LabelNumber {get {return 1112881;} }// Cloak of Death
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/CloakOfLife.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/CloakOfLife.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Server.Items
+{
+    [Flipable(0x2FB9, 0x3173)]
+    public class CloakOfLife : BaseOuterTorso
+    {
+
+        [Constructable]
+        public CloakOfLife()
+            : base(0x2FB9)
+        {
+            Weight = 2.0;
+			Hue = 0x21;
+			Attributes.RegenHits = 1;
+			Attributes.BonusHits = 3;
+        }
+
+        public CloakOfLife(Serial serial)
+            : base(serial)
+        {
+        }
+		
+		public override int LabelNumber {get {return 1112880;} }// Cloak of Life
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/CloakOfPower.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/CloakOfPower.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Server.Items
+{
+    [Flipable(0x2FB9, 0x3173)]
+    public class CloakOfPower : BaseOuterTorso
+    {
+        [Constructable]
+        public CloakOfPower()
+            : base(0x2FB9)
+        {
+            Weight = 2.0;
+			Hue = 0xFE;
+			Attributes.BonusStr = 2;
+			Attributes.BonusDex = 2;
+			Attributes.BonusInt = 2;
+        }
+
+        public CloakOfPower(Serial serial)
+            : base(serial)
+        {
+        }
+		
+		public override int LabelNumber {get {return 1112882;} }// Cloak of Power
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/CloakOfSilence.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/CloakOfSilence.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Server.Items
+{
+    [Flipable(0x2FB9, 0x3173)]
+    public class CloakOfSilence : BaseOuterTorso
+    {
+        [Constructable]
+        public CloakOfSilence()
+            : base(0x2FB9)
+        {
+            Weight = 2.0;
+			Hue = 0x2A0;
+			this.SkillBonuses.SetValues(0, SkillName.Stealth, 10);
+        }
+
+        public CloakOfSilence(Serial serial)
+            : base(serial)
+        {
+        }
+		
+		public override int LabelNumber {get {return 1112883;} }// Cloak of Silence
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/CloakOfSilence.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/CloakOfSilence.cs
@@ -11,7 +11,7 @@ namespace Server.Items
         {
             Weight = 2.0;
 			Hue = 0x2A0;
-			this.SkillBonuses.SetValues(0, SkillName.Stealth, 10);
+			SkillBonuses.SetValues(0, SkillName.Stealth, 10);
         }
 
         public CloakOfSilence(Serial serial)

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -690,7 +690,11 @@
     <Compile Include="Items\Artifacts\Equipment\Armor\Sets\Bestial\BestialEarrings.cs" />
     <Compile Include="Items\Artifacts\Equipment\Armor\Sets\Bestial\BestialLegs.cs" />
     <Compile Include="Items\Artifacts\Equipment\Armor\Sets\Luck\LuneRouge.cs" />
-    <Compile Include="Items\Artifacts\Equipment\Armor\Sets\Luck\SoleilRouge.cs" />
+    <Compile Include="Items\Artifacts\Equipment\Armor\Sets\Luck\SoleilRouge.cs" />	
+	<Compile Include="Items\Artifacts\Equipment\Clothing\CloakOfDeath.cs" />
+    <Compile Include="Items\Artifacts\Equipment\Clothing\CloakOfLife.cs" />
+    <Compile Include="Items\Artifacts\Equipment\Clothing\CloakOfPower.cs" />
+	<Compile Include="Items\Artifacts\Equipment\Clothing\CloakOfSilence.cs" />
     <Compile Include="Items\Artifacts\Equipment\Clothing\TheScholarsHalo.cs" />
     <Compile Include="Items\Artifacts\Equipment\Clothing\JadeArmband.cs" />
     <Compile Include="Items\Artifacts\Equipment\Clothing\MagicalDoor.cs" />


### PR DESCRIPTION
http://www.uoguide.com/Cloak_Of_Power
http://www.uoguide.com/Cloak_Of_Death
http://www.uoguide.com/Cloak_Of_Life
http://www.uoguide.com/Cloak_Of_Silence

Adding missing cloaks from EA event. All hues verified on EA. Correct clilocs.

This item derives from BaseOuterTorso because although it is an Elven Cloak, humans can wear it too.