### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Items/Addons/MiningCart.cs
+++ b/Scripts/Items/Addons/MiningCart.cs
@@ -16,14 +16,16 @@ namespace Server.Items
 
     public class MiningCart : BaseAddon, IRewardItem
     {
+        public override bool ForceShowProperties { get { return true; } }
+
         public override BaseAddonDeed Deed
         {
             get
             {
                 MiningCartDeed deed = new MiningCartDeed();
-                deed.IsRewardItem = this.m_IsRewardItem;
-                deed.Gems = this.m_Gems;
-                deed.Ore = this.m_Ore;
+                deed.IsRewardItem = m_IsRewardItem;
+                deed.Gems = m_Gems;
+                deed.Ore = m_Ore;
 
                 return deed;
             }
@@ -36,11 +38,11 @@ namespace Server.Items
         {
             get
             {
-                return this.m_IsRewardItem;
+                return m_IsRewardItem;
             }
             set
             {
-                this.m_IsRewardItem = value;
+                m_IsRewardItem = value;
             }
         }
 
@@ -51,7 +53,7 @@ namespace Server.Items
         {
             get
             {
-                return this.m_CartType;
+                return m_CartType;
             }
         }
 
@@ -62,11 +64,11 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Gems;
+                return m_Gems;
             }
             set
             {
-                this.m_Gems = value;
+                m_Gems = value;
             }
         }
 
@@ -77,11 +79,11 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Ore;
+                return m_Ore;
             }
             set
             {
-                this.m_Ore = value;
+                m_Ore = value;
             }
         }
 
@@ -91,53 +93,53 @@ namespace Server.Items
         public MiningCart(MiningCartType type)
             : base()
         {
-            this.m_CartType = type;
+            m_CartType = type;
 
             switch ( type )
             {
                 case MiningCartType.OreSouth:
-                    this.AddComponent(new AddonComponent(0x1A83), 0, 0, 0);
-                    this.AddComponent(new AddonComponent(0x1A82), 0, 1, 0);
-                    this.AddComponent(new AddonComponent(0x1A86), 0, -1, 0);
+                    AddComponent(new InternalAddonComponent(0x1A83, 1026786), 0, 0, 0);
+                    AddComponent(new InternalAddonComponent(0x1A82, 1026786), 0, 1, 0);
+                    AddComponent(new InternalAddonComponent(0x1A86, 1026786), 0, -1, 0);
                     break;
                 case MiningCartType.OreEast:
-                    this.AddComponent(new AddonComponent(0x1A88), 0, 0, 0);
-                    this.AddComponent(new AddonComponent(0x1A87), 1, 0, 0);
-                    this.AddComponent(new AddonComponent(0x1A8B), -1, 0, 0);
+                    AddComponent(new InternalAddonComponent(0x1A88, 1026786), 0, 0, 0);
+                    AddComponent(new InternalAddonComponent(0x1A87, 1026786), 1, 0, 0);
+                    AddComponent(new InternalAddonComponent(0x1A8B, 1026786), -1, 0, 0);
                     break;
                 case MiningCartType.GemSouth:
-                    this.AddComponent(new LocalizedAddonComponent(0x1A83, 1080388), 0, 0, 0);
-                    this.AddComponent(new LocalizedAddonComponent(0x1A82, 1080388), 0, 1, 0);
-                    this.AddComponent(new LocalizedAddonComponent(0x1A86, 1080388), 0, -1, 0);
+                    AddComponent(new InternalAddonComponent(0x1A83, 1080388), 0, 0, 0);
+                    AddComponent(new InternalAddonComponent(0x1A82, 1080388), 0, 1, 0);
+                    AddComponent(new InternalAddonComponent(0x1A86, 1080388), 0, -1, 0);
 
-                    this.AddComponent(new AddonComponent(0xF2C), 0, 0, 6);
-                    this.AddComponent(new AddonComponent(0xF1D), 0, 0, 5);
-                    this.AddComponent(new AddonComponent(0xF2B), 0, 0, 2);
-                    this.AddComponent(new AddonComponent(0xF21), 0, 0, 1);
-                    this.AddComponent(new AddonComponent(0xF22), 0, 0, 4);
-                    this.AddComponent(new AddonComponent(0xF2F), 0, 0, 5);
-                    this.AddComponent(new AddonComponent(0xF26), 0, 0, 6);
-                    this.AddComponent(new AddonComponent(0xF27), 0, 0, 3);
-                    this.AddComponent(new AddonComponent(0xF29), 0, 0, 0);
+                    AddComponent(new AddonComponent(0xF2C), 0, 0, 6);
+                    AddComponent(new AddonComponent(0xF1D), 0, 0, 5);
+                    AddComponent(new AddonComponent(0xF2B), 0, 0, 2);
+                    AddComponent(new AddonComponent(0xF21), 0, 0, 1);
+                    AddComponent(new AddonComponent(0xF22), 0, 0, 4);
+                    AddComponent(new AddonComponent(0xF2F), 0, 0, 5);
+                    AddComponent(new AddonComponent(0xF26), 0, 0, 6);
+                    AddComponent(new AddonComponent(0xF27), 0, 0, 3);
+                    AddComponent(new AddonComponent(0xF29), 0, 0, 0);
                     break;
                 case MiningCartType.GemEast:
-                    this.AddComponent(new LocalizedAddonComponent(0x1A88, 1080388), 0, 0, 0);
-                    this.AddComponent(new LocalizedAddonComponent(0x1A87, 1080388), 1, 0, 0);
-                    this.AddComponent(new LocalizedAddonComponent(0x1A8B, 1080388), -1, 0, 0);
+                    AddComponent(new InternalAddonComponent(0x1A88, 1080388), 0, 0, 0);
+                    AddComponent(new InternalAddonComponent(0x1A87, 1080388), 1, 0, 0);
+                    AddComponent(new InternalAddonComponent(0x1A8B, 1080388), -1, 0, 0);
 
-                    this.AddComponent(new AddonComponent(0xF2E), 0, 0, 6);
-                    this.AddComponent(new AddonComponent(0xF12), 0, 0, 3);
-                    this.AddComponent(new AddonComponent(0xF29), 0, 0, 1);
-                    this.AddComponent(new AddonComponent(0xF24), 0, 0, 5);
-                    this.AddComponent(new AddonComponent(0xF21), 0, 0, 1);
-                    this.AddComponent(new AddonComponent(0xF2B), 0, 0, 3);
-                    this.AddComponent(new AddonComponent(0xF2F), 0, 0, 4);
-                    this.AddComponent(new AddonComponent(0xF23), 0, 0, 3);
-                    this.AddComponent(new AddonComponent(0xF27), 0, 0, 3);
+                    AddComponent(new AddonComponent(0xF2E), 0, 0, 6);
+                    AddComponent(new AddonComponent(0xF12), 0, 0, 3);
+                    AddComponent(new AddonComponent(0xF29), 0, 0, 1);
+                    AddComponent(new AddonComponent(0xF24), 0, 0, 5);
+                    AddComponent(new AddonComponent(0xF21), 0, 0, 1);
+                    AddComponent(new AddonComponent(0xF2B), 0, 0, 3);
+                    AddComponent(new AddonComponent(0xF2F), 0, 0, 4);
+                    AddComponent(new AddonComponent(0xF23), 0, 0, 3);
+                    AddComponent(new AddonComponent(0xF27), 0, 0, 3);
                     break;
             }
 
-            this.m_Timer = Timer.DelayCall(TimeSpan.FromDays(1), TimeSpan.FromDays(1), new TimerCallback(GiveResources));
+            m_Timer = Timer.DelayCall(TimeSpan.FromDays(1), TimeSpan.FromDays(1), new TimerCallback(GiveResources));
         }
 
         public MiningCart(Serial serial)
