### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Items/Consumables/HitchingRope.cs
+++ b/Scripts/Items/Consumables/HitchingRope.cs
@@ -10,9 +10,9 @@ namespace Server.Items
         public HitchingRope()
             : base(0x14F8)
         {
-            this.Hue = 0x41F; // guessed
+            Hue = 0x41F; // guessed
 
-            this.Weight = 5;
+            Weight = 5;
         }
 
         public HitchingRope(Serial serial)
@@ -29,7 +29,7 @@ namespace Server.Items
         }//  hitching rope
         public override void OnDoubleClick(Mobile from)
         {
-            if (from.InRange(this.GetWorldLocation(), 2))
+            if (IsChildOf(from.Backpack) || (from.InRange(GetWorldLocation(), 2) && Movable))
             {
                 from.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1071159); // Select the hitching post you want to supply hitching rope.
                 from.Target = new InternalTarget(this);
@@ -60,15 +60,15 @@ namespace Server.Items
             public InternalTarget(HitchingRope rope)
                 : base(-1, false, TargetFlags.None)
             {
-                this.m_Rope = rope;
+                m_Rope = rope;
             }
 
             protected override void OnTarget(Mobile from, object targeted)
             {
-                if (this.m_Rope.Deleted)
+                if (m_Rope.Deleted)
                     return;
 
-                if (!from.InRange(this.m_Rope.GetWorldLocation(), 2))
+                if (!from.InRange(m_Rope.GetWorldLocation(), 2))
                 {
                     from.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1019045); // I can't reach that.
                 }
@@ -80,15 +80,15 @@ namespace Server.Items
                     {
                         from.SendMessage("Hitching Rope cannot be applied at this time.", 0x59);
                     }
-                    else if (postItem.Charges <= 0 && postItem.UsesRemaining <= 0)
+                    else if (postItem.Replica && postItem.Charges <= 0 && postItem.UsesRemaining == 0)
                     {
                         from.SendLocalizedMessage(1071157); // This hitching post is damaged. You can't use it any longer.
                     }
                     else
                     {
                         postItem.Charges -= 1;
-                        postItem.UsesRemaining += 15;
-                        this.m_Rope.Delete();
+                        postItem.UsesRemaining += postItem.Replica ? 15 : 30;
+                        m_Rope.Delete();
 
                         if (postItem is Item)
                         {

--- a/Scripts/Items/Containers/TreasureMapChest.cs
+++ b/Scripts/Items/Containers/TreasureMapChest.cs
@@ -199,7 +199,7 @@ namespace Server.Items
         {
             cont.Movable = false;
             cont.Locked = true;
-            int numberItems;
+            int count;
 
             if (level == 0)
             {
@@ -244,49 +244,70 @@ namespace Server.Items
                 cont.LockLevel = cont.RequiredSkill - 10;
                 cont.MaxLockLevel = cont.RequiredSkill + 40;
 
-                cont.DropItem(new Gold(level * 5000));
+                #region gold
+                cont.DropItem(new Gold(isSos ? level * 10000 : level * 5000));
+                #endregion
 
-                for (int i = 0; i < level * 5; ++i)
+                #region Scrolls
+                if (isSos)
+                {
+                    switch(level)
+                    {
+                        default: count = 20; break;
+                        case 0:
+                        case 1: count = Utility.RandomMinMax(2, 5); break;
+                        case 2: count = Utility.RandomMinMax(10, 15); break;
+                    }
+                }
+                else
+                {
+                    count = level * 5;
+                }
+
+                for (int i = 0; i < count; ++i)
                     cont.DropItem(Loot.RandomScroll(0, 63, SpellbookType.Regular));
+                #endregion
 
-				double propsScale = 1.0;
+                #region Magical Items
+                double propsScale = 1.0;
+
                 if (Core.SE)
                 {
                     switch (level)
                     {
                         case 1:
-                            numberItems = 32;
+                            count = isSos ? Utility.RandomMinMax(2, 6) : 32;
 							propsScale = 0.5625;
                             break;
                         case 2:
-                            numberItems = 40;
+                            count = isSos ? Utility.RandomMinMax(10, 15) : 40;
 							propsScale = 0.6875;
                             break;
                         case 3:
-                            numberItems = 48;
+                            count = isSos ? Utility.RandomMinMax(15, 20) : 48;
 							propsScale = 0.875;
                             break;
                         case 4:
-                            numberItems = 56;
+                            count = isSos ? Utility.RandomMinMax(15, 20) : 56;
                             break;
                         case 5:
-                            numberItems = 64;
+                            count = isSos ? Utility.RandomMinMax(15, 20) : 64;
                             break;
                         case 6:
-                            numberItems = 72;
+                            count = isSos ? Utility.RandomMinMax(15, 20) : 72;
                             break;
                         case 7:
-                            numberItems = 80;
+                            count = isSos ? Utility.RandomMinMax(15, 20) : 80;
                             break;
                         default:
-                            numberItems = 0;
+                            count = 0;
                             break;
                     }
                 }
                 else
-                    numberItems = level * 6;
+                    count = level * 6;
 
-                for (int i = 0; i < numberItems; ++i)
+                for (int i = 0; i < count; ++i)
                 {
                     Item item;
 
@@ -376,32 +397,43 @@ namespace Server.Items
                     }
                 }
             }
+            #endregion
 
-            int reagents;
-            if (level == 0)
-                reagents = 12;
-            else
-                reagents = level + 1;
-
-            for (int i = 0; i < reagents; i++)
+            #region Reagents
+            if (isSos)
             {
-                Item item = Loot.RandomPossibleReagent();
-                item.Amount = Utility.RandomMinMax(40, 60);
-                cont.DropItem(item);
+                switch (level)
+                {
+                    default: count = Utility.RandomMinMax(45, 60); break;
+                    case 0:
+                    case 1: count = Utility.RandomMinMax(15, 20); break;
+                    case 2: count = Utility.RandomMinMax(25, 40); break;
+                }
+            }
+            else
+            {
+                count = level == 0 ? 12 : Utility.RandomMinMax(40, 60) * (level + 1);
             }
 
-            int gems;
-            if (level == 0)
-                gems = 2;
-            else
-                gems = (level * 3) + 1;
-
-            for (int i = 0; i < gems; i++)
+            for (int i = 0; i < count; i++)
             {
-                Item item = Loot.RandomGem();
-                cont.DropItem(item);
+                cont.DropItemStack(Loot.RandomPossibleReagent());
             }
+            #endregion
 
+            #region Gems
+            if (level == 0)
+                count = 2;
+            else
+                count = (level * 3) + 1;
+
+            for (int i = 0; i < count; i++)
+            {
+                cont.DropItem(Loot.RandomGem());
+            }
+            #endregion
+
+            #region Imbuing Ingreds
             if (level > 1)
             {
                 Item item = Loot.Construct(m_ImbuingIngreds[Utility.Random(m_ImbuingIngreds.Length)]);
@@ -409,6 +441,7 @@ namespace Server.Items
                 item.Amount = level;
                 cont.DropItem(item);
             }
+            #endregion
 
             Item arty = null;
             Item special = null;

--- a/Scripts/Items/StoreBought/GreenGoblinStatuette.cs
+++ b/Scripts/Items/StoreBought/GreenGoblinStatuette.cs
@@ -102,6 +102,16 @@ namespace Server.Items
             base.OnItemRemoved(item);
         }
 
+        public override void OnRemoved(object parent)
+        {
+            if (TurnedOn)
+            {
+                TurnOff();
+            }
+
+            base.OnRemoved(parent);
+        }
+
         public GreenGoblinStatuette(Serial serial)
             : base(serial)
         {

--- a/Scripts/Items/StoreBought/GreyGoblinStatuette.cs
+++ b/Scripts/Items/StoreBought/GreyGoblinStatuette.cs
@@ -102,6 +102,16 @@ namespace Server.Items
             base.OnItemRemoved(item);
         }
 
+        public override void OnRemoved(object parent)
+        {
+            if (TurnedOn)
+            {
+                TurnOff();
+            }
+
+            base.OnRemoved(parent);
+        }
+
         public GreyGoblinStatuette(Serial serial)
             : base(serial)
         {

--- a/Scripts/Mobiles/AI/Magical AI/NecroAI.cs
+++ b/Scripts/Mobiles/AI/Magical AI/NecroAI.cs
@@ -69,6 +69,11 @@ namespace Server.Mobiles
 
             return null;
 		}
+
+        public override Spell GetCureSpell()
+        {
+            return null;
+        }
 		
 		public override Spell GetRandomBuffSpell()
 		{

--- a/Scripts/Mobiles/AI/NinjaAI.cs
+++ b/Scripts/Mobiles/AI/NinjaAI.cs
@@ -140,16 +140,23 @@ namespace Server.Mobiles
 			
 			if(special == null && m_NextCastTime < DateTime.UtcNow && 0.05 > Utility.RandomDouble())
 			{
-				if(m_Mobile.Hidden)
-					special = GetHiddenSpecialMove();
-				else
-					special = GetSpecialMove();
+                if (0.05 > Utility.RandomDouble())
+                {
+                    new MirrorImage(m_Mobile, null).Cast();
+                }
+                else
+                {
+                    if (m_Mobile.Hidden)
+                        special = GetHiddenSpecialMove();
+                    else
+                        special = GetSpecialMove();
 
-				if(special != null)
-				{
-					SpecialMove.SetCurrentMove(m_Mobile, special);
-                    m_NextCastTime = DateTime.UtcNow + GetCastDelay();
-				}
+                    if (special != null)
+                    {
+                        SpecialMove.SetCurrentMove(m_Mobile, special);
+                        m_NextCastTime = DateTime.UtcNow + GetCastDelay();
+                    }
+                }
 			}
 			
 			if(m_NextRanged < DateTime.UtcNow && 0.08 > Utility.RandomDouble())

--- a/Scripts/Mobiles/Bosses/DespiseBosses.cs
+++ b/Scripts/Mobiles/Bosses/DespiseBosses.cs
@@ -8,7 +8,7 @@ namespace Server.Engines.Despise
 {
 	public class DespiseBoss : BaseCreature
 	{
-		private readonly int ArtifactChance = 5;
+		public static readonly int ArtifactChance = 5;
 		
 		public virtual BaseCreature SummonWisp { get { return null; } }
         public virtual double WispScalar { get { return 0.33; } }
@@ -126,7 +126,8 @@ namespace Server.Engines.Despise
             if (m_Wisp != null && m_Wisp.Alive)
                 m_Wisp.Kill();
         }
-		
+
+        public static Type[] Artifacts { get { return m_Artifacts; } }
 		private static Type[] m_Artifacts = new Type[]
 		{
 			typeof(CompassionsEye),

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -613,6 +613,31 @@ namespace Server.Mobiles
             PetTrainingHelper.GetAbilityProfile(this, true).AddAbility(ability, false);
         }
 
+        public void RemoveMagicalAbility(MagicalAbility ability)
+        {
+            PetTrainingHelper.GetAbilityProfile(this, true).RemoveAbility(ability);
+        }
+
+        public void RemoveSpecialAbility(SpecialAbility ability)
+        {
+            PetTrainingHelper.GetAbilityProfile(this, true).RemoveAbility(ability);
+        }
+
+        public void RemoveAreaEffect(AreaEffect ability)
+        {
+            PetTrainingHelper.GetAbilityProfile(this, true).RemoveAbility(ability);
+        }
+
+        public void RemoveWeaponAbility(WeaponAbility ability)
+        {
+            PetTrainingHelper.GetAbilityProfile(this, true).RemoveAbility(ability);
+        }
+
+        public bool HasAbility(object o)
+        {
+            return PetTrainingHelper.GetAbilityProfile(this, true).HasAbility(o);
+        }
+
         public virtual double AverageThreshold { get { return 0.33; } }
 
         public List<double> _InitAverage;
@@ -674,30 +699,37 @@ namespace Server.Mobiles
 
         public void AdjustTameRequirements()
         {
-            // Currently, with increased control slots, taming skill does not seem to pass 108.0
-            if(ControlSlots <=ControlSlotsMin)
-            {
-                CurrentTameSkill = MinTameSkill;
-            }
-            else if (MinTameSkill < 108)
-            {
-                double minSkill = Math.Ceiling(MinTameSkill);
+            CurrentTameSkill = CalculateCurrentTameSkill(ControlSlots);
+        }
 
+        public double CalculateCurrentTameSkill(int currentControlSlots)
+        {
+            double minSkill = Math.Ceiling(MinTameSkill);
+            double current = 0;
+
+            if (currentControlSlots <= ControlSlotsMin)
+            {
+                current = MinTameSkill;
+            }
+            else if (MinTameSkill < 108) // Currently, with increased control slots, taming skill does not seem to pass 108.0
+            {
                 if (MinTameSkill < 0)
                 {
-                    CurrentTameSkill = Math.Ceiling(Math.Min(108.0, Math.Max(0, CurrentTameSkill) + (Math.Abs(minSkill) * .7)));
+                    current = Math.Ceiling(Math.Min(108.0, Math.Max(0, CurrentTameSkill) + (Math.Abs(minSkill) * .7)));
                 }
                 else
                 {
-                    double level = ControlSlots - ControlSlotsMin;
+                    double level = currentControlSlots - ControlSlotsMin;
                     double levelFactor = (double)(1 + (ControlSlotsMax - ControlSlotsMin)) / minSkill;
 
-                    CurrentTameSkill = Math.Ceiling(Math.Min(108.0, minSkill + (minSkill * ((levelFactor * 7) * level))));
+                    current = Math.Ceiling(Math.Min(108.0, minSkill + (minSkill * ((levelFactor * 7) * level))));
                 }
-
-                if (CurrentTameSkill < MinTameSkill)
-                    CurrentTameSkill = MinTameSkill;
             }
+
+            if (current < MinTameSkill)
+                current = MinTameSkill;
+
+            return current;
         }
         #endregion
 
@@ -8226,8 +8258,12 @@ namespace Server.Mobiles
                 c.BondingBegin = DateTime.MinValue;
                 c.OwnerAbandonTime = DateTime.MinValue;
                 c.ControlTarget = null;
-                //c.ControlOrder = OrderType.Release;
-                c.AIObject.DoOrderRelease();
+
+                if (c.AIObject != null)
+                {
+                    c.AIObject.DoOrderRelease();
+                }
+
                 // this will prevent no release of creatures left alone with AI disabled (and consequent bug of Followers)
                 c.DropBackpack();
                 c.RemoveOnSave = true;

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -3130,6 +3130,7 @@
     <Compile Include="Services\CleanUpBritannia\Items\NaturesTears.cs" />
     <Compile Include="Services\CleanUpBritannia\Items\NestWithEggs.cs" />
     <Compile Include="Services\CleanUpBritannia\Items\YuccaTree.cs" />
+    <Compile Include="Services\CleanUpBritannia\PointExchange.cs" />
     <Compile Include="Services\CommunityCollections\CommunityCollectionGump.cs" />
     <Compile Include="Services\Doom\GaryRoom.cs" />
     <Compile Include="Services\Doom\GuardianRoom.cs" />

--- a/Scripts/Services/City Loyalty System/CityLoyaltyEntry.cs
+++ b/Scripts/Services/City Loyalty System/CityLoyaltyEntry.cs
@@ -33,6 +33,9 @@ namespace Server.Engines.CityLoyalty
         public string CustomTitle { get; set; }
 
         [CommandProperty(AccessLevel.GameMaster)]
+        public bool ShowGainMessage { get; set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
         public LoyaltyRating LoyaltyRating
         {
             get
@@ -80,6 +83,7 @@ namespace Server.Engines.CityLoyalty
 		public CityLoyaltyEntry(PlayerMobile pm, City city) : base(pm)
 		{
             City = city;
+            ShowGainMessage = true;
 		}
 		
 		public void DeclareCitizenship()
@@ -122,8 +126,10 @@ namespace Server.Engines.CityLoyalty
 		public override void Serialize(GenericWriter writer)
 		{
 			base.Serialize(writer);
-			writer.Write(0);
-			
+			writer.Write(1);
+
+            writer.Write(ShowGainMessage);
+
 			writer.Write(Love);
 			writer.Write(Hate);
 			writer.Write(Neutrality);
@@ -140,18 +146,32 @@ namespace Server.Engines.CityLoyalty
 		{
 			base.Deserialize(reader);
 			int version = reader.ReadInt();
-			
-			Love = reader.ReadInt();
-			Hate = reader.ReadInt();
-			Neutrality = reader.ReadInt();
 
-			Titles = (CityTitle)reader.ReadInt();
-            TradeDealExpires = reader.ReadDateTime();
-            _Utilizing = reader.ReadBool();
-            CustomTitle = reader.ReadString();
+            switch (version)
+            {
+                case 1:
+                    ShowGainMessage = reader.ReadBool();
+                    goto case 0;
+                case 0:
 
-            CheckTradeDeal();
-			IsCitizen = reader.ReadBool();
+                    if (version == 0)
+                    {
+                        ShowGainMessage = true;
+                    }
+
+                    Love = reader.ReadInt();
+                    Hate = reader.ReadInt();
+                    Neutrality = reader.ReadInt();
+
+                    Titles = (CityTitle)reader.ReadInt();
+                    TradeDealExpires = reader.ReadDateTime();
+                    _Utilizing = reader.ReadBool();
+                    CustomTitle = reader.ReadString();
+
+                    CheckTradeDeal();
+                    IsCitizen = reader.ReadBool();
+                    break;
+            }
 		}
 	}
 }

--- a/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
+++ b/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Globalization;
 using Server.Network;
 using Server.Commands;
+using Server.Items;
 
 namespace Server.Engines.CityLoyalty
 {
@@ -96,6 +97,8 @@ namespace Server.Engines.CityLoyalty
         public static readonly int MaxBallotBoxes = Config.Get("CityLoyalty.MaxBallotBoxes", 10);
         public static readonly int AnnouncementPeriod = Config.Get("CityLoyalty.AnnouncementPeriod", 48);
 
+        public static readonly TimeSpan LoveAtrophyDuration = TimeSpan.FromHours(40);
+
         public override TextDefinition Name { get { return new TextDefinition(String.Format("{0}", this.City.ToString())); } }
         public override bool AutoAdd { get { return false; } }
         public override double MaxPoints { get { return double.MaxValue; } }
@@ -145,6 +148,9 @@ namespace Server.Engines.CityLoyalty
 
         [CommandProperty(AccessLevel.GameMaster)]
         public CityStone Stone { get; set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityMessageBoard Board { get; set; }
 
         private Mobile _Governor;
         private Mobile _GovernorElect;
@@ -306,7 +312,11 @@ namespace Server.Engines.CityLoyalty
 			}
 
             entry.Hate += (int)hate;
-            from.SendLocalizedMessage(1152321, Definition.Name); // Your deeds in the city of ~1_name~ are worthy of censure.
+
+            if (entry.ShowGainMessage)
+            {
+                from.SendLocalizedMessage(1152321, Definition.Name); // Your deeds in the city of ~1_name~ are worthy of censure.
+            }
 
             if (from == Governor && entry.LoyaltyRating < LoyaltyRating.Unknown)
                 Governor = null;
@@ -338,8 +348,10 @@ namespace Server.Engines.CityLoyalty
 				}
 			}
 
-            if(message)
+            if (message && entry.ShowGainMessage)
+            {
                 from.SendLocalizedMessage(1152320, Definition.Name); // Your deeds in the city of ~1_name~ are worthy of praise.
+            }
 
 			entry.Love += (int)love;
 		}
@@ -611,7 +623,7 @@ namespace Server.Engines.CityLoyalty
             EventSink.Login += OnLogin;
             Timer.DelayCall(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), OnTick);
 
-            CommandSystem.Register("ElectionStartTime", AccessLevel.Administrator, e => e.Mobile.SendGump(new ElectionStartTimeGump(e.Mobile as PlayerMobile)));
+            CommandSystem.Register("ElectionStartTime", AccessLevel.Administrator, e => Server.Gumps.BaseGump.SendGump(new ElectionStartTimeGump(e.Mobile as PlayerMobile)));
             CommandSystem.Register("RemoveWait", AccessLevel.Administrator, e =>
                 {
                     foreach (var city in Cities)
@@ -622,8 +634,11 @@ namespace Server.Engines.CityLoyalty
 
             CommandSystem.Register("SystemInfo", AccessLevel.Administrator, e => 
             {
-                e.Mobile.CloseGump(typeof(SystemInfoGump));
-                e.Mobile.SendGump(new SystemInfoGump());
+                if (e.Mobile is PlayerMobile)
+                {
+                    e.Mobile.CloseGump(typeof(SystemInfoGump));
+                    Server.Gumps.BaseGump.SendGump(new SystemInfoGump((PlayerMobile)e.Mobile));
+                }
             });
         }
 
@@ -657,12 +672,31 @@ namespace Server.Engines.CityLoyalty
 
             CityLoyaltySystem sys = GetCitizenship(pm);
 
-            if (sys != null && sys.ActiveTradeDeal != TradeDeal.None)
+            if (sys != null)
             {
-                CityLoyaltyEntry entry = sys.GetPlayerEntry<CityLoyaltyEntry>(pm, true);
+                if (sys.ActiveTradeDeal != TradeDeal.None)
+                {
+                    CityLoyaltyEntry entry = sys.GetPlayerEntry<CityLoyaltyEntry>(pm, true);
 
-                if(entry != null && entry.UtilizingTradeDeal)
-                    BuffInfo.AddBuff(pm, new BuffInfo(BuffIcon.CityTradeDeal, 1154168, 1154169, new TextDefinition((int)sys.ActiveTradeDeal), true));
+                    if (entry != null && entry.UtilizingTradeDeal)
+                        BuffInfo.AddBuff(pm, new BuffInfo(BuffIcon.CityTradeDeal, 1154168, 1154169, new TextDefinition((int)sys.ActiveTradeDeal), true));
+                }
+
+                int message;
+
+                if (pm.LastOnline + LoveAtrophyDuration > DateTime.UtcNow)
+                {
+                    message = 1152913; // The moons of Trammel and Felucca align to preserve your virtue status and city loyalty.
+                }
+                else
+                {
+                    message = 1152912; // The moons of Trammel and Felucca fail to preserve your virtue status and city loyalty.
+                }
+
+                Timer.DelayCall(TimeSpan.FromSeconds(.7), () =>
+                {
+                    pm.SendLocalizedMessage(message);
+                });
             }
         }
 
@@ -743,14 +777,14 @@ namespace Server.Engines.CityLoyalty
                     {
                         CityLoyaltyEntry entry = t as CityLoyaltyEntry;
 
-                        if (entry != null)
+                        if (entry != null && entry.Player != null)
                         {
                             PlayerMobile owner = entry.Player;
 
                             entry.Neutrality -= entry.Neutrality / 50;
                             entry.Hate -= entry.Hate / 50;
 
-                            if (owner != null && owner.LastOnline + TimeSpan.FromHours(40) < DateTime.UtcNow)
+                            if (owner.LastOnline + LoveAtrophyDuration < DateTime.UtcNow)
                                 entry.Love -= entry.Love / 75;
                         }
                     });
@@ -1096,7 +1130,7 @@ namespace Server.Engines.CityLoyalty
             writer.Write((int)City);
 
 			base.Serialize(writer);
-			writer.Write(1);
+			writer.Write(2);
 
             writer.Write(CitizenWait.Count);
             foreach (var kvp in CitizenWait)
@@ -1137,6 +1171,7 @@ namespace Server.Engines.CityLoyalty
 
             switch (version)
             {
+                case 2:
                 case 1:
                     {
                         int count = reader.ReadInt();
@@ -1186,6 +1221,29 @@ namespace Server.Engines.CityLoyalty
                         CitizenWait[m] = dt;
                 }
             }
+
+            // City Bulletin Board Location
+            if (version == 1)
+            {
+                Timer.DelayCall(TimeSpan.FromSeconds(10), () =>
+                    {
+                        Board = new CityMessageBoard(City, 0xA0C5);
+                        Board.MoveToWorld(Definition.BoardLocation, Map.Trammel);
+                        Console.WriteLine("City Message Board for {0} Converted!", City.ToString());
+                        /*if (Board != null)
+                        {
+                            //Board.ItemID = 0xA0C5;
+                            //board.MoveToWorld(Definition.BoardLocation, Map.Trammel);
+
+
+                            Console.WriteLine("City Message Board for {0} Converted!", City.ToString());
+                        }
+                        else
+                        {
+                            Console.WriteLine("City Message Board for {0} not found!", City.ToString());
+                        }*/
+                    });
+            }
 		}
 	}
 	
