### PR TITLE
Possible fix for OSX failure

### DIFF
--- a/Server/ScriptCompiler.cs
+++ b/Server/ScriptCompiler.cs
@@ -227,8 +227,11 @@ namespace Server
 				}
 
 				if (Core.Unix)
+                {
 					parms.CompilerOptions = String.Format( "{0} /nowarn:169,219,414 /recurse:Scripts/*.cs", parms.CompilerOptions );
-				
+                    files = new string[0];
+                }
+                
 				CompilerResults results = provider.CompileAssemblyFromFile(parms, files);
 				
 				m_AdditionalReferences.Add(path);


### PR DESCRIPTION
This appears to fix #3443 I Tested with Mono 5.10.1.47 on OSX 10.12 this change solves the crash and allows the scripts to compile on OSX again.
Needs to be tested on Linux as i don't have an install setup at the moment an d so this is untested.