### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Abilities/SlayerGroup.cs
+++ b/Scripts/Abilities/SlayerGroup.cs
@@ -76,7 +76,8 @@ namespace Server.Items
                     typeof(GreenGoblinAlchemist), typeof(GreenGoblin),
                     typeof(GrayGoblinMage), typeof(GrayGoblinKeeper),
                     typeof(GrayGoblin), typeof(GreenGoblinAlchemistRenowned),
-                    typeof(GrayGoblinMageRenowned), typeof(CorgulTheSoulBinder)
+                    typeof(GrayGoblinMageRenowned), typeof(CorgulTheSoulBinder),
+                    typeof(PirateCrew)
                 );
 
             humanoid.Entries = new SlayerEntry[]

--- a/Scripts/Gumps/ViewHousesGump.cs
+++ b/Scripts/Gumps/ViewHousesGump.cs
@@ -18,28 +18,28 @@ namespace Server.Gumps
         public ViewHousesGump(Mobile from, List<BaseHouse> list, BaseHouse sel)
             : base(50, 40)
         {
-            this.m_From = from;
-            this.m_List = list;
-            this.m_Selection = sel;
+            m_From = from;
+            m_List = list;
+            m_Selection = sel;
 
             from.CloseGump(typeof(ViewHousesGump));
 
-            this.AddPage(0);
+            AddPage(0);
 
-            this.AddBackground(0, 0, 240, 360, 5054);
-            this.AddBlackAlpha(10, 10, 220, 340);
+            AddBackground(0, 0, 240, 360, 5054);
+            AddBlackAlpha(10, 10, 220, 340);
 
             if (sel == null || sel.Deleted)
             {
-                this.m_Selection = null;
+                m_Selection = null;
 
-                this.AddHtml(35, 15, 120, 20, this.Color("House Type", White), false, false);
+                AddHtml(35, 15, 120, 20, Color("House Type", White), false, false);
 
                 if (list.Count == 0)
-                    this.AddHtml(35, 40, 160, 40, this.Color("There were no houses found for that player.", White), false, false);
+                    AddHtml(35, 40, 160, 40, Color("There were no houses found for that player.", White), false, false);
 
-                this.AddImage(190, 17, 0x25EA);
-                this.AddImage(207, 17, 0x25E6);
+                AddImage(190, 17, 0x25EA);
+                AddImage(207, 17, 0x25E6);
 
                 int page = 0;
 
@@ -48,24 +48,24 @@ namespace Server.Gumps
                     if ((i % 15) == 0)
                     {
                         if (page > 0)
-                            this.AddButton(207, 17, 0x15E1, 0x15E5, 0, GumpButtonType.Page, page + 1);
+                            AddButton(207, 17, 0x15E1, 0x15E5, 0, GumpButtonType.Page, page + 1);
 
-                        this.AddPage(++page);
+                        AddPage(++page);
 
                         if (page > 1)
-                            this.AddButton(190, 17, 0x15E3, 0x15E7, 0, GumpButtonType.Page, page - 1);
+                            AddButton(190, 17, 0x15E3, 0x15E7, 0, GumpButtonType.Page, page - 1);
                     }
 
-                    object name = this.FindHouseName(list[i]);
+                    object name = FindHouseName(list[i]);
 
-                    this.AddHtml(15, 40 + ((i % 15) * 20), 20, 20, this.Color(String.Format("{0}.", i + 1), White), false, false);
+                    AddHtml(15, 40 + ((i % 15) * 20), 20, 20, Color(String.Format("{0}.", i + 1), White), false, false);
 
                     if (name is int)
-                        this.AddHtmlLocalized(35, 40 + ((i % 15) * 20), 160, 20, (int)name, White16, false, false);
+                        AddHtmlLocalized(35, 40 + ((i % 15) * 20), 160, 20, (int)name, White16, false, false);
                     else if (name is string)
-                        this.AddHtml(35, 40 + ((i % 15) * 20), 160, 20, this.Color((string)name, White), false, false);
+                        AddHtml(35, 40 + ((i % 15) * 20), 160, 20, Color((string)name, White), false, false);
 
-                    this.AddButton(198, 39 + ((i % 15) * 20), 4005, 4007, i + 1, GumpButtonType.Reply, 0);
+                    AddButton(198, 39 + ((i % 15) * 20), 4005, 4007, i + 1, GumpButtonType.Reply, 0);
                 }
             }
             else
@@ -86,49 +86,49 @@ namespace Server.Gumps
                 else
                     location = "unknown";
 
-                this.AddHtml(10, 15, 220, 20, this.Color(this.Center("House Properties"), White), false, false);
+                AddHtml(10, 15, 220, 20, Color(Center("House Properties"), White), false, false);
 
-                this.AddHtml(15, 40, 210, 20, this.Color("Facet:", White), false, false);
-                this.AddHtml(15, 40, 210, 20, this.Color(this.Right(map == null ? "(null)" : map.Name), White), false, false);
+                AddHtml(15, 40, 210, 20, Color("Facet:", White), false, false);
+                AddHtml(15, 40, 210, 20, Color(Right(map == null ? "(null)" : map.Name), White), false, false);
 
-                this.AddHtml(15, 60, 210, 20, this.Color("Location:", White), false, false);
-                this.AddHtml(15, 60, 210, 20, this.Color(this.Right(sel.Location.ToString()), White), false, false);
+                AddHtml(15, 60, 210, 20, Color("Location:", White), false, false);
+                AddHtml(15, 60, 210, 20, Color(Right(sel.Location.ToString()), White), false, false);
 
-                this.AddHtml(15, 80, 210, 20, this.Color("Sextant:", White), false, false);
-                this.AddHtml(15, 80, 210, 20, this.Color(this.Right(location), White), false, false);
+                AddHtml(15, 80, 210, 20, Color("Sextant:", White), false, false);
+                AddHtml(15, 80, 210, 20, Color(Right(location), White), false, false);
 
-                this.AddHtml(15, 100, 210, 20, this.Color("Owner:", White), false, false);
-                this.AddHtml(15, 100, 210, 20, this.Color(this.Right(owner), White), false, false);
+                AddHtml(15, 100, 210, 20, Color("Owner:", White), false, false);
+                AddHtml(15, 100, 210, 20, Color(Right(owner), White), false, false);
 
-                this.AddHtml(15, 120, 210, 20, this.Color("Name:", White), false, false);
-                this.AddHtml(15, 120, 210, 20, this.Color(this.Right(houseName), White), false, false);
+                AddHtml(15, 120, 210, 20, Color("Name:", White), false, false);
+                AddHtml(15, 120, 210, 20, Color(Right(houseName), White), false, false);
 
-                this.AddHtml(15, 140, 210, 20, this.Color("Friends:", White), false, false);
-                this.AddHtml(15, 140, 210, 20, this.Color(this.Right(sel.Friends.Count.ToString()), White), false, false);
+                AddHtml(15, 140, 210, 20, Color("Friends:", White), false, false);
+                AddHtml(15, 140, 210, 20, Color(Right(sel.Friends.Count.ToString()), White), false, false);
 
-                this.AddHtml(15, 160, 210, 20, this.Color("Co-Owners:", White), false, false);
-                this.AddHtml(15, 160, 210, 20, this.Color(this.Right(sel.CoOwners.Count.ToString()), White), false, false);
+                AddHtml(15, 160, 210, 20, Color("Co-Owners:", White), false, false);
+                AddHtml(15, 160, 210, 20, Color(Right(sel.CoOwners.Count.ToString()), White), false, false);
 
-                this.AddHtml(15, 180, 210, 20, this.Color("Bans:", White), false, false);
-                this.AddHtml(15, 180, 210, 20, this.Color(this.Right(sel.Bans.Count.ToString()), White), false, false);
+                AddHtml(15, 180, 210, 20, Color("Bans:", White), false, false);
+                AddHtml(15, 180, 210, 20, Color(Right(sel.Bans.Count.ToString()), White), false, false);
 
-                this.AddHtml(15, 200, 210, 20, this.Color("Decays:", White), false, false);
-                this.AddHtml(15, 200, 210, 20, this.Color(this.Right(sel.CanDecay ? "Yes" : "No"), White), false, false);
+                AddHtml(15, 200, 210, 20, Color("Decays:", White), false, false);
+                AddHtml(15, 200, 210, 20, Color(Right(sel.CanDecay ? "Yes" : "No"), White), false, false);
 
-                this.AddHtml(15, 220, 210, 20, this.Color("Decay Level:", White), false, false);
-                this.AddHtml(15, 220, 210, 20, this.Color(this.Right(sel.DecayLevel.ToString()), White), false, false);
+                AddHtml(15, 220, 210, 20, Color("Decay Level:", White), false, false);
+                AddHtml(15, 220, 210, 20, Color(Right(sel.DecayLevel.ToString()), White), false, false);
 
-                this.AddButton(15, 245, 4005, 4007, 1, GumpButtonType.Reply, 0);
-                this.AddHtml(50, 245, 120, 20, this.Color("Go to house", White), false, false);
+                AddButton(15, 245, 4005, 4007, 1, GumpButtonType.Reply, 0);
+                AddHtml(50, 245, 120, 20, Color("Go to house", White), false, false);
 
-                this.AddButton(15, 265, 4005, 4007, 2, GumpButtonType.Reply, 0);
-                this.AddHtml(50, 265, 120, 20, this.Color("Open house menu", White), false, false);
+                AddButton(15, 265, 4005, 4007, 2, GumpButtonType.Reply, 0);
+                AddHtml(50, 265, 120, 20, Color("Open house menu", White), false, false);
 
-                this.AddButton(15, 285, 4005, 4007, 3, GumpButtonType.Reply, 0);
-                this.AddHtml(50, 285, 120, 20, this.Color("Demolish house", White), false, false);
+                AddButton(15, 285, 4005, 4007, 3, GumpButtonType.Reply, 0);
+                AddHtml(50, 285, 120, 20, Color("Demolish house", White), false, false);
 
