### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Abilities/Dismount.cs
+++ b/Scripts/Abilities/Dismount.cs
@@ -74,7 +74,7 @@ namespace Server.Items
 
             int delay = Core.TOL && attacker.Weapon is BaseRanged ? 8 : 10;
 
-            DoDismount(attacker, defender, mount, delay, false);
+            DoDismount(attacker, defender, mount, delay);
 
             if (!attacker.Mounted)
             {
@@ -82,7 +82,7 @@ namespace Server.Items
             }
         }
 
-        public static void DoDismount(Mobile attacker, Mobile defender, IMount mount, int delay, bool ridingSwipe)
+        public static void DoDismount(Mobile attacker, Mobile defender, IMount mount, int delay, BlockMountType type = BlockMountType.Dazed)
         {
             attacker.SendLocalizedMessage(1060082); // The force of your attack has dislodged them from their mount!
 
@@ -101,7 +101,7 @@ namespace Server.Items
                     defender.SendLocalizedMessage(1060083); // You fall off of your mount and take damage!
                 }
 
-                ((PlayerMobile)defender).SetMountBlock(ridingSwipe ? BlockMountType.RidingSwipe : BlockMountType.Dazed, TimeSpan.FromSeconds(delay), true);
+                ((PlayerMobile)defender).SetMountBlock(type, TimeSpan.FromSeconds(delay), true);
             }
             else if (mount != null)
             {

--- a/Scripts/Abilities/InfusedThrow.cs
+++ b/Scripts/Abilities/InfusedThrow.cs
@@ -30,7 +30,7 @@ namespace Server.Items
                 defender.PlaySound(0x140);
                 defender.FixedParticles(0x3728, 10, 15, 9955, EffectLayer.Waist);
 
-                Server.Items.Dismount.DoDismount(attacker, defender, mount, 10, false);
+                Server.Items.Dismount.DoDismount(attacker, defender, mount, 10);
             }
             else
             {

--- a/Scripts/Abilities/RidingSwipe.cs
+++ b/Scripts/Abilities/RidingSwipe.cs
@@ -58,8 +58,22 @@ namespace Server.Items
 
             if (!attacker.Mounted)
             {
+                BlockMountType type = BlockMountType.RidingSwipe;
                 IMount mount = defender.Mount;
-                Server.Items.Dismount.DoDismount(attacker, defender, mount, 10, true);
+
+                if (Core.SA)
+                {
+                    if (defender.Flying)
+                    {
+                        type = BlockMountType.RidingSwipeFlying;
+                    }
+                    else if (mount is EtherealMount)
+                    {
+                        type = BlockMountType.RidingSwipeEthereal;
+                    }
+                }
+
+                Server.Items.Dismount.DoDismount(attacker, defender, mount, 10, type);
 
                 if(mount is Mobile)
                     AOS.Damage((Mobile)mount, attacker, amount, 100, 0, 0, 0, 0);

--- a/Scripts/Items/Internal/EffectMobile.cs
+++ b/Scripts/Items/Internal/EffectMobile.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+
+namespace Server.Mobiles
+{
+    public class EffectMobile : Mobile
+    {
+        public static readonly TimeSpan DefaultDuration = TimeSpan.FromSeconds(1.0);
+        private static readonly List<EffectMobile> m_Free = new List<EffectMobile>();// List of available EffectMobiles
+
+        public EffectMobile(Serial serial)
+            : base(serial)
+        {
+        }
+
+        private EffectMobile()
+        {
+            CantWalk = true;
+            Hidden = true;
+        }
+
+        public static EffectMobile Create(Point3D p, Map map, TimeSpan duration)
+        {
+            EffectMobile mobile = null;
+
+            for (int i = m_Free.Count - 1; mobile == null && i >= 0; --i) // We reuse new entries first so decay works better
+            {
+                EffectMobile free = m_Free[i];
+
+                m_Free.RemoveAt(i);
+
+                if (!free.Deleted && free.Map == Map.Internal)
+                    mobile = free;
+            }
+
+            if (mobile == null)
+                mobile = new EffectMobile();
+
+            mobile.MoveToWorld(p, map);
+            mobile.BeginFree(duration);
+
+            return mobile;
+        }
+
+        public void BeginFree(TimeSpan duration)
+        {
+            new FreeTimer(this, duration).Start();
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+
+            Delete();
+        }
+
+        private class FreeTimer : Timer
+        {
+            private readonly EffectMobile m_Mobile;
+            public FreeTimer(EffectMobile mobile, TimeSpan delay)
+                : base(delay)
+            {
+                m_Mobile = mobile;
+                Priority = TimerPriority.OneSecond;
+            }
+
+            protected override void OnTick()
+            {
+                m_Mobile.Internalize();
+
+                m_Free.Add(m_Mobile);
+            }
+        }
+    }
+}

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -201,7 +201,7 @@ namespace Server
             // object being damaged is not a mobile, so we will end here
             if (m == null)
             {
-                damageable.Damage(totalDamage, from);
+                damageable.Damage(totalDamage, from, (int)type);
                 return totalDamage;
             }
 
@@ -241,7 +241,7 @@ namespace Server
                         from.Damage(originalDamage, m);
                     }
                 }
