### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Decorative/DamageableItem.cs
+++ b/Scripts/Items/Decorative/DamageableItem.cs
@@ -256,6 +256,11 @@ namespace Server.Items
         {
         }
 
+        public virtual bool CheckReflect(int circle, Mobile caster)
+        {
+            return false;
+        }
+
         public virtual void OnStatsQuery(Mobile from)
         {
             if (from.Map == Map && Utility.InUpdateRange(from, this) && from.CanSee(this))

--- a/Scripts/Regions/HouseRegion.cs
+++ b/Scripts/Regions/HouseRegion.cs
@@ -263,7 +263,9 @@ namespace Server.Regions
 
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list, Item item)
         {
-            if (m_House.IsOwner(from) && item.Parent == null && (m_House.IsLockedDown(item) || m_House.IsSecure(item)))
+            if (m_House.IsOwner(from) && item.Parent == null && 
+                (m_House.IsLockedDown(item) || m_House.IsSecure(item)) && 
+                !m_House.Addons.ContainsKey(item))
             {
                 list.Add(new ReleaseEntry(from, item, m_House));
             }

--- a/Scripts/Services/Pet Training/SpecialAbility.cs
+++ b/Scripts/Services/Pet Training/SpecialAbility.cs
@@ -663,7 +663,7 @@ namespace Server.Mobiles
 
             ResistanceMod mod = new ResistanceMod(ResistanceType.Physical, effect);
 
-            defender.FixedEffect(0x37B9, 10, 5);
+            defender.FixedParticles(0x373A, 10, 15, 5018, EffectLayer.Waist);
             defender.AddResistanceMod(mod);
 
             timer = new ExpireTimer(defender, mod, TimeSpan.FromSeconds(5.0));
@@ -820,7 +820,7 @@ namespace Server.Mobiles
 
             foreach (Mobile m in eable)
             {
-                if (m == creature || !creature.CanBeHarmful(m))
+                if (m == creature || !creature.CanBeHarmful(m, false))
                     continue;
 
                 if (m is BaseCreature && !((BaseCreature)m).IsMonster)
@@ -833,7 +833,7 @@ namespace Server.Mobiles
 
             foreach (Mobile m in list)
             {
-                creature.DoHarmful(m);
+                creature.DoHarmful(m, false);
 
                 m.FixedParticles(0x374A, 10, 15, 5013, 0x496, 0, EffectLayer.Waist);
                 m.PlaySound(0x231);
@@ -1066,7 +1066,7 @@ namespace Server.Mobiles
 			foreach(Mobile m in eable)
 			{
                 if (creature != m &&
-                    creature.CanBeHarmful(m) && 
+                    creature.CanBeHarmful(m, false) && 
                     Server.Spells.SpellHelper.ValidIndirectTarget(creature, m) && 
                     creature.InLOS(m))
 				{

--- a/Scripts/Services/Revamped Dungeons/Shame Revamped/ShameTeleporter.cs
+++ b/Scripts/Services/Revamped Dungeons/Shame Revamped/ShameTeleporter.cs
@@ -40,4 +40,67 @@ namespace Server.Engines.ShameRevamped
             }
 		}
 	}
+
+    public class ShameWallTeleporter : Teleporter
+    {
+        public ShameWallTeleporter(Point3D dest, Map map)
+            : base(dest, map, true)
+        {
+        }
+
+        public override bool CanTeleport(Mobile m)
+        {
+            if(Deleted || Map == null || Map == Map.Internal)
+                return false;
+
+            IPooledEnumerable eable = Map.GetItemsInRange(Location, 1);
+            bool active = false;
+
+            foreach (Item item in eable)
+            {
+                if (item is AddonComponent && ((AddonComponent)item).Addon is ShameWall && ((AddonComponent)item).Addon.Visible)
+                {
+                    active = true;
+                    break;
+                }
+            }
+
+            eable.Free();
+            return active;
+        }
+
+        public override void DoTeleport(Mobile m)
+        {
+            m.SendLocalizedMessage(1072790); // The wall becomes transparent, and you push your way through it.
+
+            base.DoTeleport(m);
+        }
+
+        public ShameWallTeleporter(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)1);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+
+            if (version == 0)
+            {
+                int count = reader.ReadInt();
+
+                for (int i = 0; i < count; i++)
+                {
+                    reader.ReadMobile();
+                }
+            }
+        }
+    }
 }

