### PR TITLE
Quest Serialization

### DIFF
--- a/Scripts/Services/MondainsLegacyQuests/Helpers/QuestReader.cs
+++ b/Scripts/Services/MondainsLegacyQuests/Helpers/QuestReader.cs
@@ -1,94 +1,210 @@
+#region Header
+// **********
+// ServUO - QuestReader.cs
+// **********
+#endregion
+
+#region References
 using System;
 using System.Collections.Generic;
+using System.IO;
+
 using Server.Mobiles;
+#endregion
 
 namespace Server.Engines.Quests
 {
-    public class QuestReader
-    { 
-        public static List<BaseQuest> Quests(GenericReader reader, PlayerMobile player)
-        {
-            List<BaseQuest> quests = new List<BaseQuest>();
-			
-            int count = reader.ReadInt();
-			
-            for (int i = 0; i < count; i ++)
-            {
-                BaseQuest quest = Construct(reader) as BaseQuest;
-				
-                if (quest == null)
-                    continue;
-					
-                quest.Owner = player;
-                quest.Deserialize(reader);
-				
-                quests.Add(quest);
-            }
-			
-            return quests;
-        }
+	public class QuestReader
+	{
+		public static int Version(GenericReader reader)
+		{
+			if (reader == null)
+			{
+				return -1;
+			}
 
-        public static Dictionary<QuestChain, BaseChain> Chains(GenericReader reader)
-        {
-            Dictionary<QuestChain, BaseChain> chains = new Dictionary<QuestChain, BaseChain>();
-			
-            int count = reader.ReadInt();
-			
-            for (int i = 0; i < count; i ++)
-                chains.Add((QuestChain)reader.ReadInt(), new BaseChain(Type(reader), Type(reader)));
-			
-            return chains;
-        }
+			if (reader.PeekInt() == 0x7FFFFFFF)
+			{
+				reader.ReadInt(); // Preamble 0x7FFFFFFF
 
-        public static object Object(GenericReader reader)
-        { 
-            if (reader == null)
-                return null;
-					
-            byte type = reader.ReadByte();
-			
-            switch ( type )
-            {
-                case 0x0:
-                    return null; // invalid
-                case 0x1:
-                    return reader.ReadInt();
-                case 0x2:
-                    return reader.ReadString();
-                case 0x3:
-                    return reader.ReadItem();
-                case 0x4:
-                    return reader.ReadMobile();
-            }
-			
-            return null;
-        }
+				return reader.ReadInt();
+			}
 
-        public static Type Type(GenericReader reader)
-        {
-            if (reader == null)
-                return null;
-				
-            string type = reader.ReadString();
+			return -1;
+		}
 
-            if (type != null)
-                return ScriptCompiler.FindTypeByFullName(type, false);
-            else
-                return null;
-        }
+		public static bool SubRead(GenericReader reader, Action<GenericReader> deserializer)
+		{
+			if (reader == null)
+			{
+				return false;
+			}
 
-        public static object Construct(GenericReader reader)
-        {
-            Type type = Type(reader);
-			
-            try
-            {
-                return Activator.CreateInstance(type);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-    }
+			using (var s = new MemoryStream())
+			{
+				var length = reader.ReadLong();
+
+				while (s.Length < length)
+				{
+					s.WriteByte(reader.ReadByte());
+				}
+
+				if (deserializer != null)
+				{
+					s.Position = 0;
+
+					var r = new BinaryFileReader(new BinaryReader(s));
+
+					try
+					{
+						deserializer(r);
+					}
+					catch (Exception e)
+					{
+						Console.WriteLine("Quest Load Failure: {0}", Utility.FormatDelegate(deserializer));
+						Console.WriteLine(e);
+
+						return false;
+					}
+					finally
+					{
+						r.Close();
+					}
+				}
+			}
+
+			return true;
+		}
+
+		public static List<BaseQuest> Quests(GenericReader reader, PlayerMobile player)
+		{
+			var quests = new List<BaseQuest>();
+
+			if (reader == null)
+			{
+				return quests;
+			}
+
+			var version = Version(reader);
+
+			var count = reader.ReadInt();
+
+			for (var i = 0; i < count; i++)
+			{
+				var quest = Construct(reader) as BaseQuest;
+
+				if (quest == null)
+				{
+					if (version >= 0)
+					{
+						SubRead(reader, null);
+					}
+
+					continue;
+				}
+
+				quest.Owner = player;
+
+				if (version < 0)
+				{
+					quest.Deserialize(reader);
+				}
+				else if (!SubRead(reader, quest.Deserialize))
+				{
+					continue;
+				}
+
+				quests.Add(quest);
+			}
+
+			return quests;
+		}
+
+		public static Dictionary<QuestChain, BaseChain> Chains(GenericReader reader)
+		{
+			var chains = new Dictionary<QuestChain, BaseChain>();
+
+			if (reader == null)
+			{
+				return chains;
+			}
+
+			Version(reader);
+
+			var count = reader.ReadInt();
+
+			for (var i = 0; i < count; i++)
+			{
+				var chain = reader.ReadInt();
+				var quest = Type(reader);
+				var quester = Type(reader);
+
+				if (Enum.IsDefined(typeof(QuestChain), chain) && quest != null && quester != null)
+				{
+					chains[(QuestChain)chain] = new BaseChain(quest, quester);
+				}
+			}
+
+			return chains;
+		}
+
+		public static object Object(GenericReader reader)
+		{
+			if (reader == null)
+			{
+				return null;
+			}
+
+			Version(reader);
+
+			var type = reader.ReadByte();
+
+			switch (type)
+			{
+				case 0x0:
+					return null; // invalid
+				case 0x1:
+					return reader.ReadInt();
+				case 0x2:
+					return reader.ReadString();
+				case 0x3:
+					return reader.ReadItem();
+				case 0x4:
+					return reader.ReadMobile();
+			}
+
+			return null;
+		}
+
+		public static Type Type(GenericReader reader)
+		{
+			if (reader == null)
+			{
+				return null;
+			}
+
+			var type = reader.ReadString();
+
+			if (type != null)
+			{
+				return ScriptCompiler.FindTypeByFullName(type, false);
+			}
+
+			return null;
+		}
+
+		public static object Construct(GenericReader reader)
+		{
+			var type = Type(reader);
+
+			try
+			{
+				return Activator.CreateInstance(type);
+			}
+			catch
+			{
+				return null;
+			}
+		}
+	}
 }

--- a/Scripts/Services/MondainsLegacyQuests/Helpers/QuestWriter.cs
+++ b/Scripts/Services/MondainsLegacyQuests/Helpers/QuestWriter.cs
@@ -1,86 +1,166 @@
+#region Header
+// **********
+// ServUO - QuestWriter.cs
+// **********
+#endregion
+
+#region References
 using System;
 using System.Collections.Generic;
+using System.IO;
+#endregion
 
 namespace Server.Engines.Quests
 {
-    public class QuestWriter
-    { 
-        public static void Quests(GenericWriter writer, List<BaseQuest> quests)
-        {
-            if (quests == null)
-            {
-                writer.Write((int)0);
-                return;
-            }
-			
-            writer.Write((int)quests.Count);
-			
-            for (int i = 0; i < quests.Count; i ++)
-            {
-                BaseQuest quest = quests[i];
-				
-                Type(writer, quest.GetType());
-				
-                quest.Serialize(writer);
-            }
-        }
+	public class QuestWriter
+	{
+		public static int Version(GenericWriter writer, int version)
+		{
+			if (writer == null)
+			{
+				return -1;
+			}
 
-        public static void Chains(GenericWriter writer, Dictionary<QuestChain, BaseChain> chains)
-        {
-            if (chains == null)
-            {
-                writer.Write((int)0);
-                return;
-            }
-			
-            writer.Write((int)chains.Count);
-			
-            foreach (KeyValuePair<QuestChain, BaseChain> pair in chains)
-            { 
-                writer.Write((int)pair.Key);
-				
-                Type(writer, pair.Value.CurrentQuest);
-                Type(writer, pair.Value.Quester);
-            }
-        }
+			writer.Write(0x7FFFFFFF); // Preamble
 
-        public static void Object(GenericWriter writer, object obj)
-        {
-            if (writer == null)
-                return;
-				
-            if (obj is int)
-            {
-                writer.Write((byte)0x1);
-                writer.Write((int)obj);
-            }
-            else if (obj is String)
-            {
-                writer.Write((byte)0x2);
-                writer.Write((String)obj);
-            }
-            else if (obj is Item)
-            {
-                writer.Write((byte)0x3);				
-                writer.Write((Item)obj);
-            }
-            else if (obj is Mobile)
-            {
-                writer.Write((byte)0x4);				
-                writer.Write((Mobile)obj);
-            }
-            else
-            {
-                writer.Write((byte)0x0); // invalid
-            }
-        }
+			writer.Write(version);
 
-        public static void Type(GenericWriter writer, Type type)
-        {
-            if (writer == null)
-                return;
-				
-            writer.Write(type == null ? null : type.FullName);
-        }
-    }
+			return version;
+		}
+
+		public static bool SubWrite(GenericWriter writer, Action<GenericWriter> serializer)
+		{
+			if (writer == null)
+			{
+				return false;
+			}
+
+			using (var s = new MemoryStream())
+			{
+				var w = new BinaryFileWriter(s, true);
+
+				try
+				{
+					serializer(w);
+				}
+				catch (Exception e)
+				{
+					Console.WriteLine("Quest Save Failure: {0}", Utility.FormatDelegate(serializer));
+					Console.WriteLine(e);
+
+					return false;
+				}
+				finally
+				{
+					w.Flush();
+					w.Close();
+				}
+
+				writer.Write(s.Length);
+
+				s.Position = 0;
+
+				while (s.Position < s.Length)
+				{
+					writer.Write(s.ReadByte());
+				}
+			}
+
+			return true;
+		}
+
+		public static void Quests(GenericWriter writer, List<BaseQuest> quests)
+		{
+			if (writer == null)
+			{
+				return;
+			}
+
+			Version(writer, 0);
+
+			if (quests == null)
+			{
+				writer.Write(0);
+				return;
+			}
+
+			writer.Write(quests.Count);
+
+			foreach (var quest in quests)
+			{
+				Type(writer, quest.GetType());
+
+				SubWrite(writer, quest.Serialize);
+			}
+		}
+
+		public static void Chains(GenericWriter writer, Dictionary<QuestChain, BaseChain> chains)
+		{
+			if (writer == null)
+			{
+				return;
+			}
+
+			Version(writer, 0);
+
+			if (chains == null)
+			{
+				writer.Write(0);
+				return;
+			}
+
+			writer.Write(chains.Count);
+
+			foreach (var pair in chains)
+			{
+				writer.Write((int)pair.Key);
+
+				Type(writer, pair.Value.CurrentQuest);
+				Type(writer, pair.Value.Quester);
+			}
+		}
+
+		public static void Object(GenericWriter writer, object obj)
+		{
+			if (writer == null)
+			{
+				return;
+			}
+
+			Version(writer, 0);
+
+			if (obj is int)
+			{
+				writer.Write((byte)0x1);
+				writer.Write((int)obj);
+			}
+			else if (obj is String)
+			{
+				writer.Write((byte)0x2);
+				writer.Write((String)obj);
+			}
+			else if (obj is Item)
+			{
+				writer.Write((byte)0x3);
+				writer.Write((Item)obj);
+			}
+			else if (obj is Mobile)
+			{
+				writer.Write((byte)0x4);
+				writer.Write((Mobile)obj);
+			}
+			else
+			{
+				writer.Write((byte)0x0); // invalid
+			}
+		}
+
+		public static void Type(GenericWriter writer, Type type)
+		{
+			if (writer != null)
+			{
+				writer.Write(type == null ? null : type.FullName);
+			}
+		}
+	}
 }

--- a/Scripts/Services/MondainsLegacyQuests/QuestChains.cs
+++ b/Scripts/Services/MondainsLegacyQuests/QuestChains.cs
@@ -1,69 +1,56 @@
+#region Header
+// **********
+// ServUO - QuestChains.cs
+// **********
+#endregion
+
+#region References
 using System;
+#endregion
 
 namespace Server.Engines.Quests
 {
-    public enum QuestChain
-    {
-        None,
-        Aemaeth,
-        AncientWorld,
-        BlightedGrove,
-        CovetousGhost,
-        GemkeeperWarriors,
-        HonestBeggar,
-        LibraryFriends,
-        Marauders,
-        MiniBoss,
-        SummonFey,
-        SummonFiend,
-        TuitionReimbursement,
-        Spellweaving,
-        SpellweavingS,
-        UnfadingMemories,
-        PercolemTheHunter,
-        KingVernixQuests,
-        DoughtyWarriors,
-        HonorOfDeBoors,
-        LaifemTheWeaver,
-        CloakOfHumility,
-        ValleyOfOne,
-        MyrmidexAlliance,
-        EodonianAlliance,
-        FlintTheQuartermaster,
-        AnimalTraining
-    }
+	public enum QuestChain
+	{
+		None = 0,
 
-    public class BaseChain
-    {
-        private Type m_CurrentQuest;
-        private Type m_Quester;
-        public BaseChain(Type currentQuest, Type quester)
-        {
-            this.m_CurrentQuest = currentQuest;
-            this.m_Quester = quester;
-        }
+		Aemaeth = 1,
+		AncientWorld = 2,
+		BlightedGrove = 3,
+		CovetousGhost = 4,
+		GemkeeperWarriors = 5,
+		HonestBeggar = 6,
+		LibraryFriends = 7,
+		Marauders = 8,
+		MiniBoss = 9,
+		SummonFey = 10,
+		SummonFiend = 11,
+		TuitionReimbursement = 12,
+		Spellweaving = 13,
+		SpellweavingS = 14,
+		UnfadingMemories = 15,
+		PercolemTheHunter = 16,
+		KingVernixQuests = 17,
+		DoughtyWarriors = 18,
+		HonorOfDeBoors = 19,
+		LaifemTheWeaver = 20,
+		CloakOfHumility = 21,
+		ValleyOfOne = 22,
+		MyrmidexAlliance = 23,
+		EodonianAlliance = 24,
+		FlintTheQuartermaster = 25,
+		AnimalTraining = 26
+	}
 
-        public Type CurrentQuest
-        {
-            get
-            {
-                return this.m_CurrentQuest;
-            }
-            set
-            {
-                this.m_CurrentQuest = value;
-            }
-        }
-        public Type Quester
-        {
-            get
-            {
-                return this.m_Quester;
-            }
-            set
-            {
-                this.m_Quester = value;
-            }
-        }
-    }
+	public class BaseChain
+	{
+		public Type CurrentQuest { get; set; }
+		public Type Quester { get; set; }
+
+		public BaseChain(Type currentQuest, Type quester)
+		{
+			CurrentQuest = currentQuest;
+			Quester = quester;
+		}
+	}
 }

--- a/Server/Utility.cs
+++ b/Server/Utility.cs
@@ -1405,6 +1405,21 @@ namespace Server
 			}
 		}
 
+		public static string FormatDelegate(Delegate callback)
+		{
+			if (callback == null)
+			{
+				return "null";
+			}
+
+			if (callback.Method.DeclaringType == null)
+			{
+				return callback.Method.Name;
+			}
+
+			return String.Format("{0}.{1}", callback.Method.DeclaringType.FullName, callback.Method.Name);
+		}
+
 		private static readonly Stack<ConsoleColor> m_ConsoleColors = new Stack<ConsoleColor>();
 
         public static void WriteConsoleColor(ConsoleColor color, string str)


### PR DESCRIPTION
+ Insert serialization versioning and use block data writing/reading to allow removal of quests and prevent PlayerMobile data loss at world load.
+ Quest serialization will now display relative exceptions in the console and attempt to ignore the offending data block.
* Ability to remove quests will be functional after at least one world save with this update installed.