### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Addons/BaseAddon.cs
+++ b/Scripts/Items/Addons/BaseAddon.cs
@@ -167,6 +167,14 @@ namespace Server.Items
             }
         }
 
+        public virtual void InvalidateAddonPropreties()
+        {
+            InvalidateProperties();
+
+            foreach (var component in Components)
+                component.InvalidateProperties();
+        }
+
         public BaseAddon(Serial serial)
             : base(serial)
         {

--- a/Scripts/Items/Addons/DolphinRug.cs
+++ b/Scripts/Items/Addons/DolphinRug.cs
@@ -9,7 +9,10 @@ namespace Server.Items
     [TypeAlias("Server.Items.DolphinRugEastAddon", "Server.Items.DolphinRugSouthAddon")]
     public class DolphinRugAddon : BaseAddon, IRewardItem
     {
+        public override bool ForceShowProperties { get { return true; } }
+
         private bool m_IsRewardItem;
+        private int m_ResourceCount;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool IsRewardItem
@@ -21,9 +24,27 @@ namespace Server.Items
             set
             {
                 m_IsRewardItem = value;
-                InvalidateProperties();
+                InvalidateAddonPropreties();
             }
         }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public int ResourceCount
+        {
+            get
+            {
+                return m_ResourceCount;
+            }
+            set
+            {
+                m_ResourceCount = value;
+
+                InvalidateAddonPropreties();
+            }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public DateTime NextResourceCount { get; set; }
 
         private static int[,] _EastLarge = new int[,]
         {
@@ -75,14 +96,13 @@ namespace Server.Items
         {
             get
             {
-                DolphinRugAddonDeed deed = new DolphinRugAddonDeed(RugType, m_NextUse);
+                DolphinRugAddonDeed deed = new DolphinRugAddonDeed(RugType, m_ResourceCount, NextResourceCount);
                 deed.IsRewardItem = m_IsRewardItem;
 
                 return deed;
             }
         }
 
-        private DateTime m_NextUse;
         public RugType RugType { get; set; }
 
         [Constructable]
@@ -93,15 +113,16 @@ namespace Server.Items
 
         [Constructable]
         public DolphinRugAddon(RugType type)
-            : this(type, DateTime.UtcNow)
+            : this(type, 0, DateTime.UtcNow)
         {
         }
 
         [Constructable]
-        public DolphinRugAddon(RugType type, DateTime nextuse)
+        public DolphinRugAddon(RugType type, int resCount, DateTime nextuse)
         {
-            m_NextUse = nextuse;
+            NextResourceCount = nextuse;
             RugType = type;
+            ResourceCount = resCount;
 
             int[,] list;
 
@@ -115,7 +136,7 @@ namespace Server.Items
             }
 
             for (int i = 0; i < list.Length / 4; i++)
-                AddComponent(new AddonComponent(list[i, 0]), list[i, 1], list[i, 2], list[i, 3]);
+                AddComponent(new InternalAddonComponent(list[i, 0]), list[i, 1], list[i, 2], list[i, 3]);
         }
 
         public override void OnComponentUsed(AddonComponent component, Mobile from)
@@ -124,7 +145,7 @@ namespace Server.Items
 
             if (house != null && (house.IsOwner(from) || (house.LockDowns.ContainsKey(this) && house.LockDowns[this] == from)))
             {
-                if (m_NextUse < DateTime.UtcNow)
+                if (m_ResourceCount > 0)
                 {
                     Container cont = from.Backpack;
 
@@ -138,12 +159,63 @@ namespace Server.Items
                     else
                         from.SendLocalizedMessage(1072223); // An item has been placed in your backpack.
 
-                    m_NextUse = DateTime.UtcNow + TimeSpan.FromDays(7);
+                    ResourceCount--;
+                    NextResourceCount = DateTime.UtcNow + TimeSpan.FromDays(7);
                 }
             }
             else
             {
                 from.SendLocalizedMessage(502092); // You must be in your house to do this.
+            }
+        }
+
+        private class InternalAddonComponent : AddonComponent
+        {
+            public override int LabelNumber { get { return 1150122; } } // Dolphin Rug
+
+            public InternalAddonComponent(int id)
+                : base(id)
+            {
+            }
+
+            public override void GetProperties(ObjectPropertyList list)
+            {
+                base.GetProperties(list);
+
+                if (Addon is DolphinRugAddon)
+                {
+                    list.Add(1150103, ((DolphinRugAddon)Addon).ResourceCount.ToString()); // Messages in Bottles: ~1_val~
+                }
+            }
+
+            public InternalAddonComponent(Serial serial)
+                : base(serial)
+            {
+            }
+
+            public override void Serialize(GenericWriter writer)
+            {
+                base.Serialize(writer);
+
+                writer.WriteEncodedInt(0); // version
+            }
+
+            public override void Deserialize(GenericReader reader)
+            {
+                base.Deserialize(reader);
+
+                int version = reader.ReadEncodedInt();
+            }
+        }
+
+        private void TryGiveResourceCount()
+        {
+            if (NextResourceCount < DateTime.UtcNow)
+            {
+                ResourceCount = Math.Min(10, m_ResourceCount + 1);
+                NextResourceCount = DateTime.UtcNow + TimeSpan.FromDays(7);
+
+                InvalidateAddonPropreties();
             }
         }
 
@@ -155,10 +227,14 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(2); // Version
+            writer.Write(3); // Version
+
+            TryGiveResourceCount();
+
+            writer.Write(m_ResourceCount);
 
             writer.Write((bool)m_IsRewardItem);
-            writer.Write(m_NextUse);
+            writer.Write(NextResourceCount);
             writer.Write((int)RugType);
         }
 
@@ -169,17 +245,20 @@ namespace Server.Items
 
             switch (version)
             {
+                case 3:
+                    m_ResourceCount = reader.ReadInt();
+                    goto case 2;
                 case 2:
                     m_IsRewardItem = reader.ReadBool();
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 1:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 0:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     break;
             }
         }
@@ -192,7 +271,7 @@ namespace Server.Items
         {
             get
             {
-                DolphinRugAddon addon = new DolphinRugAddon(RugType, m_NextUse);
+                DolphinRugAddon addon = new DolphinRugAddon(RugType, m_ResourceCount, NextResourceCount);
                 addon.IsRewardItem = m_IsRewardItem;
 
                 return addon;
@@ -212,7 +291,8 @@ namespace Server.Items
             }
         }
 