-                else if (!ignoreArmor)
+                else if (!ignoreArmor && from != m)
                 {
                     int reflectPhys = Math.Min(105, AosAttributes.GetValue(m, AosAttribute.ReflectPhysical));
 

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -1126,7 +1126,7 @@ namespace Server.Mobiles
 
                 if (physDamage == 0 && fireDamage == 0 && coldDamage == 0 && poisDamage == 0 && nrgyDamage == 0)
                 {
-                    target.Damage(BreathComputeDamage(), this); // Unresistable damage even in AOS
+                    AOS.Damage(target, this, BreathComputeDamage(), 0, 0, 0, 0, 0, 0, 100);
                 }
                 else
                 {

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -690,11 +690,11 @@
     <Compile Include="Items\Artifacts\Equipment\Armor\Sets\Bestial\BestialEarrings.cs" />
     <Compile Include="Items\Artifacts\Equipment\Armor\Sets\Bestial\BestialLegs.cs" />
     <Compile Include="Items\Artifacts\Equipment\Armor\Sets\Luck\LuneRouge.cs" />
-    <Compile Include="Items\Artifacts\Equipment\Armor\Sets\Luck\SoleilRouge.cs" />	
-	<Compile Include="Items\Artifacts\Equipment\Clothing\CloakOfDeath.cs" />
+    <Compile Include="Items\Artifacts\Equipment\Armor\Sets\Luck\SoleilRouge.cs" />
+    <Compile Include="Items\Artifacts\Equipment\Clothing\CloakOfDeath.cs" />
     <Compile Include="Items\Artifacts\Equipment\Clothing\CloakOfLife.cs" />
     <Compile Include="Items\Artifacts\Equipment\Clothing\CloakOfPower.cs" />
-	<Compile Include="Items\Artifacts\Equipment\Clothing\CloakOfSilence.cs" />
+    <Compile Include="Items\Artifacts\Equipment\Clothing\CloakOfSilence.cs" />
     <Compile Include="Items\Artifacts\Equipment\Clothing\TheScholarsHalo.cs" />
     <Compile Include="Items\Artifacts\Equipment\Clothing\JadeArmband.cs" />
     <Compile Include="Items\Artifacts\Equipment\Clothing\MagicalDoor.cs" />
@@ -870,6 +870,7 @@
     <Compile Include="Items\Internal\BlightedGroveTeleporters.cs" />
     <Compile Include="Items\Internal\BlueNinjaQuestTeleporter.cs" />
     <Compile Include="Items\Internal\CrystalTeleporter.cs" />
+    <Compile Include="Items\Internal\EffectMobile.cs" />
     <Compile Include="Items\Internal\GreenNinjaQuestTeleporter.cs" />
     <Compile Include="Items\Internal\ItemInterfaces.cs" />
     <Compile Include="Items\Internal\MacawSpawner.cs" />

--- a/Scripts/Services/CleanUpBritannia/Gumps.cs
+++ b/Scripts/Services/CleanUpBritannia/Gumps.cs
@@ -41,6 +41,8 @@ namespace Server.Engines.CleanUpBritannia
             {
                 ((ScrollofAlacrity)item).Skill = PowerScroll.Skills[Utility.Random(PowerScroll.Skills.Count)];
             }
+
+            item.InvalidateProperties();
         }
     }
 }

--- a/Scripts/Services/XmlSpawner/XmlSpawner Core/XmlUtils/XmlFind.cs
+++ b/Scripts/Services/XmlSpawner/XmlSpawner Core/XmlUtils/XmlFind.cs
@@ -389,6 +389,7 @@ namespace Server.Mobiles
 					(m is IMount && ((IMount)m).Rider != null) ||
                     (m is GalleonPilot) || m is PetParrot ||
                     (GenericBuyInfo.IsDisplayCache(m)) ||