--- a/Scripts/Services/Revamped Dungeons/Shame Revamped/ShameWall.cs
+++ b/Scripts/Services/Revamped Dungeons/Shame Revamped/ShameWall.cs
@@ -85,13 +85,17 @@ namespace Server.Engines.ShameRevamped
                 {
                     if (component.Location == pnts[0])
                     {
-                        var teleporter = new ConditionTeleporter();
-                        //teleporter.DeadOnly = true;
-                        teleporter.ClilocNumber = 1072790; // The wall becomes transparent, and you push your way through it.
-                        teleporter.MapDest = map;
-                        teleporter.PointDest = pnts[2];
-                        teleporter.DisableMessage = false;
+                        var oldtele = map.FindItem<ConditionTeleporter>(new Point3D(pnts[1]));
+
+                        if (oldtele != null)
+                        {
+                            WeakEntityCollection.Remove("newshame", oldtele);
+                            oldtele.Delete();
+                        }
+
+                        var teleporter = new ShameWallTeleporter(pnts[2], map);
                         teleporter.MoveToWorld(pnts[1], map);
+
                         WeakEntityCollection.Add("newshame", teleporter);
                     }
                 }
@@ -122,7 +126,7 @@ namespace Server.Engines.ShameRevamped
 		public override void Serialize(GenericWriter writer)
 		{
 			base.Serialize(writer);
-			writer.Write((int)2);
+			writer.Write((int)3);
 			
 			writer.Write(Troll);
 			writer.Write(StartSpot);
@@ -146,8 +150,8 @@ namespace Server.Engines.ShameRevamped
             if (this.Location != StartSpot || Troll == null || Troll.Deleted || !Troll.Alive)
 				Reset();
 
-            if (version == 0)
-                Timer.DelayCall(TimeSpan.FromSeconds(20), () => AddTeleporters(this));
+            if (version == 2)
+                Timer.DelayCall(() => AddTeleporters(this));
 
             if (version == 1 && StartSpot == new Point3D(5619, 57, 0) && StartMap == Map.Felucca)
             {

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -1151,28 +1151,59 @@ namespace Server.Spells
         //magic reflection
         public static bool CheckReflect(int circle, Mobile caster, ref Mobile target)
         {
+            IDamageable d = target as IDamageable;
+
+            bool reflect = CheckReflect(circle, ref caster, ref d);
+
+            if(d is Mobile)
+                target = (Mobile)d;
+
+            return reflect;
+        }
+
+        public static bool CheckReflect(int circle, ref Mobile caster, ref Mobile target)
+        {
+            IDamageable d = target as IDamageable;
+
+            bool reflect = CheckReflect(circle, ref caster, ref d);
+
+            if(d is Mobile)
+                target = (Mobile)d;
+
+            return reflect;
+        }
+
+        public static bool CheckReflect(int circle, Mobile caster, ref IDamageable target)
+        {
             return CheckReflect(circle, ref caster, ref target);
         }
 
-        public static bool CheckReflect(int circle, ref Mobile caster, ref Mobile target, DamageType type = DamageType.Spell)
+        public static bool CheckReflect(int circle, ref Mobile caster, ref IDamageable damageable, DamageType type = DamageType.Spell)
         {
             bool reflect = false;
+            Mobile target = damageable as Mobile;
 
             if (Core.AOS && type == DamageType.Spell)
             {
-                Clone clone = null;
-
                 if (target != null)
                 {
-                    clone = MirrorImage.GetDeflect(caster, target);
-                }
+                    Clone clone = MirrorImage.GetDeflect(caster, target);
 
-                if (clone != null)
+                    if (clone != null)
+                    {
+                        damageable = clone;
+                        return false;
+                    }
+                }
+                else if (damageable is DamageableItem)
                 {
-                    target = clone;
-                    return false;
+                    ((DamageableItem)damageable).CheckReflect(circle, caster);
+                    return true;
                 }
             }
+
+            if (target == null)
+                return false;
 
             if (target.MagicDamageAbsorb > 0)
             {

--- a/Scripts/Spells/First/MagicArrow.cs
+++ b/Scripts/Spells/First/MagicArrow.cs
@@ -61,16 +61,13 @@ namespace Server.Spells.First
                     return;
                 }
 
-                if (m != null)
+                if (SpellHelper.CheckReflect((int)this.Circle, ref source, ref d) && !Core.AOS)
                 {
-                    if (SpellHelper.CheckReflect((int)this.Circle, ref source, ref m))
+                    Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
                     {
-                        Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
-                        {
-                            source.MovingParticles(m, 0x379F, 7, 0, false, true, 3043, 4043, 0x211);
-                            source.PlaySound(0x20A);
-                        });
-                    }
+                        source.MovingParticles(m, 0x379F, 7, 0, false, true, 3043, 4043, 0x211);
+                        source.PlaySound(0x20A);
+                    });
                 }
 
                 double damage = 0;
