### PR TITLE
Fix #3405

### DIFF
--- a/Scripts/Spells/Skill Masteries/FistsOfFury.cs
+++ b/Scripts/Spells/Skill Masteries/FistsOfFury.cs
@@ -70,7 +70,7 @@ namespace Server.Spells.SkillMasteries
         {
             BaseWeapon wep = defender.Weapon as BaseWeapon;
 
-            if (wep != null && !(wep is Fists))
+            if (wep == null || !(wep is Fists))
             {
                 defender.SendLocalizedMessage(1155979); // You may not wield a weapon and use this ability.
                 Expire(defender);


### PR DESCRIPTION
Previous code would crash when attempting to use with an item that was not a BaseWeapon equipped. Should fix #3405.