+                    (m is EffectMobile) ||
 					(m is BaseCreature && ((BaseCreature)m).IsStabled))
 					return true;
 

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -1151,58 +1151,90 @@ namespace Server.Spells
         //magic reflection
         public static bool CheckReflect(int circle, Mobile caster, ref Mobile target)
         {
-            IDamageable d = target as IDamageable;
+            IDamageable c = caster as IDamageable;
+            IDamageable t = target as IDamageable;
 
-            bool reflect = CheckReflect(circle, ref caster, ref d);
+            bool reflect = CheckReflect(circle, ref c, ref t);
 
-            if(d is Mobile)
-                target = (Mobile)d;
+            if (c is Mobile)
+                caster = (Mobile)c;
+
+            if (t is Mobile)
+                target = (Mobile)t;
 
             return reflect;
         }
 
-        public static bool CheckReflect(int circle, ref Mobile caster, ref Mobile target)
+        public static bool CheckReflect(int circle, IDamageable caster, ref Mobile target)
         {
-            IDamageable d = target as IDamageable;
+            IDamageable t = target as IDamageable;
 
-            bool reflect = CheckReflect(circle, ref caster, ref d);
+            bool reflect = CheckReflect(circle, ref caster, ref t);
 
-            if(d is Mobile)
-                target = (Mobile)d;
+            if (t is Mobile)
+                caster = (Mobile)t;
 
             return reflect;
         }
 
         public static bool CheckReflect(int circle, Mobile caster, ref IDamageable target)
         {
-            return CheckReflect(circle, ref caster, ref target);
+            IDamageable c = caster as IDamageable;
+
+            bool reflect = CheckReflect(circle, ref c, ref target);
+
+            if (c is Mobile)
+                caster = (Mobile)c;
+
+            return reflect;
         }
 
-        public static bool CheckReflect(int circle, ref Mobile caster, ref IDamageable damageable, DamageType type = DamageType.Spell)
+        public static bool CheckReflect(int circle, ref Mobile caster, ref IDamageable target, DamageType type = DamageType.Spell)
+        {
+            IDamageable c = caster as IDamageable;
+
+            bool reflect = CheckReflect(circle, ref c, ref target);
+
+            if (c is Mobile)
+                caster = (Mobile)c;
+
+            return reflect;
+        }
+
+        public static bool CheckReflect(int circle, ref Mobile caster, ref Mobile target)
+        {
+            return CheckReflect(circle, caster, ref target);
+        }
+
+        public static bool CheckReflect(int circle, ref IDamageable source, ref IDamageable defender, DamageType type = DamageType.Spell)
         {
             bool reflect = false;
-            Mobile target = damageable as Mobile;
+            Mobile target = defender as Mobile;
 
-            if (Core.AOS && type == DamageType.Spell)
+            if (Core.AOS && type >= DamageType.Spell)
             {
-                if (target != null)
+                if (target != null && defender is Mobile)
                 {
-                    Clone clone = MirrorImage.GetDeflect(caster, target);
+                    Clone clone = MirrorImage.GetDeflect(target, (Mobile)defender);
 
                     if (clone != null)
                     {
-                        damageable = clone;
+                        defender = clone;
                         return false;
                     }
                 }
-                else if (damageable is DamageableItem)
+                else if (defender is DamageableItem && ((DamageableItem)defender).CheckReflect(circle, source))
                 {
-                    ((DamageableItem)damageable).CheckReflect(circle, caster);
+                    IDamageable temp = source;
+                    source = defender;
+                    defender = temp;
                     return true;
                 }
             }
 
-            if (target == null)
+            Mobile caster = source as Mobile;
+
+            if (target == null || caster == null)
                 return false;
 
             if (target.MagicDamageAbsorb > 0)
@@ -1229,7 +1261,7 @@ namespace Server.Spells
                     target.FixedEffect(0x37B9, 10, 5);
 
                     Mobile temp = caster;
-                    caster = target;
+                    source = target;
                     target = temp;
                 }
             }
@@ -1244,7 +1276,7 @@ namespace Server.Spells
                     target.FixedEffect(0x37B9, 10, 5);
 
                     Mobile temp = caster;
-                    caster = target;
+                    source = target;
                     target = temp;
                 }
             }