@@ -147,15 +149,15 @@ namespace Server.Items
 
         private void GiveResources()
         {
-            switch ( this.m_CartType )
+            switch ( m_CartType )
             {
                 case MiningCartType.OreSouth:
                 case MiningCartType.OreEast:
-                    this.m_Ore = Math.Min(100, this.m_Ore + 10);
+                    m_Ore = Math.Min(100, m_Ore + 10);
                     break;
                 case MiningCartType.GemSouth:
                 case MiningCartType.GemEast:
-                    this.m_Gems = Math.Min(50, this.m_Gems + 5);
+                    m_Gems = Math.Min(50, m_Gems + 5);
                     break;
             }
         }
@@ -183,17 +185,17 @@ namespace Server.Items
             *
             */
 
-            if (!from.InRange(this.GetWorldLocation(), 2) || !from.InLOS(this) || !((from.Z - this.Z) > -3 && (from.Z - this.Z) < 3))
+            if (!from.InRange(GetWorldLocation(), 2) || !from.InLOS(this) || !((from.Z - Z) > -3 && (from.Z - Z) < 3))
             {
                 from.LocalOverheadMessage(Network.MessageType.Regular, 0x3B2, 1019045); // I can't reach that.
             }
             else if (house != null && house.HasSecureAccess(from, SecureLevel.Friends))
             {
-                switch ( this.m_CartType )
+                switch ( m_CartType )
                 {
                     case MiningCartType.OreSouth:
                     case MiningCartType.OreEast:
-                        if (this.m_Ore > 0)
+                        if (m_Ore > 0)
                         {
                             Item ingots = null;
 
@@ -228,7 +230,7 @@ namespace Server.Items
                                     break;
                             }
 
-                            int amount = Math.Min(10, this.m_Ore);
+                            int amount = Math.Min(10, m_Ore);
                             ingots.Amount = amount;
 
                             if (!from.PlaceInBackpack(ingots))
@@ -238,8 +240,8 @@ namespace Server.Items
                             }
                             else
                             {
-                                this.PublicOverheadMessage(MessageType.Regular, 0, 1094724, amount.ToString()); // Ore: ~1_COUNT~
-                                this.m_Ore -= amount;
+                                PublicOverheadMessage(MessageType.Regular, 0, 1094724, amount.ToString()); // Ore: ~1_COUNT~
+                                m_Ore -= amount;
                             }
                         }
                         else
@@ -248,7 +250,7 @@ namespace Server.Items
                         break;
                     case MiningCartType.GemSouth:
                     case MiningCartType.GemEast:
-                        if (this.m_Gems > 0)
+                        if (m_Gems > 0)
                         {
                             Item gems = null;
 
@@ -302,7 +304,7 @@ namespace Server.Items
                                     break;
                             }
 
-                            int amount = Math.Min(5, this.m_Gems);
+                            int amount = Math.Min(5, m_Gems);
                             gems.Amount = amount;
 
                             if (!from.PlaceInBackpack(gems))
@@ -312,8 +314,8 @@ namespace Server.Items
                             }
                             else
                             {
-                                this.PublicOverheadMessage(MessageType.Regular, 0, 1094723, amount.ToString()); // Gems: ~1_COUNT~
-                                this.m_Gems -= amount;
+                                PublicOverheadMessage(MessageType.Regular, 0, 1094723, amount.ToString()); // Gems: ~1_COUNT~
+                                m_Gems -= amount;
                             }
                         }
                         else
@@ -323,7 +325,50 @@ namespace Server.Items
                 }
             }
             else
-                from.SendLocalizedMessage(1061637); // You are not allowed to access this.
+                from.SendLocalizedMessage(1061637); // You are not allowed to access 
+        }
+
+        private class InternalAddonComponent : LocalizedAddonComponent
+        {
+            public InternalAddonComponent(int id, int localization)
+                : base(id, localization)
+            {
+            }
+
+            public override void GetProperties(ObjectPropertyList list)
+            {
+                base.GetProperties(list);
+
+                if (Addon is MiningCart)
+                {
+                    switch (((MiningCart)Addon).CartType)
+                    {
+                        case MiningCartType.OreSouth:
+                        case MiningCartType.OreEast: list.Add(1094724, ((MiningCart)Addon).Ore.ToString()); break; // Ore: ~1_COUNT~
+                        case MiningCartType.GemSouth:
+                        case MiningCartType.GemEast: list.Add(1094723, ((MiningCart)Addon).Gems.ToString()); break; // Gems: ~1_COUNT~
+                    }
+                }
+            }
+
+            public InternalAddonComponent(Serial serial)
+                : base(serial)
+            {
+            }
+
+            public override void Serialize(GenericWriter writer)
+            {
+                base.Serialize(writer);
+
+                writer.WriteEncodedInt(0); // version
+            }
+
+            public override void Deserialize(GenericReader reader)
+            {
+                base.Deserialize(reader);
+
+                int version = reader.ReadEncodedInt();
+            }
         }
 
         public override void Serialize(GenericWriter writer)
@@ -333,15 +378,15 @@ namespace Server.Items
             writer.WriteEncodedInt(1); // version
 
             #region version 1
-            writer.Write((int)this.m_CartType);
+            writer.Write((int)m_CartType);
             #endregion
 
-            writer.Write((bool)this.m_IsRewardItem);
-            writer.Write((int)this.m_Gems);
-            writer.Write((int)this.m_Ore);
+            writer.Write((bool)m_IsRewardItem);
+            writer.Write((int)m_Gems);
+            writer.Write((int)m_Ore);
 