-        private DateTime m_NextUse;
+        private DateTime NextResourceCount;
+        private int m_ResourceCount;
         private bool m_IsRewardItem;
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -230,6 +310,20 @@ namespace Server.Items
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
+        public int ResourceCount
+        {
+            get
+            {
+                return m_ResourceCount;
+            }
+            set
+            {
+                m_ResourceCount = value;
+                InvalidateProperties();
+            }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
         public RugType RugType { get; set; }
 
         [Constructable]
@@ -240,15 +334,17 @@ namespace Server.Items
 
         [Constructable]
         public DolphinRugAddonDeed(RugType type)
-            : this(type, DateTime.UtcNow)
+            : this(type, 0, DateTime.UtcNow)
         {
         }
 
         [Constructable]
-        public DolphinRugAddonDeed(RugType type, DateTime nextuse)
+        public DolphinRugAddonDeed(RugType type, int resCount, DateTime nextuse)
         {
             RugType = type;
-            m_NextUse = nextuse;
+            NextResourceCount = nextuse;
+            ResourceCount = resCount;
+
             LootType = LootType.Blessed;
         }
 
@@ -295,10 +391,12 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(2); // Version
+            writer.Write(3); // Version
+
+            writer.Write(m_ResourceCount);
 
             writer.Write((bool)m_IsRewardItem);
-            writer.Write(m_NextUse);
+            writer.Write(NextResourceCount);
             writer.Write((int)RugType);
         }
 
@@ -309,17 +407,20 @@ namespace Server.Items
 
             switch (version)
             {
+                case 3:
+                    m_ResourceCount = reader.ReadInt();
+                    goto case 2;
                 case 2:
                     m_IsRewardItem = reader.ReadBool();
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 1:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 0:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     break;
             }
         }

--- a/Scripts/Items/Addons/RoseRug.cs
+++ b/Scripts/Items/Addons/RoseRug.cs
@@ -17,7 +17,10 @@ namespace Server.Items
     [TypeAlias("Server.Items.RoseRugEastAddon", "Server.Items.RoseRugSouthAddon")]
     public class RoseRugAddon : BaseAddon, IRewardItem
     {
+        public override bool ForceShowProperties { get { return true; } }
+
         private bool m_IsRewardItem;
+        private int m_ResourceCount;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool IsRewardItem
@@ -29,9 +32,26 @@ namespace Server.Items
             set
             {
                 m_IsRewardItem = value;
-                InvalidateProperties();
+                InvalidateAddonPropreties();
             }
         }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public int ResourceCount
+        {
+            get
+            {
+                return m_ResourceCount;
+            }
+            set
+            {
+                m_ResourceCount = value;
+                InvalidateAddonPropreties();
+            }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public DateTime NextResourceCount { get; set; }
 
         private static int[,] _EastLarge =
         {
@@ -83,14 +103,13 @@ namespace Server.Items
         {
             get
             {
-                RoseRugAddonDeed deed = new RoseRugAddonDeed(RugType, m_NextUse);
+                RoseRugAddonDeed deed = new RoseRugAddonDeed(RugType, m_ResourceCount, NextResourceCount);
                 deed.IsRewardItem = m_IsRewardItem;
 
                 return deed;
             }
         }
 
-        private DateTime m_NextUse;
         public RugType RugType { get; set; }
 
         [Constructable]
@@ -100,15 +119,16 @@ namespace Server.Items
         }
 
         [Constructable]
-        public RoseRugAddon(RugType type) : this(type, DateTime.UtcNow)
+        public RoseRugAddon(RugType type) : this(type, 0, DateTime.UtcNow)
         {
         }
 
         [Constructable]
-        public RoseRugAddon(RugType type, DateTime nextuse)
+        public RoseRugAddon(RugType type, int resCount, DateTime nextuse)
         {
-            m_NextUse = nextuse;
+            NextResourceCount = nextuse;
             RugType = type;
+            ResourceCount = resCount;
 
             int[,] list;
 
@@ -122,7 +142,7 @@ namespace Server.Items
             }
 
             for (int i = 0; i < list.Length / 4; i++)
-                AddComponent(new AddonComponent(list[i, 0]), list[i, 1], list[i, 2], list[i, 3]);
+                AddComponent(new InternalAddonComponent(list[i, 0]), list[i, 1], list[i, 2], list[i, 3]);
         }
 
         public override void OnComponentUsed(AddonComponent component, Mobile from)
@@ -131,7 +151,7 @@ namespace Server.Items
 
             if (house != null && (house.IsOwner(from) || (house.LockDowns.ContainsKey(this) && house.LockDowns[this] == from)))
             {
-                if (m_NextUse < DateTime.UtcNow)
+                if (m_ResourceCount > 0)
                 {
                     Container cont = from.Backpack;
 
@@ -145,12 +165,63 @@ namespace Server.Items
                     else
                         from.SendLocalizedMessage(1072223); // An item has been placed in your backpack.
 
-                    m_NextUse = DateTime.UtcNow + TimeSpan.FromDays(7);
+                    ResourceCount--;
+                    NextResourceCount = DateTime.UtcNow + TimeSpan.FromDays(7);
                 }
             }
             else
             {
                 from.SendLocalizedMessage(502092); // You must be in your house to do 
+            }
+        }
+
+        private class InternalAddonComponent : AddonComponent
+        {
+            public override int LabelNumber { get { return 1150121; } } // Rose Rug
+
+            public InternalAddonComponent(int id)
+                : base(id)
+            {
+            }
+
+            public override void GetProperties(ObjectPropertyList list)
+            {
+                base.GetProperties(list);
+
+                if (Addon is RoseRugAddon)
+                {
+                    list.Add(1150103, ((RoseRugAddon)Addon).ResourceCount.ToString()); // Messages in Bottles: ~1_val~
+                }
+            }
+
+            public InternalAddonComponent(Serial serial)
+                : base(serial)
+            {
+            }
+
+            public override void Serialize(GenericWriter writer)
+            {
+                base.Serialize(writer);
+
+                writer.WriteEncodedInt(0); // version
+            }
+
+            public override void Deserialize(GenericReader reader)
+            {
+                base.Deserialize(reader);
+
+                int version = reader.ReadEncodedInt();
+            }
+        }
+
+        private void TryGiveResourceCount()
+        {
+            if (NextResourceCount < DateTime.UtcNow)
+            {
+                ResourceCount = Math.Min(10, m_ResourceCount + 1);
+                NextResourceCount = DateTime.UtcNow + TimeSpan.FromDays(7);
+
+                InvalidateAddonPropreties();
             }
         }
 
@@ -163,10 +234,14 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(2); // Version
+            writer.Write(3); // Version
+
+            TryGiveResourceCount();
+
+            writer.Write(m_ResourceCount);
 
             writer.Write((bool)m_IsRewardItem);
-            writer.Write(m_NextUse);
+            writer.Write(NextResourceCount);
             writer.Write((int)RugType);
         }
 
@@ -177,17 +252,20 @@ namespace Server.Items
 
             switch (version)
             {
+                case 3:
+                    m_ResourceCount = reader.ReadInt();
+                    goto case 2;
                 case 2:
                     m_IsRewardItem = reader.ReadBool();
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 1:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 0:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     break;
             }
         }
@@ -200,7 +278,7 @@ namespace Server.Items
         {
             get
             {
-                RoseRugAddon addon = new RoseRugAddon(RugType, m_NextUse);
+                RoseRugAddon addon = new RoseRugAddon(RugType, m_ResourceCount, NextResourceCount);
                 addon.IsRewardItem = m_IsRewardItem;
 
                 return addon;
@@ -220,7 +298,8 @@ namespace Server.Items
             }
         }
 
