### PR TITLE
Update Travesty.cs

### DIFF
--- a/Scripts/Mobiles/Bosses/Travesty.cs
+++ b/Scripts/Mobiles/Bosses/Travesty.cs
@@ -127,7 +127,7 @@ namespace Server.Mobiles
 
             if (Utility.RandomDouble() < 0.025)
             {
-                switch (Utility.Random(7))
+                switch (Utility.Random(4))
                 {
                     case 0:
                         c.DropItem(new AssassinLegs());
@@ -140,15 +140,6 @@ namespace Server.Mobiles
                         break;
                     case 3:
                         c.DropItem(new MalekisHonor());
-                        break;
-                    case 4:
-                        c.DropItem(new JusticeBreastplate());
-                        break;
-                    case 5:
-                        c.DropItem(new CompassionArms());
-                        break;
-                    case 6:
-                        c.DropItem(new ValorGauntlets());
                         break;
                 }
             }


### PR DESCRIPTION
https://uo.com/wiki/ultima-online-wiki/items/artifact-collections/artifacts-virtue/

The items removed are now solely found in the anti-virtue dungeons. No idea why they were ever added to Peerless code.