@@ -1201,7 +1259,7 @@ namespace Server.Engines.CityLoyalty
 							 new Point3D(4416, 1044, -2),
                              new Point3D(4480, 1172, 0),
                              new Point3D(4551, 1051, 0),
-                             new Point3D(4474, 1176, 0),
+                             new Point3D(4478, 1170, 0),
 							 "Moonglow",
 							 1114143,
 							 1154524
@@ -1221,7 +1279,7 @@ namespace Server.Engines.CityLoyalty
                              new Point3D(1436, 1760, -2),
                              new Point3D(1446, 1694, 0),
                              new Point3D(1417, 1715, 20),
-                             new Point3D(1437, 1693, 0),
+                             new Point3D(1481, 1718, 0),
 							 "Britain",
 							 1114148,
 							 1154521
@@ -1241,7 +1299,7 @@ namespace Server.Engines.CityLoyalty
 							 new Point3D(1377, 3879, 0),
                              new Point3D(1336, 3770, 0),
                              new Point3D(1379, 3797, 0),
-                             new Point3D(1326, 3776, 0),
+                             new Point3D(1333, 3776, 0),
 							 "Jhelom",
 							 1114146,
 							 1154522
@@ -1261,7 +1319,7 @@ namespace Server.Engines.CityLoyalty
 							 new Point3D(621, 1043, 0),
                              new Point3D(631, 863, 0),
                              new Point3D(385, 914, 0),
