### PR TITLE
Update DisintegratingThesisNotes.cs

### DIFF
--- a/Scripts/Items/Quest/DisintegratingThesisNotes.cs
+++ b/Scripts/Items/Quest/DisintegratingThesisNotes.cs
@@ -9,7 +9,6 @@ namespace Server.Items
             : base(0xE36)
         {
             Weight = 1.0;
-            LootType = LootType.Blessed;
         }
 
         public DisintegratingThesisNotes(Serial serial)


### PR DESCRIPTION
Need to revert this one key being blessed.

The problem is on EA they ARE blessed but just appear on the corpse. The way we have loot drops, blessed items will not drop on the corpse this way.

Reverting until a better system is discovered.