--- a/Scripts/Spells/Bushido/MomentumStrike.cs
+++ b/Scripts/Spells/Bushido/MomentumStrike.cs
@@ -45,10 +45,10 @@ namespace Server.Spells.Bushido
 
             foreach (Mobile m in eable)
             {
-                if (m == defender)
-                    continue;
-
-                if (m.Combatant != attacker)
+                if (m == defender || 
+                    !Server.Spells.SpellHelper.ValidIndirectTarget(attacker, defender) ||
+                    !m.CanBeHarmful(attacker, false) || 
+                    !attacker.InLOS(m))
                     continue;
 
                 targets.Add(m);

--- a/Scripts/Spells/First/MagicArrow.cs
+++ b/Scripts/Spells/First/MagicArrow.cs
@@ -39,21 +39,21 @@ namespace Server.Spells.First
         public override Type[] DelayDamageFamily { get { return new Type[] { typeof(Server.Spells.Mysticism.NetherBoltSpell) }; } }
         public override void OnCast()
         {
-            this.Caster.Target = new InternalTarget(this);
+            Caster.Target = new InternalTarget(this);
         }
 
         public void Target(IDamageable d)
         {
-            Mobile m = d as Mobile;
-
-            if (!this.Caster.CanSee(d))
+            if (!Caster.CanSee(d))
             {
-                this.Caster.SendLocalizedMessage(500237); // Target can not be seen.
+                Caster.SendLocalizedMessage(500237); // Target can not be seen.
             }
-            else if (this.CheckHSequence(d))
+            else if (CheckHSequence(d))
             {
-                Mobile source = this.Caster;
-                SpellHelper.Turn(source, d);
+                IDamageable source = Caster;
+                IDamageable target = d;
+
+                SpellHelper.Turn(Caster, d);
 
                 if (Core.SA && HasDelayContext(d))
                 {
@@ -61,12 +61,12 @@ namespace Server.Spells.First
                     return;
                 }
 
-                if (SpellHelper.CheckReflect((int)this.Circle, ref source, ref d) && !Core.AOS)
+                if (SpellHelper.CheckReflect((int)Circle, ref source, ref target))
                 {
                     Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
                     {
-                        source.MovingParticles(m, 0x379F, 7, 0, false, true, 3043, 4043, 0x211);
-                        source.PlaySound(0x20A);
+                        source.MovingParticles(target, 0x36E4, 5, 0, false, true, 3043, 4043, 0x211);
+                        source.PlaySound(0x1E5);
                     });
                 }
 
@@ -76,30 +76,30 @@ namespace Server.Spells.First
                 {
                     damage = GetNewAosDamage(10, 1, 4, d);
                 }
-                else if (m != null)
+                else if (target is Mobile)
                 {
                     damage = Utility.Random(4, 4);
 
-                    if (this.CheckResisted(m))
+                    if (CheckResisted((Mobile)target))
                     {
                         damage *= 0.75;
 
-                        m.SendLocalizedMessage(501783); // You feel yourself resisting magical energy.
+                        ((Mobile)target).SendLocalizedMessage(501783); // You feel yourself resisting magical energy.
                     }
 
-                    damage *= this.GetDamageScalar(m);
+                    damage *= GetDamageScalar((Mobile)target);
                 }
 
                 if (damage > 0)
                 {
-                    this.Caster.MovingParticles(d, 0x36E4, 5, 0, false, false, 3006, 0, 0);
-                    this.Caster.PlaySound(0x1E5);
+                    Caster.MovingParticles(d, 0x36E4, 5, 0, false, false, 3006, 0, 0);
+                    Caster.PlaySound(0x1E5);
 
-                    SpellHelper.Damage(this, d, damage, 0, 100, 0, 0, 0);
+                    SpellHelper.Damage(this, target, damage, 0, 100, 0, 0, 0);
                 }
             }
 
-            this.FinishSequence();
+            FinishSequence();
         }
 
         private class InternalTarget : Target
@@ -108,20 +108,20 @@ namespace Server.Spells.First
             public InternalTarget(MagicArrowSpell owner)
                 : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
             {
-                this.m_Owner = owner;
+                m_Owner = owner;
             }
 
             protected override void OnTarget(Mobile from, object o)
             {
                 if (o is IDamageable)
                 {
-                    this.m_Owner.Target((IDamageable)o);
+                    m_Owner.Target((IDamageable)o);
                 }
             }
 
             protected override void OnTargetFinish(Mobile from)
             {
-                this.m_Owner.FinishSequence();
+                m_Owner.FinishSequence();
             }
         }
     }

--- a/Scripts/Spells/Fourth/Lightning.cs
+++ b/Scripts/Spells/Fourth/Lightning.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Targeting;
+using Server.Mobiles;
 
 namespace Server.Spells.Fourth
 {
@@ -70,7 +71,14 @@ namespace Server.Spells.Fourth
                     damage *= GetDamageScalar(mob);
                 }
 
-                Effects.SendBoltEffect(m, true, 0, false);
+                if (m is Mobile)
+                {
+                    Effects.SendBoltEffect(m, true, 0, false);
+                }
+                else
+                {
+                    Effects.SendBoltEffect(EffectMobile.Create(m.Location, m.Map, EffectMobile.DefaultDuration), true, 0, false);
+                }
 
                 if (damage > 0)
                 {

--- a/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/BombardSpell.cs
@@ -29,14 +29,17 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this, TargetFlags.Harmful);
         }
 
