### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Tools/BaseTool.cs
+++ b/Scripts/Items/Tools/BaseTool.cs
@@ -15,7 +15,7 @@ namespace Server.Items
         bool CheckAccessible(Mobile from, ref int num);
     }
 
-    public abstract class BaseTool : Item, ITool
+    public abstract class BaseTool : Item, ITool, IResource
     {
         private Mobile m_Crafter;
         private ItemQuality m_Quality;

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -6804,7 +6804,7 @@ namespace Server.Mobiles
             }
         }
 
-        public double GetDispelDifficulty()
+        public virtual double GetDispelDifficulty()
         {
             double dif = DispelDifficulty;
             if (SummonMaster != null)

--- a/Scripts/Services/BulkOrders/SmallBODs/SmallTinkerBOD.cs
+++ b/Scripts/Services/BulkOrders/SmallBODs/SmallTinkerBOD.cs
@@ -180,13 +180,12 @@ namespace Server.Engines.BulkOrders
 
         private static bool IsTool(Type t)
         {
-            return _Tools.Any(x => x == t);
+            return _Tools.Any(x => x == t || t.IsSubclassOf(x));
         }
 
         private static Type[] _Tools =
         {
-            typeof(MortarPestle), typeof(SmithHammer), typeof(SmithyHammer), typeof(Skillet),
-            typeof(SewingKit), typeof(FletcherTools), typeof(SledgeHammer), typeof(Clippers)
+            typeof(BaseTool), typeof(SmithyHammer)
         };
 
         public override bool CheckType(Type itemType)

--- a/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
+++ b/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
@@ -50,9 +50,16 @@ namespace Server.Engines.Quests
                     {
                         return quest;
                     }
-                    else if (quest.StartingMobile != null && !quest.DoneOnce && message)
+                    else if (quester is Mobile && message)
                     {
-                        quest.StartingMobile.OnOfferFailed();
+                        if (quester is MondainQuester)
+                        {
+                            ((MondainQuester)quester).OnOfferFailed();
+                        }
+                        else if (quester is Mobile)
+                        {
+                            ((Mobile)quester).Say(1080107); // I'm sorry, I have nothing for you at this time.
+                        }
                     }
                 }
 				

--- a/Scripts/Services/MondainsLegacyQuests/MondainQuester.cs
+++ b/Scripts/Services/MondainsLegacyQuests/MondainQuester.cs
@@ -142,8 +142,8 @@ namespace Server.Engines.Quests
         }
 
         public virtual void OnOfferFailed()
-        { 
-            Say(1075575); // I'm sorry, but I don't have anything else for you right now. Could you check back with me in a few minutes?
+        {
+            Say(1080107); // I'm sorry, I have nothing for you at this time.
         }
 
         public virtual void Advertise()

--- a/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Gumps.cs
+++ b/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Gumps.cs
@@ -224,7 +224,7 @@ namespace Server.Engines.VoidPool
         {
             Item item;
 
-            if (index >= 0 && index < 23)
+            if (index >= 0 && index <= 23)
             {
                 item = Activator.CreateInstance(citem.Type, (CraftResource)citem.Hue) as Item;
             }

--- a/Scripts/Services/Town Cryer/Gumps/TownCryerNewsGump.cs
+++ b/Scripts/Services/Town Cryer/Gumps/TownCryerNewsGump.cs
@@ -30,7 +30,7 @@ namespace Server.Services.TownCryer
             }
             else
             {
-                AddHtml(58, 213, 397, 271, Entry.Body.String, false, true);
+                AddHtml(58, 213, 397, 271, Color("#080808", Entry.Body.String), false, true);
             }
 
             AddHtmlLocalized(0, 150, 854, 20, CenterLoc, Entry.Title.ToString(), 0, false, false);

--- a/Scripts/Spells/Skill Masteries/DeathRay.cs
+++ b/Scripts/Spells/Skill Masteries/DeathRay.cs
@@ -125,6 +125,13 @@ namespace Server.Spells.SkillMasteries
                 double damage = (Caster.Skills[CastSkill].Base + Caster.Skills[DamageSkill].Base) * ((double)GetMasteryLevel() * .8);
                 damage /= Target is PlayerMobile ? 5.15 : 2.5;
 
+                damage *= GetDamageScalar(Target);
+
+                int sdiBonus = SpellHelper.GetSpellDamageBonus(Caster, Target, CastSkill, Caster.Player && Target.Player);
+
+                damage *= (100 + sdiBonus);
+                damage /= 100;
+
                 SpellHelper.Damage(this, Target, (int)damage, 0, 0, 0, 0, 100);
             }
 