-                             new Point3D(633, 856, 0),
+                             new Point3D(626, 863, 0),
 							 "Yew",
 							 1114138,
 							 1154529
@@ -1281,7 +1339,7 @@ namespace Server.Engines.CityLoyalty
 							 new Point3D(2499, 398, 15),
                              new Point3D(2514, 559, 0),
                              new Point3D(2424, 533, 0),
-                             new Point3D(2508, 560, 0),
+                             new Point3D(2522, 558, 0),
 							 "Minoc",
 							 1114139,
 							 1154523
@@ -1301,7 +1359,7 @@ namespace Server.Engines.CityLoyalty
                              new Point3D(2061, 2855, -2), 
                              new Point3D(1907, 2683, 0),
                              new Point3D(1851, 2772, 0),
-                             new Point3D(1904, 2690, 7),
+                             new Point3D(1907, 2679, 0),
 							 "Trinsic",
 							 1114142,
 							 1154527
@@ -1322,7 +1380,7 @@ namespace Server.Engines.CityLoyalty
 							 new Point3D(645, 2228, -2),
                              new Point3D(586, 2153, 0),
                              new Point3D(571, 2210, 0),
-                             new Point3D(590, 2152, 0),
+                             new Point3D(580, 2155, 0),
 							 "Skara Brae",
 							 1114145,
 							 1154526
@@ -1343,7 +1401,7 @@ namespace Server.Engines.CityLoyalty
 							 new Point3D(3677, 2254, 20),
                              new Point3D(3796, 2247, 20),
                              new Point3D(3680, 2269, 26),
-                             new Point3D(3781, 2256, 20),
+                             new Point3D(3795, 2259, 20),
 							 "Magincia",
 							 1114141,
 							 1154525
@@ -1364,7 +1422,7 @@ namespace Server.Engines.CityLoyalty
 							 new Point3D(3004, 834, 0),
                              new Point3D(2891, 682, 0),
                              new Point3D(3004, 822, 0),
-                             new Point3D(2894, 680, 0),
+                             new Point3D(2899, 685, 0),
 							 "Vesper",
 							 1114140,
 							 1154528