-        public void OnTarget(IDamageable target)
+        public void OnTarget(IDamageable d)
         {
-            if (target == null)
+            if (d == null)
             {
                 return;
             }
-            else if (CheckHSequence(target))
+            else if (CheckHSequence(d))
             {
+                IDamageable target = d;
+                IDamageable source = Caster;
+
                 SpellHelper.Turn(Caster, target);
 
                 if (Core.SA && HasDelayContext(target))
@@ -45,9 +48,16 @@ namespace Server.Spells.Mysticism
                     return;
                 }
 
-                SpellHelper.CheckReflect((int)Circle, Caster, ref target);
+                if (SpellHelper.CheckReflect((int)Circle, ref source, ref target))
+                {
+                    Server.Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
+                    {
+                        source.MovingEffect(target, 0x1363, 12, 1, false, true, 0, 0);
+                        source.PlaySound(0x64B);
+                    });
+                }
 
-                Caster.MovingEffect(target, 0x1363, 12, 1, false, true, 0, 0);
+                Caster.MovingEffect(d, 0x1363, 12, 1, false, true, 0, 0);
                 Caster.PlaySound(0x64B);
 
                 SpellHelper.Damage(this, target, (int)GetNewAosDamage(40, 1, 5, target), 100, 0, 0, 0, 0);

--- a/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/EagleStrikeSpell.cs
@@ -32,14 +32,17 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this, TargetFlags.Harmful);
         }
 
-        public void OnTarget(IDamageable target)
+        public void OnTarget(IDamageable d)
         {
-            if (target == null)
+            if (d == null)
             {
                 return;
             }
-            else if (CheckHSequence(target))
+            else if (CheckHSequence(d))
             {
+                IDamageable target = d;
+                IDamageable source = Caster;
+
                 SpellHelper.Turn(Caster, target);
 
                 if (Core.SA && HasDelayContext(target))
@@ -48,9 +51,16 @@ namespace Server.Spells.Mysticism
                     return;
                 }
 
-                SpellHelper.CheckReflect((int)Circle, Caster, ref target);
+                if (SpellHelper.CheckReflect((int)Circle, ref source, ref target))
+                {
+                    Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
+                    {
+                        source.MovingEffect(target, 0x407A, 8, 1, false, true, 0, 0);
+                        source.PlaySound(0x2EE);
+                    });
+                }
 
-                Caster.MovingEffect(target, 0x407A, 8, 1, false, true, 0, 0);
+                Caster.MovingEffect(d, 0x407A, 8, 1, false, true, 0, 0);
                 Caster.PlaySound(0x2EE);
 
                 Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>

--- a/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/NetherBoltSpell.cs
@@ -28,14 +28,17 @@ namespace Server.Spells.Mysticism
             Caster.Target = new InternalTarget(this, TargetFlags.Harmful);
         }
 
-        public void OnTarget(IDamageable target)
+        public void OnTarget(IDamageable d)
         {
-            if (target == null)
+            if (d == null)
             {
                 return;
             }
-            else if (CheckHSequence(target))
+            else if (CheckHSequence(d))
             {
+                IDamageable target = d;
+                IDamageable source = Caster;
+
                 SpellHelper.Turn(Caster, target);
 
                 if (Core.SA && HasDelayContext(target))
@@ -44,13 +47,20 @@ namespace Server.Spells.Mysticism
                     return;
                 }
 
-                SpellHelper.CheckReflect((int)Circle, Caster, ref target);
+                if (SpellHelper.CheckReflect((int)Circle, ref source, ref target))
+                {
+                    Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
+                    {
+                        source.MovingParticles(target, 0x36D4, 7, 0, false, true, 0x49A, 0, 0, 9502, 4019, 0x160);
+                        source.PlaySound(0x211);
+                    });
+                }
 
                 double damage = GetNewAosDamage(10, 1, 4, target);
 
                 SpellHelper.Damage(this, target, damage, 0, 0, 0, 0, 0, 100, 0);
 
-                Caster.MovingParticles(target, 0x36D4, 7, 0, false, true, 0x49A, 0, 0, 9502, 4019, 0x160);
+                Caster.MovingParticles(d, 0x36D4, 7, 0, false, true, 0x49A, 0, 0, 9502, 4019, 0x160);
                 Caster.PlaySound(0x211);
             }
 

--- a/Scripts/Spells/Seventh/MeteorSwarm.cs
+++ b/Scripts/Spells/Seventh/MeteorSwarm.cs
@@ -110,13 +110,14 @@ namespace Server.Spells.Seventh
                             m.SendLocalizedMessage(501783); // You feel yourself resisting magical energy.
                         }
 