-        private DateTime m_NextUse;
+        private DateTime NextResourceCount;
+        private int m_ResourceCount;
         private bool m_IsRewardItem;
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -238,12 +317,21 @@ namespace Server.Items
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public RugType RugType { get; set; }
-
-        [Constructable]
-        public RoseRugAddonDeed(RugType type) : this(type, DateTime.UtcNow)
+        public int ResourceCount
         {
+            get
+            {
+                return m_ResourceCount;
+            }
+            set
+            {
+                m_ResourceCount = value;
+                InvalidateProperties();
+            }
         }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public RugType RugType { get; set; }
 
         [Constructable]
         public RoseRugAddonDeed()
@@ -252,10 +340,18 @@ namespace Server.Items
         }
 
         [Constructable]
-        public RoseRugAddonDeed(RugType type, DateTime nextuse)
+        public RoseRugAddonDeed(RugType type)
+            : this(type, 0, DateTime.UtcNow)
+        {
+        }
+
+        [Constructable]
+        public RoseRugAddonDeed(RugType type, int resCount, DateTime nextuse)
         {
             RugType = type;
-            m_NextUse = nextuse;
+            NextResourceCount = nextuse;
+            ResourceCount = resCount;
+
             LootType = LootType.Blessed;
         }
 
@@ -302,10 +398,12 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(2); // Version
+            writer.Write(3); // Version
+
+            writer.Write(m_ResourceCount);
 
             writer.Write((bool)m_IsRewardItem);
-            writer.Write(m_NextUse);
+            writer.Write(NextResourceCount);
             writer.Write((int)RugType);
         }
 
@@ -316,17 +414,20 @@ namespace Server.Items
 
             switch (version)
             {
+                case 3:
+                    m_ResourceCount = reader.ReadInt();
+                    goto case 2;
                 case 2:
                     m_IsRewardItem = reader.ReadBool();
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 1:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 0:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     break;
             }
         }

--- a/Scripts/Items/Addons/SheepStatue.cs
+++ b/Scripts/Items/Addons/SheepStatue.cs
@@ -51,7 +51,7 @@ namespace Server.Items
             set
             {
                 m_IsRewardItem = value;
-                InvalidateProperties();
+                InvalidateAddonPropreties();
             }
         }
 
@@ -74,7 +74,7 @@ namespace Server.Items
                         Components[0].ItemID = 0x4A94;
                 }
 
-                InvalidateProperties();
+                InvalidateAddonPropreties();
             }
         }
 

--- a/Scripts/Items/Addons/SkullRug.cs
+++ b/Scripts/Items/Addons/SkullRug.cs
@@ -9,7 +9,10 @@ namespace Server.Items
     [TypeAlias("Server.Items.SkullRugEastAddon", "Server.Items.SkullRugSouthAddon")]
     public class SkullRugAddon : BaseAddon, IRewardItem
     {
+        public override bool ForceShowProperties { get { return true; } }
+
         private bool m_IsRewardItem;
+        private int m_ResourceCount;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool IsRewardItem
@@ -21,9 +24,26 @@ namespace Server.Items
             set
             {
                 m_IsRewardItem = value;
-                InvalidateProperties();
+                InvalidateAddonPropreties();
             }
         }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public int ResourceCount
+        {
+            get
+            {
+                return m_ResourceCount;
+            }
+            set
+            {
+                m_ResourceCount = value;
+                InvalidateAddonPropreties();
+            }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public DateTime NextResourceCount { get; set; }
 
         private static int[,] _EastLarge = new int[,]
         {
@@ -75,14 +95,13 @@ namespace Server.Items
         {
             get
             {
-                SkullRugAddonDeed deed = new SkullRugAddonDeed(RugType, m_NextUse);
+                SkullRugAddonDeed deed = new SkullRugAddonDeed(RugType, m_ResourceCount, NextResourceCount);
                 deed.IsRewardItem = m_IsRewardItem;
 
                 return deed;
             }
         }
 
-        private DateTime m_NextUse;
         public RugType RugType { get; set; }
 
         [Constructable]
@@ -93,15 +112,16 @@ namespace Server.Items
 
         [Constructable]
         public SkullRugAddon(RugType type)
-            : this(type, DateTime.UtcNow)
+            : this(type, 0, DateTime.UtcNow)
         {
         }
 
         [Constructable]
-        public SkullRugAddon(RugType type, DateTime nextuse)
+        public SkullRugAddon(RugType type, int resCount, DateTime nextuse)
         {
-            m_NextUse = nextuse;
+            NextResourceCount = nextuse;
             RugType = type;
+            ResourceCount = resCount;
 
             int[,] list;
 
@@ -115,7 +135,7 @@ namespace Server.Items
             }
 
             for (int i = 0; i < list.Length / 4; i++)
-                AddComponent(new AddonComponent(list[i, 0]), list[i, 1], list[i, 2], list[i, 3]);
+                AddComponent(new InternalAddonComponent(list[i, 0]), list[i, 1], list[i, 2], list[i, 3]);
         }
 
         public override void OnComponentUsed(AddonComponent component, Mobile from)
@@ -124,7 +144,7 @@ namespace Server.Items
 
             if (house != null && (house.IsOwner(from) || (house.LockDowns.ContainsKey(this) && house.LockDowns[this] == from)))
             {
-                if (m_NextUse < DateTime.UtcNow)
+                if (m_ResourceCount > 0)
                 {
                     Container cont = from.Backpack;
                     Map facet;
@@ -153,12 +173,61 @@ namespace Server.Items
                     else
                         from.SendLocalizedMessage(1072223); // An item has been placed in your backpack.
 
-                    m_NextUse = DateTime.UtcNow + TimeSpan.FromDays(7);
+                    ResourceCount--;
+                    NextResourceCount = DateTime.UtcNow + TimeSpan.FromDays(7);
                 }
             }
             else
             {
                 from.SendLocalizedMessage(502092); // You must be in your house to do this.
+            }
+        }
+
+        private class InternalAddonComponent : AddonComponent
+        {
+            public override int LabelNumber { get { return 1150120; } } // Skull Rug
+
+            public InternalAddonComponent(int id)
+                : base(id)
+            {
+            }
+
+            public override void GetProperties(ObjectPropertyList list)
+            {
+                base.GetProperties(list);
+
+                if (Addon is SkullRugAddon)
+                {
+                    list.Add(1150101, ((SkullRugAddon)Addon).ResourceCount.ToString()); // Treasure Maps: ~1_val~
+                }
+            }
+
+            public InternalAddonComponent(Serial serial)
+                : base(serial)
+            {
+            }
+
+            public override void Serialize(GenericWriter writer)
+            {
+                base.Serialize(writer);
+
+                writer.WriteEncodedInt(0); // version
+            }
+
+            public override void Deserialize(GenericReader reader)
+            {
+                base.Deserialize(reader);
+
+                int version = reader.ReadEncodedInt();
+            }
+        }
+
+        private void TryGiveResourceCount()
+        {
+            if (NextResourceCount < DateTime.UtcNow)
+            {
+                ResourceCount = Math.Min(10, m_ResourceCount + 1);
+                NextResourceCount = DateTime.UtcNow + TimeSpan.FromDays(7);
             }
         }
 