-            if (this.m_Timer != null)
-                writer.Write((DateTime)this.m_Timer.Next);
+            if (m_Timer != null)
+                writer.Write((DateTime)m_Timer.Next);
             else
                 writer.Write((DateTime)DateTime.UtcNow + TimeSpan.FromDays(1));
         }
@@ -355,19 +400,19 @@ namespace Server.Items
             switch ( version )
             {
                 case 1:
-                    this.m_CartType = (MiningCartType)reader.ReadInt();
+                    m_CartType = (MiningCartType)reader.ReadInt();
                     goto case 0;
                 case 0:
-                    this.m_IsRewardItem = reader.ReadBool();
-                    this.m_Gems = reader.ReadInt();
-                    this.m_Ore = reader.ReadInt();
+                    m_IsRewardItem = reader.ReadBool();
+                    m_Gems = reader.ReadInt();
+                    m_Ore = reader.ReadInt();
 
                     DateTime next = reader.ReadDateTime();
 
                     if (next < DateTime.UtcNow)
                         next = DateTime.UtcNow;
 
-                    this.m_Timer = Timer.DelayCall(next - DateTime.UtcNow, TimeSpan.FromDays(1), new TimerCallback(GiveResources));
+                    m_Timer = Timer.DelayCall(next - DateTime.UtcNow, TimeSpan.FromDays(1), new TimerCallback(GiveResources));
                     break;
             }
         }
@@ -387,10 +432,10 @@ namespace Server.Items
         {
             get
             {
-                MiningCart addon = new MiningCart(this.m_CartType);
-                addon.IsRewardItem = this.m_IsRewardItem;
-                addon.Gems = this.m_Gems;
-                addon.Ore = this.m_Ore;
+                MiningCart addon = new MiningCart(m_CartType);
+                addon.IsRewardItem = m_IsRewardItem;
+                addon.Gems = m_Gems;
+                addon.Ore = m_Ore;
 
                 return addon;
             }
@@ -405,12 +450,12 @@ namespace Server.Items
         {
             get
             {
-                return this.m_IsRewardItem;
+                return m_IsRewardItem;
             }
             set
             {
-                this.m_IsRewardItem = value;
-                this.InvalidateProperties();
+                m_IsRewardItem = value;
+                InvalidateProperties();
             }
         }
 
@@ -421,11 +466,11 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Gems;
+                return m_Gems;
             }
             set
             {
-                this.m_Gems = value;
+                m_Gems = value;
             }
         }
 
@@ -436,11 +481,11 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Ore;
+                return m_Ore;
             }
             set
             {
-                this.m_Ore = value;
+                m_Ore = value;
             }
         }
 
@@ -448,7 +493,7 @@ namespace Server.Items
         public MiningCartDeed()
             : base()
         {
-            this.LootType = LootType.Blessed;
+            LootType = LootType.Blessed;
         }
 
         public MiningCartDeed(Serial serial)
@@ -460,16 +505,16 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            if (this.m_IsRewardItem)
+            if (m_IsRewardItem)
                 list.Add(1080457); // 10th Year Veteran Reward
         }
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (this.m_IsRewardItem && !RewardSystem.CheckIsUsableBy(from, this, null))
+            if (m_IsRewardItem && !RewardSystem.CheckIsUsableBy(from, this, null))
                 return;
 
-            if (this.IsChildOf(from.Backpack))
+            if (IsChildOf(from.Backpack))
             {
                 from.CloseGump(typeof(RewardOptionGump));
                 from.SendGump(new RewardOptionGump(this));
@@ -484,9 +529,9 @@ namespace Server.Items
 
             writer.WriteEncodedInt(0); // version
 
-            writer.Write((bool)this.m_IsRewardItem);
-            writer.Write((int)this.m_Gems);
-            writer.Write((int)this.m_Ore);
+            writer.Write((bool)m_IsRewardItem);
+            writer.Write((int)m_Gems);
+            writer.Write((int)m_Ore);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -495,9 +540,9 @@ namespace Server.Items
 
             int version = reader.ReadEncodedInt();
 
-            this.m_IsRewardItem = reader.ReadBool();
-            this.m_Gems = reader.ReadInt();
-            this.m_Ore = reader.ReadInt();
+            m_IsRewardItem = reader.ReadBool();
+            m_Gems = reader.ReadInt();
+            m_Ore = reader.ReadInt();
         }
 
         public void GetOptions(RewardOptionList list)
@@ -510,9 +555,9 @@ namespace Server.Items
 
         public void OnOptionSelected(Mobile from, int choice)
         {
-            this.m_CartType = (MiningCartType)choice;
+            m_CartType = (MiningCartType)choice;
 
-            if (!this.Deleted)
+            if (!Deleted)
                 base.OnDoubleClick(from);
         }
     }

--- a/Scripts/Items/Addons/SheepStatue.cs
+++ b/Scripts/Items/Addons/SheepStatue.cs
@@ -14,11 +14,13 @@ namespace Server.Items
         [CommandProperty(AccessLevel.GameMaster)]
         public DateTime NextResourceCount { get; set; }
 
+        public override bool ForceShowProperties { get { return true; } }
+
         [Constructable]
         public SheepStatue(int itemID)
             : base()
         {
-            AddComponent(new AddonComponent(itemID), 0, 0, 0);
+            AddComponent(new InternalAddonComponent(itemID), 0, 0, 0);
             NextResourceCount = DateTime.UtcNow + TimeSpan.FromDays(1);
         }
 
@@ -137,6 +139,43 @@ namespace Server.Items
             }
             else
                 from.SendLocalizedMessage(1061637); // You are not allowed to access 