@@ -98,7 +95,7 @@ namespace Server.Spells.First
                     this.Caster.MovingParticles(d, 0x36E4, 5, 0, false, false, 3006, 0, 0);
                     this.Caster.PlaySound(0x1E5);
 
-                    SpellHelper.Damage(this, m != null ? m : d, damage, 0, 100, 0, 0, 0);
+                    SpellHelper.Damage(this, d, damage, 0, 100, 0, 0, 0);
                 }
             }
 

--- a/Scripts/Spells/Fourth/Lightning.cs
+++ b/Scripts/Spells/Fourth/Lightning.cs
@@ -48,8 +48,7 @@ namespace Server.Spells.Fourth
                 Mobile source = Caster;
                 SpellHelper.Turn(Caster, m.Location, 100);
 
-                if(mob != null)
-                    SpellHelper.CheckReflect((int)Circle, ref source, ref mob);
+                SpellHelper.CheckReflect((int)Circle, ref source, ref m);
 
                 double damage = 0;
 
@@ -75,7 +74,7 @@ namespace Server.Spells.Fourth
 
                 if (damage > 0)
                 {
-                    SpellHelper.Damage(this, mob != null ? mob : m, damage, 0, 0, 0, 0, 100);
+                    SpellHelper.Damage(this, m, damage, 0, 0, 0, 0, 100);
                 }
             }
 

--- a/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
@@ -29,10 +29,8 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this, TargetFlags.Harmful);
         }
 
-        public void OnTarget(object o)
+        public void OnTarget(IDamageable target)
         {
-            Mobile target = o as Mobile;
-
             if (target == null)
             {
                 return;
@@ -54,13 +52,16 @@ namespace Server.Spells.Mysticism
 
                 SpellHelper.Damage(this, target, (int)GetNewAosDamage(40, 1, 5, target), 100, 0, 0, 0, 0);
 
-                Timer.DelayCall(TimeSpan.FromMilliseconds(1200), () =>
+                if (target is Mobile)
                 {
-                    if (!CheckResisted(target))
+                    Timer.DelayCall(TimeSpan.FromMilliseconds(1200), () =>
                     {
-                        target.Paralyze(TimeSpan.FromSeconds(3));
-                    }
-                });
+                        if (!CheckResisted((Mobile)target))
+                        {
+                            ((Mobile)target).Paralyze(TimeSpan.FromSeconds(3));
+                        }
+                    });
+                }
             }
 
             FinishSequence();
@@ -88,10 +89,10 @@ namespace Server.Spells.Mysticism
 
                 if (!from.CanSee(o))
                     from.SendLocalizedMessage(500237); // Target can not be seen.
-                else
+                else if (o is IDamageable)
                 {
                     SpellHelper.Turn(from, o);
-                    Owner.OnTarget(o);
+                    Owner.OnTarget((IDamageable)o);
                 }
             }
 

--- a/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
@@ -32,10 +32,8 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this, TargetFlags.Harmful);
         }
 
-        public void OnTarget(object o)
+        public void OnTarget(IDamageable target)
         {
-            Mobile target = o as Mobile;
-
             if (target == null)
             {
                 return;
@@ -88,10 +86,10 @@ namespace Server.Spells.Mysticism
 
                 if (!from.CanSee(o))
                     from.SendLocalizedMessage(500237); // Target can not be seen.
-                else
+                else if (o is IDamageable)
                 {
                     SpellHelper.Turn(from, o);
-                    Owner.OnTarget(o);
+                    Owner.OnTarget((IDamageable)o);
                 }
             }
 

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
@@ -28,10 +28,8 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this, TargetFlags.Harmful);
         }
 
