### PR TITLE
Update DefBowFletching.cs

### DIFF
--- a/Scripts/Services/Craft/DefBowFletching.cs
+++ b/Scripts/Services/Craft/DefBowFletching.cs
@@ -266,11 +266,11 @@ namespace Server.Engines.Craft
             // This will override the overridable material	TODO: Verify the required skill amount
             this.AddSubRes(typeof(Board), 1072643, 00.0, 1044041, 1072652);
             this.AddSubRes(typeof(OakBoard), 1072644, 65.0, 1044041, 1072652);
-            this.AddSubRes(typeof(AshBoard), 1072645, 80.0, 1044041, 1072652);
-            this.AddSubRes(typeof(YewBoard), 1072646, 95.0, 1044041, 1072652);
-            this.AddSubRes(typeof(HeartwoodBoard), 1072647, 100.0, 1044041, 1072652);
-            this.AddSubRes(typeof(BloodwoodBoard), 1072648, 100.0, 1044041, 1072652);
-            this.AddSubRes(typeof(FrostwoodBoard), 1072649, 100.0, 1044041, 1072652);
+            this.AddSubRes(typeof(AshBoard), 1072645, 75.0, 1044041, 1072652);
+            this.AddSubRes(typeof(YewBoard), 1072646, 85.0, 1044041, 1072652);
+            this.AddSubRes(typeof(HeartwoodBoard), 1072647, 95.0, 1044041, 1072652);
+            this.AddSubRes(typeof(BloodwoodBoard), 1072648, 95.0, 1044041, 1072652);
+            this.AddSubRes(typeof(FrostwoodBoard), 1072649, 95.0, 1044041, 1072652);
             #endregion
 
             this.MarkOption = true;


### PR DESCRIPTION
The base values needed to craft with the individual resources was wrong.

It seems whoever coded it used the values for success in Lumberjacking to get the wood:
https://uo.com/wiki/ultima-online-wiki/skills/lumberjacking/

Not the actually success rate needed to craft with it though, two different things.
http://www.uoguide.com/Bowcraft_%26_Fletching