+        }
+
+        private class InternalAddonComponent : AddonComponent
+        {
+            public InternalAddonComponent(int id)
+                :base(id)
+            {
+            }
+
+            public override void GetProperties(ObjectPropertyList list)
+            {
+                base.GetProperties(list);
+
+                if (Addon is SheepStatue)
+                {
+                    list.Add(1151834, ((SheepStatue)Addon).ResourceCount.ToString()); // Resources: ~1_val~
+                }
+            }
+
+            public InternalAddonComponent(Serial serial)
+                : base(serial)
+            {
+            }
+
+            public override void Serialize(GenericWriter writer)
+            {
+                base.Serialize(writer);
+
+                writer.WriteEncodedInt(0); // version
+            }
+
+            public override void Deserialize(GenericReader reader)
+            {
+                base.Deserialize(reader);
+
+                int version = reader.ReadEncodedInt();
+            }
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Items/Books/RunicAtlas.cs
+++ b/Scripts/Items/Books/RunicAtlas.cs
@@ -57,13 +57,16 @@ namespace Server.Items
 
                 RunicAtlasGump g = from.FindGump(typeof(RunicAtlasGump)) as RunicAtlasGump;
 
-                if (g != null)
+                if (g != null && g.Atlas == this)
                 {
                     g.Page = newPage;
                     g.Refresh();
                 }
                 else
                 {
+                    if (g != null)
+                        from.CloseGump(typeof(RunicAtlasGump));
+
                     g = new RunicAtlasGump((PlayerMobile)from, this);
                     g.Page = newPage;
                     from.SendGump(g);

--- a/Scripts/Items/Equipment/Talismans/TalismanSlayer.cs
+++ b/Scripts/Items/Equipment/Talismans/TalismanSlayer.cs
@@ -129,7 +129,8 @@ namespace Server.Items
                     typeof(GreyWolf),       typeof(TsukiWolf),
                     typeof(Dog),            typeof(HellHound),
                     typeof(IceHound),       typeof(WhiteWolf),
-                    typeof(BakeKitsune),    typeof(ClanSSW)
+                    typeof(BakeKitsune),    typeof(ClanSSW),
+                    typeof(CuSidhe)
                 };
 
             m_Table[TalismanSlayerName.Goblin] = new Type[]

--- a/Scripts/Items/Functional/SeedBox/SeedBox.cs
+++ b/Scripts/Items/Functional/SeedBox/SeedBox.cs
@@ -14,8 +14,8 @@ namespace Server.Engines.Plants
     [FlipableAttribute(19288, 19290)]
     public class SeedBox : Container, IRewardItem, ISecurable
     {
-        public static readonly int MaxSeeds = 500;
-        public static readonly int MaxUnique = 200;
+        public static readonly int MaxSeeds = 5000;
+        public static readonly int MaxUnique = 300;
 
         public override int DefaultMaxItems { get { return MaxUnique; } }
         public override bool DisplaysContent { get { return false; } }
@@ -48,13 +48,14 @@ namespace Server.Engines.Plants
             get { return Entries == null ? 0 : Entries.Where(e => e != null && e.Seed != null && e.Seed.Amount > 0).Count(); }
         }
 
+        public override double DefaultWeight { get { return 10.0; } }
+
         [Constructable]
         public SeedBox() : base(19288)
         {
             Entries = new List<SeedEntry>();
 
             LootType = LootType.Blessed;
-            Weight = 10.0;
 
             Level = SecureLevel.Owner;
         }

--- a/Scripts/Misc/MondainsLegacy.cs
+++ b/Scripts/Misc/MondainsLegacy.cs
@@ -216,6 +216,8 @@ namespace Server
         }
         public static void Initialize()
         {
+            EventSink.OnKilledBy += OnKilledBy;
+
 			CommandSystem.Register("DecorateML", AccessLevel.Administrator, new CommandEventHandler(DecorateML_OnCommand));
 			CommandSystem.Register("DecorateMLDelete", AccessLevel.Administrator, new CommandEventHandler(DecorateMLDelete_OnCommand));
 			CommandSystem.Register("SettingsML", AccessLevel.Administrator, new CommandEventHandler(SettingsML_OnCommand));
@@ -367,9 +369,20 @@ namespace Server
             }
         }
 
+        public static void OnKilledBy(OnKilledByEventArgs e)
+        {
+            BaseCreature killed = e.Killed as BaseCreature;
+            Mobile killer = e.KilledBy;
+
+            if (killed != null && killed.GivesMLMinorArtifact && CheckArtifactChance(killer, killed))
+            {
+                MondainsLegacy.GiveArtifactTo(killer);
+            }
+        }
+
         public static bool CheckArtifactChance(Mobile m, BaseCreature bc)
         {
-            if (!Core.ML || bc is BasePeerless) // Peerless drops to the corpse, this will handled elsewhere
+            if (!Core.ML || bc is BasePeerless) // Peerless drops to the corpse, this is handled elsewhere
                 return false;
 
             return Paragon.CheckArtifactChance(m, bc);

--- a/Scripts/Mobiles/AI/Magical AI/NecroAI.cs
+++ b/Scripts/Mobiles/AI/Magical AI/NecroAI.cs
@@ -49,15 +49,23 @@ namespace Server.Mobiles
 				select = 4;
 			else if (mana >= 11)
 				select = 3;
-			
-			switch (Utility.Random(select))
-			{
+
+            switch (Utility.Random(select))
+            {
                 case 0: return new CurseWeaponSpell(m_Mobile, null);
-				case 1: return new CorpseSkinSpell(m_Mobile, null);
-				case 2: return new EvilOmenSpell(m_Mobile, null);
-				case 3: return new BloodOathSpell(m_Mobile, null);
-				case 4: return new MindRotSpell(m_Mobile, null);
-			}
+                case 1:
+                    Spell spell;
+
+                    if (NecroMageAI.CheckCastCorpseSkin(m_Mobile))
+                        spell = new CorpseSkinSpell(m_Mobile, null);
+                    else
+                        spell = new CurseWeaponSpell(m_Mobile, null);
+
+                    return spell;
+                case 2: return new EvilOmenSpell(m_Mobile, null);
+                case 3: return new BloodOathSpell(m_Mobile, null);
+                case 4: return new MindRotSpell(m_Mobile, null);
+            }
 
             return null;
 		}

--- a/Scripts/Mobiles/AI/Magical AI/NecromageAI.cs
+++ b/Scripts/Mobiles/AI/Magical AI/NecromageAI.cs
@@ -82,7 +82,15 @@ namespace Server.Mobiles
 
                 switch (Utility.Random(select))
                 {
-                    case 0: return new CorpseSkinSpell(m_Mobile, null);
+                    case 0:
+                        Spell spell;
+
+                        if (CheckCastCorpseSkin(m_Mobile))
+                            spell = new CorpseSkinSpell(m_Mobile, null);
+                        else
+                            spell = new EvilOmenSpell(m_Mobile, null);
+
+                        return spell;
                     case 1: return new EvilOmenSpell(m_Mobile, null);
                     case 2: return new BloodOathSpell(m_Mobile, null);
                     case 3: return new MindRotSpell(m_Mobile, null);
@@ -180,6 +188,11 @@ namespace Server.Mobiles
             }
 
             return true;
+        }
+
+        public static bool CheckCastCorpseSkin(BaseCreature bc)
+        {
+            return bc.ColdDamage != 100 && bc.PhysicalDamage != 100;
         }
     }
 }

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -6296,98 +6296,6 @@ namespace Server.Mobiles
         public virtual bool GivesMLMinorArtifact { get { return false; } }
         #endregion
 