-        public void OnTarget(object o)
+        public void OnTarget(IDamageable target)
         {
-            Mobile target = o as Mobile;
-
             if (target == null)
             {
                 return;
@@ -53,7 +51,7 @@ namespace Server.Spells.Mysticism
                 SpellHelper.Damage(this, target, damage, 0, 0, 0, 0, 0, 100, 0);
 
                 Caster.MovingParticles(target, 0x36D4, 7, 0, false, true, 0x49A, 0, 0, 9502, 4019, 0x160);
-                target.PlaySound(0x211);
+                Caster.PlaySound(0x211);
             }
 
             FinishSequence();
@@ -81,10 +79,10 @@ namespace Server.Spells.Mysticism
 
                 if (!from.CanSee(o))
                     from.SendLocalizedMessage(500237); // Target can not be seen.
-                else
+                else if (o is IDamageable)
                 {
                     SpellHelper.Turn(from, o);
-                    Owner.OnTarget(o);
+                    Owner.OnTarget((IDamageable)o);
                 }
             }
 

--- a/Scripts/Spells/Mysticism/SpellDefinitions/PurgeMagicSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/PurgeMagicSpell.cs
@@ -52,7 +52,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this, TargetFlags.Harmful);
         }
 
-        public void OnTarget(Object o)
+        public void OnTarget(object o)
         {
             Mobile target = o as Mobile;
 

--- a/Scripts/Spells/Mysticism/SpellDefinitions/SleepSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/SleepSpell.cs
@@ -28,7 +28,7 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this, TargetFlags.Harmful);
         }
 
-        public void OnTarget(Object o)
+        public void OnTarget(object o)
         {
             Mobile target = o as Mobile;
 

--- a/Scripts/Spells/Second/Harm.cs
+++ b/Scripts/Spells/Second/Harm.cs
@@ -53,8 +53,7 @@ namespace Server.Spells.Second
                 SpellHelper.Turn(this.Caster, m);
                 Mobile source = this.Caster;
 
-                if(mob != null)
-                    SpellHelper.CheckReflect((int)this.Circle, ref source, ref mob);
+                SpellHelper.CheckReflect((int)this.Circle, ref source, ref m);
 
                 double damage = 0;
 				
@@ -102,7 +101,7 @@ namespace Server.Spells.Second
 
                 if (damage > 0)
                 {
-                    SpellHelper.Damage(this, mob != null ? mob : m, damage, 0, 0, 100, 0, 0);
+                    SpellHelper.Damage(this, m, damage, 0, 0, 100, 0, 0);
                 }
             }
 

--- a/Scripts/Spells/Seventh/ChainLightning.cs
+++ b/Scripts/Spells/Seventh/ChainLightning.cs
@@ -109,17 +109,17 @@ namespace Server.Spells.Seventh
                         }
 
                         Mobile source = Caster;
+                        SpellHelper.CheckReflect((int)Circle, ref source, ref id, SpellDamageType);
 
                         if (m != null)
                         {
-                            SpellHelper.CheckReflect((int)Circle, ref source, ref m, SpellDamageType);
                             damage *= GetDamageScalar(m);
                         }
 
                         Effects.SendBoltEffect(id, true, 0, false);
 
-                        Caster.DoHarmful(m != null ? m : id);
-                        SpellHelper.Damage(this, m != null ? m : id, damage, 0, 0, 0, 0, 100);
+                        Caster.DoHarmful(id);
+                        SpellHelper.Damage(this, id, damage, 0, 0, 0, 0, 100);
                     }
                 }
                 else

--- a/Scripts/Spells/Seventh/FlameStrike.cs
+++ b/Scripts/Spells/Seventh/FlameStrike.cs
@@ -48,8 +48,7 @@ namespace Server.Spells.Seventh
                 Mobile source = this.Caster;
                 Mobile mob = m as Mobile;
 
-                if(mob != null)
-                    SpellHelper.CheckReflect((int)this.Circle, ref source, ref mob);
+                SpellHelper.CheckReflect((int)this.Circle, ref source, ref m);
 
                 double damage = 0;
 
@@ -84,7 +83,7 @@ namespace Server.Spells.Seventh
 
                 if (damage > 0)
                 {
-                    SpellHelper.Damage(this, mob != null ? mob : m, damage, 0, 100, 0, 0, 0);
+                    SpellHelper.Damage(this, m, damage, 0, 100, 0, 0, 0);
                 }
             }
 