--- a/Scripts/Services/City Loyalty System/Gumps.cs
+++ b/Scripts/Services/City Loyalty System/Gumps.cs
@@ -11,20 +11,18 @@ using Server.Items;
 
 namespace Server.Engines.CityLoyalty
 {
-    public class BaseCityGump : Gump
+    public class BaseCityGump : BaseGump
     {
-        public PlayerMobile User { get; set; }
         public CityLoyaltySystem Citizenship { get; set; }
 
-        public BaseCityGump(PlayerMobile pm) : base(120, 120)
+        public BaseCityGump(PlayerMobile pm) : base(pm, 120, 120)
         {
-            User = pm;
             Citizenship = CityLoyaltySystem.GetCitizenship(User, false);
 
             pm.CloseGump(typeof(BaseCityGump));
         }
 
-        public virtual void AddGumpLayout()
+        public override void AddGumpLayout()
         {
             AddHtmlLocalized(0, 7, 345, 20, 1154645, "#1152190", 0, false, false); // City Loyalty
 
@@ -36,14 +34,41 @@ namespace Server.Engines.CityLoyalty
             AddImage(20, 317, 8001);
             AddImage(20, 387, 8003);
 
-            AddHtmlLocalized(65, 395, 200, 16, 1152189, false, false);
+            AddHtmlLocalized(65, 395, 200, 16, 1152189, false, false); // Loyalty Ratings
             AddButton(50, 400, 2103, 2104, 500, GumpButtonType.Reply, 0);
+
+            AddHtmlLocalized(175, 395, 200, 16, 1157159, false, false); // Toggle Gain Message
+            AddButton(160, 400, 2103, 2104, 501, GumpButtonType.Reply, 0);
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
             if (info.ButtonID == 500)
                 User.SendGump(new LoyaltyRatingGump(User));
+
+            if (info.ButtonID == 501)
+            {
+                if (Citizenship != null)
+                {
+                    CityLoyaltyEntry entry = Citizenship.GetPlayerEntry<CityLoyaltyEntry>(User);
+
+                    if (entry != null)
+                    {
+                        if (entry.ShowGainMessage)
+                        {
+                            entry.ShowGainMessage = false;
+                            User.SendLocalizedMessage(1157160); //You will no longer receive City Loyalty gain messages.
+                        }
+                        else
+                        {
+                            entry.ShowGainMessage = true;
+                            User.SendLocalizedMessage(1157161); //You will now receive City Loyalty gain messages.
+                        }
+                    }
+                }
+
+                Refresh();
+            }
         }
     }
 
@@ -51,7 +76,6 @@ namespace Server.Engines.CityLoyalty
 	{
 		public CityLoyaltyGump(PlayerMobile pm) : base(pm)
 		{
-            AddGumpLayout();
 		}
 		
 		public override void AddGumpLayout()
@@ -114,9 +138,9 @@ namespace Server.Engines.CityLoyalty
             }
 		}
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
-            base.OnResponse(state, info);
+            base.OnResponse(info);
 
             if (!CityLoyaltySystem.IsSetup())
                 return;
@@ -125,10 +149,10 @@ namespace Server.Engines.CityLoyalty
             {
                 case 0: break;
                 case 1:
-                    User.SendGump(new CityTitlesGump(User));
+                    BaseGump.SendGump(new CityTitlesGump(User));
                     break;
                 case 2:
-                    User.SendGump(new RenounceCitizenshipGump(User));
+                    BaseGump.SendGump(new RenounceCitizenshipGump(User));
                     break;
                 case 3:
                 default:
@@ -136,7 +160,7 @@ namespace Server.Engines.CityLoyalty
                     if (id >= 0 && id < CityLoyaltySystem.Cities.Count)
                     {
                         if(Citizenship == null)
-                            User.SendGump(new DeclareCitizenshipGump(CityLoyaltySystem.Cities[id], User));
+                            BaseGump.SendGump(new DeclareCitizenshipGump(CityLoyaltySystem.Cities[id], User));
                     }
                     break;
             }
@@ -150,7 +174,6 @@ namespace Server.Engines.CityLoyalty
         public DeclareCitizenshipGump(CityLoyaltySystem toDeclare, PlayerMobile pm) : base(pm)
         {
             City = toDeclare;
-            AddGumpLayout();
         }
 
         public override void AddGumpLayout()
@@ -176,9 +199,9 @@ namespace Server.Engines.CityLoyalty
             AddButton(100, 305, 2103, 2104, 2, GumpButtonType.Reply, 0);
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
-            base.OnResponse(state, info);
+            base.OnResponse(info);
 
             if(info.ButtonID == 1 && City != null)
             {
@@ -188,7 +211,7 @@ namespace Server.Engines.CityLoyalty
                 }
             }
             else if (info.ButtonID == 2)
-                User.SendGump(new CityLoyaltyGump(User));
+                BaseGump.SendGump(new CityLoyaltyGump(User));
         }
     }
 
@@ -197,7 +220,6 @@ namespace Server.Engines.CityLoyalty
         public RenounceCitizenshipGump(PlayerMobile pm)
             : base(pm)
         {
-            AddGumpLayout();
         }
 
         public override void AddGumpLayout()
@@ -222,9 +244,9 @@ namespace Server.Engines.CityLoyalty
             AddButton(100, 305, 2103, 2104, 2, GumpButtonType.Reply, 0);
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
-            base.OnResponse(state, info);
+            base.OnResponse(info);
 
             if (info.ButtonID == 1 && Citizenship != null)
             {
@@ -235,7 +257,7 @@ namespace Server.Engines.CityLoyalty
                 }
             }
             else if (info.ButtonID == 2)
-                User.SendGump(new CityLoyaltyGump(User));
+                BaseGump.SendGump(new CityLoyaltyGump(User));
         }
     }
 
@@ -243,7 +265,6 @@ namespace Server.Engines.CityLoyalty
 	{
 		public CityTitlesGump(PlayerMobile pm) : base(pm)
 		{
-            AddGumpLayout();
 		}
 		
 		public override void AddGumpLayout()
@@ -292,16 +313,16 @@ namespace Server.Engines.CityLoyalty
             /*Click the gem next to an available title for more information about obtaining that title.*/
 		}
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
-            base.OnResponse(state, info);
+            base.OnResponse(info);
 
             if (info.ButtonID > 0 && info.ButtonID < 500)
             {
                 CityTitle t = (CityTitle)info.ButtonID - 1;
 
                 if (!Citizenship.HasTitle(User, t))
-                    User.SendGump(new CityTitlesInfoGump(User, t));
+                    BaseGump.SendGump(new CityTitlesInfoGump(User, t));
             }
         }
 	}
@@ -313,7 +334,6 @@ namespace Server.Engines.CityLoyalty
 		public CityTitlesInfoGump(PlayerMobile pm, CityTitle title) : base(pm)
 		{
 			Title = title;
-            AddGumpLayout();
 		}
 		
 		public override void AddGumpLayout()
@@ -352,9 +372,9 @@ namespace Server.Engines.CityLoyalty
             AddButton(40, 370, 2103, 2104, 2, GumpButtonType.Reply, 0);
 		}
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
-            base.OnResponse(state, info);
+            base.OnResponse(info);
 
             if (info.ButtonID == 1)
             {
@@ -368,28 +388,24 @@ namespace Server.Engines.CityLoyalty
             }
             else if (info.ButtonID == 2)
             {
-                User.SendGump(new CityTitlesGump(User));
+                BaseGump.SendGump(new CityTitlesGump(User));
             }
         }
 	}
 
-    public class CityStoneGump : Gump
+    public class CityStoneGump : BaseGump
     {
-        public PlayerMobile User { get; set; }
         public CityLoyaltySystem City { get; set; }
 
         public CityStoneGump(PlayerMobile pm, CityLoyaltySystem city)
-            : base(50, 50)
+            : base(pm, 50, 50)
         {
-            User = pm;
             City = city;
 
             pm.CloseGump(typeof(CityStoneGump));
-
-            AddGumpLayout();
         }
 
-        public void AddGumpLayout()
+        public override void AddGumpLayout()
         {
             if (City.Election == null || !City.Election.Ongoing)
             {
@@ -425,35 +441,31 @@ namespace Server.Engines.CityLoyalty
             }
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
             switch (info.ButtonID)
             {
                 case 0: break;
                 case 1: City.Election.TryNominate(User); break;
-                case 2: User.SendGump(new NomineesGump(User, City)); break;
-                case 3: User.SendGump(new CandidatesGump(User, City)); break;
+                case 2: BaseGump.SendGump(new NomineesGump(User, City)); break;
+                case 3: BaseGump.SendGump(new CandidatesGump(User, City)); break;
             }
         }
     }
 
-    public class NomineesGump : Gump
+    public class NomineesGump : BaseGump
     {
-        public PlayerMobile User { get; set; }
         public CityLoyaltySystem City { get; set; }
 
         public NomineesGump(PlayerMobile pm, CityLoyaltySystem city)
-            : base(50, 50)
+            : base(pm, 50, 50)
         {
-            User = pm;
             City = city;
 
             pm.CloseGump(typeof(NomineesGump));
-
-            AddGumpLayout();
         }
 
-        public void AddGumpLayout()
+        public override void AddGumpLayout()
         {
             AddBackground(0, 0, 600, 400, 5054);
             AddHtmlLocalized(10, 12, 200, 20, 1153906, 0xFFFF, false, false); // Current Nominees
@@ -505,10 +517,10 @@ namespace Server.Engines.CityLoyalty
             }
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
             if (info.ButtonID == 1)
-                User.SendGump(new CityStoneGump(User, City));
+                BaseGump.SendGump(new CityStoneGump(User, City));
             else if (info.ButtonID == 2)
                 City.Election.TryWithdraw(User);
             else if (info.ButtonID >= 100)
@@ -528,25 +540,21 @@ namespace Server.Engines.CityLoyalty
         }
     }
 