-                this.AddButton(15, 305, 4005, 4007, 4, GumpButtonType.Reply, 0);
-                this.AddHtml(50, 305, 120, 20, this.Color("Refresh house", White), false, false);
+                AddButton(15, 305, 4005, 4007, 4, GumpButtonType.Reply, 0);
+                AddHtml(50, 305, 120, 20, Color("Refresh house", White), false, false);
             }
         }
 
@@ -178,55 +178,55 @@ namespace Server.Gumps
 
         public override void OnResponse(Server.Network.NetState sender, RelayInfo info)
         {
-            if (this.m_Selection == null)
+            if (m_Selection == null)
             {
                 int v = info.ButtonID - 1;
 
-                if (v >= 0 && v < this.m_List.Count)
-                    this.m_From.SendGump(new ViewHousesGump(this.m_From, this.m_List, this.m_List[v]));
+                if (v >= 0 && v < m_List.Count)
+                    m_From.SendGump(new ViewHousesGump(m_From, m_List, m_List[v]));
             }
-            else if (!this.m_Selection.Deleted)
+            else if (!m_Selection.Deleted)
             {
                 switch ( info.ButtonID )
                 {
                     case 0:
                         {
-                            this.m_From.SendGump(new ViewHousesGump(this.m_From, this.m_List, null));
+                            m_From.SendGump(new ViewHousesGump(m_From, m_List, null));
                             break;
                         }
                     case 1:
                         {
-                            Map map = this.m_Selection.Map;
+                            Map map = m_Selection.Map;
 
                             if (map != null && map != Map.Internal)
-                                this.m_From.MoveToWorld(this.m_Selection.BanLocation, map);
+                                m_From.MoveToWorld(m_Selection.BanLocation, map);
 
-                            this.m_From.SendGump(new ViewHousesGump(this.m_From, this.m_List, this.m_Selection));
+                            m_From.SendGump(new ViewHousesGump(m_From, m_List, m_Selection));
 
                             break;
                         }
                     case 2:
                         {
-                            this.m_From.SendGump(new ViewHousesGump(this.m_From, this.m_List, this.m_Selection));
+                            m_From.SendGump(new ViewHousesGump(m_From, m_List, m_Selection));
 
-                            HouseSign sign = this.m_Selection.Sign;
+                            HouseSign sign = m_Selection.Sign;
 
                             if (sign != null && !sign.Deleted)
-                                sign.OnDoubleClick(this.m_From);
+                                sign.OnDoubleClick(m_From);
 
                             break;
                         }
                     case 3:
                         {
-                            this.m_From.SendGump(new ViewHousesGump(this.m_From, this.m_List, this.m_Selection));
-                            this.m_From.SendGump(new HouseDemolishGump(this.m_From, this.m_Selection));
+                            m_From.SendGump(new ViewHousesGump(m_From, m_List, m_Selection));
+                            m_From.SendGump(new HouseDemolishGump(m_From, m_Selection));
 
                             break;
                         }
                     case 4:
                         {
-                            this.m_Selection.RefreshDecay();
-                            this.m_From.SendGump(new ViewHousesGump(this.m_From, this.m_List, this.m_Selection));
+                            m_Selection.RefreshDecay();
+                            m_From.SendGump(new ViewHousesGump(m_From, m_List, m_Selection));
 
                             break;
                         }
@@ -283,8 +283,8 @@ namespace Server.Gumps
 
         public void AddBlackAlpha(int x, int y, int width, int height)
         {
-            this.AddImageTiled(x, y, width, height, 2624);
-            this.AddAlphaRegion(x, y, width, height);
+            AddImageTiled(x, y, width, height, 2624);
+            AddAlphaRegion(x, y, width, height);
         }
 
         private class HouseComparer : IComparer<BaseHouse>

--- a/Scripts/Items/Addons/BaseAddonContainerDeed.cs
+++ b/Scripts/Items/Addons/BaseAddonContainerDeed.cs
@@ -95,11 +95,6 @@ namespace Server.Items
 
             this.Resource = CraftResources.GetFromType(resourceType);
 
-            CraftContext context = craftSystem.GetContext(from);
-
-            if (context != null && context.DoNotColor)
-                this.Hue = 0;
-
             return quality;
         }
 

--- a/Scripts/Items/Addons/BaseAddonDeed.cs
+++ b/Scripts/Items/Addons/BaseAddonDeed.cs
@@ -103,12 +103,6 @@ namespace Server.Items
                 resourceType = craftItem.Resources.GetAt(0).ItemType;
 
             Resource = CraftResources.GetFromType(resourceType);
-
-            CraftContext context = craftSystem.GetContext(from);
-
-            if (Hue != 0 && (!UseCraftResource || (context != null && context.DoNotColor)))
-				Hue = 0;
-
             return quality;
         }
 

--- a/Scripts/Items/Consumables/DragonBardingDeed.cs
+++ b/Scripts/Items/Consumables/DragonBardingDeed.cs
@@ -188,12 +188,6 @@ namespace Server.Items
                 resourceType = craftItem.Resources.GetAt(0).ItemType;
 
             this.Resource = CraftResources.GetFromType(resourceType);
-
-            CraftContext context = craftSystem.GetContext(from);
-
-            if (context != null && context.DoNotColor)
-                this.Hue = 0;
-
             return quality;
         }
         #endregion

--- a/Scripts/Items/Consumables/MessageInABottle.cs
+++ b/Scripts/Items/Consumables/MessageInABottle.cs
@@ -21,9 +21,9 @@ namespace Server.Items
         public MessageInABottle(Map map, int level)
             : base(0x099F)
         {
-            this.Weight = 1.0;
-            this.m_TargetMap = map;
-            this.m_Level = level;
+            Weight = 1.0;
+            m_TargetMap = map;
+            m_Level = level;
         }
 
         public MessageInABottle(Serial serial)
@@ -43,11 +43,11 @@ namespace Server.Items
         {
             get
             {
-                return this.m_TargetMap;
+                return m_TargetMap;
             }
             set
             {
-                this.m_TargetMap = value;
+                m_TargetMap = value;
             }
         }
         [CommandProperty(AccessLevel.GameMaster)]
@@ -55,11 +55,11 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Level;
+                return m_Level;
             }
             set
             {
-                this.m_Level = Math.Max(1, Math.Min(value, 4));
+                m_Level = Math.Max(1, Math.Min(value, 4));
             }
         }
         public static int GetRandomLevel()
@@ -76,9 +76,9 @@ namespace Server.Items
 
             writer.Write((int)3); // version
 
-            writer.Write((int)this.m_Level);
+            writer.Write((int)m_Level);
 
-            writer.Write(this.m_TargetMap);
+            writer.Write(m_TargetMap);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -92,33 +92,33 @@ namespace Server.Items
                 case 3:
                 case 2:
                     {
-                        this.m_Level = reader.ReadInt();
+                        m_Level = reader.ReadInt();
                         goto case 1;
                     }
                 case 1:
                     {
-                        this.m_TargetMap = reader.ReadMap();
+                        m_TargetMap = reader.ReadMap();
                         break;
                     }
                 case 0:
                     {
-                        this.m_TargetMap = Map.Trammel;
+                        m_TargetMap = Map.Trammel;
                         break;
                     }
             }
 
             if (version < 2)
-                this.m_Level = GetRandomLevel();
+                m_Level = GetRandomLevel();
 
-            if (version < 3 && this.m_TargetMap == Map.Tokuno)
-                this.m_TargetMap = Map.Trammel;
+            if (version < 3 && m_TargetMap == Map.Tokuno)
+                m_TargetMap = Map.Trammel;
         }
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (this.IsChildOf(from.Backpack))
+            if (IsChildOf(from.Backpack))
             {
-                this.ReplaceWith(new SOS(this.m_TargetMap, this.m_Level));
+                ReplaceWith(new SOS(m_TargetMap, m_Level));
                 from.LocalOverheadMessage(Network.MessageType.Regular, 0x3B2, 501891); // You extract the message from the bottle.
             }
             else

--- a/Scripts/Items/Consumables/SOS.cs
+++ b/Scripts/Items/Consumables/SOS.cs
@@ -10,7 +10,7 @@ namespace Server.Items
         {
             get
             {
-                if (this.IsAncient)
+                if (IsAncient)
                     return 1063450; // an ancient SOS
 
                 return 1041081; // a waterstained SOS
@@ -27,7 +27,7 @@ namespace Server.Items
         {
             get
             {
-                return (this.m_Level >= 4);
+                return (m_Level >= 4);
             }
         }
 
@@ -36,13 +36,13 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Level;
+                return m_Level;
             }
             set
             {
-                this.m_Level = Math.Max(1, Math.Min(value, 4));
-                this.UpdateHue();
-                this.InvalidateProperties();
+                m_Level = Math.Max(1, Math.Min(value, 4));
+                UpdateHue();
+                InvalidateProperties();
             }
         }
 
@@ -51,11 +51,11 @@ namespace Server.Items
         {
             get
             {
-                return this.m_TargetMap;
+                return m_TargetMap;
             }
             set
             {
-                this.m_TargetMap = value;
+                m_TargetMap = value;
             }
         }
 
@@ -64,11 +64,11 @@ namespace Server.Items
         {
             get
             {
-                return this.m_TargetLocation;
+                return m_TargetLocation;
             }
             set
             {
-                this.m_TargetLocation = value;
+                m_TargetLocation = value;
             }
         }
 
@@ -77,20 +77,20 @@ namespace Server.Items
         {
             get
             {
-                return this.m_MessageIndex;
+                return m_MessageIndex;
             }
             set
             {
-                this.m_MessageIndex = value;
+                m_MessageIndex = value;
             }
         }
 
         public void UpdateHue()
         {
-            if (this.IsAncient)
-                this.Hue = 0x481;
+            if (IsAncient)
+                Hue = 0x481;
             else
-                this.Hue = 0;
+                Hue = 0;
         }
 
         [Constructable]