--- a/Scripts/Spells/Seventh/MeteorSwarm.cs
+++ b/Scripts/Spells/Seventh/MeteorSwarm.cs
@@ -112,21 +112,21 @@ namespace Server.Spells.Seventh
 
                         Mobile source = Caster;
 
+                        if (SpellHelper.CheckReflect((int)Circle, ref source, ref id, SpellDamageType) && !Core.AOS)
+                        {
+                            Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
+                                {
+                                    source.MovingParticles(m, 0x36D4, 7, 0, false, true, 9501, 1, 0, 0x100);
+                                });
+                        }
+
                         if (m != null)
                         {
-                            if (SpellHelper.CheckReflect((int)Circle, ref source, ref m, SpellDamageType))
-                            {
-                                Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
-                                    {
-                                        source.MovingParticles(m, 0x36D4, 7, 0, false, true, 9501, 1, 0, 0x100);
-                                    });
-                            }
-
                             damage *= GetDamageScalar(m);
                         }
 
                         Caster.DoHarmful(id);
-                        SpellHelper.Damage(this, m != null ? m : id, damage, 0, 100, 0, 0, 0);
+                        SpellHelper.Damage(this, id, damage, 0, 100, 0, 0, 0);
 
                         Caster.MovingParticles(id, 0x36D4, 7, 0, false, true, 9501, 1, 0, 0x100);
                     }

--- a/Scripts/Spells/Sixth/EnergyBolt.cs
+++ b/Scripts/Spells/Sixth/EnergyBolt.cs
@@ -32,32 +32,29 @@ namespace Server.Spells.Sixth
         }
         public override void OnCast()
         {
-            this.Caster.Target = new InternalTarget(this);
+            Caster.Target = new InternalTarget(this);
         }
 
         public void Target(IDamageable m)
         {
             Mobile mob = m as Mobile;
 
-            if (!this.Caster.CanSee(m))
+            if (!Caster.CanSee(m))
             {
-                this.Caster.SendLocalizedMessage(500237); // Target can not be seen.
+                Caster.SendLocalizedMessage(500237); // Target can not be seen.
             }
-            else if (this.CheckHSequence(m))
+            else if (CheckHSequence(m))
             {
-                Mobile source = this.Caster;
-                SpellHelper.Turn(this.Caster, m);
+                Mobile source = Caster;
+                SpellHelper.Turn(Caster, m);
 
-                if (mob != null)
+                if (SpellHelper.CheckReflect((int)Circle, ref source, ref m) && !Core.AOS)
                 {
-                    if (SpellHelper.CheckReflect((int)this.Circle, ref source, ref mob))
+                    Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
                     {
-                        Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
-                        {
-                            source.MovingParticles(mob, 0x379F, 7, 0, false, true, 3043, 4043, 0x211);
-                            source.PlaySound(0x20A);
-                        });
-                    }
+                        source.MovingParticles(mob, 0x379F, 7, 0, false, true, 3043, 4043, 0x211);
+                        source.PlaySound(0x20A);
+                    });
                 }
 
                 double damage = 0;
@@ -70,7 +67,7 @@ namespace Server.Spells.Sixth
                 {
                     damage = Utility.Random(24, 18);
 
-                    if (this.CheckResisted(mob))
+                    if (CheckResisted(mob))
                     {
                         damage *= 0.75;
 
@@ -78,21 +75,21 @@ namespace Server.Spells.Sixth
                     }
 
                     // Scale damage based on evalint and resist
-                    damage *= this.GetDamageScalar(mob);
+                    damage *= GetDamageScalar(mob);
                 }
 
                 // Do the effects
-                this.Caster.MovingParticles(m, 0x379F, 7, 0, false, true, 3043, 4043, 0x211);
-                this.Caster.PlaySound(0x20A);
+                Caster.MovingParticles(m, 0x379F, 7, 0, false, true, 3043, 4043, 0x211);
+                Caster.PlaySound(0x20A);
 
                 if (damage > 0)
                 {
                     // Deal the damage
-                    SpellHelper.Damage(this, mob != null ? mob : m, damage, 0, 0, 0, 0, 100);
+                    SpellHelper.Damage(this, m, damage, 0, 0, 0, 0, 100);
                 }
             }
 