-    public class CandidatesGump : Gump
+    public class CandidatesGump : BaseGump
     {
-        public PlayerMobile User { get; set; }
         public CityLoyaltySystem City { get; set; }
 
         List<BallotEntry> Candidates { get; set; }
 
         public CandidatesGump(PlayerMobile pm, CityLoyaltySystem city)
-            : base(50, 50)
+            : base(pm, 50, 50)
         {
-            User = pm;
             City = city;
 
             pm.CloseGump(typeof(CandidatesGump));
-
-            AddGumpLayout();
         }
 
-        public void AddGumpLayout()
+        public override void AddGumpLayout()
         {
             AddBackground(0, 0, 600, 400, 5054);
             AddHtmlLocalized(10, 12, 200, 20, 1153914, 0xFFFF, false, false); // Candidate List
@@ -603,10 +611,10 @@ namespace Server.Engines.CityLoyalty
             }
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
             if (info.ButtonID == 1)
-                User.SendGump(new CityStoneGump(User, City));
+                BaseGump.SendGump(new CityStoneGump(User, City));
             else if (info.ButtonID == 2)
                 City.Election.TryWithdraw(User);
             else if (info.ButtonID >= 100)
@@ -626,21 +634,17 @@ namespace Server.Engines.CityLoyalty
         }
     }
 
-    public class ChooseTradeDealGump : Gump
+    public class ChooseTradeDealGump : BaseGump
     {
-        public PlayerMobile User { get; set; }
         public CityLoyaltySystem City { get; set; }
 
         public ChooseTradeDealGump(PlayerMobile pm, CityLoyaltySystem city)
-            : base(75, 75)
+            : base(pm, 75, 75)
         {
-            User = pm;
             City = city;
-
-            AddGumpLayout();
         }
 
-        public void AddGumpLayout()
+        public override void AddGumpLayout()
         {
             AddImage(0, 0, 8000);
             AddImage(20, 37, 8001);
@@ -668,10 +672,8 @@ namespace Server.Engines.CityLoyalty
             }
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
-            base.OnResponse(state, info);
-
             if (info.ButtonID == 0)
                 return;
 
@@ -681,11 +683,11 @@ namespace Server.Engines.CityLoyalty
             {
                 if (City.Treasury < CityLoyaltySystem.TradeDealCost)
                 {
-                    City.HeraldMessage(state.Mobile, 1154057); // Begging thy pardon but the City Treasury doth nay have the funds available to make such a deal!
+                    City.HeraldMessage(User, 1154057); // Begging thy pardon but the City Treasury doth nay have the funds available to make such a deal!
                 }
                 else if (User.AccessLevel == AccessLevel.Player && City.TradeDealStart != DateTime.MinValue && City.TradeDealStart + TimeSpan.FromDays(CityLoyaltySystem.TradeDealCooldown) > DateTime.UtcNow)
                 {
-                    City.HeraldMessage(state.Mobile, 1154056); // You may only make a trade deal once per real world week!
+                    City.HeraldMessage(User, 1154056); // You may only make a trade deal once per real world week!
                 }
                 else
                 {
@@ -711,25 +713,21 @@ namespace Server.Engines.CityLoyalty
         };
     }
 
-    public class PlayerTitleGump : Gump
+    public class PlayerTitleGump : BaseGump
     {
-        public PlayerMobile User { get; set; }
         public PlayerMobile Citizen { get; set; }
         public CityLoyaltySystem City { get; set; }
 
         public PlayerTitleGump(PlayerMobile pm, PlayerMobile citizen, CityLoyaltySystem sys)
-            : base(50, 50)
+            : base(pm, 50, 50)
         {
-            User = pm;
             Citizen = citizen;
             City = sys;
 
             pm.CloseGump(typeof(PlayerTitleGump));
-
-            AddGumpLayout();
         }
 
-        public void AddGumpLayout()
+        public override void AddGumpLayout()
         {
             AddBackground(0, 0, 400, 400, 5054);
             AddHtmlLocalized(0, 15, 400, 20, 1154015, false, false); // <CENTER>City Title</CENTER>
@@ -741,7 +739,7 @@ namespace Server.Engines.CityLoyalty
             AddButton(15, 145, 4023, 4024, 1, GumpButtonType.Reply, 0); 
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
             TextRelay relay = info.GetTextEntry(1);
             CityLoyaltyEntry entry = City.GetPlayerEntry<CityLoyaltyEntry>(Citizen);
@@ -790,22 +788,18 @@ namespace Server.Engines.CityLoyalty
         }
     }
 
-    public class AcceptOfficeGump : Gump
+    public class AcceptOfficeGump : BaseGump
     {
-        public PlayerMobile User { get; set; }
         public CityLoyaltySystem City { get; set; }
 
-        public AcceptOfficeGump(PlayerMobile pm, CityLoyaltySystem city) : base(50, 50)
+        public AcceptOfficeGump(PlayerMobile pm, CityLoyaltySystem city) : base(pm, 50, 50)
         {
-            User = pm;
             City = city;
 
             pm.CloseGump(typeof(AcceptOfficeGump));
-
-            AddGumpLayout();
         }
 
-        public void AddGumpLayout()
+        public override void AddGumpLayout()
         {
             AddBackground(0, 0, 600, 600, 9380);
 
@@ -827,9 +821,9 @@ namespace Server.Engines.CityLoyalty
             AddHtmlLocalized(450, 548, 150, 20, 1115372, false, false); // Decline
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
-            PlayerMobile pm = state.Mobile as PlayerMobile;
+            PlayerMobile pm = User as PlayerMobile;
 
             if (pm == null)
                 return;
@@ -850,16 +844,15 @@ namespace Server.Engines.CityLoyalty
         }
     }
 
-    public class ElectionStartTimeGump : Gump
+    public class ElectionStartTimeGump : BaseGump
     {
-        public PlayerMobile User { get; set; }
-
-        public ElectionStartTimeGump(PlayerMobile pm) : base(50, 50)
+        public ElectionStartTimeGump(PlayerMobile pm) : base(pm, 50, 50)
         {
-            User = pm;
-
             pm.CloseGump(typeof(ElectionStartTimeGump));
+        }
 
+        public override void AddGumpLayout()
+        {
             AddBackground(0, 0, 400, 400, 5054);
             AddHtml(0, 15, 400, 20, "<center>Election Start Times</center>", false, false);
 
@@ -898,7 +891,7 @@ namespace Server.Engines.CityLoyalty
             }
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
             if (info.ButtonID < 1 || (CityLoyaltySystem.Britain.Election != null && CityLoyaltySystem.Britain.Election.Ongoing))
                 return;
@@ -910,7 +903,7 @@ namespace Server.Engines.CityLoyalty
                     sys.Election.GetDefaultStartTimes();
                 }
 
-                state.Mobile.SendMessage("Election start times reset to default.");
+                User.SendMessage("Election start times reset to default.");
                 return;
             }
 
@@ -955,7 +948,7 @@ namespace Server.Engines.CityLoyalty
 
             if (times.Count > 0)
             {
-                DateTime[] starttimes = CityElection.ValidateStartTimes(state.Mobile, times.ToArray());
+                DateTime[] starttimes = CityElection.ValidateStartTimes(User, times.ToArray());
 
                 if (starttimes != null)
                 {
@@ -964,7 +957,7 @@ namespace Server.Engines.CityLoyalty
                         sys.Election.StartTimes = starttimes;
                     }
 
-                    state.Mobile.SendMessage("Election start times reset.");
+                    User.SendMessage("Election start times reset.");
                 }
             }
         }
@@ -974,15 +967,18 @@ namespace Server.Engines.CityLoyalty
     /// I cannot find ANYWHERE what "Open Inventory" context menu entry does on EA.
     /// Its apparent it is a Governor only function, however no docs can be found on it.
     /// </summary>
-    public class OpenInventoryGump : Gump
+    public class OpenInventoryGump : BaseGump
     {
         public CityLoyaltySystem City { get; set; }
 
-        public OpenInventoryGump(CityLoyaltySystem city)
-            : base(50, 50)
+        public OpenInventoryGump(PlayerMobile pm, CityLoyaltySystem city)
+            : base(pm, 50, 50)
         {
             City = city;
+        }
 
+        public override void AddGumpLayout()
+        {
             if (City == null || City.Stone == null || City.Stone.Boxes == null)
                 return;
 
@@ -994,10 +990,10 @@ namespace Server.Engines.CityLoyalty
             AddLabel(200, 40, 0, "Remove");
 
             City.Stone.Boxes.ForEach(b =>
-                {
-                    if (b.Deleted)
-                        City.Stone.Boxes.Remove(b);
-                });
+            {
+                if (b.Deleted)
+                    City.Stone.Boxes.Remove(b);
+            });
 
             for (int i = 0; i < City.Stone.Boxes.Count; i++)
             {
@@ -1009,9 +1005,9 @@ namespace Server.Engines.CityLoyalty
             }
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
-            Mobile m = state.Mobile;
+            Mobile m = User;
 
             if (info.ButtonID == 0)
                 return;
@@ -1047,19 +1043,23 @@ namespace Server.Engines.CityLoyalty
                             }
 
                             m.CloseGump(typeof(OpenInventoryGump));