-                        Mobile source = Caster;
+                        IDamageable source = Caster;
+                        IDamageable target = id;
 
-                        if (SpellHelper.CheckReflect((int)Circle, ref source, ref id, SpellDamageType) && !Core.AOS)
+                        if (SpellHelper.CheckReflect((int)Circle, ref source, ref target, SpellDamageType))
                         {
                             Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
                                 {
-                                    source.MovingParticles(m, 0x36D4, 7, 0, false, true, 9501, 1, 0, 0x100);
+                                    source.MovingParticles(target, 0x36D4, 7, 0, false, true, 9501, 1, 0, 0x100);
                                 });
                         }
 
@@ -126,14 +127,13 @@ namespace Server.Spells.Seventh
                         }
 
                         Caster.DoHarmful(id);
-                        SpellHelper.Damage(this, id, damage, 0, 100, 0, 0, 0);
+                        SpellHelper.Damage(this, target, damage, 0, 100, 0, 0, 0);
 
                         Caster.MovingParticles(id, 0x36D4, 7, 0, false, true, 9501, 1, 0, 0x100);
                     }
                 }
 
-                targets.Clear();
-                targets.TrimExcess();
+                ColUtility.Free(targets);
             }
 
             FinishSequence();

--- a/Scripts/Spells/Sixth/EnergyBolt.cs
+++ b/Scripts/Spells/Sixth/EnergyBolt.cs
@@ -37,22 +37,22 @@ namespace Server.Spells.Sixth
 
         public void Target(IDamageable m)
         {
-            Mobile mob = m as Mobile;
-
             if (!Caster.CanSee(m))
             {
                 Caster.SendLocalizedMessage(500237); // Target can not be seen.
             }
             else if (CheckHSequence(m))
             {
-                Mobile source = Caster;
+                IDamageable source = Caster;
+                IDamageable target = m;
+
                 SpellHelper.Turn(Caster, m);
 
-                if (SpellHelper.CheckReflect((int)Circle, ref source, ref m) && !Core.AOS)
+                if (SpellHelper.CheckReflect((int)Circle, ref source, ref target))
                 {
                     Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
                     {
-                        source.MovingParticles(mob, 0x379F, 7, 0, false, true, 3043, 4043, 0x211);
+                        source.MovingParticles(target, 0x379F, 7, 0, false, true, 3043, 4043, 0x211);
                         source.PlaySound(0x20A);
                     });
                 }
@@ -63,8 +63,9 @@ namespace Server.Spells.Sixth
                 {
                     damage = GetNewAosDamage(40, 1, 5, m);
                 }
-                else if (mob != null)
+                else if (m is Mobile)
                 {
+                    Mobile mob = m as Mobile;
                     damage = Utility.Random(24, 18);
 
                     if (CheckResisted(mob))
@@ -85,7 +86,7 @@ namespace Server.Spells.Sixth
                 if (damage > 0)
                 {
                     // Deal the damage
-                    SpellHelper.Damage(this, m, damage, 0, 0, 0, 0, 100);
+                    SpellHelper.Damage(this, target, damage, 0, 0, 0, 0, 100);
                 }
             }
 

--- a/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
+++ b/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
@@ -66,7 +66,19 @@ namespace Server.Spells.SkillMasteries
             {
                 if (CheckHSequence(m))
                 {
-                    SpellHelper.CheckReflect(0, Caster, ref m);
+                    IDamageable target = m;
+                    IDamageable source = Caster;
+
+                    SpellHelper.Turn(Caster, target);
+
+                    if (SpellHelper.CheckReflect(0, ref source, ref target))
+                    {
+                        Server.Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
+                        {
+                            source.MovingParticles(target, 0x9BB5, 7, 0, false, true, 9502, 4019, 0x160);
+                            source.PlaySound(0x5CE);
+                        });
+                    }
 
                     double skill = (Caster.Skills[CastSkill].Value + GetWeaponSkill() + (GetMasteryLevel() * 40)) / 3;
                     double damage = skill + (double)Caster.Karma / 1000;
@@ -81,11 +93,11 @@ namespace Server.Spells.SkillMasteries
                     Caster.MovingParticles(m, 0x9BB5, 7, 0, false, true, 9502, 4019, 0x160);
                     Caster.PlaySound(0x5CE);
 
-                    SpellHelper.Damage(this, m, damage, 0, 0, 0, 0, 100);
+                    SpellHelper.Damage(this, target, damage, 0, 0, 0, 0, 100);
 
-                    if (m is Mobile && !CheckResisted((Mobile)m) && ((Mobile)m).NetState != null)
+                    if (target is Mobile && !CheckResisted((Mobile)target) && ((Mobile)target).NetState != null)
                     {
-                        Mobile mob = m as Mobile;
+                        Mobile mob = target as Mobile;
 
                         if (!TransformationSpellHelper.UnderTransformation(mob, typeof(AnimalForm)))
                             mob.SendSpeedControl(SpeedControlType.WalkSpeed);

--- a/Scripts/Spells/Third/Fireball.cs
+++ b/Scripts/Spells/Third/Fireball.cs
@@ -31,27 +31,27 @@ namespace Server.Spells.Third
         }
         public override void OnCast()
         {
-            this.Caster.Target = new InternalTarget(this);
+            Caster.Target = new InternalTarget(this);
         }
 
         public void Target(IDamageable m)
         {
-            if (!this.Caster.CanSee(m))
+            if (!Caster.CanSee(m))
             {
-                this.Caster.SendLocalizedMessage(500237); // Target can not be seen.
+                Caster.SendLocalizedMessage(500237); // Target can not be seen.
             }
-            else if (this.CheckHSequence(m))
+            else if (CheckHSequence(m))
             {
-                Mobile source = this.Caster;
-                Mobile target = m as Mobile;
+                IDamageable source = Caster;
+                IDamageable target = m;
 
-                SpellHelper.Turn(source, m);
+                SpellHelper.Turn(Caster, m);
 
-                if (SpellHelper.CheckReflect((int)this.Circle, ref source, ref m) && !Core.AOS)
+                if (SpellHelper.CheckReflect((int)Circle, ref source, ref target))
                 {
                     Timer.DelayCall(TimeSpan.FromSeconds(.5), () =>
                         {
-                            source.MovingParticles(m, 0x36D4, 7, 0, false, true, 9502, 4019, 0x160);
+                            source.MovingParticles(target, 0x36D4, 7, 0, false, true, 9502, 4019, 0x160);
                             source.PlaySound(Core.AOS ? 0x15E : 0x44B);
                         });
                 }
@@ -62,30 +62,30 @@ namespace Server.Spells.Third
                 {
                     damage = GetNewAosDamage(19, 1, 5, m);
                 }
-                else if (target != null)
+                else if (m is Mobile)
                 {
                     damage = Utility.Random(10, 7);
 
-                    if (this.CheckResisted(target))
+                    if (CheckResisted((Mobile)m))
                     {
                         damage *= 0.75;
 
-                        target.SendLocalizedMessage(501783); // You feel yourself resisting magical energy.
+                        ((Mobile)m).SendLocalizedMessage(501783); // You feel yourself resisting magical energy.
                     }
 
-                    damage *= this.GetDamageScalar(target);
+                    damage *= GetDamageScalar((Mobile)m);
                 }
 
                 if (damage > 0)
                 {
-                    this.Caster.MovingParticles(m, 0x36D4, 7, 0, false, true, 9502, 4019, 0x160);
-                    this.Caster.PlaySound(Core.AOS ? 0x15E : 0x44B);
+                    Caster.MovingParticles(m, 0x36D4, 7, 0, false, true, 9502, 4019, 0x160);
+                    Caster.PlaySound(Core.AOS ? 0x15E : 0x44B);
 
-                    SpellHelper.Damage(this, m, damage, 0, 100, 0, 0, 0);
+                    SpellHelper.Damage(this, target, damage, 0, 100, 0, 0, 0);
                 }
             }
 
-            this.FinishSequence();
+            FinishSequence();
         }
 
         private class InternalTarget : Target
@@ -94,18 +94,18 @@ namespace Server.Spells.Third
             public InternalTarget(FireballSpell owner)
                 : base(Core.ML ? 10 : 12, false, TargetFlags.Harmful)
             {
-                this.m_Owner = owner;
+                m_Owner = owner;
             }
 
             protected override void OnTarget(Mobile from, object o)
             {
                 if (o is IDamageable)
-                    this.m_Owner.Target((IDamageable)o);
+                    m_Owner.Target((IDamageable)o);
             }
 
             protected override void OnTargetFinish(Mobile from)
             {
-                this.m_Owner.FinishSequence();
+                m_Owner.FinishSequence();
             }
         }
     }

