### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Misc/CurrentExpansion.cs
+++ b/Scripts/Misc/CurrentExpansion.cs
@@ -46,7 +46,7 @@ namespace Server
 				PacketHandlers.SingleClickProps = true; // single click for everything is overriden to check object property list
 			}
 
-			Mobile.ActionDelay = 1000;
+			Mobile.ActionDelay = Core.TOL ? 500 : Core.AOS ? 1000 : 500;
 			Mobile.AOSStatusHandler = AOS.GetStatus;
 		}
 	}

--- a/Scripts/Mobiles/Bosses/Barracoon.cs
+++ b/Scripts/Mobiles/Bosses/Barracoon.cs
@@ -279,7 +279,8 @@ namespace Server.Mobiles
         {
             if (target == null || target.Deleted) //sanity
                 return;
-            if (0.6 >= Utility.RandomDouble()) // 60% chance to polymorph attacker into a ratman
+
+            if (target.Player && 0.6 >= Utility.RandomDouble()) // 60% chance to polymorph attacker into a ratman
                 Polymorph(target);
 
             if (0.1 >= Utility.RandomDouble()) // 10% chance to more ratmen

--- a/Scripts/Multis/BaseHouse.cs
+++ b/Scripts/Multis/BaseHouse.cs
@@ -4876,11 +4876,13 @@ namespace Server.Multis
             Item = item;
             Mobile = m;
             House = house;
+
+            Enabled = Mobile.Alive;
         }
 
         public override void OnClick()
         {
-            if (BaseHouse.FindHouseAt(Mobile) == House && House.IsOwner(Mobile))
+            if (Mobile.Alive && BaseHouse.FindHouseAt(Mobile) == House && House.IsOwner(Mobile))
             {
                 if (Mobile.Backpack == null || !Mobile.Backpack.CheckHold(Mobile, Item, false))
                 {

--- a/Scripts/Services/Chat/ChatSystem.cs
+++ b/Scripts/Services/Chat/ChatSystem.cs
@@ -33,7 +33,7 @@ namespace Server.Engines.Chat
             var chatName = from.Name;
 
             SendCommandTo(from, ChatCommand.OpenChatWindow, chatName);
-            ChatUser.AddChatUser(from);
+            Channel.Default.AddUser(ChatUser.AddChatUser(from));
         }
 
         public static void ChatAction(NetState state, PacketReader pvSrc)

--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -773,7 +773,7 @@ namespace Server.Mobiles
                 new TrainingDefinition(typeof(Vollem), Class.MagicalAndTailed, MagicalAbility.None, SpecialAbilityNone, WepAbilityNone, AreaEffectNone, 3, 5),
                 new TrainingDefinition(typeof(Walrus), Class.None, MagicalAbility.StandardClawedOrTailed, SpecialAbilityAnimalStandard, WepAbility1, AreaEffectNone, 1, 3),
                 new TrainingDefinition(typeof(WhiteWolf), Class.ClawedAndTailed, MagicalAbility.StandardClawedOrTailed, SpecialAbilityClawedAndTailed, WepAbility1, AreaEffectNone, 1, 3),
-                new TrainingDefinition(typeof(WhiteWyrm), Class.MagicalClawedAndTailed, MagicalAbility.Dragon1, SpecialAbilityClawedTailedAndMagical2, WepAbility2, AreaEffectEarthen, 3, 5),
+                new TrainingDefinition(typeof(WhiteWyrm), Class.MagicalClawedAndTailed, MagicalAbility.Dragon1, SpecialAbilityClawedTailedAndMagical2, WepAbility2, AreaEffectEarthen, 4, 5),
                 new TrainingDefinition(typeof(WildTiger), Class.ClawedAndTailed, MagicalAbility.Poisoning, SpecialAbilityNone, WepAbility3, AreaEffectNone, 2, 5),
                 new TrainingDefinition(typeof(WildWhiteTiger), Class.ClawedAndTailed, MagicalAbility.Poisoning, SpecialAbilityNone, WepAbility3, AreaEffectNone, 2, 5),
                 new TrainingDefinition(typeof(WildBlackTiger), Class.ClawedAndTailed, MagicalAbility.Poisoning, SpecialAbilityNone, WepAbility3, AreaEffectNone, 2, 5),

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/InvasionSpawner/Creatures.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/InvasionSpawner/Creatures.cs
@@ -560,6 +560,40 @@ namespace Server.Engines.Blackthorn
             Karma = -48000;  
         }
 
+        public override void OnDeath(Container c)
+        {
+            base.OnDeath(c);
+
+            var rights = GetLootingRights();
+            rights.Sort();
+
+            List<Mobile> list = rights.Select(x => x.m_Mobile).Where(m => m.InRange(c.Location, 20)).ToList();
+
+            if(list.Count > 0)
+            {
+                for (int i = 0; i < 2; i++)
+                {
+                    Mobile drop;
+                    Item item = InvasionController.CreateItem(list[0]);
+
+                    if (list.Count == 1 || i >= list.Count)
+                        drop = list[0];
+                    else
+                        drop = list[i];
+
+                    drop.SendLocalizedMessage(1154530); // You notice the crest of Minax on your fallen foe's equipment and decide it may be of some value...
+
+                    if (drop.Backpack == null || !drop.Backpack.TryDropItem(drop, item, false))
+                    {
+                        drop.BankBox.DropItem(item);
+                        drop.SendLocalizedMessage(1079730); // // The item has been placed into your bank box.
+                    }
+                }
+            }
+
+            ColUtility.Free(list);
+        }
+
         public override void GenerateLoot()
         {
             this.AddLoot(LootPack.UltraRich, 2);

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/InvasionSpawner/InvasionController.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/InvasionSpawner/InvasionController.cs
@@ -374,12 +374,13 @@ namespace Server.Engines.Blackthorn
                 {
                     foreach (Mobile damager in rights.Where(mob => mob.InRange(Beacon.Location, 12)))
                     {
-                        Item i = Loot.RandomArmorOrShieldOrWeaponOrJewelry(LootPackEntry.IsInTokuno(damager), LootPackEntry.IsMondain(damager), LootPackEntry.IsStygian(damager));
+                        if (0.15 < Utility.RandomDouble())
+                            continue;
 
+                        Item i = CreateItem(damager);
+                        
                         if (i != null)
                         {
-                            RunicReforging.GenerateRandomItem(i, damager, Utility.RandomMinMax(700, 800), damager is PlayerMobile ? ((PlayerMobile)damager).RealLuck : damager.Luck, ReforgedPrefix.None, ReforgedSuffix.Minax);
-
                             damager.PlaySound(0x5B4);
                             damager.SendLocalizedMessage(1154554); // You recover an artifact bearing the crest of Minax from the rubble.
 
@@ -397,6 +398,18 @@ namespace Server.Engines.Blackthorn
                     }
                 }
             }
+        }
+
+        public static Item CreateItem(Mobile damager)
+        {
+            Item i = Loot.RandomArmorOrShieldOrWeaponOrJewelry(LootPackEntry.IsInTokuno(damager), LootPackEntry.IsMondain(damager), LootPackEntry.IsStygian(damager));
+
+            if (i != null)
+            {
+                RunicReforging.GenerateRandomItem(i, damager, Utility.RandomMinMax(700, 800), damager is PlayerMobile ? ((PlayerMobile)damager).RealLuck : 0, ReforgedPrefix.None, ReforgedSuffix.Minax);
+            }
+
+            return i;
         }
 
         public void Cleanup()

--- a/Scripts/Services/Revamped Dungeons/TheExodusEncounter/Loot/GargishDupresSword.cs
+++ b/Scripts/Services/Revamped Dungeons/TheExodusEncounter/Loot/GargishDupresSword.cs
@@ -4,40 +4,29 @@ using Server.Spells;
 
 namespace Server.Items
 {
-    public class GargishDupresSword : VikingSword
+    public class GargishDupresSword : StoneWarSword
     {
         public override bool IsArtifact { get { return true; } }
-        public override WeaponAbility PrimaryAbility{ get{ return WeaponAbility.CrushingBlow; } }
-        public override WeaponAbility SecondaryAbility{ get{ return WeaponAbility.ParalyzingBlow; } }
 
         [Constructable]
         public GargishDupresSword()
         {
-            this.Hue = 0xA91;
-            this.ItemID = 0x0900;
-            this.Attributes.BonusStr = 10;
-            this.Attributes.AttackChance = 25;
-            this.Attributes.WeaponSpeed = 35;
-            this.Attributes.WeaponDamage = 100;
-            this.WeaponAttributes.HitManaDrain = 50;
+            Hue = 0xA91;
+
+            Attributes.BonusStr = 10;
+            Attributes.AttackChance = 25;
+            Attributes.WeaponSpeed = 35;
+            Attributes.WeaponDamage = 100;
+            WeaponAttributes.HitManaDrain = 50;
         }
         
         public GargishDupresSword(Serial serial) : base(serial)
         {
         }
 
-        public override int InitMinHits { get { return 255; } }
-        public override int InitMaxHits { get { return 255; } }
-        public override int AosMinDamage { get { return 15; } }
-        public override int AosMaxDamage { get { return 17; } }
-
         public override bool CanFortify { get { return false; } }
 
         public override int LabelNumber { get { return 1153551; } }
-
-        public override Race RequiredRace { get { return Race.Gargoyle; } }
-
-        public override bool CanBeWornByGargoyles { get { return true; } }
 
         public override void Serialize( GenericWriter writer )
         {

--- a/Scripts/Services/Vendor Searching/VendorSearch.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearch.cs
@@ -166,14 +166,10 @@ namespace Server.Engines.VendorSearching
 						return false;
 					}
 				}
-				else if(o is SlayerName && (!(item is ISlayer) || ((((ISlayer)item).Slayer != (SlayerName)o && ((ISlayer)item).Slayer2 != (SlayerName)o))))
-				{
-					return false;
-				}
-                else if (o is TalismanSlayerName && (!(item is BaseTalisman) || ((BaseTalisman)item).Slayer != (TalismanSlayerName)o))
-				{
-					return false;
-				}
+                else if (!CheckSlayer(item, o))
+                {
+                    return false;
+                }
                 else if (o is AosElementAttribute)
                 {
                     if (item is BaseWeapon)
@@ -254,8 +250,6 @@ namespace Server.Engines.VendorSearching
                     {
                         return false;
                     }
-
-
                 }
                 else if (o is Misc)
                 {
@@ -283,7 +277,7 @@ namespace Server.Engines.VendorSearching
                                 return false;
                             break;
                         case Misc.PromotionalToken:
-                            if(!(item is PromotionalToken))
+                            if (!(item is PromotionalToken))
                                 return false;
                             break;
                         case Misc.Cursed:
@@ -367,6 +361,33 @@ namespace Server.Engines.VendorSearching
 
             return true;
 		}
+
+        private static bool CheckSlayer(Item item, object o)
+        {
+            if (o is TalismanSlayerName && (TalismanSlayerName)o == TalismanSlayerName.Undead)
+            {
+                if (!(item is ISlayer) || ((((ISlayer)item).Slayer != SlayerName.Silver && ((ISlayer)item).Slayer2 != SlayerName.Silver)))
+                {
+                    if (!(item is BaseTalisman) || ((BaseTalisman)item).Slayer != TalismanSlayerName.Undead)
+                    {
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                if (o is SlayerName && (!(item is ISlayer) || ((((ISlayer)item).Slayer != (SlayerName)o && ((ISlayer)item).Slayer2 != (SlayerName)o))))
+                {
+                    return false;
+                }
+                else if (o is TalismanSlayerName && (!(item is BaseTalisman) || ((BaseTalisman)item).Slayer != (TalismanSlayerName)o))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
 
         private static bool CheckCanRepair(Item item)
         {
@@ -912,12 +933,19 @@ namespace Server.Engines.VendorSearching
             }
             else if (d == null)
             {
-                Details.Add(new SearchDetail(o, name, value, cat));
+                d = new SearchDetail(o, name, value, cat);
+
+                Details.Add(d);
             }
             else if (d.Value != value)
             {
                 d.Value = value;
             }
+
+            /*if (d.Attribute is TalismanSlayerName && (TalismanSlayerName)d.Attribute == TalismanSlayerName.Undead)
+            {
+                TryAddDetails(SlayerName.Silver, name, value, cat);
+            }*/
         }
 
         public bool IsEmpty

--- a/Scripts/Services/Virtues/Honor.cs
+++ b/Scripts/Services/Virtues/Honor.cs
@@ -160,7 +160,7 @@ namespace Server
             source.Direction = source.GetDirectionTo(target);
             source.SendLocalizedMessage(1115884); // You Started Honorable Combat!
 
-            if (!source.Mounted)
+            if (!source.Mounted && !source.IsBodyMod)
                 source.Animate(32, 5, 1, true, true, 0);
 
             BuffInfo.AddBuff(source, new BuffInfo(BuffIcon.Honored, 1075649, 1153815, String.Format("{0}", target.Name)));

--- a/Scripts/Services/XmlSpawner/XmlSpawner Core/XmlUtils/XmlFind.cs
+++ b/Scripts/Services/XmlSpawner/XmlSpawner Core/XmlUtils/XmlFind.cs
@@ -20,6 +20,7 @@ using System.Text;
 using Server.Accounting;
 using System.Threading;
 using Server.Engines.XmlSpawner2;
+using System.Linq;
 
 /*
 ** XmlFind
@@ -390,9 +391,9 @@ namespace Server.Mobiles
                     (m is GalleonPilot) || m is PetParrot ||
                     (GenericBuyInfo.IsDisplayCache(m)) ||
                     (m is EffectMobile) ||
-					(m is BaseCreature && ((BaseCreature)m).IsStabled))
+					(m is BaseCreature && ((BaseCreature)m).IsStabled) ||
+                    (m is PlayerVendor && BaseHouse.AllHouses.Any(x => x.InternalizedVendors.Contains(m))))
 					return true;
-
 			}
 			else
 				if (o is Item)


### PR DESCRIPTION
- Costumes no longer add name hue or hide guild title
- Insered Era Check for mobile action delay
- Barracoon no longer morphs Pets
- House Lockdown Retrieve context entry no longer works if player is dead
- Players now go to chat default channel
- White Wyrms min/max control slots adjusted per EA, 4-5 with rare chance of 3
- Blackthorn invasion captains now drop 2 minax arties to top 2 damagers
- Gargish Dupre's Sword now derives from Stone War Sword
- Vendor Search will now display 'Undead Slayer' weapons and talismans properly
- Honor no longer animates players with an active body mod
- XmlFind should no longer show temporary internalized vendors