-        #region Special Drops
-        private static readonly Type[] m_Artifacts = new[]
-        {
-            typeof(AegisOfGrace), typeof(BladeDance), typeof(Bonesmasher), typeof(FeyLeggings), typeof(FleshRipper),
-            typeof(HelmOfSwiftness), typeof(PadsOfTheCuSidhe), typeof(RaedsGlory), typeof(RighteousAnger),
-            typeof(RobeOfTheEclipse), typeof(RobeOfTheEquinox), typeof(SoulSeeker), typeof(TalonBite), typeof(BloodwoodSpirit),
-            typeof(TotemOfVoid), typeof(QuiverOfRage), typeof(QuiverOfElements), typeof(BrightsightLenses), typeof(Boomstick),
-            typeof(WildfireBow), typeof(Windsong)
-        };
-
-        public static void GiveMinorArtifact(Mobile m)
-        {
-            Item item = Activator.CreateInstance(m_Artifacts[Utility.Random(m_Artifacts.Length)]) as Item;
-            m.PlaySound(0x5B4);
-
-            if (item == null)
-            {
-                return;
-            }
-
-            if (m.AddToBackpack(item))
-            {
-                m.SendLocalizedMessage(1062317);
-                // For your valor in combating the fallen beast, a special artifact has been bestowed on you.
-                m.SendLocalizedMessage(1072223); // An item has been placed in your backpack.
-            }
-            else if (m.BankBox != null && m.BankBox.TryDropItem(m, item, false))
-            {
-                m.SendLocalizedMessage(1062317);
-                // For your valor in combating the fallen beast, a special artifact has been bestowed on you.
-                m.SendLocalizedMessage(1072224); // An item has been placed in your bank box.
-            }
-            else
-            {
-                item.MoveToWorld(m.Location, m.Map);
-                m.SendLocalizedMessage(1072523); // You find an artifact, but your backpack and bank are too full to hold it.
-            }
-        }
-
-        public static void CheckRecipeDrop(BaseCreature bc, Container c)
-        {
-            if (SpellHelper.IsEodon(c.Map, c.Location))
-            {
-                double chance = (double)bc.Fame / 1000000;
-                int luck = 0;
-
-                if (bc.LastKiller != null)
-                {
-                    luck = bc.LastKiller is PlayerMobile ? ((PlayerMobile)bc.LastKiller).RealLuck : bc.LastKiller.Luck;
-                }
-
-                if (luck > 0)
-                    chance += (double)luck / 152000;
-
-                if (chance > Utility.RandomDouble())
-                {
-                    if (0.33 > Utility.RandomDouble())
-                    {
-                        Item item = Server.Loot.Construct(_ArmorDropTypes[Utility.Random(_ArmorDropTypes.Length)]);
-
-                        if (item != null)
-                            c.DropItem(item);
-                    }
-                    else
-                    {
-                        Item scroll = new RecipeScroll(_RecipeTypes[Utility.Random(_RecipeTypes.Length)]);
-
-                        if (scroll != null)
-                            c.DropItem(scroll);
-                    }
-                }
-            }
-        }
-
-        public static Type[] ArmorDropTypes { get { return _ArmorDropTypes; } }
-        private static Type[] _ArmorDropTypes =
-        {
-            typeof(AloronsBustier), typeof(AloronsGorget), typeof(AloronsHelm), typeof(AloronsLegs), typeof(AloronsLongSkirt), typeof(AloronsSkirt), typeof(AloronsTunic),
-            typeof(DardensBustier), typeof(DardensHelm), typeof(DardensLegs), typeof(DardensSleeves), typeof(DardensTunic)
-        };
-
-        public static int[] RecipeTypes { get { return _RecipeTypes; } }
-        private static int[] _RecipeTypes =
-        {
-            560, 561, 562, 563, 564, 565, 566,
-            570, 571, 572, 573, 574, 575, 576, 577,
-            580, 581, 582, 583, 584
-            //602, 603, 604,  // nutcrackers
-            //800             // runic atlas
-        };
-        #endregion
-
         public virtual void OnRelease(Mobile from)
         {
             if (m_Allured)
@@ -6409,16 +6317,6 @@ namespace Server.Mobiles
             {
                 XmlParagon.GiveArtifactTo(mob, this);
             }
-
-            #region Mondain's Legacy
-            if (GivesMLMinorArtifact)
-            {
-                if (MondainsLegacy.CheckArtifactChance(mob, this))
-                {
-                    MondainsLegacy.GiveArtifactTo(mob);
-                }
-            }
-            #endregion
 
             EventSink.InvokeOnKilledBy(new OnKilledByEventArgs(this, mob));
         }
@@ -6627,9 +6525,6 @@ namespace Server.Mobiles
                         }
                     }
 
-                    // Eodon Recipe/Armor set drops
-                    CheckRecipeDrop(this, c);
-
                     for (int i = 0; i < titles.Count; ++i)
                     {
                         Titles.AwardFame(titles[i], fame[i], true);
@@ -6661,14 +6556,6 @@ namespace Server.Mobiles
                     c.Delete();
                 }
             }