@@ -109,14 +109,14 @@ namespace Server.Items
         public SOS(Map map, int level)
             : base(0x14EE)
         {
-            this.Weight = 1.0;
+            Weight = 1.0;
 
-            this.m_Level = level;
-            this.m_MessageIndex = Utility.Random(MessageEntry.Entries.Length);
-            this.m_TargetMap = map;
-            this.m_TargetLocation = FindLocation(this.m_TargetMap);
+            m_Level = level;
+            m_MessageIndex = Utility.Random(MessageEntry.Entries.Length);
+            m_TargetMap = map;
+            m_TargetLocation = FindLocation(m_TargetMap);
 
-            this.UpdateHue();
+            UpdateHue();
         }
 
         public SOS(Serial serial)
@@ -130,11 +130,11 @@ namespace Server.Items
 
             writer.Write((int)4); // version
 
-            writer.Write(this.m_Level);
+            writer.Write(m_Level);
 
-            writer.Write(this.m_TargetMap);
-            writer.Write(this.m_TargetLocation);
-            writer.Write(this.m_MessageIndex);
+            writer.Write(m_TargetMap);
+            writer.Write(m_TargetLocation);
+            writer.Write(m_MessageIndex);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -149,54 +149,54 @@ namespace Server.Items
                 case 3:
                 case 2:
                     {
-                        this.m_Level = reader.ReadInt();
+                        m_Level = reader.ReadInt();
                         goto case 1;
                     }
                 case 1:
                     {
-                        this.m_TargetMap = reader.ReadMap();
-                        this.m_TargetLocation = reader.ReadPoint3D();
-                        this.m_MessageIndex = reader.ReadInt();
+                        m_TargetMap = reader.ReadMap();
+                        m_TargetLocation = reader.ReadPoint3D();
+                        m_MessageIndex = reader.ReadInt();
 
                         break;
                     }
                 case 0:
                     {
-                        this.m_TargetMap = this.Map;
+                        m_TargetMap = Map;
 
-                        if (this.m_TargetMap == null || this.m_TargetMap == Map.Internal)
-                            this.m_TargetMap = Map.Trammel;
+                        if (m_TargetMap == null || m_TargetMap == Map.Internal)
+                            m_TargetMap = Map.Trammel;
 
-                        this.m_TargetLocation = FindLocation(this.m_TargetMap);
-                        this.m_MessageIndex = Utility.Random(MessageEntry.Entries.Length);
+                        m_TargetLocation = FindLocation(m_TargetMap);
+                        m_MessageIndex = Utility.Random(MessageEntry.Entries.Length);
 
                         break;
                     }
             }
 
             if (version < 2)
-                this.m_Level = MessageInABottle.GetRandomLevel();
+                m_Level = MessageInABottle.GetRandomLevel();
 
             if (version < 3)
-                this.UpdateHue();
+                UpdateHue();
 
-            if (version < 4 && this.m_TargetMap == Map.Tokuno)
-                this.m_TargetMap = Map.Trammel;
+            if (version < 4 && m_TargetMap == Map.Tokuno)
+                m_TargetMap = Map.Trammel;
         }
 		
         public override void OnDoubleClick(Mobile from)
         {
-            if (this.IsChildOf(from.Backpack))
+            if (IsChildOf(from.Backpack))
             {
                 MessageEntry entry;
 
-                if (this.m_MessageIndex >= 0 && this.m_MessageIndex < MessageEntry.Entries.Length)
-                    entry = MessageEntry.Entries[this.m_MessageIndex];
+                if (m_MessageIndex >= 0 && m_MessageIndex < MessageEntry.Entries.Length)
+                    entry = MessageEntry.Entries[m_MessageIndex];
                 else
-                    entry = MessageEntry.Entries[this.m_MessageIndex = Utility.Random(MessageEntry.Entries.Length)];
+                    entry = MessageEntry.Entries[m_MessageIndex = Utility.Random(MessageEntry.Entries.Length)];
 
                 //from.CloseGump( typeof( MessageGump ) );
-                from.SendGump(new MessageGump(entry, this.m_TargetMap, this.m_TargetLocation));
+                from.SendGump(new MessageGump(entry, m_TargetMap, m_TargetLocation));
             }
             else
             {
@@ -317,20 +317,20 @@ namespace Server.Items
                 else
                     fmt = "?????";
 
-                this.AddPage(0);
+                AddPage(0);
 
-                this.AddBackground(0, 40, 350, 300, 2520);
+                AddBackground(0, 40, 350, 300, 2520);
 
-                this.AddHtmlLocalized(30, 80, 285, 160, 1018326, true, true); /* This is a message hastily scribbled by a passenger aboard a sinking ship.
+                AddHtmlLocalized(30, 80, 285, 160, 1018326, true, true); /* This is a message hastily scribbled by a passenger aboard a sinking ship.
                 * While it is probably too late to save the passengers and crew,
                 * perhaps some treasure went down with the ship!
                 * The message gives the ship's last known sextant co-ordinates.
                 */
 
-                this.AddHtml(35, 240, 230, 20, fmt, false, false);
+                AddHtml(35, 240, 230, 20, fmt, false, false);
 
-                this.AddButton(35, 265, 4005, 4007, 0, GumpButtonType.Reply, 0);
-                this.AddHtmlLocalized(70, 265, 100, 20, 1011036, false, false); // OKAY
+                AddButton(35, 265, 4005, 4007, 0, GumpButtonType.Reply, 0);
+                AddHtmlLocalized(70, 265, 100, 20, 1011036, false, false); // OKAY
             }
         }
         #endif
@@ -347,29 +347,29 @@ namespace Server.Items
             {
                 get
                 {
-                    return this.m_Width;
+                    return m_Width;
                 }
             }
             public int Height
             {
                 get
                 {
-                    return this.m_Height;
+                    return m_Height;
                 }
             }
             public string Message
             {
                 get
                 {
-                    return this.m_Message;
+                    return m_Message;
                 }
             }
 
             public MessageEntry(int width, int height, string message)
             {
-                this.m_Width = width;
-                this.m_Height = height;
-                this.m_Message = message;
+                m_Width = width;
+                m_Height = height;
+                m_Message = message;
             }
 
             private static readonly MessageEntry[] m_Entries = new MessageEntry[]

--- a/Scripts/Items/Consumables/TaxidermyKit.cs
+++ b/Scripts/Items/Consumables/TaxidermyKit.cs
@@ -66,7 +66,7 @@ namespace Server.Items
 			new TrophyInfo( typeof( Troll ),		  0x1E66,		1041092, 1041106 ),
             new TrophyInfo( typeof( RedHerring ),     0x1E62,		1113567, 1113569 ),
             new TrophyInfo( typeof( MudPuppy ),		  0x1E62,		1113568, 1113570 ),
-            //HighSeas - not yet :)
+
             new TrophyInfo( typeof( AutumnDragonfish),     0,       1116124, 1116185 ),
             new TrophyInfo( typeof( BullFish ),            1,       1116129, 1116190 ),
             new TrophyInfo( typeof( FireFish ),            2,       1116127, 1116188 ),

--- a/Scripts/Items/Containers/Container.cs
+++ b/Scripts/Items/Containers/Container.cs
@@ -114,6 +114,23 @@ namespace Server.Items
             }
         }
 