-            this.FinishSequence();
+            FinishSequence();
         }
 
         private class InternalTarget : Target
@@ -101,18 +98,18 @@ namespace Server.Spells.Sixth
             public InternalTarget(EnergyBoltSpell owner)
                 : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
             {
-                this.m_Owner = owner;
+                m_Owner = owner;
             }
 
             protected override void OnTarget(Mobile from, object o)
             {
                 if (o is IDamageable)
-                    this.m_Owner.Target((IDamageable)o);
+                    m_Owner.Target((IDamageable)o);
             }
 
             protected override void OnTargetFinish(Mobile from)
             {
-                this.m_Owner.FinishSequence();
+                m_Owner.FinishSequence();
             }
         }
     }

--- a/Scripts/Spells/Sixth/Explosion.cs
+++ b/Scripts/Spells/Sixth/Explosion.cs
@@ -39,37 +39,34 @@ namespace Server.Spells.Sixth
         }
         public override void OnCast()
         {
-            this.Caster.Target = new InternalTarget(this);
+            Caster.Target = new InternalTarget(this);
         }
 
         public void Target(IDamageable m)
         {
-            Mobile defender = m as Mobile;
-
             if (Core.SA && HasDelayContext(m))
             {
                 DoHurtFizzle();
                 return;
             }
 
-            if (!this.Caster.CanSee(m))
+            if (!Caster.CanSee(m))
             {
-                this.Caster.SendLocalizedMessage(500237); // Target can not be seen.
+                Caster.SendLocalizedMessage(500237); // Target can not be seen.
             }
-            else if (this.Caster.CanBeHarmful(m) && this.CheckSequence())
+            else if (Caster.CanBeHarmful(m) && CheckSequence())
             {
-                Mobile attacker = this.Caster;
+                Mobile attacker = Caster;
 
-                SpellHelper.Turn(this.Caster, m);
+                SpellHelper.Turn(Caster, m);
 
-                if(defender != null)
-                    SpellHelper.CheckReflect((int)this.Circle, this.Caster, ref defender);
+                SpellHelper.CheckReflect((int)Circle, Caster, ref m);
 
-                InternalTimer t = new InternalTimer(this, attacker, defender != null ? defender : m);
+                InternalTimer t = new InternalTimer(this, attacker, m);
                 t.Start();
             }
 
-            this.FinishSequence();
+            FinishSequence();
         }
 
         private class InternalTimer : Timer
@@ -85,10 +82,10 @@ namespace Server.Spells.Sixth
                 m_Attacker = attacker;
                 m_Target = target;
 
-                if (this.m_Spell != null)
-                    this.m_Spell.StartDelayedDamageContext(attacker, this);
+                if (m_Spell != null)
+                    m_Spell.StartDelayedDamageContext(attacker, this);
 
-                this.Priority = TimerPriority.FiftyMS;
+                Priority = TimerPriority.FiftyMS;
             }
 
             protected override void OnTick()
@@ -107,14 +104,14 @@ namespace Server.Spells.Sixth
                     {
                         damage = Utility.Random(23, 22);
 
-                        if (this.m_Spell.CheckResisted(defender))
+                        if (m_Spell.CheckResisted(defender))
                         {
                             damage *= 0.75;
 
                             defender.SendLocalizedMessage(501783); // You feel yourself resisting magical energy.
                         }
 
-                        damage *= this.m_Spell.GetDamageScalar(defender);
+                        damage *= m_Spell.GetDamageScalar(defender);
                     }
 
                     if (defender != null)
@@ -130,11 +127,11 @@ namespace Server.Spells.Sixth
 
                     if (damage > 0)
                     {
-                        SpellHelper.Damage(this.m_Spell, this.m_Target, damage, 0, 100, 0, 0, 0);
+                        SpellHelper.Damage(m_Spell, m_Target, damage, 0, 100, 0, 0, 0);
                     }
 
-                    if (this.m_Spell != null)
-                        this.m_Spell.RemoveDelayedDamageContext(this.m_Attacker);
+                    if (m_Spell != null)
+                        m_Spell.RemoveDelayedDamageContext(m_Attacker);
                 }
             }
         }