-
-            #region SA
-            if(!c.Deleted && !Controlled && !Summoned)
-                IngredientDropEntry.CheckDrop(this, c);
-
-            if (LastKiller is BaseVoidCreature)
-                ((BaseVoidCreature)LastKiller).Mutate(VoidEvolution.Killing);
-            #endregion
         }
 
         /* To save on cpu usage, RunUO creatures only reacquire creatures under the following circumstances:

--- a/Scripts/Multis/BaseHouse.cs
+++ b/Scripts/Multis/BaseHouse.cs
@@ -497,9 +497,7 @@ namespace Server.Multis
         public virtual int GetAosCurSecures(out int fromSecures, out int fromVendors, out int fromLockdowns, out int fromMovingCrate)
         {
             /* Secured container, container counts as fromLockdowns, items count as fromSecures
-             * Locked Down Container, container and items count as fromLockdowns
-             * 
-             */
+             * Locked Down Container, container and items count as fromLockdowns */
 
             fromSecures = 0;
             fromVendors = 0;

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
@@ -169,6 +169,8 @@ namespace Server.Engines.Shadowguard
 
     public class HurricaneElemental : VileWaterElemental
     {
+        public override bool CanMoveOverObstacles { get { return false; } }
+
         [Constructable]
         public HurricaneElemental()
         {

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
@@ -124,6 +124,9 @@ namespace Server.Engines.Shadowguard
 
     public class VileWaterElemental : WaterElemental
     {
+        public override bool CanMoveOverObstacles { get { return false; } }
+
+        [Constructable]
         public VileWaterElemental()
         {
             Name = "a vile water elemental";

--- a/Scripts/Services/Expansions/TimeOfLegends.cs
+++ b/Scripts/Services/Expansions/TimeOfLegends.cs
@@ -7,6 +7,7 @@ using Server.Engines.Quests;
 using Server.Engines.CannedEvil;
 using Server.Engines.Shadowguard;
 using Server.Gumps;
+using Server.Spells;
 
 namespace Server
 {
@@ -18,6 +19,8 @@ namespace Server
 
             if (DateTime.UtcNow < _EndCurrencyWarning)
                 EventSink.Login += new LoginEventHandler(OnLogin);
+
+            EventSink.CreatureDeath += CheckRecipeDrop;
         }
 
         private  static readonly DateTime _EndCurrencyWarning = new DateTime(2017, 3, 1, 1, 1, 1);
@@ -104,5 +107,59 @@ namespace Server
                             e.Mobile.SendGump(new NewCurrencyHelpGump());
                     });
         }
+
+        public static void CheckRecipeDrop(CreatureDeathEventArgs e)
+        {
+            BaseCreature bc = e.Creature as BaseCreature;
+            var c = e.Corpse;
+            var killer = e.Killer;
+
+            if (SpellHelper.IsEodon(c.Map, c.Location))
+            {
+                double chance = (double)bc.Fame / 1000000;
+                int luck = 0;
+
+                if (killer != null)
+                {
+                    luck = Math.Min(1800, killer is PlayerMobile ? ((PlayerMobile)killer).RealLuck : killer.Luck);
+                }
+
+                if (luck > 0)
+                    chance += (double)luck / 152000;
+
+                if (chance > Utility.RandomDouble())
+                {
+                    if (0.33 > Utility.RandomDouble())
+                    {
+                        Item item = Server.Loot.Construct(_ArmorDropTypes[Utility.Random(_ArmorDropTypes.Length)]);
+
+                        if (item != null)
+                            c.DropItem(item);
+                    }
+                    else
+                    {
+                        Item scroll = new RecipeScroll(_RecipeTypes[Utility.Random(_RecipeTypes.Length)]);
+
+                        if (scroll != null)
+                            c.DropItem(scroll);
+                    }
+                }
+            }
+        }
+
+        public static Type[] ArmorDropTypes { get { return _ArmorDropTypes; } }
+        private static Type[] _ArmorDropTypes =
+        {
+            typeof(AloronsBustier), typeof(AloronsGorget), typeof(AloronsHelm), typeof(AloronsLegs), typeof(AloronsLongSkirt), typeof(AloronsSkirt), typeof(AloronsTunic),
+            typeof(DardensBustier), typeof(DardensHelm), typeof(DardensLegs), typeof(DardensSleeves), typeof(DardensTunic)
+        };
+
+        public static int[] RecipeTypes { get { return _RecipeTypes; } }
+        private static int[] _RecipeTypes =
+        {
+            560, 561, 562, 563, 564, 565, 566,
+            570, 571, 572, 573, 574, 575, 576, 577,
+            580, 581, 582, 583, 584
+        };
 	}
 }

--- a/Scripts/Services/PVP Arena System/ArenaManager.cs
+++ b/Scripts/Services/PVP Arena System/ArenaManager.cs
@@ -76,6 +76,14 @@ namespace Server.Engines.ArenaSystem
             }
         }
 