+        public virtual void DropItemStack(Item dropped)
+        {
+            List<Item> list = Items;
+
+            ItemFlags.SetTaken(dropped, true);
+
+            for (int i = 0; i < list.Count; ++i)
+            {
+                Item item = list[i];
+
+                if (!(item is Container) && item.StackWith(null, dropped, false))
+                    return;
+            }
+
+            DropItem(dropped);
+        }
+
         public override bool TryDropItem(Mobile from, Item dropped, bool sendFullMessage)
         {
             if (!CheckHold(from, dropped, sendFullMessage, !CheckStack(from, dropped)))

--- a/Scripts/Items/Containers/ShipsStrongbox.cs
+++ b/Scripts/Items/Containers/ShipsStrongbox.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using Server.Multis;
+
+namespace Server.Items
+{
+    [FlipableAttribute(0xE80, 0x9A8)]
+    public class ShipsStrongbox : LockableContainer
+    {
+        [Constructable]
+        public ShipsStrongbox()
+            : this (Utility.RandomMinMax(1, 3))
+        {
+        }
+
+        [Constructable]
+        public ShipsStrongbox(int level)
+            : base(0xE80)
+        {
+            Hue = level >= 4 ? 0x481 : 0x836;
+            level = Math.Min(4, Math.Max(1, level));
+
+            DropItem(new Gold(10000 * level));
+
+            for (int i = 0; i < level * 20; i++)
+            {
+                DropItemStack(Loot.RandomGem());
+            }
+
+            for (int i = 0; i < (level * 5) + Utility.Random(5); i++)
+            {
+                switch (Utility.Random(8))
+                {
+                    case 0: DropItemStack(new BlueDiamond()); break;
+                    case 1: DropItemStack(new FireRuby()); break;
+                    case 2: DropItemStack(new BrilliantAmber()); break;
+                    case 3: DropItemStack(new PerfectEmerald()); break;
+                    case 4: DropItemStack(new DarkSapphire()); break;
+                    case 5: DropItemStack(new Turquoise()); break;
+                    case 6: DropItemStack(new EcruCitrine()); break;
+                    case 7: DropItemStack(new WhitePearl()); break;
+                }
+            }
+
+            if (Utility.RandomBool())
+            {
+                DropItem(new GoldIngot(level * 100));
+            }
+            else
+            {
+                DropItem(new CopperIngot(level * 100));
+            }
+        }
+
+        public ShipsStrongbox(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int LabelNumber { get { return 1149959; } }// A ship's strongbox
+        public override int DefaultMaxWeight { get { return 400; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Decorative/CraftableFurniture.cs
+++ b/Scripts/Items/Decorative/CraftableFurniture.cs
@@ -182,11 +182,6 @@ namespace Server.Items
 
             this.Resource = CraftResources.GetFromType(resourceType);
 
-            CraftContext context = craftSystem.GetContext(from);
-
-            if (context != null && context.DoNotColor)
-                this.Hue = 0;
-
             return quality;
         }
         #endregion

--- a/Scripts/Items/Equipment/Armor/BaseArmor.cs
+++ b/Scripts/Items/Equipment/Armor/BaseArmor.cs
@@ -3048,11 +3048,6 @@ namespace Server.Items
 
             PlayerConstructed = true;
 
-            CraftContext context = craftSystem.GetContext(from);
-
-            if (context != null && context.DoNotColor)
-                Hue = 0;
-
             if (Quality == ItemQuality.Exceptional && !craftItem.ForceNonExceptional)
             {
                 DistributeExceptionalBonuses(from, (tool is BaseRunicTool ? 6 : Core.SE ? 15 : 14)); // Not sure since when, but right now 15 points are added, not 14.

--- a/Scripts/Items/Equipment/Clothing/BaseClothing.cs
+++ b/Scripts/Items/Equipment/Clothing/BaseClothing.cs
@@ -2028,8 +2028,6 @@ namespace Server.Items
             if (makersMark)
                 Crafter = from;
 
-            CraftContext context = craftSystem.GetContext(from);
-
             #region Mondain's Legacy
             if (!craftItem.ForceNonExceptional)
             {
@@ -2042,7 +2040,7 @@ namespace Server.Items
 
                     Resource = CraftResources.GetFromType(resourceType);
                 }
-                else if(context == null || !context.DoNotColor)
+                else
                 {
                     Hue = resHue;
                 }

--- a/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
+++ b/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
@@ -1246,11 +1246,6 @@ namespace Server.Items
             if (!craftItem.ForceNonExceptional)
                 Resource = CraftResources.GetFromType(resourceType);
 
-            CraftContext context = craftSystem.GetContext(from);
-
-            if (context != null && context.DoNotColor)
-                Hue = 0;
-
             if (1 < craftItem.Resources.Count)
             {
                 resourceType = craftItem.Resources.GetAt(1).ItemType;

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -6124,11 +6124,6 @@ namespace Server.Items
 
 				CraftContext context = craftSystem.GetContext(from);
 
-				if (context != null && context.DoNotColor)
-				{
-					Hue = 0;
-				}
-
 				if (Quality == ItemQuality.Exceptional)
 				{
 					Attributes.WeaponDamage += 35;
@@ -6159,13 +6154,6 @@ namespace Server.Items
 					if (thisResource == ((BaseRunicTool)tool).Resource)
 					{
 						Resource = thisResource;
-
-						CraftContext context = craftSystem.GetContext(from);
-
-						if (context != null && context.DoNotColor)
-						{
-							Hue = 0;
-						}
 
 						switch (thisResource)
 						{

--- a/Scripts/Items/Resource/PlantClippings.cs
+++ b/Scripts/Items/Resource/PlantClippings.cs
@@ -54,6 +54,19 @@ namespace Server.Items
                 list.Add(info.IsBright() ? 1112121 : 1112122, String.Format("#{0}", info.Name)); //bright ~1_COLOR~ plant clippings
         }
 
+        public override bool WillStack(Mobile from, Item dropped)
+        {
+            return dropped is IPlantHue && ((IPlantHue)dropped).PlantHue == m_PlantHue && base.WillStack(from, dropped);
+        }
+
+        public override void OnAfterDuped(Item newItem)
+        {
+            if (newItem is IPlantHue)
+                ((IPlantHue)newItem).PlantHue = this.PlantHue;
+
+            base.OnAfterDuped(newItem);
+        }
+
         public PlantClippings(Serial serial)
             : base(serial)
         {

--- a/Scripts/Items/Resource/PotionKeg.cs
+++ b/Scripts/Items/Resource/PotionKeg.cs
@@ -10,7 +10,7 @@ namespace Server.Items
         public PotionKeg()
             : base(0x1940)
         {
-            this.UpdateWeight();
+            UpdateWeight();
         }
 
         public PotionKeg(Serial serial)
@@ -23,15 +23,15 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Held;
+                return m_Held;
             }
             set
             {
-                if (this.m_Held != value)
+                if (m_Held != value)
                 {
-                    this.m_Held = value;
-                    this.UpdateWeight();
-                    this.InvalidateProperties();
+                    m_Held = value;
+                    UpdateWeight();
+                    InvalidateProperties();
                 }
             }
         }
@@ -40,24 +40,24 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Type;
+                return m_Type;
             }
             set
             {
-                this.m_Type = value;
-                this.InvalidateProperties();
+                m_Type = value;
+                InvalidateProperties();
             }
         }
         public override int LabelNumber
         { 
             get
             {
-                if (this.m_Held > 0 && (int)this.m_Type >= (int)PotionEffect.Conflagration)
+                if (m_Held > 0 && (int)m_Type >= (int)PotionEffect.Conflagration)
                 {
-                    return 1072658 + (int)this.m_Type - (int)PotionEffect.Conflagration;
+                    return 1072658 + (int)m_Type - (int)PotionEffect.Conflagration;
                 }
 
-                return (this.m_Held > 0 ? 1041620 + (int)this.m_Type : 1041641); 
+                return (m_Held > 0 ? 1041620 + (int)m_Type : 1041641); 
             }
         }
         public static void Initialize()
@@ -67,9 +67,9 @@ namespace Server.Items
 
         public virtual void UpdateWeight()
         {
-            int held = Math.Max(0, Math.Min(this.m_Held, 100));
+            int held = Math.Max(0, Math.Min(m_Held, 100));
 
-            this.Weight = 20 + ((held * 80) / 100);
+            Weight = 20 + ((held * 80) / 100);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -78,8 +78,8 @@ namespace Server.Items
 
             writer.Write((int)1); // version
 
-            writer.Write((int)this.m_Type);
-            writer.Write((int)this.m_Held);
+            writer.Write((int)m_Type);
+            writer.Write((int)m_Held);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -93,8 +93,8 @@ namespace Server.Items
                 case 1:
                 case 0:
                     {
-                        this.m_Type = (PotionEffect)reader.ReadInt();
-                        this.m_Held = reader.ReadInt();
+                        m_Type = (PotionEffect)reader.ReadInt();
+                        m_Held = reader.ReadInt();
 
                         break;
                     }
@@ -110,27 +110,27 @@ namespace Server.Items
 
             int number;
 
-            if (this.m_Held <= 0)
+            if (m_Held <= 0)
                 number = 502246; // The keg is empty.
-            else if (this.m_Held < 5)
+            else if (m_Held < 5)
                 number = 502248; // The keg is nearly empty.
-            else if (this.m_Held < 20)
+            else if (m_Held < 20)
                 number = 502249; // The keg is not very full.
-            else if (this.m_Held < 30)
+            else if (m_Held < 30)
                 number = 502250; // The keg is about one quarter full.
-            else if (this.m_Held < 40)
+            else if (m_Held < 40)
                 number = 502251; // The keg is about one third full.
-            else if (this.m_Held < 47)
+            else if (m_Held < 47)
                 number = 502252; // The keg is almost half full.
-            else if (this.m_Held < 54)
+            else if (m_Held < 54)
                 number = 502254; // The keg is approximately half full.
-            else if (this.m_Held < 70)
+            else if (m_Held < 70)
                 number = 502253; // The keg is more than half full.
-            else if (this.m_Held < 80)
+            else if (m_Held < 80)
                 number = 502255; // The keg is about three quarters full.
-            else if (this.m_Held < 96)
+            else if (m_Held < 96)
                 number = 502256; // The keg is very full.
-            else if (this.m_Held < 100)
+            else if (m_Held < 100)
                 number = 502257; // The liquid is almost to the top of the keg.
             else
                 number = 502258; // The keg is completely full.
@@ -144,39 +144,39 @@ namespace Server.Items
 
             int number;
 
-            if (this.m_Held <= 0)
+            if (m_Held <= 0)
                 number = 502246; // The keg is empty.
-            else if (this.m_Held < 5)
+            else if (m_Held < 5)
                 number = 502248; // The keg is nearly empty.
-            else if (this.m_Held < 20)
+            else if (m_Held < 20)
                 number = 502249; // The keg is not very full.
-            else if (this.m_Held < 30)
+            else if (m_Held < 30)
                 number = 502250; // The keg is about one quarter full.
-            else if (this.m_Held < 40)
+            else if (m_Held < 40)
                 number = 502251; // The keg is about one third full.
-            else if (this.m_Held < 47)
+            else if (m_Held < 47)
                 number = 502252; // The keg is almost half full.
-            else if (this.m_Held < 54)
+            else if (m_Held < 54)
                 number = 502254; // The keg is approximately half full.
-            else if (this.m_Held < 70)
+            else if (m_Held < 70)
                 number = 502253; // The keg is more than half full.
-            else if (this.m_Held < 80)
+            else if (m_Held < 80)
                 number = 502255; // The keg is about three quarters full.
-            else if (this.m_Held < 96)
+            else if (m_Held < 96)
                 number = 502256; // The keg is very full.
-            else if (this.m_Held < 100)
+            else if (m_Held < 100)
                 number = 502257; // The liquid is almost to the top of the keg.
             else
                 number = 502258; // The keg is completely full.
 
-            this.LabelTo(from, number);
+            LabelTo(from, number);
         }
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (from.InRange(this.GetWorldLocation(), 2))
+            if (from.InRange(GetWorldLocation(), 2))
             {
-                if (this.m_Held > 0)
+                if (m_Held > 0)
                 {
                     Container pack = from.Backpack;
 
@@ -184,14 +184,14 @@ namespace Server.Items
                     {
                         from.SendLocalizedMessage(502242); // You pour some of the keg's contents into an empty bottle...
 
-                        BasePotion pot = this.FillBottle();
+                        BasePotion pot = FillBottle();
 
                         if (pack.TryDropItem(from, pot, false))
                         {
                             from.SendLocalizedMessage(502243); // ...and place it into your backpack.
                             from.PlaySound(0x240);
 
-                            if (--this.Held == 0)
+                            if (--Held == 0)
                                 from.SendLocalizedMessage(502245); // The keg is now empty.
                         }
                         else
@@ -221,9 +221,9 @@ namespace Server.Items
             if (item is BasePotion)
             {
                 BasePotion pot = (BasePotion)item;
-                int toHold = Math.Min(100 - this.m_Held, pot.Amount);
+                int toHold = Math.Min(100 - m_Held, pot.Amount);
 
-                if (pot.PotionEffect == PotionEffect.Darkglow || pot.PotionEffect == PotionEffect.Invisibility || pot.PotionEffect == PotionEffect.Parasitic)
+                if (pot.PotionEffect == PotionEffect.Darkglow || pot.PotionEffect == PotionEffect.Parasitic)
                 {
                     from.SendLocalizedMessage(502232); // The keg is not designed to hold that type of object.
                     return false;
@@ -233,12 +233,12 @@ namespace Server.Items
                     from.SendLocalizedMessage(502233); // The keg will not hold any more!
                     return false;
                 }
-                else if (this.m_Held == 0)
+                else if (m_Held == 0)
                 {
-                    if (this.GiveBottle(from, toHold))
+                    if (GiveBottle(from, toHold))
                     {
-                        this.m_Type = pot.PotionEffect;
-                        this.Held = toHold;
+                        m_Type = pot.PotionEffect;
+                        Held = toHold;
 
                         from.PlaySound(0x240);
 
@@ -257,16 +257,16 @@ namespace Server.Items
                         return false;
                     }
                 }
-                else if (pot.PotionEffect != this.m_Type)
+                else if (pot.PotionEffect != m_Type)
                 {
                     from.SendLocalizedMessage(502236); // You decide that it would be a bad idea to mix different types of potions.
                     return false;
                 }
                 else
                 {
-                    if (this.GiveBottle(from, toHold))
+                    if (GiveBottle(from, toHold))
                     {
-                        this.Held += toHold;
+                        Held += toHold;
 
                         from.PlaySound(0x240);
 
@@ -310,7 +310,7 @@ namespace Server.Items
 
         public BasePotion FillBottle()
         {
-            switch ( this.m_Type )
+            switch ( m_Type )
             {
                 default:
                 case PotionEffect.Nightsight:
@@ -370,6 +370,9 @@ namespace Server.Items
                     return new ConfusionBlastPotion();
                 case PotionEffect.ConfusionBlastGreater:
                     return new GreaterConfusionBlastPotion();
+
+                case PotionEffect.Invisibility:
+                    return new InvisibilityPotion();
             }
         }
     }

--- a/Scripts/Mobiles/NPCs/Chyloth.cs
+++ b/Scripts/Mobiles/NPCs/Chyloth.cs
@@ -20,8 +20,10 @@ namespace Server.Engines.Quests.Doom
             1, 0,
             1, 1
         };
+
         private Mobile m_AngryAt;
         private BellOfTheDead m_Bell;
+
         [Constructable]
         public Chyloth()
             : base("the Ferryman")
@@ -37,22 +39,22 @@ namespace Server.Engines.Quests.Doom
         {
             get
             {
-                return this.m_Bell;
+                return m_Bell;
             }
             set
             {
-                this.m_Bell = value;
+                m_Bell = value;
             }
         }
         public Mobile AngryAt
         {
             get
             {
-                return this.m_AngryAt;
+                return m_AngryAt;
             }
             set
             {
-                this.m_AngryAt = value;
+                m_AngryAt = value;
             }
         }
         public static void TeleportToFerry(Mobile from)
@@ -70,23 +72,23 @@ namespace Server.Engines.Quests.Doom
 
         public override void InitBody()
         {
-            this.InitStats(100, 100, 25);
+            InitStats(100, 100, 25);
 
-            this.Hue = 0x8455;
-            this.Body = 0x190;
+            Hue = 0x8455;
+            Body = 0x190;
 
-            this.Name = "Chyloth";
+            Name = "Chyloth";
         }
 
         public override void InitOutfit()
         {
-            this.EquipItem(new ChylothShroud());
-            this.EquipItem(new ChylothStaff());
+            EquipItem(new ChylothShroud());
+            EquipItem(new ChylothStaff());
         }
 
         public virtual void BeginGiveWarning()
         {
-            if (this.Deleted || this.m_AngryAt == null)
+            if (Deleted || m_AngryAt == null)
                 return;
 
             Timer.DelayCall(TimeSpan.FromSeconds(4.0), new TimerCallback(EndGiveWarning));
@@ -94,18 +96,18 @@ namespace Server.Engines.Quests.Doom
 
         public virtual void EndGiveWarning()
         {
-            if (this.Deleted || this.m_AngryAt == null)
+            if (Deleted || m_AngryAt == null)
                 return;
 
-            this.PublicOverheadMessage(MessageType.Regular, 0x3B2, 1050013, this.m_AngryAt.Name); // You have summoned me in vain ~1_NAME~!  Only the dead may cross!
-            this.PublicOverheadMessage(MessageType.Regular, 0x3B2, 1050014); // Why have you disturbed me, mortal?!?
+            PublicOverheadMessage(MessageType.Regular, 0x3B2, 1050013, m_AngryAt.Name); // You have summoned me in vain ~1_NAME~!  Only the dead may cross!
+            PublicOverheadMessage(MessageType.Regular, 0x3B2, 1050014); // Why have you disturbed me, mortal?!?
 
-            this.BeginSummonDragon();
+            BeginSummonDragon();
         }
 
         public virtual void BeginSummonDragon()
         {
-            if (this.Deleted || this.m_AngryAt == null)
+            if (Deleted || m_AngryAt == null)
                 return;
 
             Timer.DelayCall(TimeSpan.FromSeconds(30.0), new TimerCallback(EndSummonDragon));
@@ -118,33 +120,33 @@ namespace Server.Engines.Quests.Doom
 
         public virtual void EndRemove()
         {
-            if (this.Deleted)
+            if (Deleted)
                 return;
 
-            Point3D loc = this.Location;
-            Map map = this.Map;
+            Point3D loc = Location;
+            Map map = Map;
 
             Effects.SendLocationParticles(EffectItem.Create(loc, map, EffectItem.DefaultDuration), 0x3728, 10, 10, 0, 0, 2023, 0);
             Effects.PlaySound(loc, map, 0x1FE);
 
-            this.Delete();
+            Delete();
         }
 
         public virtual void EndSummonDragon()
         {
-            if (this.Deleted || this.m_AngryAt == null)
+            if (Deleted || m_AngryAt == null)
                 return;
 
-            Map map = this.m_AngryAt.Map;
+            Map map = m_AngryAt.Map;
 
             if (map == null)
                 return;
 
-            if (!this.m_AngryAt.Region.IsPartOf("Doom"))
+            if (!m_AngryAt.Region.IsPartOf("Doom"))
                 return;
 
-            this.PublicOverheadMessage(MessageType.Regular, 0x3B2, 1050015); // Feel the wrath of my legions!!!
-            this.PublicOverheadMessage(MessageType.Regular, 0x3B2, false, "MUHAHAHAHA HAHAH HAHA"); // A wee bit crazy, aren't we?
+            PublicOverheadMessage(MessageType.Regular, 0x3B2, 1050015); // Feel the wrath of my legions!!!
+            PublicOverheadMessage(MessageType.Regular, 0x3B2, false, "MUHAHAHAHA HAHAH HAHA"); // A wee bit crazy, aren't we?
 
             SkeletalDragon dragon = new SkeletalDragon();
 
@@ -154,12 +156,12 @@ namespace Server.Engines.Quests.Doom
 
             for (int i = 0; i < m_Offsets.Length; i += 2)
             {
-                int x = this.m_AngryAt.X + m_Offsets[(offset + i) % m_Offsets.Length];
-                int y = this.m_AngryAt.Y + m_Offsets[(offset + i + 1) % m_Offsets.Length];
+                int x = m_AngryAt.X + m_Offsets[(offset + i) % m_Offsets.Length];
+                int y = m_AngryAt.Y + m_Offsets[(offset + i + 1) % m_Offsets.Length];
 
-                if (map.CanSpawnMobile(x, y, this.m_AngryAt.Z))
+                if (map.CanSpawnMobile(x, y, m_AngryAt.Z))
                 {
-                    dragon.MoveToWorld(new Point3D(x, y, this.m_AngryAt.Z), map);
+                    dragon.MoveToWorld(new Point3D(x, y, m_AngryAt.Z), map);
                     foundLoc = true;
                     break;
                 }
@@ -177,12 +179,12 @@ namespace Server.Engines.Quests.Doom
             }
 
             if (!foundLoc)
-                dragon.MoveToWorld(this.m_AngryAt.Location, map);
+                dragon.MoveToWorld(m_AngryAt.Location, map);
 
-            dragon.Combatant = this.m_AngryAt;
+            dragon.Combatant = m_AngryAt;
 
-            if (this.m_Bell != null)
-                this.m_Bell.Dragon = dragon;
+            if (m_Bell != null)
+                m_Bell.Dragon = dragon;
         }
 
         public override bool OnDragDrop(Mobile from, Item dropped)
@@ -191,8 +193,8 @@ namespace Server.Engines.Quests.Doom
             {
                 dropped.Delete();
 
-                this.PublicOverheadMessage(MessageType.Regular, 0x3B2, 1050046, from.Name); // Very well, ~1_NAME~, I accept your token. You may cross.
-                this.BeginRemove(TimeSpan.FromSeconds(4.0));
+                PublicOverheadMessage(MessageType.Regular, 0x3B2, 1050046, from.Name); // Very well, ~1_NAME~, I accept your token. You may cross.
+                BeginRemove(TimeSpan.FromSeconds(4.0));
 
                 Party p = PartySystem.Party.Get(from);
 
@@ -205,8 +207,8 @@ namespace Server.Engines.Quests.Doom
 
                         if (member != from && member.Map == Map.Malas && member.Region.IsPartOf("Doom"))
                         {
-                            if (this.m_AngryAt == member)
-                                this.m_AngryAt = null;
+                            if (m_AngryAt == member)
+                                m_AngryAt = null;
 
                             member.CloseGump(typeof(ChylothPartyGump));
                             member.SendGump(new ChylothPartyGump(from, member));
@@ -214,8 +216,8 @@ namespace Server.Engines.Quests.Doom
                     }
                 }
 
-                if (this.m_AngryAt == from)
-                    this.m_AngryAt = null;
+                if (m_AngryAt == from)
+                    m_AngryAt = null;
 
                 TeleportToFerry(from);
 
@@ -256,72 +258,72 @@ namespace Server.Engines.Quests.Doom
         public ChylothPartyGump(Mobile leader, Mobile member)
             : base(150, 50)
         {
-            this.m_Leader = leader;
-            this.m_Member = member;
+            m_Leader = leader;
+            m_Member = member;
 
-            this.Closable = false;
+            Closable = false;
 
-            this.AddPage(0);
+            AddPage(0);
 
-            this.AddImage(0, 0, 3600);
+            AddImage(0, 0, 3600);
 
-            this.AddImageTiled(0, 14, 15, 200, 3603);
-            this.AddImageTiled(380, 14, 14, 200, 3605);
-            this.AddImage(0, 201, 3606);
-            this.AddImageTiled(15, 201, 370, 16, 3607);
-            this.AddImageTiled(15, 0, 370, 16, 3601);
-            this.AddImage(380, 0, 3602);
-            this.AddImage(380, 201, 3608);
-            this.AddImageTiled(15, 15, 365, 190, 2624);
+            AddImageTiled(0, 14, 15, 200, 3603);
+            AddImageTiled(380, 14, 14, 200, 3605);
+            AddImage(0, 201, 3606);
+            AddImageTiled(15, 201, 370, 16, 3607);
+            AddImageTiled(15, 0, 370, 16, 3601);
+            AddImage(380, 0, 3602);
+            AddImage(380, 201, 3608);
+            AddImageTiled(15, 15, 365, 190, 2624);
 
-            this.AddRadio(30, 140, 9727, 9730, true, 1);
-            this.AddHtmlLocalized(65, 145, 300, 25, 1050050, 0x7FFF, false, false); // Yes, let's go!
+            AddRadio(30, 140, 9727, 9730, true, 1);
+            AddHtmlLocalized(65, 145, 300, 25, 1050050, 0x7FFF, false, false); // Yes, let's go!
 
-            this.AddRadio(30, 175, 9727, 9730, false, 0);
-            this.AddHtmlLocalized(65, 178, 300, 25, 1050049, 0x7FFF, false, false); // No thanks, I'd rather stay here.
+            AddRadio(30, 175, 9727, 9730, false, 0);
+            AddHtmlLocalized(65, 178, 300, 25, 1050049, 0x7FFF, false, false); // No thanks, I'd rather stay here.
 
-            this.AddHtmlLocalized(30, 20, 360, 35, 1050047, 0x7FFF, false, false); // Another player has paid Chyloth for your passage across lake Mortis:
+            AddHtmlLocalized(30, 20, 360, 35, 1050047, 0x7FFF, false, false); // Another player has paid Chyloth for your passage across lake Mortis:
 
-            this.AddHtmlLocalized(30, 105, 345, 40, 1050048, 0x5B2D, false, false); // Do you wish to accept their invitation at this time?
+            AddHtmlLocalized(30, 105, 345, 40, 1050048, 0x5B2D, false, false); // Do you wish to accept their invitation at this time?
 
-            this.AddImage(65, 72, 5605);
+            AddImage(65, 72, 5605);
 
-            this.AddImageTiled(80, 90, 200, 1, 9107);
-            this.AddImageTiled(95, 92, 200, 1, 9157);
+            AddImageTiled(80, 90, 200, 1, 9107);
+            AddImageTiled(95, 92, 200, 1, 9157);
 
-            this.AddLabel(90, 70, 1645, leader.Name);
+            AddLabel(90, 70, 1645, leader.Name);
 
-            this.AddButton(290, 175, 247, 248, 2, GumpButtonType.Reply, 0);
+            AddButton(290, 175, 247, 248, 2, GumpButtonType.Reply, 0);
 
-            this.AddImageTiled(15, 14, 365, 1, 9107);
-            this.AddImageTiled(380, 14, 1, 190, 9105);
-            this.AddImageTiled(15, 205, 365, 1, 9107);
-            this.AddImageTiled(15, 14, 1, 190, 9105);
-            this.AddImageTiled(0, 0, 395, 1, 9157);
-            this.AddImageTiled(394, 0, 1, 217, 9155);
-            this.AddImageTiled(0, 216, 395, 1, 9157);
-            this.AddImageTiled(0, 0, 1, 217, 9155);
+            AddImageTiled(15, 14, 365, 1, 9107);
+            AddImageTiled(380, 14, 1, 190, 9105);
+            AddImageTiled(15, 205, 365, 1, 9107);
+            AddImageTiled(15, 14, 1, 190, 9105);
+            AddImageTiled(0, 0, 395, 1, 9157);
+            AddImageTiled(394, 0, 1, 217, 9155);
+            AddImageTiled(0, 216, 395, 1, 9157);
+            AddImageTiled(0, 0, 1, 217, 9155);
         }
 
         public override void OnResponse(NetState sender, RelayInfo info)
         {
             if (info.ButtonID == 2 && info.IsSwitched(1))
             {
-                if (this.m_Member.Region.IsPartOf("Doom"))
+                if (m_Member.Region.IsPartOf("Doom"))
                 {
-                    this.m_Leader.SendLocalizedMessage(1050054, this.m_Member.Name); // ~1_NAME~ has accepted your invitation to cross lake Mortis.
+                    m_Leader.SendLocalizedMessage(1050054, m_Member.Name); // ~1_NAME~ has accepted your invitation to cross lake Mortis.
 
-                    Chyloth.TeleportToFerry(this.m_Member);
+                    Chyloth.TeleportToFerry(m_Member);
                 }
                 else
                 {
-                    this.m_Member.SendLocalizedMessage(1050051); // The invitation has been revoked.
+                    m_Member.SendLocalizedMessage(1050051); // The invitation has been revoked.
                 }
             }
             else
             {
-                this.m_Member.SendLocalizedMessage(1050052); // You have declined their invitation.
-                this.m_Leader.SendLocalizedMessage(1050053, this.m_Member.Name); // ~1_NAME~ has declined your invitation to cross lake Mortis.
+                m_Member.SendLocalizedMessage(1050052); // You have declined their invitation.
+                m_Leader.SendLocalizedMessage(1050053, m_Member.Name); // ~1_NAME~ has declined your invitation to cross lake Mortis.
             }
         }
     }

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -5230,6 +5230,22 @@ namespace Server.Mobiles
 
                 Skills[name].Cap = Skills[name].Base;
             }
+
+            if (name == SkillName.Poisoning && Skills[name].Base > 0 && 
+                !Controlled &&
+                !AbilityProfile.HasAbility(MagicalAbility.Poisoning))
+            {
+                SetMagicalAbility(MagicalAbility.Poisoning);
+            }
+
+            if (!Controlled && name == SkillName.Magery && AbilityProfile != null && 
+                !AbilityProfile.HasAbility(MagicalAbility.Magery) && 
+                Skills[SkillName.Magery].Base > 0 && 
+                (AI == AIType.AI_Mage || AI == AIType.AI_Necro || AI == AIType.AI_NecroMage || AI == AIType.AI_Mystic || AI == AIType.AI_Spellweaving))
+
+            {
+                SetMagicalAbility(MagicalAbility.Magery);
+            }
         }
 
         public void SetSkill(SkillName name, double min, double max)
@@ -5253,7 +5269,7 @@ namespace Server.Mobiles
 
             if (name == SkillName.Poisoning && Skills[name].Base > 0 && 
                 !Controlled &&
-                !PetTrainingHelper.ValidateTrainingPoint(this, MagicalAbility.Poisoning))
+                !AbilityProfile.HasAbility(MagicalAbility.Poisoning))
             {
                 SetMagicalAbility(MagicalAbility.Poisoning);
             }

--- a/Scripts/Multis/BaseHouse.cs
+++ b/Scripts/Multis/BaseHouse.cs
@@ -919,7 +919,17 @@ namespace Server.Multis
 
                             if (item is IAddon)
                             {
-                                Item deed = ((IAddon)item).Deed;
+                                Item deed;
+
+                                if (item is FishTrophy)
+                                {
+                                    deed = ((FishTrophy)item).TrophyDeed;
+                                }
+                                else
+                                {
+                                    deed = ((IAddon)item).Deed;
+                                }
+
                                 bool retainDeedHue = false;	//if the items aren't hued but the deed itself is
                                 int hue = 0;
 

--- a/Scripts/Multis/Boats/BaseBoat.cs
+++ b/Scripts/Multis/Boats/BaseBoat.cs
@@ -2184,12 +2184,7 @@ namespace Server.Multis
 
         public int PlayerCount()
         {
-            int count = 0;
-
-            foreach (var m in GetMobilesOnBoard())
-                count++;
-
-            return count;
+            return GetMobilesOnBoard().Where(m => m is PlayerMobile).Count();
         }
 
         public void TillerManSay(object message)

--- a/Scripts/Regions/HouseRegion.cs
+++ b/Scripts/Regions/HouseRegion.cs
@@ -107,11 +107,19 @@ namespace Server.Regions
             }
 
             return true;
-        }
+        }*/
 
         public override void OnEnter(Mobile m)
         {
-            if (m.NetState == null)
+            if (m.AccessLevel == AccessLevel.Player && m_House != null && m_House.IsFriend(m))
+            {
+                if (Core.AOS && m_House is HouseFoundation)
+                {
+                    m_House.RefreshDecay();
+                }
+            }
+
+            /*if (m.NetState == null)
                 return;
 
             foreach (var item in GetEnumeratedItems())
@@ -120,8 +128,8 @@ namespace Server.Regions
                 {
                     item.SendInfoTo(m.NetState);
                 }
-            }
-        }*/
+            }*/
+        }
 
         public override bool SendInaccessibleMessage(Item item, Mobile from)
         {

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -713,6 +713,7 @@
     <Compile Include="Items\Consumables\IrresistiblyTastyTreat.cs" />
     <Compile Include="Items\Consumables\SkinTingeingTincture.cs" />
     <Compile Include="Items\Consumables\TastyTreat.cs" />
+    <Compile Include="Items\Containers\ShipsStrongbox.cs" />
     <Compile Include="Items\Decorative\AllegiancePouch.cs" />
     <Compile Include="Items\Decorative\Bridle.cs" />
     <Compile Include="Items\Decorative\DecorativeCarpet.cs" />

--- a/Scripts/Services/BasketWeaving/MiscSAResources.cs
+++ b/Scripts/Services/BasketWeaving/MiscSAResources.cs
@@ -66,6 +66,19 @@ namespace Server.Items
             }
         }
 
+        public override bool WillStack(Mobile from, Item dropped)
+        {
+            return dropped is IPlantHue && ((IPlantHue)dropped).PlantHue == m_PlantHue && base.WillStack(from, dropped);
+        }
+
+        public override void OnAfterDuped(Item newItem)
+        {
+            if (newItem is IPlantHue)
+                ((IPlantHue)newItem).PlantHue = this.PlantHue;
+
+            base.OnAfterDuped(newItem);
+        }
+
         public DryReeds(Serial serial)
             : base(serial)
         {
@@ -149,6 +162,19 @@ namespace Server.Items
                 cliloc = info.IsBright() ? 1112288 : 1112289;
                 list.Add(cliloc, String.Format("#{0}", info.Name));
             }
+        }
+
+        public override bool WillStack(Mobile from, Item dropped)
+        {
+            return dropped is IPlantHue && ((IPlantHue)dropped).PlantHue == m_PlantHue && base.WillStack(from, dropped);
+        }
+
+        public override void OnAfterDuped(Item newItem)
+        {
+            if (newItem is IPlantHue)
+                ((IPlantHue)newItem).PlantHue = this.PlantHue;
+
+            base.OnAfterDuped(newItem);
         }
 
         public SoftenedReeds(Serial serial)

--- a/Scripts/Services/CleanUpBritannia/Gumps.cs
+++ b/Scripts/Services/CleanUpBritannia/Gumps.cs
@@ -39,7 +39,7 @@ namespace Server.Engines.CleanUpBritannia
         {
             if (item is ScrollofAlacrity)
             {
-                ((ScrollofAlacrity)item).Skill = PowerScroll.Skills[Utility.Random(PowerScroll.Skills.Count)];
+                ((ScrollofAlacrity)item).Skill = (SkillName)Utility.Random(SkillInfo.Table.Length);
             }
 
             item.InvalidateProperties();

--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -1711,6 +1711,9 @@ namespace Server.Engines.Craft
                         ((MapItem)item).Facet = from.Map;
                     #endregion
 
+                    CraftContext context = craftSystem.GetContext(from);
+                    int originalHue = item.Hue;
+
 					if (item is ICraftable)
 					{
 						endquality = ((ICraftable)item).OnCraft(quality, makersMark, from, craftSystem, typeRes, tool, this, resHue);
@@ -1727,6 +1730,12 @@ namespace Server.Engines.Craft
                     if (item.Hue == 0 && RetainsColorFromCloth(item) && m_ClothHue != 0)
                     {
                         item.Hue = m_ClothHue;
+                    }
+
+                    // This takes into account for natural hues, ie plant hues
+                    if (item.Hue != originalHue && context.DoNotColor)
+                    {
+                        item.Hue = originalHue;
                     }
 
 					if (maxAmount > 0)
@@ -1753,8 +1762,6 @@ namespace Server.Engines.Craft
                     {
                         ((IPigmentHue)item).PigmentHue = m_PlantPigmentHue;
                     }
-
-                    CraftContext context = craftSystem.GetContext(from);
 
                     if (context.QuestOption == CraftQuestOption.QuestItem)
                     {

--- a/Scripts/Services/Craft/DefCarpentry.cs
+++ b/Scripts/Services/Craft/DefCarpentry.cs
@@ -410,12 +410,12 @@ namespace Server.Engines.Craft
             #region Mondain's Legacy
             if (Core.ML)
             {
-                index = AddCraft(typeof(ArcaneBookshelfSouthDeed), 1044292, 1072871, 94.7, 119.7, typeof(Board), 1044041, 80, 1044351);
+                index = AddCraft(typeof(ArcaneBookShelfDeedSouth), 1044292, 1072871, 94.7, 119.7, typeof(Board), 1044041, 80, 1044351);
                 AddRecipe(index, (int)CarpRecipes.ArcaneBookshelfSouth);
                 ForceNonExceptional(index);
                 SetNeededExpansion(index, Expansion.ML);
 
-                index = AddCraft(typeof(ArcaneBookshelfEastDeed), 1044292, 1073371, 94.7, 119.7, typeof(Board), 1044041, 80, 1044351);
+                index = AddCraft(typeof(ArcaneBookShelfDeedEast), 1044292, 1073371, 94.7, 119.7, typeof(Board), 1044041, 80, 1044351);
                 AddRecipe(index, (int)CarpRecipes.ArcaneBookshelfEast);
                 ForceNonExceptional(index);
                 SetNeededExpansion(index, Expansion.ML);
@@ -438,12 +438,12 @@ namespace Server.Engines.Craft
                 ForceNonExceptional(index);
                 SetNeededExpansion(index, Expansion.ML);
 
-                index = AddCraft(typeof(ElvenDresserSouthDeed), 1044292, 1072864, 75.0, 100.0, typeof(Board), 1044041, 45, 1044351);
+                index = AddCraft(typeof(ElvenDresserDeedSouth), 1044292, 1072864, 75.0, 100.0, typeof(Board), 1044041, 45, 1044351);
                 AddRecipe(index, (int)CarpRecipes.ElvenDresserSouth);
                 ForceNonExceptional(index);
                 SetNeededExpansion(index, Expansion.ML);
 
-                index = AddCraft(typeof(ElvenDresserEastDeed), 1044292, 1073388, 75.0, 100.0, typeof(Board), 1044041, 45, 1044351);
+                index = AddCraft(typeof(ElvenDresserDeedEast), 1044292, 1073388, 75.0, 100.0, typeof(Board), 1044041, 45, 1044351);
                 AddRecipe(index, (int)CarpRecipes.ElvenDresserEast);
                 ForceNonExceptional(index);
                 SetNeededExpansion(index, Expansion.ML);

--- a/Scripts/Services/Expansions/High Seas/Items/Fish/Trophies.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Fish/Trophies.cs
@@ -2,6 +2,7 @@
 using System;
 using Server.Mobiles;
 using Server.Multis;
+using System.Linq;
 
 namespace Server.Items
 {
@@ -300,6 +301,21 @@ namespace Server.Items
             }
         }
 
+        public Item TrophyDeed
+        {
+            get
+            {
+                var info = TaxidermyKit.TrophyInfos.FirstOrDefault(i => i.CreatureType == m_TypeName);
+
+                if (info != null)
+                {
+                    return new FishTrophyDeed(m_FishWeight, m_Fisher, m_DateCaught, info.DeedNumber, info.AddonNumber, info.NorthID);
+                }
+
+                return null;
+            }
+        }
+
         public override void OnChop(Mobile from)
         {
             if (Components.Count > 0)
@@ -313,21 +329,24 @@ namespace Server.Items
             if (m_TypeName == null)
                 return;
 
-            foreach (TaxidermyKit.TrophyInfo info in TaxidermyKit.TrophyInfos)
-            {
-                if (info.CreatureType == m_TypeName)
-                {
-                    BaseHouse house = BaseHouse.FindHouseAt(c);
+            var info = TaxidermyKit.TrophyInfos.FirstOrDefault(i => i.CreatureType == m_TypeName);
 
-                    if (house != null && (house.IsCoOwner(from) || (house.Addons.ContainsKey(this) && house.Addons[this] == from)))
-                    {
-                        from.AddToBackpack(new FishTrophyDeed(m_FishWeight, m_Fisher, m_DateCaught, info.DeedNumber, info.AddonNumber, info.NorthID));
-                        Delete();
-                    }
-                    else
-                    {
-                        from.SendLocalizedMessage(502092); // You must be in your house to do this.
-                    }
+            if (info != null)
+            {
+                BaseHouse house = BaseHouse.FindHouseAt(c);
+
+                if (house != null && (house.IsCoOwner(from) || (house.Addons.ContainsKey(this) && house.Addons[this] == from)))
+                {
+                    from.AddToBackpack(new FishTrophyDeed(m_FishWeight, m_Fisher, m_DateCaught, info.DeedNumber, info.AddonNumber, info.NorthID));
+
+                    if(house.Addons.ContainsKey(this))
+                        house.Addons.Remove(this);
+
+                    Delete();
+                }
+                else
+                {
+                    from.SendLocalizedMessage(502092); // You must be in your house to do this.
                 }
             }
         }

--- a/Scripts/Services/ExploringTheDeep/Mobiles/DiabolicalSeaweed.cs
+++ b/Scripts/Services/ExploringTheDeep/Mobiles/DiabolicalSeaweed.cs
@@ -13,39 +13,39 @@ namespace Server.Mobiles
         public DiabolicalSeaweed()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.0, 0.0)
         {
-            this.Name = "Diabolical Seaweed";
-            this.Body = 129;
-            this.Hue = 1914;
+            Name = "Diabolical Seaweed";
+            Body = 129;
+            Hue = 1914;
 
-            this.SetStr(452, 485);
-            this.SetDex(401, 420);
-            this.SetInt(126, 140);
+            SetStr(452, 485);
+            SetDex(401, 420);
+            SetInt(126, 140);
 
-            this.SetHits(501, 532);
+            SetHits(501, 532);
 
-            this.SetDamage(10, 23);
+            SetDamage(10, 23);
 
-            this.SetDamageType(ResistanceType.Physical, 60);
-            this.SetDamageType(ResistanceType.Poison, 40);
+            SetDamageType(ResistanceType.Physical, 60);
+            SetDamageType(ResistanceType.Poison, 40);
 
-            this.SetResistance(ResistanceType.Physical, 35, 40);
-            this.SetResistance(ResistanceType.Fire, 20, 30);
-            this.SetResistance(ResistanceType.Cold, 10, 20);
-            this.SetResistance(ResistanceType.Poison, 100);
-            this.SetResistance(ResistanceType.Energy, 10, 20);
+            SetResistance(ResistanceType.Physical, 35, 40);
+            SetResistance(ResistanceType.Fire, 20, 30);
+            SetResistance(ResistanceType.Cold, 10, 20);
+            SetResistance(ResistanceType.Poison, 100);
+            SetResistance(ResistanceType.Energy, 10, 20);
 
-            this.SetSkill(SkillName.MagicResist, 50.1, 54.7);
-            this.SetSkill(SkillName.Tactics, 100.3, 114.8);
-            this.SetSkill(SkillName.Wrestling, 45.1, 59.5);
+            SetSkill(SkillName.MagicResist, 50.1, 54.7);
+            SetSkill(SkillName.Tactics, 100.3, 114.8);
+            SetSkill(SkillName.Wrestling, 45.1, 59.5);
 
-            this.Fame = 3000;
-            this.Karma = -3000;
-            this.CantWalk = true;
+            Fame = 3000;
+            Karma = -3000;
+            CantWalk = true;
 
-            this.VirtualArmor = 60;
+            VirtualArmor = 60;
 
-            this.m_Timer = new PullTimer(this);
-            this.m_Timer.Start();
+            m_Timer = new PullTimer(this);
+            m_Timer.Start();
 
             switch (Utility.Random(8))
             {
@@ -69,10 +69,10 @@ namespace Server.Mobiles
 
         public override void OnAfterDelete()
         {
-            if (this.m_Timer != null)
-                this.m_Timer.Stop();
+            if (m_Timer != null)
+                m_Timer.Stop();
 
-            this.m_Timer = null;
+            m_Timer = null;
 
             base.OnAfterDelete();
         }
@@ -85,22 +85,22 @@ namespace Server.Mobiles
             public PullTimer(DiabolicalSeaweed owner)
                 : base(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1))
             {
-                this.m_Owner = owner;
-                this.Priority = TimerPriority.TwoFiftyMS;
+                m_Owner = owner;
+                Priority = TimerPriority.TwoFiftyMS;
             }
 
             protected override void OnTick()
             {
-                if (this.m_Owner.Deleted)
+                if (m_Owner.Deleted)
                 {
-                    this.Stop();
+                    Stop();
                     return;
                 }
 
                 IPooledEnumerable eable = m_Owner.GetMobilesInRange(9);
                 foreach (Mobile m in eable)
                 {
-                    if (m == null || m is DiabolicalSeaweed || !this.m_Owner.CanBeHarmful(m) || m.AccessLevel == AccessLevel.Player)
+                    if (m == null || m is DiabolicalSeaweed || !m_Owner.CanBeHarmful(m) || m.AccessLevel == AccessLevel.Player)
                         continue;
 
                     int offsetX = Math.Abs(m.Location.X - m_Owner.Location.X);
@@ -126,16 +126,16 @@ namespace Server.Mobiles
 
                 foreach (Mobile m in m_ToDrain)
                 {
-                    this.m_Owner.DoHarmful(m);
+                    m_Owner.DoHarmful(m);
 
                     //m.FixedParticles( 0x376A, 10, 15, 5052, EffectLayer.Waist );
                     //m.PlaySound(0x1F1);
                     int drain = Utility.RandomMinMax(1, 10);
-                    int ownerlocX = this.m_Owner.Location.X + Utility.RandomMinMax(-1, 1);
-                    int ownerlocY = this.m_Owner.Location.Y + Utility.RandomMinMax(-1, 1);
-                    int ownerlocZ = this.m_Owner.Location.Z;
-                    m.MoveToWorld(new Point3D(ownerlocX, ownerlocY, ownerlocZ), this.m_Owner.Map);
-                    m.Damage(drain, this.m_Owner);
+                    int ownerlocX = m_Owner.Location.X + Utility.RandomMinMax(-1, 1);
+                    int ownerlocY = m_Owner.Location.Y + Utility.RandomMinMax(-1, 1);
+                    int ownerlocZ = m_Owner.Location.Z;
+                    m.MoveToWorld(new Point3D(ownerlocX, ownerlocY, ownerlocZ), m_Owner.Map);
+                    m.Damage(drain, m_Owner);
                 }
 
                 m_ToDrain.Clear();
@@ -158,7 +158,7 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Meager);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -175,8 +175,8 @@ namespace Server.Mobiles
 
             int version = reader.ReadInt();
 
-            this.m_Timer = new PullTimer(this);
-            this.m_Timer.Start();
+            m_Timer = new PullTimer(this);
+            m_Timer.Start();
 
         }
     }

--- a/Scripts/Skills/DetectHidden.cs
+++ b/Scripts/Skills/DetectHidden.cs
@@ -174,13 +174,13 @@ namespace Server.SkillHandlers
 
         private static bool CanDetect(Mobile src, Mobile target)
         {
-            if (src.Blessed || (src is BaseCreature && ((BaseCreature)src).IsInvulnerable))
+            if (src.Map == null || src.Blessed || (src is BaseCreature && ((BaseCreature)src).IsInvulnerable))
                 return false;
 
             if (target.Blessed || (target is BaseCreature && ((BaseCreature)target).IsInvulnerable))
                 return false;
 
-            return src.CanBeHarmful(target, false) && SpellHelper.ValidIndirectTarget(src, target);
+            return src.CanBeHarmful(target, false) && (src.Map.Rules != MapRules.FeluccaRules || SpellHelper.ValidIndirectTarget(src, target));
         }
     }
 }

--- a/Scripts/Skills/Fishing.cs
+++ b/Scripts/Skills/Fishing.cs
@@ -466,14 +466,23 @@ namespace Server.Engines.Harvest
                         }
 
                         LockableContainer chest;
-						
-                        if (Utility.RandomBool())
-                            chest = new MetalGoldenChest();
+
+                        if (0.01 > Utility.RandomDouble())
+                        {
+                            chest = new ShipsStrongbox(sos.Level);
+                        }
                         else
-                            chest = new WoodenChest();
+                        {
+                            if (Utility.RandomBool())
+                                chest = new MetalGoldenChest();
+                            else
+                                chest = new WoodenChest();
+                        }
 
                         if (sos.IsAncient)
+                        {
                             chest.Hue = 0x481;
+                        }
 
                         TreasureMapChest.Fill(chest, from is PlayerMobile ? ((PlayerMobile)from).RealLuck : from.Luck, Math.Max(1, Math.Min(4, sos.Level)), true, from.Map);
                         sos.OnSOSComplete(chest);

--- a/Scripts/Spells/Bushido/MomentumStrike.cs
+++ b/Scripts/Spells/Bushido/MomentumStrike.cs
@@ -45,13 +45,11 @@ namespace Server.Spells.Bushido
 
             foreach (Mobile m in eable)
             {
-                if (m == defender || m == attacker ||
-                    !Server.Spells.SpellHelper.ValidIndirectTarget(attacker, defender) ||
-                    !m.CanBeHarmful(attacker, false) || 
-                    !attacker.InLOS(m))
-                    continue;
-
-                targets.Add(m);
+                if (m != defender && m != attacker && m.CanBeHarmful(attacker, false) && attacker.InLOS(m) && 
+                    Server.Spells.SpellHelper.ValidIndirectTarget(attacker, m))
+                {
+                    targets.Add(m);
+                }
             }
             eable.Free();
 

--- a/Scripts/Spells/Skill Masteries/CommandUndead.cs
+++ b/Scripts/Spells/Skill Masteries/CommandUndead.cs
@@ -92,6 +92,11 @@ namespace Server.Spells.SkillMasteries
                                 }
                             }
 
+                            if (bc is SkeletalDragon)
+                            {
+                                Server.Engines.Quests.Doom.BellOfTheDead.TryRemoveDragon((SkeletalDragon)bc);
+                            }
+
                             Caster.PlaySound(0x5C4);
                             Caster.SendLocalizedMessage(1156013); // You command the undead to follow and protect you.
                         }


### PR DESCRIPTION
- Added Orc Pirates to Repond Slayer Group
- Refreshing houses now works for friend+ while opening doors, stepping on plot (customizable houses), and accessing the house sign
- Added Ship's Strong Box, 1/100 drop chance while fishing up SOS Chest
- Fish Trophies now re-deed to moving crate
- Poisoning ability now applies to dread spiders
- Arcane Bookshelf and Elven Dresser now crafts the correct container addon
- Peerless altar now removes pets via AllFollowers and no longer uses pet table. This will remove pets such as familiars that are casted/summomed after the encounter begins
- Detect Hidden should now work properly
- Momentum strike should now attack the proper targets. It basically uses the same rules as AOE spells
- Added Invisibility potions to potion kegs
- Fixed issue in BaseBoat where players weren't counted properly
- Added Function to BaseContainer where adding items will check for a stack (DropItemStack). Before, this was only achievable with TryDropItem, which requires a mobile to be passed in as an argument.
-Craft Option DoNotColor is now handled in CraftItem CompleteCraft for efficiency. DoNoColor checks taken out of OnCraft methods of individual scrips.
- Fixed, or at least added a different way to checking for Doom Guardian Room to reset.
- Doom Bell Skeletal Dragon not unlinks when tamed via command undead
- Added all skills to Scrolls of Alacrity