### PR TITLE
Siege Mode moongate.cs update

### DIFF
--- a/Scripts/Items/Internal/Moongate.cs
+++ b/Scripts/Items/Internal/Moongate.cs
@@ -138,7 +138,7 @@ namespace Server.Items
             {
                 m.SendLocalizedMessage(1049543); // You decide against traveling to Felucca while you are still young.
             }
-            else if ((m.Murderer && m_TargetMap != Map.Felucca) || (m_TargetMap == Map.Tokuno && (flags & ClientFlags.Tokuno) == 0) || (m_TargetMap == Map.Malas && (flags & ClientFlags.Malas) == 0) || (m_TargetMap == Map.Ilshenar && (flags & ClientFlags.Ilshenar) == 0))
+            else if ((m.Murderer && m_TargetMap != Map.Felucca && !Siege.SiegeShard) || (m_TargetMap == Map.Tokuno && (flags & ClientFlags.Tokuno) == 0) || (m_TargetMap == Map.Malas && (flags & ClientFlags.Malas) == 0) || (m_TargetMap == Map.Ilshenar && (flags & ClientFlags.Ilshenar) == 0))				
             {
                 m.SendLocalizedMessage(1019004); // You are not allowed to travel there.
             }


### PR DESCRIPTION
The file did not contain the Siege Shard functionality verification , as a consequence of which the PK characters did not have the ability to move through the non-public moongate outside of Felucca.