+        public override void OnDoubleClick(Mobile from)
+        {
+            if (CanPaperdollBeOpenedBy(from))
+            {
+                DisplayPaperdollTo(from);
+            }
+        }
+
         public ArenaManager(Serial serial)
             : base(serial)
         {

--- a/Scripts/Services/Pet Training/Gumps.cs
+++ b/Scripts/Services/Pet Training/Gumps.cs
@@ -188,31 +188,31 @@ namespace Server.Mobiles
             AddHtmlLocalized(47, 74, 160, 18, 3001030, 0xC8, false, false); // Combat Ratings
 
             AddHtmlLocalized(53, 92, 160, 18, 1044103, _Label, false, false); // Wrestling
-            AddHtml(180, 92, 75, 18, FormatSkill(Creature, SkillName.Wrestling), false, false);
+            AddHtml(180, 92, 100, 18, FormatSkill(Creature, SkillName.Wrestling), false, false);
 
             AddHtmlLocalized(53, 110, 160, 18, 1044087, _Label, false, false); // Tactics
-            AddHtml(180, 110, 75, 18, FormatSkill(Creature, SkillName.Tactics), false, false);
+            AddHtml(180, 110, 100, 18, FormatSkill(Creature, SkillName.Tactics), false, false);
 
             AddHtmlLocalized(53, 128, 160, 18, 1044086, _Label, false, false); // Magic Resistance
-            AddHtml(180, 128, 75, 18, FormatSkill(Creature, SkillName.MagicResist), false, false);
+            AddHtml(180, 128, 100, 18, FormatSkill(Creature, SkillName.MagicResist), false, false);
 
             AddHtmlLocalized(53, 146, 160, 18, 1044061, _Label, false, false); // Anatomy
-            AddHtml(180, 146, 75, 18, FormatSkill(Creature, SkillName.Anatomy), false, false);
+            AddHtml(180, 146, 100, 18, FormatSkill(Creature, SkillName.Anatomy), false, false);
 
             AddHtmlLocalized(53, 164, 160, 18, 1002082, _Label, false, false); // Healing
-            AddHtml(180, 164, 75, 18, FormatSkill(Creature, SkillName.Healing), false, false);
+            AddHtml(180, 164, 100, 18, FormatSkill(Creature, SkillName.Healing), false, false);
 
             AddHtmlLocalized(53, 182, 160, 18, 1002122, _Label, false, false); // Poisoning
-            AddHtml(180, 182, 75, 18, FormatSkill(Creature, SkillName.Poisoning), false, false);
+            AddHtml(180, 182, 100, 18, FormatSkill(Creature, SkillName.Poisoning), false, false);
 
             AddHtmlLocalized(53, 200, 160, 18, 1044074, _Label, false, false); // Detect Hidden
-            AddHtml(180, 200, 75, 18, FormatSkill(Creature, SkillName.DetectHidden), false, false);
+            AddHtml(180, 200, 100, 18, FormatSkill(Creature, SkillName.DetectHidden), false, false);
 
             AddHtmlLocalized(53, 218, 160, 18, 1002088, _Label, false, false); // Hiding
-            AddHtml(180, 218, 75, 18, FormatSkill(Creature, SkillName.Hiding), false, false);
+            AddHtml(180, 218, 100, 18, FormatSkill(Creature, SkillName.Hiding), false, false);
 
             AddHtmlLocalized(53, 236, 160, 18, 1002118, _Label, false, false); // Parrying
-            AddHtml(180, 236, 75, 18, FormatSkill(Creature, SkillName.Parry), false, false);
+            AddHtml(180, 236, 100, 18, FormatSkill(Creature, SkillName.Parry), false, false);
 
             AddButton(240, 328, 0x15E1, 0x15E5, 0, GumpButtonType.Page, 6);
             AddButton(217, 328, 0x15E3, 0x15E7, 0, GumpButtonType.Page, 4);
@@ -224,31 +224,31 @@ namespace Server.Mobiles
             AddHtmlLocalized(47, 74, 160, 18, 3001032, 0xC8, false, false); // Lore & Knowledge
 
             AddHtmlLocalized(53, 92, 160, 18, 1044085, _Label, false, false); // Magery
-            AddHtml(180, 92, 75, 18, FormatSkill(Creature, SkillName.Magery), false, false);
+            AddHtml(180, 92, 100, 18, FormatSkill(Creature, SkillName.Magery), false, false);
 
             AddHtmlLocalized(53, 110, 160, 18, 1044076, _Label, false, false); // Eval Int
-            AddHtml(180, 110, 75, 18, FormatSkill(Creature, SkillName.EvalInt), false, false);
+            AddHtml(180, 110, 100, 18, FormatSkill(Creature, SkillName.EvalInt), false, false);
 
             AddHtmlLocalized(53, 128, 160, 18, 1044106, _Label, false, false); // Meditation
-            AddHtml(180, 128, 75, 18, FormatSkill(Creature, SkillName.Meditation), false, false);
+            AddHtml(180, 128, 100, 18, FormatSkill(Creature, SkillName.Meditation), false, false);
 
             AddHtmlLocalized(53, 146, 160, 18, 1044109, _Label, false, false); // Necromancy
-            AddHtml(180, 146, 75, 18, FormatSkill(Creature, SkillName.Necromancy), false, false);
+            AddHtml(180, 146, 100, 18, FormatSkill(Creature, SkillName.Necromancy), false, false);
 
             AddHtmlLocalized(53, 164, 160, 18, 1002140, _Label, false, false); // Spirit Speak
-            AddHtml(180, 164, 75, 18, FormatSkill(Creature, SkillName.SpiritSpeak), false, false);
+            AddHtml(180, 164, 100, 18, FormatSkill(Creature, SkillName.SpiritSpeak), false, false);
 
             AddHtmlLocalized(53, 182, 160, 18, 1044115, _Label, false, false); // Mysticism
-            AddHtml(180, 182, 75, 18, FormatSkill(Creature, SkillName.Mysticism), false, false);
+            AddHtml(180, 182, 100, 18, FormatSkill(Creature, SkillName.Mysticism), false, false);
 
             AddHtmlLocalized(53, 200, 160, 18, 1044110, _Label, false, false); // Focus
-            AddHtml(180, 200, 75, 18, FormatSkill(Creature, SkillName.Focus), false, false);
+            AddHtml(180, 200, 100, 18, FormatSkill(Creature, SkillName.Focus), false, false);
 
             AddHtmlLocalized(53, 218, 160, 18, 1044114, _Label, false, false); // Spellweaving
-            AddHtml(180, 218, 75, 18, FormatSkill(Creature, SkillName.Spellweaving), false, false);
+            AddHtml(180, 218, 100, 18, FormatSkill(Creature, SkillName.Spellweaving), false, false);
 
             AddHtmlLocalized(53, 236, 160, 18, 1044075, _Label, false, false); // Discordance
-            AddHtml(180, 236, 75, 18, FormatSkill(Creature, SkillName.Discordance), false, false);
+            AddHtml(180, 236, 100, 18, FormatSkill(Creature, SkillName.Discordance), false, false);
 
             AddButton(240, 328, 0x15E1, 0x15E5, 0, GumpButtonType.Page, 7);
             AddButton(217, 328, 0x15E3, 0x15E7, 0, GumpButtonType.Page, 5);
@@ -260,13 +260,13 @@ namespace Server.Mobiles
             AddHtmlLocalized(47, 74, 160, 18, 3001032, 0xC8, false, false); // Lore & Knowledge
 
             AddHtmlLocalized(53, 92, 160, 18, 1044112, _Label, false, false); // Bushido
-            AddHtml(180, 92, 75, 18, FormatSkill(Creature, SkillName.Bushido), false, false);
+            AddHtml(180, 92, 100, 18, FormatSkill(Creature, SkillName.Bushido), false, false);
 
             AddHtmlLocalized(53, 110, 160, 18, 1044113, _Label, false, false); // Ninjitsu
-            AddHtml(180, 110, 75, 18, FormatSkill(Creature, SkillName.Ninjitsu), false, false);
+            AddHtml(180, 110, 100, 18, FormatSkill(Creature, SkillName.Ninjitsu), false, false);
 
             AddHtmlLocalized(53, 128, 160, 18, 1044111, _Label, false, false); // Chivalry
-            AddHtml(180, 128, 75, 18, FormatSkill(Creature, SkillName.Chivalry), false, false);
+            AddHtml(180, 128, 100, 18, FormatSkill(Creature, SkillName.Chivalry), false, false);
 
             AddImage(28, 146, 0x826);
 
@@ -508,7 +508,10 @@ namespace Server.Mobiles
 
         private static string FormatSkill(BaseCreature c, SkillName name)
         {
-            return AnimalLoreGump.FormatSkill(c, name);
+            if (c.Skills[name].Base < 10.0)
+                return "<div align=right>---</div>";
+
+            return String.Format("<div align=right>{0:F1}/{1}</div>", c.Skills[name].Value, c.Skills[name].Cap);
         }
 
         private static string FormatAttributes(int cur, int max)

--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -713,7 +713,7 @@ namespace Server.Mobiles
                 new TrainingDefinition(typeof(IronBeetle), Class.Insectoid, MagicalAbility.StandardClawedOrTailed, SpecialAbilityMagicalInsectoid, WepAbility1, AreaEffectNone, 2, 5),
                 new TrainingDefinition(typeof(JackRabbit), Class.None, MagicalAbility.StandardClawedOrTailed, SpecialAbilityAnimalStandard, WepAbility1, AreaEffectNone, 1, 2),
                 new TrainingDefinition(typeof(Kirin), Class.MagicalClawedAndTailed, MagicalAbility.Dragon2, SpecialAbilityClawedTailedAndMagical2, WepAbility2, AreaEffectArea1, 2, 5),
-                new TrainingDefinition(typeof(Lasher), Class.Magical, MagicalAbility.None, SpecialAbilityNone, WepAbilityNone, AreaEffectNone, 1, 3),
+                new TrainingDefinition(typeof(Lasher), Class.Magical, MagicalAbility.None, SpecialAbilityNone, WepAbilityNone, AreaEffectNone, 1, 4),
                 new TrainingDefinition(typeof(LavaLizard), Class.ClawedTailedMagicalAndTokuno, MagicalAbility.LavaLizard, SpecialAbilityNone, WepAbility6, AreaEffectArea1, 1, 4),
                 new TrainingDefinition(typeof(LesserHiryu), Class.ClawedTailedMagicalAndTokuno, MagicalAbility.Tokuno1, SpecialAbilityNone, WepAbility7, AreaEffectArea1, 1, 5),
                 new TrainingDefinition(typeof(Lion), Class.ClawedAndTailed, MagicalAbility.Poisoning, SpecialAbilityBitingClawedAndTailed, WepAbility1, AreaEffectArea3, 2, 5),

--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -777,7 +777,7 @@ namespace Server.Mobiles
                 new TrainingDefinition(typeof(WildTiger), Class.ClawedAndTailed, MagicalAbility.Poisoning, SpecialAbilityNone, WepAbility3, AreaEffectNone, 2, 5),
                 new TrainingDefinition(typeof(WildWhiteTiger), Class.ClawedAndTailed, MagicalAbility.Poisoning, SpecialAbilityNone, WepAbility3, AreaEffectNone, 2, 5),
                 new TrainingDefinition(typeof(WildBlackTiger), Class.ClawedAndTailed, MagicalAbility.Poisoning, SpecialAbilityNone, WepAbility3, AreaEffectNone, 2, 5),
-                new TrainingDefinition(typeof(Windrunner), Class.TailedAndNecromantic, MagicalAbility.None, SpecialAbilityNone, WepAbilityNone, AreaEffectNone, 1, 3),
+                new TrainingDefinition(typeof(Windrunner), Class.TailedAndNecromantic, MagicalAbility.None, SpecialAbilityNone, WepAbilityNone, AreaEffectNone, 1, 4),
                 new TrainingDefinition(typeof(WolfSpider), Class.None, MagicalAbility.Vartiety, SpecialAbilityBitingAnimal, WepAbility1, AreaEffectDisease, 1, 3),  
             };
             #endregion