--- a/Server/Interfaces.cs
+++ b/Server/Interfaces.cs
@@ -117,7 +117,26 @@ namespace Server
         int PoisonResistance { get; }
         int EnergyResistance { get; }
 
+        void PlaySound(int soundID);
+
         void OnStatsQuery(Mobile from);
-        void Damage(int amount, Mobile from);
+        void Damage(int amount, Mobile from, int type);
+
+        void MovingEffect(IEntity to, int itemID, int speed, int duration, bool fixedDirection, bool explodes, int hue, int renderMode);
+        void MovingEffect(IEntity to, int itemID, int speed, int duration, bool fixedDirection, bool explodes);
+
+        void MovingParticles(IEntity to, int itemID, int speed, int duration, bool fixedDirection, bool explodes, int hue, int renderMode, int effect, int explodeEffect, int explodeSound, EffectLayer layer, int unknown);
+        void MovingParticles(IEntity to, int itemID, int speed, int duration, bool fixedDirection, bool explodes, int hue, int renderMode, int effect, int explodeEffect, int explodeSound, int unknown);
+        void MovingParticles(IEntity to, int itemID, int speed, int duration, bool fixedDirection, bool explodes, int effect, int explodeEffect, int explodeSound, int unknown);
+        void MovingParticles(IEntity to, int itemID, int speed, int duration, bool fixedDirection, bool explodes, int effect, int explodeEffect, int explodeSound);
+
+        void FixedEffect(int itemID, int speed, int duration, int hue, int renderMode);
+        void FixedEffect(int itemID, int speed, int duration);
+
+        void FixedParticles(int itemID, int speed, int duration, int effect, int hue, int renderMode, EffectLayer layer, int unknown);
+        void FixedParticles(int itemID, int speed, int duration, int effect, int hue, int renderMode, EffectLayer layer);
+        void FixedParticles(int itemID, int speed, int duration, int effect, EffectLayer layer, int unknown);
+        void FixedParticles(int itemID, int speed, int duration, int effect, EffectLayer layer);
+        void BoltEffect(int hue);
     }
 }