@@ -171,10 +240,14 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(2); // Version
+            writer.Write(3); // Version
+
+            TryGiveResourceCount();
+
+            writer.Write(m_ResourceCount);
 
             writer.Write((bool)m_IsRewardItem);
-            writer.Write(m_NextUse);
+            writer.Write(NextResourceCount);
             writer.Write((int)RugType);
         }
 
@@ -185,17 +258,20 @@ namespace Server.Items
 
             switch (version)
             {
+                case 3:
+                    m_ResourceCount = reader.ReadInt();
+                    goto case 2;
                 case 2:
                     m_IsRewardItem = reader.ReadBool();
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 1:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 0:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     break;
             }
         }
@@ -208,7 +284,7 @@ namespace Server.Items
         {
             get
             {
-                SkullRugAddon addon = new SkullRugAddon(RugType, m_NextUse);
+                SkullRugAddon addon = new SkullRugAddon(RugType, m_ResourceCount, NextResourceCount);
                 addon.IsRewardItem = m_IsRewardItem;
 
                 return addon;
@@ -228,7 +304,8 @@ namespace Server.Items
             }
         }
 
-        private DateTime m_NextUse;
+        private DateTime NextResourceCount;
+        private int m_ResourceCount;
         private bool m_IsRewardItem;
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -246,6 +323,20 @@ namespace Server.Items
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
+        public int ResourceCount
+        {
+            get
+            {
+                return m_ResourceCount;
+            }
+            set
+            {
+                m_ResourceCount = value;
+                InvalidateProperties();
+            }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
         public RugType RugType { get; set; }
 
         [Constructable]
@@ -256,15 +347,17 @@ namespace Server.Items
 
         [Constructable]
         public SkullRugAddonDeed(RugType type)
-            : this(type, DateTime.UtcNow)
+            : this(type, 0, DateTime.UtcNow)
         {
         }
 
         [Constructable]
-        public SkullRugAddonDeed(RugType type, DateTime nextuse)
+        public SkullRugAddonDeed(RugType type, int resCount, DateTime nextuse)
         {
             RugType = type;
-            m_NextUse = nextuse;
+            NextResourceCount = nextuse;
+            ResourceCount = resCount;
+
             LootType = LootType.Blessed;
         }
 
@@ -311,10 +404,12 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(2); // Version
+            writer.Write(3); // Version
+
+            writer.Write(m_ResourceCount);
 
             writer.Write((bool)m_IsRewardItem);
-            writer.Write(m_NextUse);
+            writer.Write(NextResourceCount);
             writer.Write((int)RugType);
         }
 
@@ -325,17 +420,20 @@ namespace Server.Items
 
             switch (version)
             {
+                case 3:
+                    m_ResourceCount = reader.ReadInt();
+                    goto case 2;
                 case 2:
                     m_IsRewardItem = reader.ReadBool();
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 1:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     RugType = (RugType)reader.ReadInt();
                     break;
                 case 0:
-                    m_NextUse = reader.ReadDateTime();
+                    NextResourceCount = reader.ReadDateTime();
                     break;
             }
         }

--- a/Scripts/Items/Consumables/MelisandesHairDye.cs
+++ b/Scripts/Items/Consumables/MelisandesHairDye.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Gumps;
+using Server.Mobiles;
 
 namespace Server.Items
 {
@@ -9,7 +10,7 @@ namespace Server.Items
         public MelisandesHairDye()
             : base(0xEFF)
         {
-            this.Hue = Utility.RandomMinMax(0x47E, 0x499);
+            Hue = Utility.RandomMinMax(0x47E, 0x499);
         }
 
         public MelisandesHairDye(Serial serial)
@@ -26,10 +27,10 @@ namespace Server.Items
         }// Hair Dye
         public override void OnDoubleClick(Mobile from)
         {
-            if (this.IsChildOf(from.Backpack))
+            if (IsChildOf(from.Backpack))
             {
-                if (MondainsLegacy.CheckML(from))
-                    from.SendGump(new ConfirmGump(this));
+                if (from is PlayerMobile && MondainsLegacy.CheckML(from))
+                    BaseGump.SendGump(new HairDyeConfirmGump(from as PlayerMobile, Hue, this));
             }
             else
                 from.SendLocalizedMessage(1042001); // That must be in your pack for you to use it.
@@ -47,53 +48,6 @@ namespace Server.Items
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
-        }
-
-        private class ConfirmGump : BaseConfirmGump
-        {
-            private readonly Item m_Item;
-            public ConfirmGump(Item item)
-                : base()
-            {
-                this.m_Item = item;
-            }
-
-            public override int TitleNumber
-            {
-                get
-                {
-                    return 1074395;
-                }
-            }// <div align=right>Use Permanent Hair Dye</div>
-            public override int LabelNumber
-            {
-                get
-                {
-                    return 1074396;
-                }
-            }// This special hair dye is made of a unique mixture of leaves, permanently changing one's hair color until another dye is used.
-            public override void Confirm(Mobile from)
-            {
-                if (this.m_Item != null && !this.m_Item.Deleted && this.m_Item.IsChildOf(from.Backpack))
-                {
-                    if (from.HairItemID != 0)
-                    {
-                        from.HairHue = this.m_Item.Hue;
-                        from.PlaySound(0x240);
-                        from.SendLocalizedMessage(502622); // You dye your hair.
-                        this.m_Item.Delete();
-                    }
-                    else
-                        from.SendLocalizedMessage(502623); // You have no hair to dye and you cannot use this.
-                }
-                else
-                    from.SendLocalizedMessage(1073461); // You don't have enough dye.
-            }
-
-            public override void Refuse(Mobile from)
-            {
-                from.SendLocalizedMessage(502620); // You decide not to dye your hair.
-            }
         }
     }
 }

--- a/Scripts/Items/Decorative/Corpses/Corpse.cs
+++ b/Scripts/Items/Decorative/Corpses/Corpse.cs
@@ -183,7 +183,27 @@ namespace Server.Items
 			return true;
 		}
 