-                            m.SendGump(new OpenInventoryGump(City));
+                            BaseGump.SendGump(new OpenInventoryGump(User, City));
                         }, box, true));
                 }
             }
         }
     }
 
-    public class CityMessageBoardGump : Gump
+    public class CityMessageBoardGump : BaseGump
     {
         private int _Red = 0x8B0000;
 
-        public CityMessageBoardGump()
-            : base(100, 100)
+        public CityMessageBoardGump(PlayerMobile pm)
+            : base(pm, 100, 100)
+        {
+        }
+
+        public override void AddGumpLayout()
         {
             AddBackground(0, 0, 554, 350, 9380);
 
@@ -1075,7 +1075,7 @@ namespace Server.Engines.CityLoyalty
             }
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
             if (info.ButtonID == 0)
                 return;
@@ -1083,34 +1083,41 @@ namespace Server.Engines.CityLoyalty
             int id = info.ButtonID - 100;
 
             if(id >= 0 && id < CityLoyaltySystem.Cities.Count)
-                state.Mobile.SendGump(new CityMessageGump(state.Mobile, CityLoyaltySystem.Cities[id]));
+                BaseGump.SendGump(new CityMessageGump(User, CityLoyaltySystem.Cities[id]));
         }
     }
 
-    public class CityMessageGump : Gump
+    public class CityMessageGump : BaseGump
     {
         public CityLoyaltySystem City { get; set; }
 
-        public CityMessageGump(Mobile m, CityLoyaltySystem city)
-            : base(100, 100)
+        public CityMessageGump(PlayerMobile m, CityLoyaltySystem city)
+            : base(m, 100, 100)
         {
             City = city;
+        }
 
+        public override void AddGumpLayout()
+        {
             AddBackground(0, 0, 554, 350, 9380);
             AddHtmlLocalized(25, 55, 500, 20, 1154915, City.Definition.Name, 0, false, false); // The Latest News from the City of ~1_CITY~
 
-            if(City.PostedOn != DateTime.MinValue)
+            if (City.PostedOn != DateTime.MinValue)
                 AddHtmlLocalized(25, 85, 500, 20, 1154916, String.Format("{0}\t{1}", City.Governor != null ? City.Governor.Name : "somebody", City.PostedOn.ToShortDateString()), 0, false, false); // Posted by ~1_NAME~ on ~2_date~
-            
-            AddHtml(25, 115, 500, 20, city.Headline, false, false);
-            AddHtml(25, 195, 500, 150, city.Body, false, false);
+
+            AddHtml(25, 115, 500, 20, City.Headline, false, false);
+            AddHtml(25, 195, 500, 150, City.Body, false, false);
         }
     }
 
-    public class SystemInfoGump : Gump
+    public class SystemInfoGump : BaseGump
     {
-        public SystemInfoGump()
-            : base(50, 50)
+        public SystemInfoGump(PlayerMobile pm)
+            : base(pm, 50, 50)
+        {
+        }
+
+        public override void AddGumpLayout()
         {
             AddBackground(0, 0, 400, (CityLoyaltySystem.Cities.Count * 25) + 100, 5054);
 
@@ -1132,7 +1139,7 @@ namespace Server.Engines.CityLoyalty
             }
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
             if (info.ButtonID == 0)
                 return;
@@ -1141,25 +1148,28 @@ namespace Server.Engines.CityLoyalty
 
             if (id >= 0 && id < CityLoyaltySystem.Cities.Count)
             {
-                state.Mobile.SendGump(new CityInfoGump(CityLoyaltySystem.Cities[id]));
+                BaseGump.SendGump(new CityInfoGump(User, CityLoyaltySystem.Cities[id]));
             }
         }
     }
 
-    public class CityInfoGump : Gump
+    public class CityInfoGump : BaseGump
     {
         public CityLoyaltySystem City { get; set; }
 
-        public CityInfoGump(CityLoyaltySystem city)
-            : base(50, 50)
+        public CityInfoGump(PlayerMobile pm, CityLoyaltySystem city)
+            : base(pm, 50, 50)
         {
             City = city;
+        }
 
+        public override void AddGumpLayout()
+        {
             int page = 0;
             AddPage(page);
 
             AddBackground(0, 0, 500, 400, 5054);
-            AddHtml(0, 15, 400, 20, String.Format("<center>City Info - {0}</center>", city.Definition.Name), false, false);
+            AddHtml(0, 15, 400, 20, String.Format("<center>City Info - {0}</center>", City.Definition.Name), false, false);
 
             AddLabel(10, 35, 0, "Player");
             AddLabel(150, 35, 0, "Love");
@@ -1174,9 +1184,9 @@ namespace Server.Engines.CityLoyalty
             AddButton(10, 370, 4014, 4016, 1, GumpButtonType.Reply, 0);
             AddLabel(45, 370, 0, "BACK");
 
-            for (int i = 0; i < city.PlayerTable.Count; i++)
+            for (int i = 0; i < City.PlayerTable.Count; i++)
             {
-                CityLoyaltyEntry entry = city.PlayerTable[i] as CityLoyaltyEntry;
+                CityLoyaltyEntry entry = City.PlayerTable[i] as CityLoyaltyEntry;
 
                 if (entry == null)
                     continue;
@@ -1188,7 +1198,7 @@ namespace Server.Engines.CityLoyalty
                 AddHtml(300, 60 + (pageIndex * 25), 150, 20, String.IsNullOrEmpty(entry.CustomTitle) ? "" : entry.CustomTitle, false, false);
                 AddButton(450, 60 + (pageIndex * 25), 4005, 4007, i + 100, GumpButtonType.Reply, 0);
 
-                if (pageIndex >= 11 && i < city.PlayerTable.Count - 1)
+                if (pageIndex >= 11 && i < City.PlayerTable.Count - 1)
                 {
                     pageIndex = 0;
 
@@ -1204,14 +1214,14 @@ namespace Server.Engines.CityLoyalty
             }
         }
 
-        public override void OnResponse(NetState state, RelayInfo info)
+        public override void OnResponse(RelayInfo info)
         {
             if (info.ButtonID == 0)
                 return;
 
             if (info.ButtonID == 1)
             {
-                state.Mobile.SendGump(new SystemInfoGump());
+                BaseGump.SendGump(new SystemInfoGump(User));
                 return;
             }
 
@@ -1219,8 +1229,8 @@ namespace Server.Engines.CityLoyalty
 
             if (id >= 0 && id < City.PlayerTable.Count)
             {
-                state.Mobile.SendGump(new CityInfoGump(City));
-                state.Mobile.SendGump(new PropertiesGump(state.Mobile, City.PlayerTable[id]));
+                Refresh();
+                User.SendGump(new PropertiesGump(User, City.PlayerTable[id]));
             }
         }
     }

--- a/Scripts/Services/City Loyalty System/Items/CityStone.cs
+++ b/Scripts/Services/City Loyalty System/Items/CityStone.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Server.ContextMenus;
 using Server.Targeting;
+using Server.Gumps;
 
 namespace Server.Engines.CityLoyalty
 {
@@ -28,8 +29,8 @@ namespace Server.Engines.CityLoyalty
         {
             if (CityLoyaltySystem.Enabled && CityLoyaltySystem.IsSetup() && from is PlayerMobile && from.InRange(from.Location, 3))
             {
-                if (City != null && City.IsCitizen(from))
-                    from.SendGump(new CityStoneGump(from as PlayerMobile, City));
+                if (from is PlayerMobile && City != null && City.IsCitizen(from))
+                    BaseGump.SendGump(new CityStoneGump(from as PlayerMobile, City));
                 else
                     from.SendLocalizedMessage(1153888); // Only Citizens of this City may use the Election Stone. 
             }
@@ -99,7 +100,7 @@ namespace Server.Engines.CityLoyalty
                                 {
                                     if (City.IsCitizen(pm))
                                     {
-                                        mob.SendGump(new PlayerTitleGump(mob as PlayerMobile, pm, City));
+                                        BaseGump.SendGump(new PlayerTitleGump(mob as PlayerMobile, pm, City));
                                     }
                                     else
                                         mob.SendLocalizedMessage(1154029); // You may only bestow a title on citizens of this city!
@@ -114,15 +115,15 @@ namespace Server.Engines.CityLoyalty
             {
                 if (City.IsGovernor(m))
                 {
-                    m.SendGump(new ChooseTradeDealGump(m as PlayerMobile, City));
+                    BaseGump.SendGump(new ChooseTradeDealGump(m as PlayerMobile, City));
                 }
             }, enabled: City.IsGovernor(from)));
 
             list.Add(new SimpleContextMenuEntry(from, 1154277, m => // Open Inventory WTF is this?
             {
-                if (City.IsGovernor(m))
+                if (m is PlayerMobile && City.IsGovernor(m))
                 {
-                    m.SendGump(new OpenInventoryGump(City));
+                    BaseGump.SendGump(new OpenInventoryGump((PlayerMobile)m, City));
                 }
             }, enabled: City.IsGovernor(from)));
 
@@ -187,9 +188,9 @@ namespace Server.Engines.CityLoyalty
 
             list.Add(new SimpleContextMenuEntry(from, 1154068, m => // Accept Office
             {
-                if (m == City.GovernorElect && City.Governor == null)
+                if (m is PlayerMobile && m == City.GovernorElect && City.Governor == null)
                 {
-                    m.SendGump(new AcceptOfficeGump(m as PlayerMobile, City));
+                    BaseGump.SendGump(new AcceptOfficeGump(m as PlayerMobile, City));
                 }
             }, enabled: City.GovernorElect == from && City.Governor == null && City.GetLoyaltyRating(from) >= LoyaltyRating.Unknown));
         }

--- a/Scripts/Services/City Loyalty System/Setup.cs
+++ b/Scripts/Services/City Loyalty System/Setup.cs
@@ -90,7 +90,7 @@ namespace Server.Engines.CityLoyalty
                     itemdonation = new CityItemDonation(sys.City, minister);
                     petdonation = new CityPetDonation(sys.City, minister);
                     box = new BoxOfRopes(sys.City);
-                    board = new CityMessageBoard(sys.City, sys.City == City.Trinsic ? 7775 : 7774);
+                    board = new CityMessageBoard(sys.City, 0xA0C5);
 
                     if (!HasType(sys, minister.GetType()))
                     {
@@ -139,8 +139,11 @@ namespace Server.Engines.CityLoyalty
                     else
                         box.Delete();
 
-                    if(!HasType(sys, board.GetType()))
+                    if (!HasType(sys, board.GetType()))
+                    {
                         board.MoveToWorld(sys.Definition.BoardLocation, Map.Trammel);
+                        sys.Board = board;
+                    }
                     else
                         board.Delete();
                     

--- a/Scripts/Services/CleanUpBritannia/PointExchange.cs
+++ b/Scripts/Services/CleanUpBritannia/PointExchange.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using Server;
+using Server.Gumps;
+using Server.Mobiles;
+using Server.Items;
+
+namespace Server.Engines.Points
+{
+	public class PointExchanceStone : Item
+	{
+		public override int LabelNumber { get { return 1158449; } } // Cleanup Point Exchange
+        public override bool ForceShowProperties { get { return true; } }
+
+		[Constructable]
+		public PointExchanceStone()
+            : base(0xEDD)
+		{
+			Hue = 1037;
+            Movable = false;
+		}
+
+        public override void OnDoubleClick(Mobile m)
+        {
+            if (m.InRange(Location, 3))
+            {
+                if (m is PlayerMobile)
+                {
+                    m.CloseGump(typeof(InternalGump));
+                    BaseGump.SendGump(new InternalGump((PlayerMobile)m));
+                }
+            }
+            else
+            {
+                m.LocalOverheadMessage(Server.Network.MessageType.Regular, 0x3B2, 1019045); // I can't reach that.
+            }
+        }
+
+        private class InternalGump : BaseGump
+        {
+            public CleanUpBritanniaData System { get { return PointsSystem.CleanUpBritannia; } }
+
+            public InternalGump(PlayerMobile pm)
+                : base(pm, 100, 100)
+            {
+            }
+
+            public override void AddGumpLayout()
+            {
+                int points = (int)PointsSystem.CleanUpBritannia.GetPoints(User);
+                int accountPoints = (int)PointsSystem.CleanUpBritannia.GetPointsFromExchange(User);
+
+                AddBackground(0, 0, 370, 245, 0x53);
+                AddHtmlLocalized(0, 15, 370, 20, CenterLoc, "#1158449", 0x7FFF, false, false);
+
+                AddHtmlLocalized(15, 40, 340, 20, 1158454, points.ToString("N0"), 0x7FFF, false, false); // Your Cleanup Point Balance: ~1_VALUE~
+                AddHtmlLocalized(15, 70, 340, 20, 1158455, accountPoints.ToString("N0"), 0x7FFF, false, false); // Points Currently in Exchange: ~1_VALUE~
+
+                AddButton(20, 105, 4005, 4006, 1, GumpButtonType.Reply, 0);
+                AddHtmlLocalized(60, 105, 100, 20, 1158466, 0x7FFF, false, false); // Deposit Points
+
+                AddButton(20, 127, 4005, 4006, 2, GumpButtonType.Reply, 0);
+                AddHtmlLocalized(60, 127, 100, 20, 1158465, 0x7FFF, false, false); // Withdraw Points
+
+                AddHtmlLocalized(15, 170, 340, 20, 1158459, points.ToString("N0"), C32216(0xb478ed), false, false); // You can currently deposit ~1_VALUE~ points.
+                AddHtmlLocalized(15, 200, 340, 20, 1158458, accountPoints.ToString("N0"), C32216(0xb478ed), false, false); // You can currently withdraw ~1_VALUE~ points.
+            }
+
+            public override void OnResponse(RelayInfo info)
+            {
+                switch (info.ButtonID)
+                {
+                    case 0:
+                        return;
+                    case 1:
+                        PointsSystem.CleanUpBritannia.AddPointsToExchange(User);
+                        break;
+                    case 2:
+                        PointsSystem.CleanUpBritannia.RemovePointsFromExchange(User);
+                        break;
+                }
+
+                Refresh();
+            }
+        }
+
+        public PointExchanceStone(Serial serial)
+			: base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 0 );
+		}
+
+		public override void Deserialize( GenericReader reader )
+		{
+			base.Deserialize( reader );
+
+			int version = reader.ReadInt();
+		}
+	}
+}