--- a/Scripts/Services/Underworld/Navrey's Lair/NavreysPillar.cs
+++ b/Scripts/Services/Underworld/Navrey's Lair/NavreysPillar.cs
@@ -64,9 +64,9 @@ namespace Server.Items
         public NavreysPillar(NavreysController controller, PillarType type)
             : base(0x3BF)
         {
-            this.m_Controller = controller;
-            this.m_Type = type;
-            this.Movable = false;
+            m_Controller = controller;
+            m_Type = type;
+            Movable = false;
         }
 
         public override void OnDoubleClick(Mobile from)
@@ -100,7 +100,7 @@ namespace Server.Items
 
             int version = reader.ReadInt();
 
-            m_State = (NavreysPillarState)reader.ReadInt();
+            State = (NavreysPillarState)reader.ReadInt();
             m_Controller = (NavreysController)reader.ReadItem();
             m_Type = (PillarType)reader.ReadInt();
         }

--- a/Scripts/Services/VeteranRewards/DaviesLocker.cs
+++ b/Scripts/Services/VeteranRewards/DaviesLocker.cs
@@ -224,6 +224,16 @@ namespace Server.Engines.VeteranRewards
                     SetSecureLevelEntry.AddTo(from, (DaviesLockerAddon)Addon, list);
             }
 
+            public override void GetProperties(ObjectPropertyList list)
+            {
+                base.GetProperties(list);
+
+                if (Addon is DaviesLockerAddon)
+                {
+                    list.Add(1153648, ((DaviesLockerAddon)Addon).Entries.Count.ToString());
+                }
+            }
+
             public DaviesLockerComponent(Serial serial)
                 : base(serial)
             {

--- a/Scripts/Skills/Imbuing/ResourceDrops.cs
+++ b/Scripts/Skills/Imbuing/ResourceDrops.cs
@@ -38,6 +38,8 @@ namespace Server.Items
 
         public static void Initialize()
         {
+            EventSink.CreatureDeath += OnCreatureDeath;
+
             m_IngredientTable = new List<IngredientDropEntry>();
             //Bottle of Ichor/Spider Carapace
             m_IngredientTable.Add(new IngredientDropEntry(typeof(TrapdoorSpider), true, .05, typeof(SpiderCarapace)));
@@ -131,6 +133,22 @@ namespace Server.Items
             m_IngredientTable.Add(new IngredientDropEntry(typeof(BaseCreature), false, "Lands of the Lich", .05, typeof(EssenceDirection)));
             m_IngredientTable.Add(new IngredientDropEntry(typeof(BaseCreature), false, "Secret Garden", .05, typeof(EssenceFeeling)));
             m_IngredientTable.Add(new IngredientDropEntry(typeof(BaseCreature), false, "Skeletal Dragon", .05, typeof(EssencePersistence)));
+        }
+
+        public static void OnCreatureDeath(CreatureDeathEventArgs e)
+        {
+            BaseCreature bc = e.Creature as BaseCreature;
+            Container c = e.Corpse;
+
+            if (bc != null && c != null && !c.Deleted && !bc.Controlled && !bc.Summoned)
+            {
+                CheckDrop(bc, c);
+            }
+
+            if (e.Killer is BaseVoidCreature)
+            {
+                ((BaseVoidCreature)e.Killer).Mutate(VoidEvolution.Killing);
+            }
         }
 
         public static void CheckDrop(BaseCreature bc, Container c)


### PR DESCRIPTION
- Fixed object properties on mining cart and sheep statue
- Fixed erroneous gump on Runic Atlas
- Added Cusidhe to Wolf slayer
- Seed Box should always wight 10 stones
- Necro AI will no longer cast corpse skin in that creature has physical or cold damage Type
- Arena Manager should no longer offer animal training Quest
- Added skill cap to animal lore Gump
- Fixed navreys pillar during deserialization
- Davies lovker now shows contents in property list
- Vile Water Elementals can no longer move over canals

Enhancements:
Consolidated several functions in BaseCreature, using CreatureKilled/KilledBy events to clean up code. Basically, imbuing drops, ML arty drops and TOL recipe/armor set drops are now handed in thier respected systems.