-		private void AssignInstancedLoot()
+        public override void AddItem(Item item)
+        {
+            base.AddItem(item);
+
+            if (InstancedCorpse)
+            {
+                AssignInstancedLoot(item);
+            }
+        }
+
+        private void AssignInstancedLoot()
+        {
+            AssignInstancedLoot(this.Items);
+        }
+
+        public void AssignInstancedLoot(Item item)
+        {
+            AssignInstancedLoot(new Item[] { item });
+        }
+
+        private void AssignInstancedLoot(IEnumerable<Item> items)
 		{
 			if (m_Aggressors.Count == 0 || Items.Count == 0)
 			{
@@ -198,10 +218,8 @@ namespace Server.Items
 			var m_Stackables = new List<Item>();
 			var m_Unstackables = new List<Item>();
 
-			for (int i = 0; i < Items.Count; i++)
+            foreach (var item in items)
 			{
-				Item item = Items[i];
-
 				if (item.LootType != LootType.Cursed) //Don't have curesd items take up someone's item spot.. (?)
 				{
 					if (item.Stackable)

--- a/Scripts/Items/Functional/SeedBox/SeedBox.cs
+++ b/Scripts/Items/Functional/SeedBox/SeedBox.cs
@@ -60,6 +60,11 @@ namespace Server.Engines.Plants
             Level = SecureLevel.Owner;
         }
 
+        public override int GetTotal(TotalType type)
+        {
+            return 0;
+        }
+
         public override void OnDoubleClick(Mobile m)
         {
             if (IsChildOf(m.Backpack) || (CheckAccessible(m) && m.InRange(this.GetWorldLocation(), 3)))

--- a/Scripts/Items/StoreBought/GreenGoblinStatuette.cs
+++ b/Scripts/Items/StoreBought/GreenGoblinStatuette.cs
@@ -5,6 +5,9 @@ namespace Server.Items
 {
     public class GreenGoblinStatuette : MonsterStatuette
     {
+        [CommandProperty(AccessLevel.GameMaster)]
+        public Mobile User { get; set; }
+
         [Constructable]
         public GreenGoblinStatuette()
             : base(MonsterStatuetteType.GreenGoblin)
@@ -17,9 +20,7 @@ namespace Server.Items
             {
                 if (TurnedOn)
                 {
-                    TurnedOn = false;
-
-                    from.BodyMod = 0;
+                    TurnOff();
                 }
                 else
                 {
@@ -37,15 +38,68 @@ namespace Server.Items
                     }
                     else
                     {
-                        TurnedOn = true;
-
-                        from.BodyMod = 723;
-                        from.HueMod = 0;
-
-                        from.FixedParticles(0x3728, 1, 13, 5042, EffectLayer.Waist);
+                        TurnOn(from);
                     }
                 }
             }
+        }
+
+        public void TurnOn(Mobile from)
+        {
+            User = from;
+            TurnedOn = true;
+
+            from.BodyMod = 723;
+            from.HueMod = 0;
+
+            ItemID = 0xA098;
+
+            from.FixedParticles(0x3728, 1, 13, 5042, EffectLayer.Waist);
+        }
+
+        public void TurnOff()
+        {
+            TurnedOn = false;
+
+            if (User != null)
+            {
+                User.BodyMod = 0;
+                User.HueMod = -1;
+            }
+
+            ItemID = 0xA097;
+
+            User = null;
+        }
+
+        public override bool OnDragLift(Mobile from)
+        {
+            if (TurnedOn)
+            {
+                TurnOff();
+            }
+
+            return base.OnDragLift(from);
+        }
+
+        public override void OnDelete()
+        {
+            if (TurnedOn)
+            {
+                TurnOff();
+            }
+
+            base.OnDelete();
+        }
+
+        public override void OnItemRemoved(Item item)
+        {
+            if (TurnedOn)
+            {
+                TurnOff();
+            }
+
+            base.OnItemRemoved(item);
         }
 
         public GreenGoblinStatuette(Serial serial)
@@ -57,7 +111,8 @@ namespace Server.Items
         {
             base.Serialize(writer);
 
-            writer.Write((int)0);
+            writer.Write((int)1);
+            writer.Write(User);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -65,6 +120,18 @@ namespace Server.Items
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
+
+            switch(version)
+            {
+                case 1:
+                    User = reader.ReadMobile();
+                    break;
+            }
+
+            if(User != null)
+            {
+                TurnOn(User);
+            }
         }
     }
 }

--- a/Scripts/Items/StoreBought/GreyGoblinStatuette.cs
+++ b/Scripts/Items/StoreBought/GreyGoblinStatuette.cs
@@ -5,6 +5,9 @@ namespace Server.Items
 {
     public class GreyGoblinStatuette : MonsterStatuette
     {
+        [CommandProperty(AccessLevel.GameMaster)]
+        public Mobile User { get; set; }
+
         [Constructable]
         public GreyGoblinStatuette()
             : base(MonsterStatuetteType.GreyGoblin)
@@ -17,9 +20,7 @@ namespace Server.Items
             {
                 if (TurnedOn)
                 {
-                    TurnedOn = false;
-
-                    from.BodyMod = 0;
+                    TurnOff();
                 }
                 else
                 {
@@ -37,15 +38,68 @@ namespace Server.Items
                     }
                     else
                     {
-                        TurnedOn = true;
-
-                        from.BodyMod = 334;
-                        from.HueMod = 0;
-
-                        from.FixedParticles(0x3728, 1, 13, 5042, EffectLayer.Waist);
+                        TurnOn(from);
                     }
                 }
             }
+        }
+
+        public void TurnOn(Mobile from)
+        {
+            User = from;
+            TurnedOn = true;
+
+            from.BodyMod = 723;
+            from.HueMod = 0;
+
+            ItemID = 0xA098;
+
+            from.FixedParticles(0x3728, 1, 13, 5042, EffectLayer.Waist);
+        }
+
+        public void TurnOff()
+        {
+            TurnedOn = false;
+
+            if (User != null)
+            {
+                User.BodyMod = 0;
+                User.HueMod = -1;
+            }
+
+            ItemID = 0xA097;
+
+            User = null;
+        }
+
+        public override bool OnDragLift(Mobile from)
+        {
+            if (TurnedOn)
+            {
+                TurnOff();
+            }
+
+            return base.OnDragLift(from);
+        }
+
+        public override void OnDelete()
+        {
+            if (TurnedOn)
+            {
+                TurnOff();
+            }
+
+            base.OnDelete();
+        }
+
+        public override void OnItemRemoved(Item item)
+        {
+            if (TurnedOn)
+            {
+                TurnOff();
+            }
+
+            base.OnItemRemoved(item);
         }
 
         public GreyGoblinStatuette(Serial serial)
@@ -57,7 +111,8 @@ namespace Server.Items
         {
             base.Serialize(writer);
 
-            writer.Write((int)0);
+            writer.Write((int)1);
+            writer.Write(User);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -65,6 +120,18 @@ namespace Server.Items
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
+
+            switch (version)
+            {
+                case 1:
+                    User = reader.ReadMobile();
+                    break;
+            }
+
+            if (User != null)
+            {
+                TurnOn(User);
+            }
         }
     }
 }

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -402,6 +402,8 @@ namespace Server
             Spells.Mysticism.PurgeMagicSpell.OnMobileDoDamage(from);
             #endregion
 
+            BaseCostume.OnDamaged(m);
+
             return totalDamage;
         }
 