--- a/Scripts/Services/Expansions/High Seas/Quests/ProfessionFishQuest/FishQuestHelper.cs
+++ b/Scripts/Services/Expansions/High Seas/Quests/ProfessionFishQuest/FishQuestHelper.cs
@@ -403,7 +403,7 @@ namespace Server.Engines.Quests
             if (from == null)
                 return 0;
 
-            double skill = from.Skills[SkillName.Fishing].Value;
+            double skill = from.Skills[SkillName.Fishing].Base;
 
             if (skill < 80.0)
                 return 11;

--- a/Scripts/Services/LoyaltySystem/LoyaltyRatingGump.cs
+++ b/Scripts/Services/LoyaltySystem/LoyaltyRatingGump.cs
@@ -61,7 +61,7 @@ namespace Server.Engines.Points
             PlayerMobile pm = state.Mobile as PlayerMobile;
 
             if (CityLoyaltySystem.Enabled && CityLoyaltySystem.Cities != null && pm != null && info.ButtonID == 1)
-                pm.SendGump(new CityLoyaltyGump(pm));
+                BaseGump.SendGump(new CityLoyaltyGump(pm));
         }
     }
 }

--- a/Scripts/Services/Pet Training/AbilityProfile.cs
+++ b/Scripts/Services/Pet Training/AbilityProfile.cs
@@ -153,6 +153,30 @@ namespace Server.Mobiles
             return true;
         }
 
+        public void RemoveAbility(MagicalAbility ability)
+        {
+            if ((MagicalAbility & ability) != 0)
+            {
+                MagicalAbility ^= ability;
+                RemovePetAdvancement(ability);
+            }
+        }
+
+        public void RemoveAbility(SpecialAbility ability)
+        {
+            if (SpecialAbilities == null || !SpecialAbilities.Any(a => a == ability))
+                return;
+
+            var list = SpecialAbilities.ToList();
+
+            list.Remove(ability);
+            RemovePetAdvancement(ability);
+
+            SpecialAbilities = list.ToArray();
+
+            ColUtility.Free(list);
+        }
+
         public void RemoveAbility(WeaponAbility ability)
         {
             if (WeaponAbilities == null || !WeaponAbilities.Any(a => a == ability))
@@ -164,6 +188,21 @@ namespace Server.Mobiles
             RemovePetAdvancement(ability);
 
             WeaponAbilities = list.ToArray();
+
+            ColUtility.Free(list);
+        }
+
+        public void RemoveAbility(AreaEffect ability)
+        {
+            if (AreaEffects == null || !AreaEffects.Any(a => a == ability))
+                return;
+
+            var list = AreaEffects.ToList();
+
+            list.Remove(ability);
+            RemovePetAdvancement(ability);
+
+            AreaEffects = list.ToArray();
 
             ColUtility.Free(list);
         }