--- a/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
+++ b/Scripts/Spells/Skill Masteries/HolyFistSpell.cs
@@ -93,6 +93,16 @@ namespace Server.Spells.SkillMasteries
                     Caster.MovingParticles(m, 0x9BB5, 7, 0, false, true, 9502, 4019, 0x160);
                     Caster.PlaySound(0x5CE);
 
+                    if (m is Mobile)
+                    {
+                        damage *= GetDamageScalar((Mobile)m);
+                    }
+
+                    int sdiBonus = SpellHelper.GetSpellDamageBonus(Caster, m, CastSkill, m is Mobile ? Caster.Player && ((Mobile)m).Player : false);
+
+                    damage *= (100 + sdiBonus);
+                    damage /= 100;
+
                     SpellHelper.Damage(this, target, damage, 0, 0, 0, 0, 100);
 
                     if (target is Mobile && !CheckResisted((Mobile)target) && ((Mobile)target).NetState != null)

--- a/Scripts/Spells/Skill Masteries/Rampage.cs
+++ b/Scripts/Spells/Skill Masteries/Rampage.cs
@@ -24,7 +24,6 @@ namespace Server.Spells.SkillMasteries
  
         public override int RequiredMana { get { return 20; } }
         public override int DamageThreshold { get { return 1; } }
-        public override bool DamageCanDisrupt { get { return true; } }
 
         public override SkillName CastSkill { get { return SkillName.Wrestling; } }
  

--- a/Scripts/Spells/Skill Masteries/SummonReaper.cs
+++ b/Scripts/Spells/Skill Masteries/SummonReaper.cs
@@ -83,10 +83,14 @@ namespace Server.Spells.SkillMasteries
     public class SummonedReaper : BaseCreature
     {
         private DateTime _StartTime;
+        private int m_DispelDifficulty;
+
+        public override double DispelDifficulty { get { return m_DispelDifficulty; } }
+        public override double DispelFocus { get { return 45.0; } }
 
         [Constructable]
         public SummonedReaper(Mobile caster, SummonReaperSpell spell)
-            : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
+            : base(AIType.AI_Spellweaving, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
             Name = "a reaper";
             Body = 47;
@@ -133,6 +137,7 @@ namespace Server.Spells.SkillMasteries
                     }
                 });
 
+            m_DispelDifficulty = 91 + (int)((caster.Skills[SkillName.Spellweaving].Base * 83) / 5.2);
             _StartTime = DateTime.UtcNow + TimeSpan.FromSeconds(3);
 
             SetWeaponAbility(WeaponAbility.WhirlwindAttack);

--- a/Scripts/Spells/Spellweaving/WordOfDeath.cs
+++ b/Scripts/Spells/Spellweaving/WordOfDeath.cs
@@ -69,13 +69,11 @@ namespace Server.Spells.Spellweaving
                     int minDamage = (int)this.Caster.Skills.Spellweaving.Value / 5;
                     int maxDamage = (int)this.Caster.Skills.Spellweaving.Value / 3;
                     damage = Utility.RandomMinMax(minDamage, maxDamage);
-                    int damageBonus = AosAttributes.GetValue(this.Caster, AosAttribute.SpellDamage);
-					
-                    if (m.Player && damageBonus > 15)
-                        damageBonus = 15;
-                    damage *= damageBonus + 100;
-                    damage /= 100;
                 }
+
+                int damageBonus = SpellHelper.GetSpellDamageBonus(Caster, m, CastSkill, Caster.Player && m.Player);
+                damage *= damageBonus + 100;
+                damage /= 100;
 
                 int[] types = new int[4];
                 types[Utility.Random(types.Length)] = 100;


### PR DESCRIPTION
- All derived BaseTools can no longer have bod Resource
- Failed quest offer, regardless of quest type, gives fail Message
- VoidPool Reward Crash fix
- Fixed Town Crier News Gump font hue when using custom entries
- Added SDI Bonus to Death Ray, HOly Fist and Nether Blast Spells
- Damage to caster no longer removes Rampage
- SummonReaper now scales its dispel difficulty per EA
- Added uncapped Spell Damage (except PVP) to Word of Death