### PR TITLE
Add a recursive copy function to the autobackup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ PHONY : default build clean run
 default: run
 
 debug: 
-	${MCS} -target:library -out:${CURPATH}/Ultima.dll -r:${REFS} -nowarn:${NOWARNS} -d:DEBUG -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SDKPATH}/*.cs
-	${MCS} -win32icon:${SRVPATH}/servuo.ico -r:${CURPATH}/Ultima.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/ServUO.exe -d:DEBUG -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SRVPATH}/*.cs
+	${MCS} -target:library -define:MONO -out:${CURPATH}/Ultima.dll -r:${REFS} -nowarn:${NOWARNS} -d:DEBUG -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SDKPATH}/*.cs
+	${MCS} -win32icon:${SRVPATH}/servuo.ico -define:MONO -r:${CURPATH}/Ultima.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/ServUO.exe -d:DEBUG -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SRVPATH}/*.cs
 	sed -i.bak -e 's/<!--//g; s/-->//g' ServUO.exe.config
 
 run: build
@@ -28,10 +28,10 @@ clean:
 	rm -f *.bin
 
 Ultima.dll: Ultima/*.cs
-	${MCS} -target:library -out:${CURPATH}/Ultima.dll -r:${REFS} -nowarn:${NOWARNS} -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SDKPATH}/*.cs
+	${MCS} -target:library -define:MONO -out:${CURPATH}/Ultima.dll -r:${REFS} -nowarn:${NOWARNS} -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SDKPATH}/*.cs
 
 ServUO.exe: Ultima.dll Server/*.cs
-	${MCS} -win32icon:${SRVPATH}/servuo.ico -r:${CURPATH}/Ultima.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/ServUO.exe -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SRVPATH}/*.cs
+	${MCS} -win32icon:${SRVPATH}/servuo.ico -define:MONO -r:${CURPATH}/Ultima.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/ServUO.exe -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SRVPATH}/*.cs
 
 ServUO.sh: ServUO.exe
 	echo "#!/bin/sh" > ${CURPATH}/ServUO.sh

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ PHONY : default build clean run
 default: run
 
 debug: 
-	${MCS} -target:library -define:MONO -out:${CURPATH}/Ultima.dll -r:${REFS} -nowarn:${NOWARNS} -d:DEBUG -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SDKPATH}/*.cs
-	${MCS} -win32icon:${SRVPATH}/servuo.ico -define:MONO -r:${CURPATH}/Ultima.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/ServUO.exe -d:DEBUG -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SRVPATH}/*.cs
+	${MCS} -target:library -out:${CURPATH}/Ultima.dll -r:${REFS} -nowarn:${NOWARNS} -d:DEBUG -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SDKPATH}/*.cs
+	${MCS} -win32icon:${SRVPATH}/servuo.ico -r:${CURPATH}/Ultima.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/ServUO.exe -d:DEBUG -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SRVPATH}/*.cs
 	sed -i.bak -e 's/<!--//g; s/-->//g' ServUO.exe.config
 
 run: build
@@ -28,10 +28,10 @@ clean:
 	rm -f *.bin
 
 Ultima.dll: Ultima/*.cs
-	${MCS} -target:library -define:MONO -out:${CURPATH}/Ultima.dll -r:${REFS} -nowarn:${NOWARNS} -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SDKPATH}/*.cs
+	${MCS} -target:library -out:${CURPATH}/Ultima.dll -r:${REFS} -nowarn:${NOWARNS} -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SDKPATH}/*.cs
 
 ServUO.exe: Ultima.dll Server/*.cs
-	${MCS} -win32icon:${SRVPATH}/servuo.ico -define:MONO -r:${CURPATH}/Ultima.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/ServUO.exe -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SRVPATH}/*.cs
+	${MCS} -win32icon:${SRVPATH}/servuo.ico -r:${CURPATH}/Ultima.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/ServUO.exe -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SRVPATH}/*.cs
 
 ServUO.sh: ServUO.exe
 	echo "#!/bin/sh" > ${CURPATH}/ServUO.sh

--- a/Scripts/Misc/AutoSave.cs
+++ b/Scripts/Misc/AutoSave.cs
@@ -157,14 +157,14 @@ namespace Server.Misc
 
             if (Directory.Exists(saves))
             {
-#if MONO
+#if __MonoCS__
                 DirectoryCopy(saves, FormatDirectory(root, m_Backups[m_Backups.Length - 1], GetTimeStamp()), true);
 #else
                 Directory.Move(saves, FormatDirectory(root, m_Backups[m_Backups.Length - 1], GetTimeStamp()));
 #endif
             }
         }
-#if MONO
+#if __MonoCS__
         private static void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs)
             {
                 // Get the subdirectories for the specified directory.

--- a/Scripts/Misc/AutoSave.cs
+++ b/Scripts/Misc/AutoSave.cs
@@ -157,14 +157,14 @@ namespace Server.Misc
 
             if (Directory.Exists(saves))
             {
-#if __MonoCS__
-                DirectoryCopy(saves, FormatDirectory(root, m_Backups[m_Backups.Length - 1], GetTimeStamp()), true);
-#else
-                Directory.Move(saves, FormatDirectory(root, m_Backups[m_Backups.Length - 1], GetTimeStamp()));
-#endif
+                Type t = Type.GetType ("Mono.Runtime");
+                if (t != null)
+                    DirectoryCopy(saves, FormatDirectory(root, m_Backups[m_Backups.Length - 1], GetTimeStamp()), true);
+                else
+                    Directory.Move(saves, FormatDirectory(root, m_Backups[m_Backups.Length - 1], GetTimeStamp()));
             }
         }
-#if __MonoCS__
+
         private static void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs)
             {
                 // Get the subdirectories for the specified directory.
@@ -202,7 +202,7 @@ namespace Server.Misc
                     }
                 }
             }
-#endif
+
         private static DirectoryInfo Match(string[] paths, string match)
         {
             for (int i = 0; i < paths.Length; ++i)

--- a/Scripts/Misc/AutoSave.cs
+++ b/Scripts/Misc/AutoSave.cs
@@ -156,8 +156,46 @@ namespace Server.Misc
             string saves = Path.Combine(Core.BaseDirectory, "Saves");
 
             if (Directory.Exists(saves))
-                Directory.Move(saves, FormatDirectory(root, m_Backups[m_Backups.Length - 1], GetTimeStamp()));
+                DirectoryCopy(saves, FormatDirectory(root, m_Backups[m_Backups.Length - 1], GetTimeStamp()), true);
         }
+
+        private static void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs)
+            {
+                // Get the subdirectories for the specified directory.
+                DirectoryInfo dir = new DirectoryInfo(sourceDirName);
+
+                if (!dir.Exists)
+                {
+                    throw new DirectoryNotFoundException(
+                        "Source directory does not exist or could not be found: "
+                        + sourceDirName);
+                }
+
+                DirectoryInfo[] dirs = dir.GetDirectories();
+                // If the destination directory doesn't exist, create it.
+                if (!Directory.Exists(destDirName))
+                {
+                    Directory.CreateDirectory(destDirName);
+                }
+
+                // Get the files in the directory and copy them to the new location.
+                FileInfo[] files = dir.GetFiles();
+                foreach (FileInfo file in files)
+                {
+                    string temppath = Path.Combine(destDirName, file.Name);
+                    file.CopyTo(temppath, false);
+                }
+
+                // If copying subdirectories, copy them and their contents to new location.
+                if (copySubDirs)
+                {
+                    foreach (DirectoryInfo subdir in dirs)
+                    {
+                        string temppath = Path.Combine(destDirName, subdir.Name);
+                        DirectoryCopy(subdir.FullName, temppath, copySubDirs);
+                    }
+                }
+            }
 
         private static DirectoryInfo Match(string[] paths, string match)
         {

--- a/Scripts/Misc/AutoSave.cs
+++ b/Scripts/Misc/AutoSave.cs
@@ -156,9 +156,15 @@ namespace Server.Misc
             string saves = Path.Combine(Core.BaseDirectory, "Saves");
 
             if (Directory.Exists(saves))
+            {
+#if MONO
                 DirectoryCopy(saves, FormatDirectory(root, m_Backups[m_Backups.Length - 1], GetTimeStamp()), true);
+#else
+                Directory.Move(saves, FormatDirectory(root, m_Backups[m_Backups.Length - 1], GetTimeStamp()));
+#endif
+            }
         }
-
+#if MONO
         private static void DirectoryCopy(string sourceDirName, string destDirName, bool copySubDirs)
             {
                 // Get the subdirectories for the specified directory.
@@ -196,7 +202,7 @@ namespace Server.Misc
                     }
                 }
             }
-
+#endif
         private static DirectoryInfo Match(string[] paths, string match)
         {
             for (int i = 0; i < paths.Length; ++i)


### PR DESCRIPTION
Add a recursive copy function to the autobackup, rather than moving the folder.

I tested this on my Linux (Ubuntu 18.04) server and my Windows 10 server and the backups worked without losing my save data. (I was having no issues on Windows, but I tested it there to make sure I didn't break it.)