--- a/Scripts/Services/Pet Training/Gumps.cs
+++ b/Scripts/Services/Pet Training/Gumps.cs
@@ -24,6 +24,7 @@ namespace Server.Mobiles
         public override void AddGumpLayout()
         {
             var profile = PetTrainingHelper.GetAbilityProfile(Creature);
+            var trainProfile = PetTrainingHelper.GetTrainingProfile(Creature, true);
 
             AddPage(0);
             AddBackground(0, 24, 310, 325, 0x24A4);
@@ -34,11 +35,10 @@ namespace Server.Mobiles
             AddImage(40, 62, 0x82B);
             AddImage(40, 258, 0x82B);
 
-            if (Creature.Controlled && Creature.ControlMaster == User)
+            if (Creature.Controlled && Creature.ControlMaster == User && PetTrainingHelper.CanControl(User, Creature, trainProfile))
             {
                 AddImage(28, 272, 0x826);
 
-                var trainProfile = PetTrainingHelper.GetTrainingProfile(Creature, true);
                 var def = PetTrainingHelper.GetTrainingDefinition(Creature);
 
                 if (trainProfile.HasBegunTraining && def != null && def.Class != Class.Untrainable)
@@ -69,6 +69,7 @@ namespace Server.Mobiles
                 }
                 else if (Creature.ControlSlots < Creature.ControlSlotsMax)
                 {
+
                     AddHtmlLocalized(47, 270, 160, 18, 1157487, 0xC8, false, false); // Begin Animal Training
                     AddButton(53, 288, 0x837, 0x838, 4, GumpButtonType.Reply, 0);
                 }
@@ -1601,7 +1602,7 @@ namespace Server.Mobiles
                     {
                         User.SendLocalizedMessage(1157501); // Your pet looks to have already completed that training. 
                     }
-                    else
+                    else if (PetTrainingHelper.CanControl(User, Creature, profile))
                     {
                         BaseGump.SendGump(new PetTrainingConfirmGump(User, 1157502, TrainingPoint.TrainPoint is MagicalAbility ? 1157566 : 1157503, () =>
                             {

--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -939,7 +939,17 @@ namespace Server.Mobiles
         #endregion
 
         #region Training Helpers
+        public static bool CanControl(Mobile m, BaseCreature bc, TrainingProfile trainProfile)
+        {
+            double skill = m.Skills[SkillName.AnimalTaming].Base; // TODO: Base?
 
+            if (trainProfile.HasIncreasedControlSlot)
+            {
+                return skill >= bc.CalculateCurrentTameSkill(bc.ControlSlots);
+            }
+
+            return skill >= bc.CalculateCurrentTameSkill(bc.ControlSlots + 1);
+        }
         public static int GetTrainingCapTotal(PetStat stat)
         {
             switch (stat)
@@ -1346,7 +1356,7 @@ namespace Server.Mobiles
             {
                 var profile = GetAbilityProfile(bc);
 
-                if (profile != null && profile.TokunoTame)
+                if (profile != null/* && profile.TokunoTame*/)
                 {
                     bc.CheckSkill(skill, 0.0, bc.Skills[skill].Cap);
                 }

--- a/Scripts/Services/PointsSystems/CasinoData.cs
+++ b/Scripts/Services/PointsSystems/CasinoData.cs
@@ -32,5 +32,23 @@ namespace Server.Engines.Points
 		{
             return new TextDefinition(1153485); // Fortune's Fire Resort & Casino
 		}
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            if (this.Version >= 2)
+            {
+                int version = reader.ReadInt();
+
+                // all deserialize code in here
+            }
+        }
     }
 }

--- a/Scripts/Services/PointsSystems/DespiseCrystals.cs
+++ b/Scripts/Services/PointsSystems/DespiseCrystals.cs
@@ -29,5 +29,23 @@ namespace Server.Engines.Points
 		{
 			return new TextDefinition(1123418);
 		}
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            if (this.Version >= 2)
+            {
+                int version = reader.ReadInt();
+
+                // all deserialize code in here
+            }
+        }
 	}
 }

--- a/Scripts/Services/PointsSystems/PointsSystem.cs
+++ b/Scripts/Services/PointsSystems/PointsSystem.cs
@@ -222,10 +222,12 @@ namespace Server.Engines.Points
         {
             return new PointsEntry(pm);
         }
+        
+        public int Version { get; set; }
 
         public virtual void Serialize(GenericWriter writer)
         {
-            writer.Write((int)1);
+            writer.Write((int)2);
 
             writer.Write(PlayerTable.Count);
 
@@ -238,19 +240,20 @@ namespace Server.Engines.Points
 
         public virtual void Deserialize(GenericReader reader)
         {
-            int version = reader.ReadInt();
+            Version = reader.ReadInt();
 
-            switch (version)
+            switch (Version)
             {
-                case 0:
+                case 2: // added serialize/deserialize in all base classes. Poor implementation on my part, should have had from the get-go
                 case 1:
+                case 0:
                     int count = reader.ReadInt();
                     for (int i = 0; i < count; i++)
                     {
                         PlayerMobile player = reader.ReadMobile() as PlayerMobile;
                         PointsEntry entry = GetSystemEntry(player);
-                        
-                        if (version > 0)
+
+                        if (Version > 0)
                             entry.Deserialize(reader);
                         else
                             entry.Points = reader.ReadDouble();

--- a/Scripts/Services/PointsSystems/QueensLoyalty.cs
+++ b/Scripts/Services/PointsSystems/QueensLoyalty.cs
@@ -174,5 +174,23 @@ namespace Server.Engines.Points
 			Entries[typeof(AWorthyPropositionQuest)]			= new Tuple<double, double>(50, 5.0);
 			Entries[typeof(UnusualGoods)]     					= new Tuple<double, double>(75, 7.5);
 		}
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            if (this.Version >= 2)
+            {
+                int version = reader.ReadInt();
+
+                // all deserialize code in here
+            }
+        }
 	}
 }

--- a/Scripts/Services/PointsSystems/ShameCrystals.cs
+++ b/Scripts/Services/PointsSystems/ShameCrystals.cs
@@ -29,5 +29,23 @@ namespace Server.Engines.Points
 		{
             return new TextDefinition(1123444);
 		}
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            if (this.Version >= 2)
+            {
+                int version = reader.ReadInt();
+
+                // all deserialize code in here
+            }
+        }
 	}
 }

--- a/Scripts/Services/PointsSystems/VoidPool.cs
+++ b/Scripts/Services/PointsSystems/VoidPool.cs
@@ -32,6 +32,24 @@ namespace Server.Engines.Points
 		{
 			return new TextDefinition(1152531); // The Void Pool
 		}
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            if (this.Version >= 2)
+            {
+                int version = reader.ReadInt();
+
+                // all deserialize code in here
+            }
+        }
 	}
 
     public class VoidPoolInfo : ContextMenuEntry

--- a/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Creatures/Cora.cs
+++ b/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Creatures/Cora.cs
@@ -302,6 +302,37 @@ using Server.Engines.VoidPool;
             }
         }
 
+        public override void OnKilledBy(Mobile mob)
+        {
+            if (Siege.SiegeShard && mob is PlayerMobile)
+            {
+                int chance = Server.Engines.Despise.DespiseBoss.ArtifactChance + (int)Math.Min(10, ((PlayerMobile)mob).Luck / 180);
+
+                if (chance >= Utility.Random(100))
+                {
+                    Type t = Server.Engines.Despise.DespiseBoss.Artifacts[Utility.Random(Server.Engines.Despise.DespiseBoss.Artifacts.Length)];
+
+                    if (t != null)
+                    {
+                        Item arty = Loot.Construct(t);
+
+                        if (arty != null)
+                        {
+                            Container pack = mob.Backpack;
+
+                            if (pack == null || !pack.TryDropItem(mob, arty, false))
+                            {
+                                mob.BankBox.DropItem(arty);
+                                mob.SendMessage("An artifact has been placed in your bankbox!");
+                            }
+                            else
+                                mob.SendLocalizedMessage(1153440); // An artifact has been placed in your backpack!
+                        }
+                    }
+                }
+            }
+        }
+
         public CoraTheSorceress(Serial serial)
             : base(serial)
 		{

--- a/Scripts/Services/Town Cryer/Gumps/TownCryerGreetingsGump.cs
+++ b/Scripts/Services/Town Cryer/Gumps/TownCryerGreetingsGump.cs
@@ -47,7 +47,7 @@ namespace Server.Services.TownCryer
             AddHtml(395, 570, 35, 20, Center(String.Format("{0}/{1}", (Page + 1).ToString(), (Pages + 1).ToString())), false, false);
 
             AddButton(525, 625, 0x5FF, 0x600, 5, GumpButtonType.Reply, 0);
-            AddHtmlLocalized(550, 625, 200, 20, 1158386, false, false); // Close and do not show this version again
+            AddHtmlLocalized(550, 625, 300, 20, 1158386, false, false); // Close and do not show this version again
         }
 
         public override void OnResponse(RelayInfo info)

--- a/Scripts/Services/UltimaStore/UltimaStore.cs
+++ b/Scripts/Services/UltimaStore/UltimaStore.cs
@@ -299,7 +299,7 @@ namespace Server.Engines.UOStore
 
             Register(new StoreEntry(typeof(FallenLogDeed), 1071088, 1156649, 0, 0x9C88, 0, 200, cat));
             Register(new StoreEntry(typeof(LampPost2), 1071089, 1156650, 0xB22, 0, 0, 200, cat, ConstructLampPost));
-            Register(new StoreEntry(typeof(HitchingPost), 1071090, 1156651, 0x14E7, 0, 0, 200, cat));
+            Register(new StoreEntry(typeof(HitchingPost), 1071090, 1156651, 0x14E7, 0, 0, 200, cat, ConstructHitchingPost));
             Register(new StoreEntry(typeof(AncestralGravestone), 1071096, 1156653, 0x1174, 0, 0, 200, cat));
             Register(new StoreEntry(typeof(WoodenBookcase), 1071102, 1156655, 0x0A9D, 0, 0, 200, cat));
             Register(new StoreEntry(typeof(SnowTreeDeed), 1071103, 1156656, 0, 0x9C8A, 0, 200, cat));
@@ -492,6 +492,11 @@ namespace Server.Engines.UOStore
         public static Item ConstructBOBCoverTwo(Mobile m, StoreEntry entry)
         {
             return new BagOfBulkOrderCovers(1, 11);
+        }
+
+        public static Item ConstructHitchingPost(Mobile m, StoreEntry entry)
+        {
+            return new HitchingPost(false);
         }
         #endregion
 


### PR DESCRIPTION
- Differentiation between store bought and tinker made hitching posts
- City Loyalty System bulletin boards updated per EA
- Converted all City Loyalty Gumps to BaseGump
- Green/Grey Goblin Statuettes now deactivate when they leave the original container
- Necro AI no longer casts cure spell
- Added Mirror Image to Ninja AI
- Siege shards now drop New Despise Artifacts on Cora the Sorceress
- Fish Monger Quest now reads base skill, not real skill for skill requirements
- Added City Loyalty Points messaging toggle
- Added Cleanup Britannia Poitns Exchange
- Added Serializiation/Deserialization to all PointsSystem classes
- Added check for taming requirements prior to pets control slot increase (first training iteration for that level). If the player does not meet the requirement for the next slot increase, they will not be able to train the pet, pet EA