### PR TITLE
Update Makefile ServUO.exe.config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ default: run
 debug: 
 	${MCS} -target:library -out:${CURPATH}/Ultima.dll -r:${REFS} -nowarn:${NOWARNS} -d:DEBUG -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SDKPATH}/*.cs
 	${MCS} -win32icon:${SRVPATH}/servuo.ico -r:${CURPATH}/Ultima.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/ServUO.exe -d:DEBUG -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SRVPATH}/*.cs
+	sed 's/<!--//g; s/-->//g' ServUO.exe.config
 
 run: build
 	${CURPATH}/ServUO.sh
@@ -36,3 +37,4 @@ ServUO.sh: ServUO.exe
 	echo "#!/bin/sh" > ${CURPATH}/ServUO.sh
 	echo "mono ${CURPATH}/ServUO.exe" >> ${CURPATH}/ServUO.sh
 	chmod a+x ${CURPATH}/ServUO.sh
+	sed 's/<!--//g; s/-->//g' ServUO.exe.config

--- a/ServUO.exe.config
+++ b/ServUO.exe.config
@@ -1,5 +1,4 @@
-<?xml version="1.0"?>
-
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
@@ -7,9 +6,7 @@
   <runtime>
     <gcServer enabled="false" />
   </runtime>
-  <!-- UNCOMMENT ON UNIX for NOW -->
-  <!--
-  <dllmap os="!windows" dll="libz"   target="libz.so.1" />
-  <dllmap os="!windows" dll="drng32" target="libdrng.so" />
-  <dllmap os="!windows" dll="drng64" target="libdrng.so" /> -->
+  <!--<dllmap dll="libz" target="libz.so.1" />
+  <dllmap dll="drng32" target="libdrng.so" />
+  <dllmap dll="drng64" target="libdrng.so" />-->
 </configuration>


### PR DESCRIPTION
Linux/Unix/OSX specific options stay commented out. Running 'make' or 'make debug' will remove relevant commented code.

I'll keep an eye on a better solution.

*+ Added sed -i to remove `<!-- and -->` to uncomment relevant code for unix based systems.