--- a/Server/Map.cs
+++ b/Server/Map.cs
@@ -1018,26 +1018,28 @@ namespace Server
             return null;
         }
 
-         public TMob FindMobile<TMob>(Point3D p, int range = 0) where TMob : Mobile
-         {
-             IPooledEnumerable eable = GetMobilesInRange(p, range);
+        public TMob FindMobile<TMob>(Point3D p, int range = 0) where TMob : Mobile
+        {
+            IPooledEnumerable eable = GetMobilesInRange(p, range);
 
-             foreach (Mobile m in eable)
-             {
-                 if (m.GetType() == typeof(TMob))
-                 {
-                     eable.Free();
-                     return m as TMob;
-                 }
-             }
+            foreach (Mobile m in eable)
+            {
+                if (m.GetType() == typeof(TMob))
+                {
+                    eable.Free();
+                    return m as TMob;
+                }
+            }
 
-             eable.Free();
-             return null;
-         }
+            eable.Free();
+            return null;
+        }
+
+
         #endregion
 
-         #region Spawn Position
-         public Point3D GetSpawnPosition(Point3D center, int range)
+        #region Spawn Position
+        public Point3D GetSpawnPosition(Point3D center, int range)
         {
             for (int i = 0; i < 10; i++)
             {
@@ -1054,17 +1056,17 @@ namespace Server
             return center;
         }
 
-         public Point3D GetRandomSpawnPoint(Rectangle2D rec)
-         {
-             if (this == Map.Internal)
-                 return Point3D.Zero;
+        public Point3D GetRandomSpawnPoint(Rectangle2D rec)
+        {
+            if (this == Map.Internal)
+                return Point3D.Zero;
 
-             int x = Utility.RandomMinMax(rec.X, rec.X + rec.Width);
-             int y = Utility.RandomMinMax(rec.Y, rec.Y + rec.Height);
-             int z = GetAverageZ(x, y);
+            int x = Utility.RandomMinMax(rec.X, rec.X + rec.Width);
+            int y = Utility.RandomMinMax(rec.Y, rec.Y + rec.Height);
+            int z = GetAverageZ(x, y);
 
-             return new Point3D(x, y, z);
-         }
+            return new Point3D(x, y, z);
+        }
         #endregion
 
         private class ZComparer : IComparer<Item>

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -5510,6 +5510,10 @@ namespace Server
 		public virtual void OnDamage(int amount, Mobile from, bool willKill)
 		{ }
 
+        public virtual void Damage(int amount, Mobile from, int type)
+        {
+        }
+
 		public virtual void Damage(int amount)
 		{
 			Damage(amount, null);


### PR DESCRIPTION
- Fixed riding swipe (on ethy) message
- Riding swipe victims (on ehty) can now re-mount once 10 second dazed effect wears off
- added proper target checks for momentum strike
- fixed spell reflection, should only effect pre-aos servers

Additions
- added sound/effects/particle support for Damageable items. It is now implemented via IDamageable, which is inherited by Mobile. Calling sound/particles/effects will no be the same as calling them for a mobile
- Added EffectMobile for certain effects that require a mobile, ie bolt effect.