@@ -145,18 +142,18 @@ namespace Server.Spells.Sixth
             public InternalTarget(ExplosionSpell owner)
                 : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
             {
-                this.m_Owner = owner;
+                m_Owner = owner;
             }
 
             protected override void OnTarget(Mobile from, object o)
             {
                 if (o is IDamageable)
-                    this.m_Owner.Target((IDamageable)o);
+                    m_Owner.Target((IDamageable)o);
             }
 
             protected override void OnTargetFinish(Mobile from)
             {
-                this.m_Owner.FinishSequence();
+                m_Owner.FinishSequence();
             }
         }
     }

--- a/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
+++ b/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
@@ -60,7 +60,7 @@ namespace Server.Spells.SkillMasteries
 
         protected override void OnTarget(object o)
         {
-            Mobile m = o as Mobile;
+            IDamageable m = o as IDamageable;
 
             if (m != null)
             {
@@ -83,16 +83,18 @@ namespace Server.Spells.SkillMasteries
 
                     SpellHelper.Damage(this, m, damage, 0, 0, 0, 0, 100);
 
-                    if (!CheckResisted(m) && m.NetState != null)
+                    if (m is Mobile && !CheckResisted((Mobile)m) && ((Mobile)m).NetState != null)
                     {
-                        if (!TransformationSpellHelper.UnderTransformation(m, typeof(AnimalForm)))
-                            m.SendSpeedControl(SpeedControlType.WalkSpeed);
+                        Mobile mob = m as Mobile;
+
+                        if (!TransformationSpellHelper.UnderTransformation(mob, typeof(AnimalForm)))
+                            mob.SendSpeedControl(SpeedControlType.WalkSpeed);
 
                         Server.Timer.DelayCall(TimeSpan.FromSeconds(skill / 60), () =>
                             {
-                                if (!TransformationSpellHelper.UnderTransformation(m, typeof(AnimalForm)) &&
-                                    !TransformationSpellHelper.UnderTransformation(m, typeof(Server.Spells.Spellweaving.ReaperFormSpell)))
-                                    m.SendSpeedControl(SpeedControlType.Disable);
+                                if (!TransformationSpellHelper.UnderTransformation(mob, typeof(AnimalForm)) &&
+                                    !TransformationSpellHelper.UnderTransformation(mob, typeof(Server.Spells.Spellweaving.ReaperFormSpell)))
+                                    mob.SendSpeedControl(SpeedControlType.Disable);
                             });
                     }
                 }

--- a/Scripts/Spells/Third/Fireball.cs
+++ b/Scripts/Spells/Third/Fireball.cs
@@ -47,16 +47,13 @@ namespace Server.Spells.Third
 
                 SpellHelper.Turn(source, m);
 
-                if (target != null)
+                if (SpellHelper.CheckReflect((int)this.Circle, ref source, ref m) && !Core.AOS)
                 {
-                    if (SpellHelper.CheckReflect((int)this.Circle, ref source, ref target))
-                    {
-                        Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
-                            {
-                                source.MovingParticles(target, 0x36D4, 7, 0, false, true, 9502, 4019, 0x160);
-                                source.PlaySound(Core.AOS ? 0x15E : 0x44B);
-                            });
-                    }
+                    Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
+                        {
+                            source.MovingParticles(m, 0x36D4, 7, 0, false, true, 9502, 4019, 0x160);
+                            source.PlaySound(Core.AOS ? 0x15E : 0x44B);
+                        });
                 }
 
                 double damage = 0;
@@ -84,7 +81,7 @@ namespace Server.Spells.Third
                     this.Caster.MovingParticles(m, 0x36D4, 7, 0, false, true, 9502, 4019, 0x160);
                     this.Caster.PlaySound(Core.AOS ? 0x15E : 0x44B);
 
-                    SpellHelper.Damage(this, target != null ? target : m, damage, 0, 100, 0, 0, 0);
+                    SpellHelper.Damage(this, m, damage, 0, 100, 0, 0, 0);
                 }
             }
 


### PR DESCRIPTION
- Added overridable function in DamageableItem for reflecting spells for future use
- Added Mystic direct damaging spell support for damaging IDamageableItem
- Added IDamageable support for CheckReflect in SpellHelper
- Shame: removed conditional teleporters and added teleporter specific for Shame
- Explosive goo is now in line with EA
- Fixed particles for Grasping Claw to match EA
- Retrieve context menu option no longer available for house container addons