--- a/Scripts/Mobiles/NPCs/CustomHairstylist.cs
+++ b/Scripts/Mobiles/NPCs/CustomHairstylist.cs
@@ -757,6 +757,11 @@ namespace Server.Mobiles
                                         if (m_FacialHair)
                                         {
                                             m_From.FacialHairItemID = itemID;
+
+                                            if (itemID != 0)
+                                            {
+                                                m_From.FacialHairHue = m_From.HairHue;
+                                            }
                                         }
                                         else
                                         {

--- a/Scripts/Services/BulkOrders/LargeBODs/LargeBOD.cs
+++ b/Scripts/Services/BulkOrders/LargeBODs/LargeBOD.cs
@@ -17,21 +17,21 @@ namespace Server.Engines.BulkOrders
         public LargeBOD(int hue, int amountMax, bool requireExeptional, BulkMaterialType material, LargeBulkEntry[] entries)
             : base(Core.AOS ? 0x2258 : 0x14EF)
         {
-            this.Weight = 1.0;
-            this.Hue = hue; // Blacksmith: 0x44E; Tailoring: 0x483
-            this.LootType = LootType.Blessed;
+            Weight = 1.0;
+            Hue = hue; // Blacksmith: 0x44E; Tailoring: 0x483
+            LootType = LootType.Blessed;
 
-            this.m_AmountMax = amountMax;
-            this.m_RequireExceptional = requireExeptional;
-            this.m_Material = material;
-            this.m_Entries = entries;
+            m_AmountMax = amountMax;
+            m_RequireExceptional = requireExeptional;
+            m_Material = material;
+            m_Entries = entries;
         }
 
         public LargeBOD()
             : base(Core.AOS ? 0x2258 : 0x14EF)
         {
-            this.Weight = 1.0;
-            this.LootType = LootType.Blessed;
+            Weight = 1.0;
+            LootType = LootType.Blessed;
         }
 
         public LargeBOD(Serial serial)
@@ -44,12 +44,12 @@ namespace Server.Engines.BulkOrders
         {
             get
             {
-                return this.m_AmountMax;
+                return m_AmountMax;
             }
             set
             {
-                this.m_AmountMax = value;
-                this.InvalidateProperties();
+                m_AmountMax = value;
+                InvalidateProperties();
             }
         }
         [CommandProperty(AccessLevel.GameMaster)]
@@ -57,12 +57,12 @@ namespace Server.Engines.BulkOrders
         {
             get
             {
-                return this.m_RequireExceptional;
+                return m_RequireExceptional;
             }
             set
             {
-                this.m_RequireExceptional = value;
-                this.InvalidateProperties();
+                m_RequireExceptional = value;
+                InvalidateProperties();
             }
         }
         [CommandProperty(AccessLevel.GameMaster)]
@@ -70,24 +70,24 @@ namespace Server.Engines.BulkOrders
         {
             get
             {
-                return this.m_Material;
+                return m_Material;
             }
             set
             {
-                this.m_Material = value;
-                this.InvalidateProperties();
+                m_Material = value;
+                InvalidateProperties();
             }
         }
         public LargeBulkEntry[] Entries
         {
             get
             {
-                return this.m_Entries;
+                return m_Entries;
             }
             set
             {
-                this.m_Entries = value;
-                this.InvalidateProperties();
+                m_Entries = value;
+                InvalidateProperties();
             }
         }
         [CommandProperty(AccessLevel.GameMaster)]
@@ -95,9 +95,9 @@ namespace Server.Engines.BulkOrders
         {
             get
             {
-                for (int i = 0; i < this.m_Entries.Length; ++i)
+                for (int i = 0; i < m_Entries.Length; ++i)
                 {
-                    if (this.m_Entries[i].Amount < this.m_AmountMax)
+                    if (m_Entries[i].Amount < m_AmountMax)
                         return false;
                 }
 
@@ -107,7 +107,7 @@ namespace Server.Engines.BulkOrders
             {
                 if (value)
                 {
-                    for (int i = 0; i < this.m_Entries.Length; ++i)
+                    for (int i = 0; i < m_Entries.Length; ++i)
                     {
                         m_Entries[i].Amount = m_AmountMax;
                     }
@@ -145,12 +145,12 @@ namespace Server.Engines.BulkOrders
         public virtual void GetRewards(out Item reward, out int gold, out int fame)
         {
             reward = null;
-            gold = this.ComputeGold();
-            fame = this.ComputeFame();
+            gold = ComputeGold();
+            fame = ComputeFame();
 
             if (!BulkOrderSystem.NewSystemEnabled)
             {
-                List<Item> rewards = this.ComputeRewards(false);
+                List<Item> rewards = ComputeRewards(false);
 
                 if (rewards.Count > 0)
                 {
@@ -171,31 +171,31 @@ namespace Server.Engines.BulkOrders
 
             list.Add(1060655); // large bulk order
 
-            if (this.m_RequireExceptional)
+            if (m_RequireExceptional)
                 list.Add(1045141); // All items must be exceptional.
 
-            if (this.m_Material != BulkMaterialType.None)
-                list.Add(SmallBODGump.GetMaterialNumberFor(this.m_Material)); // All items must be made with x material.
+            if (m_Material != BulkMaterialType.None)
+                list.Add(SmallBODGump.GetMaterialNumberFor(m_Material)); // All items must be made with x material.
 
-            list.Add(1060656, this.m_AmountMax.ToString()); // amount to make: ~1_val~
+            list.Add(1060656, m_AmountMax.ToString()); // amount to make: ~1_val~
 
-            for (int i = 0; i < this.m_Entries.Length; ++i)
-                list.Add(1060658 + i, "#{0}\t{1}", this.m_Entries[i].Details.Number, this.m_Entries[i].Amount); // ~1_val~: ~2_val~
+            for (int i = 0; i < m_Entries.Length; ++i)
+                list.Add(1060658 + i, "#{0}\t{1}", m_Entries[i].Details.Number, m_Entries[i].Amount); // ~1_val~: ~2_val~
         }
 
         public override void OnDoubleClickNotAccessible(Mobile from)
         {
-            this.OnDoubleClick(from);
+            OnDoubleClick(from);
         }
 
         public override void OnDoubleClickSecureTrade(Mobile from)
         {
-            this.OnDoubleClick(from);
+            OnDoubleClick(from);
         }
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (this.IsChildOf(from.Backpack) || this.InSecureTrade || this.RootParent is PlayerVendor)
+            if (IsChildOf(from.Backpack) || InSecureTrade || RootParent is PlayerVendor)
 			{
 				EventSink.InvokeBODUsed(new BODUsedEventArgs(from, this));
 				from.SendGump(new LargeBODGump(from, this));
@@ -208,7 +208,7 @@ namespace Server.Engines.BulkOrders
 
         public void BeginCombine(Mobile from)
         {
-            if (!this.Complete)
+            if (!Complete)
                 from.Target = new LargeBODTarget(this);
             else
                 from.SendLocalizedMessage(1045166); // The maximum amount of requested items have already been combined to this deed.
@@ -224,25 +224,25 @@ namespace Server.Engines.BulkOrders
 
                     LargeBulkEntry entry = null;
 
-                    for (int i = 0; entry == null && i < this.m_Entries.Length; ++i)
+                    for (int i = 0; entry == null && i < m_Entries.Length; ++i)
                     {
-                        if (this.m_Entries[i].Details.Type == small.Type)
-                            entry = this.m_Entries[i];
+                        if (small.CheckType(m_Entries[i].Details.Type))
+                            entry = m_Entries[i];
                     }
 
                     if (entry == null)
                     {
                         from.SendLocalizedMessage(1045160); // That is not a bulk order for this large request.
                     }
-                    else if (this.m_RequireExceptional && !small.RequireExceptional)
+                    else if (m_RequireExceptional && !small.RequireExceptional)
                     {
                         from.SendLocalizedMessage(1045161); // Both orders must be of exceptional quality.
                     }
-                    else if (small.Material != this.m_Material && this.m_Material != BulkMaterialType.None)
+                    else if (small.Material != m_Material && m_Material != BulkMaterialType.None)
                     {
                         from.SendLocalizedMessage(1157311); // Both orders must use the same resource type.
                     }
-                    else if (this.m_AmountMax != small.AmountMax)
+                    else if (m_AmountMax != small.AmountMax)
                     {
                         from.SendLocalizedMessage(1045163); // The two orders have different requested amounts and cannot be combined.
                     }
@@ -250,7 +250,7 @@ namespace Server.Engines.BulkOrders
                     {
                         from.SendLocalizedMessage(1045164); // The order to combine with is not completed.
                     }
-                    else if (entry.Amount >= this.m_AmountMax)
+                    else if (entry.Amount >= m_AmountMax)
                     {
                         from.SendLocalizedMessage(1045166); // The maximum amount of requested items have already been combined to this deed.
                     }
@@ -263,8 +263,8 @@ namespace Server.Engines.BulkOrders
 
                         from.SendGump(new LargeBODGump(from, this));
 
-                        if (!this.Complete)
-                            this.BeginCombine(from);
+                        if (!Complete)
+                            BeginCombine(from);
                     }
                 }
                 else
@@ -284,14 +284,14 @@ namespace Server.Engines.BulkOrders
 
             writer.Write((int)1); // version
 
-            writer.Write(this.m_AmountMax);
-            writer.Write(this.m_RequireExceptional);
-            writer.Write((int)this.m_Material);
+            writer.Write(m_AmountMax);
+            writer.Write(m_RequireExceptional);
+            writer.Write((int)m_Material);
 
-            writer.Write((int)this.m_Entries.Length);
+            writer.Write((int)m_Entries.Length);
 
-            for (int i = 0; i < this.m_Entries.Length; ++i)
-                this.m_Entries[i].Serialize(writer);
+            for (int i = 0; i < m_Entries.Length; ++i)
+                m_Entries[i].Serialize(writer);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -305,26 +305,26 @@ namespace Server.Engines.BulkOrders
                 case 1:
                 case 0:
                     {
-                        this.m_AmountMax = reader.ReadInt();
-                        this.m_RequireExceptional = reader.ReadBool();
-                        this.m_Material = (BulkMaterialType)reader.ReadInt();
+                        m_AmountMax = reader.ReadInt();
+                        m_RequireExceptional = reader.ReadBool();
+                        m_Material = (BulkMaterialType)reader.ReadInt();
 
-                        this.m_Entries = new LargeBulkEntry[reader.ReadInt()];
+                        m_Entries = new LargeBulkEntry[reader.ReadInt()];
 
-                        for (int i = 0; i < this.m_Entries.Length; ++i)
-                            this.m_Entries[i] = new LargeBulkEntry(this, reader, version);
+                        for (int i = 0; i < m_Entries.Length; ++i)
+                            m_Entries[i] = new LargeBulkEntry(this, reader, version);
                         break;
                     }
             }
 
-            if (this.Weight == 0.0)
-                this.Weight = 1.0;
+            if (Weight == 0.0)
+                Weight = 1.0;
 
-            if (Core.AOS && this.ItemID == 0x14EF)
-                this.ItemID = 0x2258;
+            if (Core.AOS && ItemID == 0x14EF)
+                ItemID = 0x2258;
 
-            if (this.Parent == null && this.Map == Map.Internal && this.Location == Point3D.Zero)
-                this.Delete();
+            if (Parent == null && Map == Map.Internal && Location == Point3D.Zero)
+                Delete();
         }
     }
 }

--- a/Scripts/Services/BulkOrders/LargeBODs/LargeBODGump.cs
+++ b/Scripts/Services/BulkOrders/LargeBODs/LargeBODGump.cs
@@ -15,15 +15,15 @@ namespace Server.Engines.BulkOrders
         public LargeBODGump(Mobile from, LargeBOD deed)
             : base(25, 25)
         {
-            this.m_From = from;
-            this.m_Deed = deed;
+            m_From = from;
+            m_Deed = deed;
 
-            this.m_From.CloseGump(typeof(LargeBODGump));
-            this.m_From.CloseGump(typeof(SmallBODGump));
+            m_From.CloseGump(typeof(LargeBODGump));
+            m_From.CloseGump(typeof(SmallBODGump));
 
             LargeBulkEntry[] entries = deed.Entries;
 
-            this.AddPage(0);
+            AddPage(0);
 
             int height = 0;
 
@@ -39,23 +39,23 @@ namespace Server.Engines.BulkOrders
                     height += 24;
             }
 
-            this.AddBackground(50, 10, 455, 218 + height + (entries.Length * 24), 5054);
+            AddBackground(50, 10, 455, 218 + height + (entries.Length * 24), 5054);
 
-            this.AddImageTiled(58, 20, 438, 200 + height + (entries.Length * 24), 2624);
-            this.AddAlphaRegion(58, 20, 438, 200 + height + (entries.Length * 24));
+            AddImageTiled(58, 20, 438, 200 + height + (entries.Length * 24), 2624);
+            AddAlphaRegion(58, 20, 438, 200 + height + (entries.Length * 24));
 
-            this.AddImage(45, 5, 10460);
-            this.AddImage(480, 5, 10460);
-            this.AddImage(45, 203 + height + (entries.Length * 24), 10460);
-            this.AddImage(480, 203 + height + (entries.Length * 24), 10460);
+            AddImage(45, 5, 10460);
+            AddImage(480, 5, 10460);
+            AddImage(45, 203 + height + (entries.Length * 24), 10460);
+            AddImage(480, 203 + height + (entries.Length * 24), 10460);
 
-            this.AddHtmlLocalized(225, 25, 120, 20, 1045134, 0x7FFF, false, false); // A large bulk order
+            AddHtmlLocalized(225, 25, 120, 20, 1045134, 0x7FFF, false, false); // A large bulk order
 
-            this.AddHtmlLocalized(75, 48, 250, 20, 1045138, 0x7FFF, false, false); // Amount to make:
-            this.AddLabel(275, 48, 1152, deed.AmountMax.ToString());
+            AddHtmlLocalized(75, 48, 250, 20, 1045138, 0x7FFF, false, false); // Amount to make:
+            AddLabel(275, 48, 1152, deed.AmountMax.ToString());
 
-            this.AddHtmlLocalized(75, 72, 120, 20, 1045137, 0x7FFF, false, false); // Items requested:
-            this.AddHtmlLocalized(275, 76, 200, 20, 1045153, 0x7FFF, false, false); // Amount finished:
+            AddHtmlLocalized(75, 72, 120, 20, 1045137, 0x7FFF, false, false); // Items requested:
+            AddHtmlLocalized(275, 76, 200, 20, 1045153, 0x7FFF, false, false); // Amount finished:
 
             int y = 96;
 
@@ -64,27 +64,27 @@ namespace Server.Engines.BulkOrders
                 LargeBulkEntry entry = entries[i];
                 SmallBulkEntry details = entry.Details;
 
-                this.AddHtmlLocalized(75, y, 210, 20, details.Number, 0x7FFF, false, false);
-                this.AddLabel(275, y, 0x480, entry.Amount.ToString());
+                AddHtmlLocalized(75, y, 210, 20, details.Number, 0x7FFF, false, false);
+                AddLabel(275, y, 0x480, entry.Amount.ToString());
 
                 y += 24;
             }
 
             if (deed.RequireExceptional || deed.Material != BulkMaterialType.None)
             {
-                this.AddHtmlLocalized(75, y, 200, 20, 1045140, 0x7FFF, false, false); // Special requirements to meet:
+                AddHtmlLocalized(75, y, 200, 20, 1045140, 0x7FFF, false, false); // Special requirements to meet:
                 y += 24;
             }
 
             if (deed.RequireExceptional)
             {
-                this.AddHtmlLocalized(75, y, 300, 20, 1045141, 0x7FFF, false, false); // All items must be exceptional.
+                AddHtmlLocalized(75, y, 300, 20, 1045141, 0x7FFF, false, false); // All items must be exceptional.
                 y += 24;
             }
 
             if (deed.Material != BulkMaterialType.None)
             {
-                this.AddHtmlLocalized(75, y, 300, 20, SmallBODGump.GetMaterialNumberFor(deed.Material), 0x7FFF, false, false); // All items must be made with x material.
+                AddHtmlLocalized(75, y, 300, 20, SmallBODGump.GetMaterialNumberFor(deed.Material), 0x7FFF, false, false); // All items must be made with x material.
                 y += 24;
             }
 
@@ -108,32 +108,32 @@ namespace Server.Engines.BulkOrders
                 AddHtmlLocalized(160, y, 300, 20, 1045154, 0x7FFF, false, false); // Combine this deed with the item requested.
                 y += 24;
 
-                this.AddButton(125, y, 4005, 4007, 4, GumpButtonType.Reply, 0);
-                this.AddHtmlLocalized(160, y, 300, 20, 1157304, 0x7FFF, false, false); // Combine this deed with contained items.
+                AddButton(125, y, 4005, 4007, 4, GumpButtonType.Reply, 0);
+                AddHtmlLocalized(160, y, 300, 20, 1157304, 0x7FFF, false, false); // Combine this deed with contained items.
                 y += 24;
 
-                this.AddButton(125, y, 4005, 4007, 1, GumpButtonType.Reply, 0);
-                this.AddHtmlLocalized(160, y, 120, 20, 1011441, 0x7FFF, false, false); // EXIT
+                AddButton(125, y, 4005, 4007, 1, GumpButtonType.Reply, 0);
+                AddHtmlLocalized(160, y, 120, 20, 1011441, 0x7FFF, false, false); // EXIT
             }
             else
             {
-                this.AddButton(125, 168 + (entries.Length * 24), 4005, 4007, 2, GumpButtonType.Reply, 0);
-                this.AddHtmlLocalized(160, 168 + (entries.Length * 24), 300, 20, 1045155, 0x7FFF, false, false); // Combine this deed with another deed.
+                AddButton(125, 168 + (entries.Length * 24), 4005, 4007, 2, GumpButtonType.Reply, 0);
+                AddHtmlLocalized(160, 168 + (entries.Length * 24), 300, 20, 1045155, 0x7FFF, false, false); // Combine this deed with another deed.
 
-                this.AddButton(125, 192 + (entries.Length * 24), 4005, 4007, 1, GumpButtonType.Reply, 0);
-                this.AddHtmlLocalized(160, 192 + (entries.Length * 24), 120, 20, 1011441, 0x7FFF, false, false); // EXIT
+                AddButton(125, 192 + (entries.Length * 24), 4005, 4007, 1, GumpButtonType.Reply, 0);
+                AddHtmlLocalized(160, 192 + (entries.Length * 24), 120, 20, 1011441, 0x7FFF, false, false); // EXIT
             }
         }
 
         public override void OnResponse(NetState sender, RelayInfo info)
         {
-            if (this.m_Deed.Deleted || !this.m_Deed.IsChildOf(this.m_From.Backpack))
+            if (m_Deed.Deleted || !m_Deed.IsChildOf(m_From.Backpack))
                 return;
 
             if (info.ButtonID == 2) // Combine
             {
-                this.m_From.SendGump(new LargeBODGump(this.m_From, this.m_Deed));
-                this.m_Deed.BeginCombine(this.m_From);
+                m_From.SendGump(new LargeBODGump(m_From, m_Deed));
+                m_Deed.BeginCombine(m_From);
             }
             else if (info.ButtonID == 3) // bank button
             {
@@ -149,7 +149,7 @@ namespace Server.Engines.BulkOrders
                     }
                 }
 
-                this.m_From.SendGump(new LargeBODGump(this.m_From, this.m_Deed));
+                m_From.SendGump(new LargeBODGump(m_From, m_Deed));
             }
             else if (info.ButtonID == 4) // combine from container
             {

--- a/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
+++ b/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
@@ -28,7 +28,7 @@ namespace Server.Engines.Quests
 
         public static BaseQuest RandomQuest(PlayerMobile from, Type[] quests, object quester)
         {
-            return RandomQuest(from, quests, quester, quests.Length == 1);
+            return RandomQuest(from, quests, quester, quests != null && quests.Length == 1);
         }
 
         public static BaseQuest RandomQuest(PlayerMobile from, Type[] quests, object quester, bool message)

--- a/Scripts/Services/UltimaStore/UltimaStore.cs
+++ b/Scripts/Services/UltimaStore/UltimaStore.cs
@@ -925,6 +925,7 @@ namespace Server.Engines.UOStore
             : base(0x09AB)
         {
             Movable = false;
+            Visible = false;
         }
 
         public void AddDisplayItem(Item item)


### PR DESCRIPTION
- Quest System Crash Fix
- Dolphin Rug, Rose Rug and Skull Rug now show amount of resources remaining
- Mining Cart, Sheep Statue should now update properties when resource is taken
- Added resource count to tree stump
- Melisande's Hair Dye now uses the correct hair dye Gump
- Items added to corpse after loot generation will now be subject to instanced Loot
- Seed Box now only weighs 10 stones regardless of how many seeds are contained
- Costumes now only work when equip/un-equipping
- Green/Grey Goblin statuettes now show proper id when turned on/off.
- Green/Grey Goblin statuettes now removed effects if item is moved/deleted
- No beard to beard now colors beard the same color as the players hair
- Certain small Tinker bods will now combine with large bods
- UO Store container is now hidden, even though its in green acres where players shouldnt be able to access it.