### PR TITLE
Add files via upload

### DIFF
--- a/Scripts/Services/Craft/DefAlchemy.cs
+++ b/Scripts/Services/Craft/DefAlchemy.cs
@@ -147,7 +147,6 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(ElixirOfRebirth), 1116348, 1112762, 65.0, 115.0, typeof(MedusaBlood), 1031702, 1, 1044253);
                 AddRes(index, typeof(SpidersSilk), 1044360, 3, 1044368);
                 AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             if (Core.TOL)
@@ -157,7 +156,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(PlantClippings), 1112131, 5, 1044253);
                 AddRes(index, typeof(MyrmidexEggsac), 1156725, 5, 1044253);
                 AddRecipe(index, (int)AlchemyRecipes.BarrabHemolymphConcentrate);
-                SetNeededExpansion(index, Expansion.TOL);
             }
                 
             // Enhancement
@@ -182,7 +180,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Bloodmoss), 1044354, 4, 1044362);
                 AddRes(index, typeof(Nightshade), 1044358, 3, 1044366);
                 AddRecipe(index, (int)TinkerRecipes.InvisibilityPotion);
-                SetNeededExpansion(index, Expansion.ML);
             }
             
             if (Core.TOL)
@@ -192,14 +189,12 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Vanilla), 1080000, 10, 1080008);
                 AddRes(index, typeof(LavaBerry), 1156727, 5, 1044253);
                 AddRecipe(index, (int)AlchemyRecipes.JukariBurnPoiltice);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(KurakAmbushersEssence), 1116349, 1156728, 51.0, 151.0, typeof(Bottle), 1044529, 1, 500315);
                 AddRes(index, typeof(Bloodmoss), 1044354, 20, 1044362);
                 AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044253);
                 AddRes(index, typeof(TigerPelt), 1156727, 10, 1044253);
                 AddRecipe(index, (int)AlchemyRecipes.KurakAmbushersEssence);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(BarakoDraftOfMight), 1116349, 1156729, 51.0, 151.0, typeof(Bottle), 1044529, 1, 500315);
                 AddRes(index, typeof(SpidersSilk), 1044360, 20, 1044368);
@@ -207,14 +202,12 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(PerfectBanana), 1156730, 5, 1044253);
                 SetBeverageType(index, BeverageType.Liquor);
                 AddRecipe(index, (int)AlchemyRecipes.BarakoDraftOfMight);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(UraliTranceTonic), 1116349, 1156734, 51.0, 151.0, typeof(Bottle), 1044529, 1, 500315);
                 AddRes(index, typeof(MandrakeRoot), 1044357, 20, 1044365);
                 AddRes(index, typeof(YellowScales), 1156799, 10, 1044253);
                 AddRes(index, typeof(RiverMoss), 1156731, 5, 1044253);
                 AddRecipe(index, (int)AlchemyRecipes.UraliTranceTonic);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(SakkhraProphylaxisPotion), 1116349, 1156732, 51.0, 151.0, typeof(Bottle), 1044529, 1, 500315);
                 AddRes(index, typeof(Nightshade), 1044358, 20, 1044366);
@@ -222,7 +215,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(BlueCorn), 1156733, 5, 1044253);
                 SetBeverageType(index, BeverageType.Wine);
                 AddRecipe(index, (int)AlchemyRecipes.SakkhraProphylaxisPotion);
-                SetNeededExpansion(index, Expansion.TOL);
             }
 
             // Toxic
@@ -243,12 +235,10 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(ParasiticPotion), 1116350, 1072942, 65.0, 115.0, typeof(Bottle), 1044529, 1, 500315);
                 AddRes(index, typeof(ParasiticPlant), 1073474, 5, 1044253);
                 AddRecipe(index, (int)TinkerRecipes.ParasiticPotion);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(DarkglowPotion), 1116350, 1072943, 65.0, 115.0, typeof(Bottle), 1044529, 1, 500315);
                 AddRes(index, typeof(LuminescentFungi), 1073475, 5, 1044253);
                 AddRecipe(index, (int)TinkerRecipes.DarkglowPotion);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ScouringToxin), 1116350, 1112292, 75.0, 100.0, typeof(ToxicVenomSac), 1112291, 1, 1044253);
                 AddRes(index, typeof(Bottle), 1044529, 1, 500315);
@@ -284,19 +274,16 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(BlackPowder), 1116351, 1095826, 65.0, 115.0, typeof(SulfurousAsh), 1023980, 1, 1044253);
                 AddRes(index, typeof(Saltpeter), 1116302, 6, 1044253);
                 AddRes(index, typeof(Charcoal), 1116303, 1, 1044253);
-                SetNeededExpansion(index, Expansion.HS);
 
                 index = AddCraft(typeof(Matchcord), 1116351, 1095184, 25.0, 80.0, typeof(DarkYarn), 1023615, 1, 1044253);
                 AddRes(index, typeof(BaseBeverage), 1024088, 1, 1044253);
                 AddRes(index, typeof(Saltpeter), 1116302, 1, 1044253);
                 AddRes(index, typeof(Potash), 1116319, 1, 1044253);
-                SetNeededExpansion(index, Expansion.HS);
 
                 index = AddCraft(typeof(Fusecord), 1116351, 1116305, 55.0, 105.0, typeof(DarkYarn), 1023615, 1, 1044253);
                 AddRes(index, typeof(BaseBeverage), 1024088, 1, 1044253);
                 AddRes(index, typeof(BlackPowder), 1095826, 1, 1044253);
                 AddRes(index, typeof(Potash), 1116319, 1, 1044253);
-                SetNeededExpansion(index, Expansion.HS);
             }
 
             // Strange Brew
@@ -304,14 +291,12 @@ namespace Server.Engines.Craft
             {                
                 index = AddCraft(typeof(SmokeBomb), 1116353, 1030248, 90.0, 120.0, typeof(Eggs), 1044477, 1, 1044253);
                 AddRes(index, typeof(Ginseng), 1044356, 3, 1044364);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             if (Core.ML)
             {
                 index = AddCraft(typeof(HoveringWisp), 1116353, 1072881, 65.0, 115.0, typeof(CapturedEssence), 1032686, 4, 1044253);
                 AddRecipe(index, (int)TinkerRecipes.HoveringWisp);
-                SetNeededExpansion(index, Expansion.ML);
             }
 
             if (Core.SA)
@@ -320,14 +305,12 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(ColorFixative), 1112135, 1, 1044253);
                 SetItemHue(index, 2101);
                 SetRequireResTarget(index);
-                SetNeededExpansion(index, Expansion.SA);
 
-                index = this.AddCraft(typeof(NexusCore), 1116353, 1153501, 90.0, 120.0, typeof(MandrakeRoot), 1015013, 10, 1044253);
+                index = AddCraft(typeof(NexusCore), 1116353, 1153501, 90.0, 120.0, typeof(MandrakeRoot), 1015013, 10, 1044253);
                 AddRes(index, typeof(SpidersSilk), 1015007, 10, 1044253);
                 AddRes(index, typeof(DarkSapphire), 1032690, 5, 1044253);
                 AddRes(index, typeof(CrushedGlass), 1113351, 5, 1044253);
-                this.ForceNonExceptional(index);
-                this.SetNeededExpansion(index, Expansion.SA);
+                ForceNonExceptional(index);
             }
 
             // Ingrediants
@@ -338,50 +321,41 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Bottle), 1023854, 1, 1044253);
                 SetItemHue(index, 2101);
                 SetRequireResTarget(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(ColorFixative), 1044495, 1112135, 75.0, 100.0, typeof(SilverSerpentVenom), 1112173, 1, 1044253);
                 AddRes(index, typeof(BaseBeverage), 1022503, 1, 1044253);
                 SetBeverageType(index, BeverageType.Wine);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(CrystalGranules), 1044495, 1112329, 75.0, 100.0, typeof(ShimmeringCrystals), 1075095, 1, 1044253);
                 SetItemHue(index, 2625);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(CrystalDust), 1044495, 1112328, 75.0, 100.0, typeof(CrystallineFragments), 1153988, 4, 1044253);
-                SetItemHue(index, 2103);
-                SetNeededExpansion(index, Expansion.SA);                
+                SetItemHue(index, 2103);               
 
                 index = AddCraft(typeof(SoftenedReeds), 1044495, 1112249, 75.0, 100.0, typeof(DryReeds), 1112248, 1, 1112250);
                 AddRes(index, typeof(ScouringToxin), 1112292, 2, 1112326);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(VialOfVitriol), 1044495, 1113331, 90.0, 100.0, typeof(ParasiticPotion), 1072848, 1, 1113754);
                 AddRes(index, typeof (Nightshade), 1044358, 30, 1044366);
                 AddSkill(index, SkillName.Magery, 75.0, 100.0);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(BottleIchor), 1044495, 1113361, 90.0, 100.0, typeof(DarkglowPotion), 1072849, 1, 1113755);
                 AddRes(index, typeof(SpidersSilk), 1044360, 1, 1044368);
                 AddSkill(index, SkillName.Magery, 75.0, 100.0);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             if (Core.HS)
             {
                 index = AddCraft(typeof(Potash), 1044495, 1116319, 0.0, 50.0, typeof(Board), 1044041, 1, 1044253);
                 AddRes(index, typeof(BaseBeverage), 1024088, 1, 1044253);
-                SetNeededExpansion(index, Expansion.HS);
             }
 
             if (Core.SA)
             {
-                index = this.AddCraft(typeof(GoldDust), 1044495, 1153504, 90.0, 120.0, typeof(Gold), 3000083, 1000, 1150747);
-                this.ForceNonExceptional(index);
-                this.SetNeededExpansion(index, Expansion.SA);
+                index = AddCraft(typeof(GoldDust), 1044495, 1153504, 90.0, 120.0, typeof(Gold), 3000083, 1000, 1150747);
+                ForceNonExceptional(index);
             }
         }
     }

--- a/Scripts/Services/Craft/DefBlacksmithy.cs
+++ b/Scripts/Services/Craft/DefBlacksmithy.cs
@@ -342,51 +342,37 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(PlateMempo), 1111704, 1030180, 80.0, 130.0, typeof(IronIngot), 1044036, 18, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(PlateDo), 1111704, 1030184, 80.0, 130.0, typeof(IronIngot), 1044036, 28, 1044037);
                 //Double check skill
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(PlateHiroSode), 1111704, 1030187, 80.0, 130.0, typeof(IronIngot), 1044036, 16, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(PlateSuneate), 1111704, 1030195, 65.0, 115.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(PlateHaidate), 1111704, 1030200, 65.0, 115.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             if (Core.SA)
             {
                 #region SA
                 index = AddCraft(typeof(FemaleGargishPlateArms), 1111704, 1095336, 66.3, 116.3, typeof(IronIngot), 1044036, 18, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishPlateChest), 1111704, 1095338, 75.0, 125.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishPlateLegs), 1111704, 1095342, 68.8, 118.8, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishPlateKilt), 1111704, 1095340, 58.9, 108.9, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishPlateArms), 1111704, 1095336, 66.3, 116.3, typeof(IronIngot), 1044036, 18, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishPlateChest), 1111704, 1095338, 75.0, 125.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishPlateLegs), 1111704, 1095342, 68.8, 118.8, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
-                index = AddCraft(typeof(GargishPlateKilt), 1111704, 1095340, 58.9, 108.9, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.SA);                
+                index = AddCraft(typeof(GargishPlateKilt), 1111704, 1095340, 58.9, 108.9, typeof(IronIngot), 1044036, 12, 1044037);             
 
                 index = AddCraft(typeof(GargishAmulet), 1111704, 1098595, 60.0, 110.0, typeof(IronIngot), 1044036, 3, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(BritchesOfWarding), 1111704, 1157345, 120.0, 120.1, typeof(IronIngot), 1044036, 18, 1044037);
                 AddRes(index, typeof(LeggingsOfBane), 1061100, 1, 1053098);
@@ -394,7 +380,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(BloodOfTheDarkFather), 1157343, 5, 1053098);
                 AddRecipe(index, (int)SmithRecipes.BritchesOfWarding);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.SA);
                 #endregion
             }
             #endregion
@@ -410,42 +395,31 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(ChainHatsuburi), 1011079, 1030175, 30.0, 80.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(PlateHatsuburi), 1011079, 1030176, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(HeavyPlateJingasa), 1011079, 1030178, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(LightPlateJingasa), 1011079, 1030188, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(SmallPlateJingasa), 1011079, 1030191, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(DecorativePlateKabuto), 1011079, 1030179, 90.0, 140.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(PlateBattleKabuto), 1011079, 1030192, 90.0, 140.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(StandardPlateKabuto), 1011079, 1030196, 90.0, 140.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 if (Core.ML)
                 {
                     index = AddCraft(typeof(Circlet), 1011079, 1032645, 62.1, 112.1, typeof(IronIngot), 1044036, 6, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(RoyalCirclet), 1011079, 1032646, 70.0, 120.0, typeof(IronIngot), 1044036, 6, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(GemmedCirclet), 1011079, 1032647, 75.0, 125.0, typeof(IronIngot), 1044036, 6, 1044037);
                     AddRes(index, typeof(Tourmaline), 1044237, 1, 1044240);
                     AddRes(index, typeof(Amethyst), 1044236, 1, 1044240);
                     AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
-                    SetNeededExpansion(index, Expansion.ML);
                 }
             }
             #endregion
@@ -467,22 +441,16 @@ namespace Server.Engines.Craft
             if (Core.SA)
             {
                 index = AddCraft(typeof(SmallPlateShield), 1011080, 1095770, -25.0, 25.0, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishKiteShield), 1011080, 1095774, 4.6, 54.6, typeof(IronIngot), 1044036, 16, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(LargePlateShield), 1011080, 1095772, 24.3, 74.3, typeof(IronIngot), 1044036, 18, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(MediumPlateShield), 1011080, 1095771, -10.2, 39.8, typeof(IronIngot), 1044036, 14, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishChaosShield), 1011080, 1095808, 85.0, 135.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishOrderShield), 1011080, 1095810, 85.0, 135.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
             }
             #endregion
 
@@ -511,51 +479,36 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(NoDachi), 1011081, 1030221, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(Wakizashi), 1011081, 1030223, 50.0, 100.0, typeof(IronIngot), 1044036, 8, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(Lajatang), 1011081, 1030226, 80.0, 130.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(Daisho), 1011081, 1030228, 60.0, 110.0, typeof(IronIngot), 1044036, 15, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(Tekagi), 1011081, 1030230, 55.0, 105.0, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(Shuriken), 1011081, 1030231, 45.0, 95.0, typeof(IronIngot), 1044036, 5, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(Kama), 1011081, 1030232, 40.0, 90.0, typeof(IronIngot), 1044036, 14, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(Sai), 1011081, 1030234, 50.0, 100.0, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 if (Core.ML)
                 {
                     index = AddCraft(typeof(RadiantScimitar), 1011081, 1031571, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(WarCleaver), 1011081, 1031567, 70.0, 120.0, typeof(IronIngot), 1044036, 18, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(ElvenSpellblade), 1011081, 1031564, 70.0, 120.0, typeof(IronIngot), 1044036, 14, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(AssassinSpike), 1011081, 1031565, 70.0, 120.0, typeof(IronIngot), 1044036, 9, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(Leafblade), 1011081, 1031566, 70.0, 120.0, typeof(IronIngot), 1044036, 12, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(RuneBlade), 1011081, 1031570, 70.0, 120.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(ElvenMachete), 1011081, 1031573, 70.0, 120.0, typeof(IronIngot), 1044036, 14, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(RuneCarvingKnife), 1011081, 1072915, 70.0, 120.0, typeof(IronIngot), 1044036, 9, 1044037);
                     AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
@@ -563,7 +516,6 @@ namespace Server.Engines.Craft
                     AddRes(index, typeof(Muculent), 1032680, 10, 1053098);
                     AddRecipe(index, (int)SmithRecipes.RuneCarvingKnife);
                     ForceNonExceptional(index);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(ColdForgedBlade), 1011081, 1072916, 70.0, 120.0, typeof(IronIngot), 1044036, 18, 1044037);
                     AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
@@ -571,7 +523,6 @@ namespace Server.Engines.Craft
                     AddRes(index, typeof(Blight), 1032675, 10, 1053098);
                     AddRecipe(index, (int)SmithRecipes.ColdForgedBlade);
                     ForceNonExceptional(index);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(OverseerSunderedBlade), 1011081, 1072920, 70.0, 120.0, typeof(IronIngot), 1044036, 15, 1044037);
                     AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
@@ -579,7 +530,6 @@ namespace Server.Engines.Craft
                     AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
                     AddRecipe(index, (int)SmithRecipes.OverseerSunderedBlade);
                     ForceNonExceptional(index);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(LuminousRuneBlade), 1011081, 1072922, 70.0, 120.0, typeof(IronIngot), 1044036, 15, 1044037);
                     AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
@@ -587,152 +537,122 @@ namespace Server.Engines.Craft
                     AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
                     AddRecipe(index, (int)SmithRecipes.LuminousRuneBlade);
                     ForceNonExceptional(index);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(TrueSpellblade), 1011081, 1073513, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
                     AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.TrueSpellblade);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(IcySpellblade), 1011081, 1073514, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
                     AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.IcySpellblade);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(FierySpellblade), 1011081, 1073515, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
                     AddRes(index, typeof(FireRuby), 1032695, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.FierySpellblade);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(SpellbladeOfDefense), 1011081, 1073516, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
                     AddRes(index, typeof(WhitePearl), 1032694, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.SpellbladeOfDefense);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(TrueAssassinSpike), 1011081, 1073517, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
                     AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.TrueAssassinSpike);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(ChargedAssassinSpike), 1011081, 1073518, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
                     AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.ChargedAssassinSpike);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(MagekillerAssassinSpike), 1011081, 1073519, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
                     AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.MagekillerAssassinSpike);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(WoundingAssassinSpike), 1011081, 1073520, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
                     AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.WoundingAssassinSpike);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(TrueLeafblade), 1011081, 1073521, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
                     AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.TrueLeafblade);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(Luckblade), 1011081, 1073522, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
                     AddRes(index, typeof(WhitePearl), 1032694, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.Luckblade);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(MagekillerLeafblade), 1011081, 1073523, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
                     AddRes(index, typeof(FireRuby), 1032695, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.MagekillerLeafblade);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(LeafbladeOfEase), 1011081, 1073524, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
                     AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.LeafbladeOfEase);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(KnightsWarCleaver), 1011081, 1073525, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
                     AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.KnightsWarCleaver);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(ButchersWarCleaver), 1011081, 1073526, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
                     AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.ButchersWarCleaver);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(SerratedWarCleaver), 1011081, 1073527, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
                     AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.SerratedWarCleaver);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(TrueWarCleaver), 1011081, 1073528, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
                     AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.TrueWarCleaver);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(AdventurersMachete), 1011081, 1073533, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
                     AddRes(index, typeof(WhitePearl), 1032694, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.AdventurersMachete);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(OrcishMachete), 1011081, 1073534, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
                     AddRes(index, typeof(Scourge), 1072136, 1, 1042081);
                     AddRecipe(index, (int)SmithRecipes.OrcishMachete);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(MacheteOfDefense), 1011081, 1073535, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
                     AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.MacheteOfDefense);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(DiseasedMachete), 1011081, 1073536, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
                     AddRes(index, typeof(Blight), 1072134, 1, 1042081);
                     AddRecipe(index, (int)SmithRecipes.DiseasedMachete);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(Runesabre), 1011081, 1073537, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                     AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.Runesabre);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(MagesRuneBlade), 1011081, 1073538, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                     AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.MagesRuneBlade);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(RuneBladeOfKnowledge), 1011081, 1073539, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                     AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.RuneBladeOfKnowledge);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(CorruptedRuneBlade), 1011081, 1073540, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                     AddRes(index, typeof(Corruption), 1072135, 1, 1042081);
                     AddRecipe(index, (int)SmithRecipes.CorruptedRuneBlade);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(TrueRadiantScimitar), 1011081, 1073541, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                     AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.TrueRadiantScimitar);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(DarkglowScimitar), 1011081, 1073542, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                     AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.DarkglowScimitar);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(IcyScimitar), 1011081, 1073543, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                     AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.IcyScimitar);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(TwinklingScimitar), 1011081, 1073544, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                     AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
                     AddRecipe(index, (int)SmithRecipes.TwinklingScimitar);
-                    SetNeededExpansion(index, Expansion.ML);
 
                     index = AddCraft(typeof(BoneMachete), 1011081, 1020526, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
                     AddRes(index, typeof(Bone), 1049064, 6, 1049063);
                     AddRecipe(index, (int)SmithRecipes.BoneMachete);
-                    SetNeededExpansion(index, Expansion.ML);
                 }
             }
 
@@ -741,34 +661,24 @@ namespace Server.Engines.Craft
                 #region SA
 
                 index = AddCraft(typeof(GargishKatana), 1011081, 1097490, 44.1, 94.1, typeof(IronIngot), 1044036, 8, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishKryss), 1011081, 1097492, 36.7, 86.7, typeof(IronIngot), 1044036, 8, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishBoneHarvester), 1011081, 1097502, 33.0, 83.0, typeof(IronIngot), 1044036, 10, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishTekagi), 1011081, 1097510, 55.0, 105.0, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishDaisho), 1011081, 1097512, 60.0, 110.0, typeof(IronIngot), 1044036, 15, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(DreadSword), 1011081, 1095372, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishTalwar), 1011081, 1095373, 75.0, 150.0, typeof(IronIngot), 1044036, 18, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishDagger), 1011081, 1095362, 0.0, 100.0, typeof(IronIngot), 1044036, 3, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
-                index = AddCraft(typeof(BloodBlade), 1011081, 1095370, 44.1, 125.0, typeof(IronIngot), 1044036, 8, 1044037);
-                SetNeededExpansion(index, Expansion.SA);               
+                index = AddCraft(typeof(BloodBlade), 1011081, 1095370, 44.1, 125.0, typeof(IronIngot), 1044036, 8, 1044037);             
 
                 index = AddCraft(typeof(Shortblade), 1011081, 1095374, 28.0, 100.0, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 #endregion
             }
@@ -786,40 +696,32 @@ namespace Server.Engines.Craft
             if (Core.ML)
             {
                 index = AddCraft(typeof(OrnateAxe), 1011082, 1031572, 70.0, 120.0, typeof(IronIngot), 1044036, 18, 1044037);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(GuardianAxe), 1011082, 1073545, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                 AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
                 AddRecipe(index, (int)SmithRecipes.GuardianAxe);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(SingingAxe), 1011082, 1073546, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                 AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
                 AddRecipe(index, (int)SmithRecipes.SingingAxe);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ThunderingAxe), 1011082, 1073547, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                 AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
                 AddRecipe(index, (int)SmithRecipes.ThunderingAxe);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(HeavyOrnateAxe), 1011082, 1073548, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                 AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
                 AddRecipe(index, (int)SmithRecipes.HeavyOrnateAxe);
-                SetNeededExpansion(index, Expansion.ML);
             }
 
             #region SA
             if (Core.SA)
             {
                 index = AddCraft(typeof(GargishBattleAxe), 1011082, 1097480, 30.5, 80.5, typeof(IronIngot), 1044036, 14, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishAxe), 1011082, 1097482, 34.2, 84.2, typeof(IronIngot), 1044036, 14, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(DualShortAxes), 1011082, 1095360, 75.0, 125.0, typeof(IronIngot), 1044036, 24, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
             }
             #endregion
 
@@ -866,22 +768,16 @@ namespace Server.Engines.Craft
             if (Core.SA)
             {
                 index = AddCraft(typeof(GargishBardiche), 1011083, 1097484, 31.7, 81.7, typeof(IronIngot), 1044036, 18, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishWarFork), 1011083, 1097494, 42.9, 92.9, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishScythe), 1011083, 1097500, 39.0, 89.0, typeof(IronIngot), 1044036, 14, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishPike), 1011083, 1097504, 47.0, 97.0, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishLance), 1011083, 1097506, 48.0, 98.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(DualPointedSpear), 1011083, 1095365, 47.0, 97.0, typeof(IronIngot), 1044036, 16, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             #endregion
@@ -906,14 +802,13 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(Tessen), 1011084, 1030222, 85.0, 135.0, typeof(IronIngot), 1044036, 16, 1044037);
                 AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
                 AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
+
             }
 
             #region Mondain's Legacy
             if (Core.ML)
             {
                 index = AddCraft(typeof(DiamondMace), 1011084, 1031568, 70.0, 120.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ShardThrasher), 1011084, 1072918, 70.0, 120.0, typeof(IronIngot), 1044036, 20, 1044037);
                 AddRes(index, typeof(EyeOfTheTravesty), 1073126, 1, 1042081);
@@ -921,27 +816,22 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Corruption), 1072135, 10, 1042081);
                 AddRecipe(index, (int)SmithRecipes.ShardTrasher);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(RubyMace), 1011084, 1073529, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
                 AddRes(index, typeof(FireRuby), 1032695, 1, 1044240);
                 AddRecipe(index, (int)SmithRecipes.RubyMace);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(EmeraldMace), 1011084, 1073530, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
                 AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
                 AddRecipe(index, (int)SmithRecipes.EmeraldMace);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(SapphireMace), 1011084, 1073531, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
                 AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
                 AddRecipe(index, (int)SmithRecipes.SapphireMace);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(SilverEtchedMace), 1011084, 1073532, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
                 AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
                 AddRecipe(index, (int)SmithRecipes.SilverEtchedMace);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -950,18 +840,14 @@ namespace Server.Engines.Craft
             if (Core.SA)
             {
                 index = AddCraft(typeof(GargishWarHammer), 1011084, 1097496, 34.2, 84.2, typeof(IronIngot), 1044036, 16, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishMaul), 1011084, 1097498, 19.4, 69.4, typeof(IronIngot), 1044036, 10, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishTessen), 1011084, 1097508, 85.0, 135.0, typeof(IronIngot), 1044036, 16, 1044037);
                 AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
                 AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
-                index = AddCraft(typeof(DiscMace), 1011084, 1095366, 70.0, 120.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SA);                
+                index = AddCraft(typeof(DiscMace), 1011084, 1095366, 70.0, 120.0, typeof(IronIngot), 1044036, 20, 1044037);               
             }
 
             #endregion
@@ -973,28 +859,22 @@ namespace Server.Engines.Craft
             if (Core.HS)
             {
                 index = AddCraft(typeof(LightCannonball), 1116354, 1116266, 0.0, 50.0, typeof(IronIngot), 1044036, 6, 1044037);
-                SetNeededExpansion(index, Expansion.HS);
 
                 index = AddCraft(typeof(HeavyCannonball), 1116354, 1116267, 10.0, 60.0, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.HS);
 
                 index = AddCraft(typeof(LightGrapeshot), 1116354, 1116030, 0.0, 50.0, typeof(IronIngot), 1044036, 6, 1044037);
                 AddRes(index, typeof(Cloth), 1044286, 1, 1044287);
-                SetNeededExpansion(index, Expansion.HS);
 
                 index = AddCraft(typeof(HeavyGrapeshot), 1116354, 1116166, 15.0, 70.0, typeof(IronIngot), 1044036, 12, 1044037);
                 AddRes(index, typeof(Cloth), 1044286, 2, 1044287);
-                SetNeededExpansion(index, Expansion.HS);
 
                 index = AddCraft(typeof(LightShipCannonDeed), 1116354, 1095790, 65.0, 120.0, typeof(IronIngot), 1044036, 900, 1044037);
                 AddRes(index, typeof(Board), 1044041, 50, 1044351);
                 AddSkill(index, SkillName.Carpentry, 65.0, 100.0);
-                SetNeededExpansion(index, Expansion.HS);
 
                 index = AddCraft(typeof(HeavyShipCannonDeed), 1116354, 1095794, 70.0, 120.0, typeof(IronIngot), 1044036, 1800, 1044037);
                 AddRes(index, typeof(Board), 1044041, 75, 1044351);
                 AddSkill(index, SkillName.Carpentry, 70.0, 100.0);
-                SetNeededExpansion(index, Expansion.HS);
             }
 
             #endregion
@@ -1004,13 +884,10 @@ namespace Server.Engines.Craft
             if (Core.SA)
             {
                 index = AddCraft(typeof(Boomerang), 1079508, 1095359, 75.0, 125.0, typeof(IronIngot), 1044036, 5, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(Cyclone), 1079508, 1095364, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(SoulGlaive), 1079508, 1095363, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             #endregion
@@ -1036,23 +913,20 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(CrushedGlass), 1011173, 1113351, 110.0, 135.0, typeof(BlueDiamond), 1032696, 1, 1044253);
                 AddRes(index, typeof(GlassSword), 1095371, 5, 1044253);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(PowderedIron), 1011173, 1113353, 110.0, 135.0, typeof(WhitePearl), 1026253, 1, 1044253);
                 AddRes(index, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             AddCraft(typeof(MetalKeg), 1011173, 1150675, 85.0, 100.0, typeof(IronIngot), 1044036, 25, 1044253);
 
             if (Core.SA)
             {
-                index = this.AddCraft(typeof(ExodusSacrificalDagger), 1011173, 1153500, 95.0, 120.0, typeof(IronIngot), 1044036, 12, 1044253);
+                index = AddCraft(typeof(ExodusSacrificalDagger), 1011173, 1153500, 95.0, 120.0, typeof(IronIngot), 1044036, 12, 1044253);
                 AddRes(index, typeof(BlueDiamond), 1032696, 2, 1044253);
                 AddRes(index, typeof(FireRuby), 1032695, 2, 1044253);
                 AddRes(index, typeof(SmallPieceofBlackrock), 1150016, 10, 1044253);
-                this.ForceNonExceptional(index);
-                this.SetNeededExpansion(index, Expansion.SA);
+                ForceNonExceptional(index);
 
                 index = AddCraft(typeof(GlovesOfFeudalGrip), 1011173, 1157349, 120.0, 120.1, typeof(RedScales), 1060883, 18, 1060884);
                 SetUseSubRes2(index, true);
@@ -1061,7 +935,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(BloodOfTheDarkFather), 1157343, 5, 1053098);
                 AddRecipe(index, (int)SmithRecipes.GlovesOfFeudalGrip);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             #endregion

--- a/Scripts/Services/Craft/DefBowFletching.cs
+++ b/Scripts/Services/Craft/DefBowFletching.cs
@@ -128,7 +128,6 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(ElvenFletching), 1044457, 1113346, 90.0, 130.0, typeof(Feather), 1044562, 20, 1044563);
                 AddRes(index, typeof(FaeryDust), 1113358, 1, 1044253);
-                this.SetNeededExpansion(index, Expansion.SA);
             }
 
             this.AddCraft(typeof(Kindling), 1044457, 1023553, 0.0, 00.0, typeof(Board), 1044041, 1, 1044351);
@@ -147,9 +146,8 @@ namespace Server.Engines.Craft
 
             if (Core.SE)
             {
-                index = this.AddCraft(typeof(FukiyaDarts), 1044565, 1030246, 50.0, 90.0, typeof(Board), 1044041, 1, 1044351);
+                index = AddCraft(typeof(FukiyaDarts), 1044565, 1030246, 50.0, 90.0, typeof(Board), 1044041, 1, 1044351);
                 this.SetUseAllRes(index, true);
-                this.SetNeededExpansion(index, Expansion.SE);
             }
 
             // Weapons
@@ -165,98 +163,82 @@ namespace Server.Engines.Craft
 
             if (Core.SE)
             {
-                index = this.AddCraft(typeof(Yumi), 1044566, 1030224, 90.0, 130.0, typeof(Board), 1044041, 10, 1044351);
-                this.SetNeededExpansion(index, Expansion.SE);
+                index = AddCraft(typeof(Yumi), 1044566, 1030224, 90.0, 130.0, typeof(Board), 1044041, 10, 1044351);
             }
 
             #region Mondain's Legacy
             if (Core.ML)
             {
-                index = this.AddCraft(typeof(ElvenCompositeLongbow), 1044566, 1031562, 95.0, 145.0, typeof(Board), 1044041, 20, 1044351);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(ElvenCompositeLongbow), 1044566, 1031562, 95.0, 145.0, typeof(Board), 1044041, 20, 1044351);
 
-                index = this.AddCraft(typeof(MagicalShortbow), 1044566, 1031551, 85.0, 135.0, typeof(Board), 1044041, 15, 1044351);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(MagicalShortbow), 1044566, 1031551, 85.0, 135.0, typeof(Board), 1044041, 15, 1044351);
 
-                index = this.AddCraft(typeof(BlightGrippedLongbow), 1044566, 1072907, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
-                this.AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
-                this.AddRes(index, typeof(Blight), 1032675, 10, 1053098);
-                this.AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.BlightGrippedLongbow);
-                this.ForceNonExceptional(index);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(BlightGrippedLongbow), 1044566, 1072907, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
+                AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
+                AddRes(index, typeof(Blight), 1032675, 10, 1053098);
+                AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
+                AddRecipe(index, (int)BowRecipes.BlightGrippedLongbow);
+                ForceNonExceptional(index);
 
-                index = this.AddCraft(typeof(FaerieFire), 1044566, 1072908, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
-                this.AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
-                this.AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
-                this.AddRes(index, typeof(Taint), 1032679, 10, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.FaerieFire);
-                this.ForceNonExceptional(index);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(FaerieFire), 1044566, 1072908, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
+                AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
+                AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+                AddRes(index, typeof(Taint), 1032679, 10, 1053098);
+                AddRecipe(index, (int)BowRecipes.FaerieFire);
+                ForceNonExceptional(index);
 
-                index = this.AddCraft(typeof(SilvanisFeywoodBow), 1044566, 1072955, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
-                this.AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
-                this.AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
-                this.AddRes(index, typeof(Muculent), 1032680, 10, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.SilvanisFeywoodBow);
-                this.ForceNonExceptional(index);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(SilvanisFeywoodBow), 1044566, 1072955, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
+                AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
+                AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
+                AddRes(index, typeof(Muculent), 1032680, 10, 1053098);
+                AddRecipe(index, (int)BowRecipes.SilvanisFeywoodBow);
+                ForceNonExceptional(index);
 
-                index = this.AddCraft(typeof(MischiefMaker), 1044566, 1072910, 75.0, 125.0, typeof(Board), 1044041, 15, 1044351);
-                this.AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
-                this.AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
-                this.AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.MischiefMaker);
-                this.ForceNonExceptional(index);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(MischiefMaker), 1044566, 1072910, 75.0, 125.0, typeof(Board), 1044041, 15, 1044351);
+                AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
+                AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
+                AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+                AddRecipe(index, (int)BowRecipes.MischiefMaker);
+                ForceNonExceptional(index);
 
-                index = this.AddCraft(typeof(TheNightReaper), 1044566, 1072912, 75.0, 125.0, typeof(Board), 1044041, 10, 1044351);
-                this.AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
-                this.AddRes(index, typeof(Blight), 1032675, 10, 1053098);
-                this.AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.TheNightReaper);
-                this.ForceNonExceptional(index);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(TheNightReaper), 1044566, 1072912, 75.0, 125.0, typeof(Board), 1044041, 10, 1044351);
+                AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
+                AddRes(index, typeof(Blight), 1032675, 10, 1053098);
+                AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
+                AddRecipe(index, (int)BowRecipes.TheNightReaper);
+                ForceNonExceptional(index);
 
-                index = this.AddCraft(typeof(BarbedLongbow), 1044566, 1073505, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
-                this.AddRes(index, typeof(FireRuby), 1026254, 1, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.BarbedLongbow);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(BarbedLongbow), 1044566, 1073505, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
+                AddRes(index, typeof(FireRuby), 1026254, 1, 1053098);
+                AddRecipe(index, (int)BowRecipes.BarbedLongbow);
 
-                index = this.AddCraft(typeof(SlayerLongbow), 1044566, 1073506, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
-                this.AddRes(index, typeof(BrilliantAmber), 1026256, 1, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.SlayerLongbow);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(SlayerLongbow), 1044566, 1073506, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
+                AddRes(index, typeof(BrilliantAmber), 1026256, 1, 1053098);
+                AddRecipe(index, (int)BowRecipes.SlayerLongbow);
 
-                index = this.AddCraft(typeof(FrozenLongbow), 1044566, 1073507, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
-                this.AddRes(index, typeof(Turquoise), 1026250, 1, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.FrozenLongbow);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(FrozenLongbow), 1044566, 1073507, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
+                AddRes(index, typeof(Turquoise), 1026250, 1, 1053098);
+                AddRecipe(index, (int)BowRecipes.FrozenLongbow);
 
-                index = this.AddCraft(typeof(LongbowOfMight), 1044566, 1073508, 75.0, 125.0, typeof(Board), 1044041, 10, 1044351);
-                this.AddRes(index, typeof(BlueDiamond), 1026255, 1, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.LongbowOfMight);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(LongbowOfMight), 1044566, 1073508, 75.0, 125.0, typeof(Board), 1044041, 10, 1044351);
+                AddRes(index, typeof(BlueDiamond), 1026255, 1, 1053098);
+                AddRecipe(index, (int)BowRecipes.LongbowOfMight);
 
-                index = this.AddCraft(typeof(RangersShortbow), 1044566, 1073509, 75.0, 125.0, typeof(Board), 1044041, 15, 1044351);
-                this.AddRes(index, typeof(PerfectEmerald), 1026251, 1, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.RangersShortbow);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(RangersShortbow), 1044566, 1073509, 75.0, 125.0, typeof(Board), 1044041, 15, 1044351);
+                AddRes(index, typeof(PerfectEmerald), 1026251, 1, 1053098);
+                AddRecipe(index, (int)BowRecipes.RangersShortbow);
 
-                index = this.AddCraft(typeof(LightweightShortbow), 1044566, 1073510, 75.0, 125.0, typeof(Board), 1044041, 15, 1044351);
-                this.AddRes(index, typeof(WhitePearl), 1026253, 1, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.LightweightShortbow);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(LightweightShortbow), 1044566, 1073510, 75.0, 125.0, typeof(Board), 1044041, 15, 1044351);
+                AddRes(index, typeof(WhitePearl), 1026253, 1, 1053098);
+                AddRecipe(index, (int)BowRecipes.LightweightShortbow);
 
-                index = this.AddCraft(typeof(MysticalShortbow), 1044566, 1073511, 75.0, 125.0, typeof(Board), 1044041, 15, 1044351);
-                this.AddRes(index, typeof(EcruCitrine), 1026252, 1, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.MysticalShortbow);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(MysticalShortbow), 1044566, 1073511, 75.0, 125.0, typeof(Board), 1044041, 15, 1044351);
+                AddRes(index, typeof(EcruCitrine), 1026252, 1, 1053098);
+                AddRecipe(index, (int)BowRecipes.MysticalShortbow);
 
-                index = this.AddCraft(typeof(AssassinsShortbow), 1044566, 1073512, 75.0, 125.0, typeof(Board), 1044041, 15, 1044351);
-                this.AddRes(index, typeof(DarkSapphire), 1026249, 1, 1053098);
-                this.AddRecipe(index, (int)BowRecipes.AssassinsShortbow);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(AssassinsShortbow), 1044566, 1073512, 75.0, 125.0, typeof(Board), 1044041, 15, 1044351);
+                AddRes(index, typeof(DarkSapphire), 1026249, 1, 1053098);
+                AddRecipe(index, (int)BowRecipes.AssassinsShortbow);
             }
 
             this.SetSubRes(typeof(Board), 1072643);

--- a/Scripts/Services/Craft/DefCarpentry.cs
+++ b/Scripts/Services/Craft/DefCarpentry.cs
@@ -165,21 +165,17 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(RedHangingLantern), 1044294, 1029412, 65.0, 90.0, typeof(Board), 1044041, 5, 1044351);
                 AddRes(index, typeof(BlankScroll), 1044377, 10, 1044378);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(WhiteHangingLantern), 1044294, 1029416, 65.0, 90.0, typeof(Board), 1044041, 5, 1044351);
                 AddRes(index, typeof(BlankScroll), 1044377, 10, 1044378);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(ShojiScreen), 1044294, 1029423, 80.0, 105.0, typeof(Board), 1044041, 75, 1044351);
                 AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
                 AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(BambooScreen), 1044294, 1029428, 80.0, 105.0, typeof(Board), 1044041, 75, 1044351);
                 AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
                 AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             if (Core.AOS)	//Duplicate Entries to preserve ordering depending on era
@@ -194,56 +190,45 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(WoodenContainerEngraver), 1044294, 1072153, 75.0, 100.0, typeof(Board), 1044041, 4, 1044351);
                 AddRes(index, typeof(IronIngot), 1044036, 2, 1044037);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(RunedSwitch), 1044294, 1072896, 70.0, 120.0, typeof(Board), 1044041, 2, 1044351);
                 AddRes(index, typeof(EnchantedSwitch), 1072893, 1, 1053098);
                 AddRes(index, typeof(RunedPrism), 1073465, 1, 1053098);
                 AddRes(index, typeof(JeweledFiligree), 1072894, 1, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ArcanistStatueSouthDeed), 1044294, 1072885, 0.0, 35.0, typeof(Board), 1044041, 250, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ArcanistStatueEastDeed), 1044294, 1072886, 0.0, 35.0, typeof(Board), 1044041, 250, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(WarriorStatueSouthDeed), 1044294, 1072887, 0.0, 35.0, typeof(Board), 1044041, 250, 1044351);
                 AddRecipe(index, (int)CarpRecipes.WarriorStatueSouth);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(WarriorStatueEastDeed), 1044294, 1072888, 0.0, 35.0, typeof(Board), 1044041, 250, 1044351);
                 AddRecipe(index, (int)CarpRecipes.WarriorStatueEast);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(SquirrelStatueSouthDeed), 1044294, 1072884, 0.0, 35.0, typeof(Board), 1044041, 250, 1044351);
                 AddRecipe(index, (int)CarpRecipes.SquirrelStatueSouth);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(SquirrelStatueEastDeed), 1044294, 1073398, 0.0, 35.0, typeof(Board), 1044041, 250, 1044351);
                 AddRecipe(index, (int)CarpRecipes.SquirrelStatueEast);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(GiantReplicaAcorn), 1044294, 1072889, 80.0, 105.0, typeof(Board), 1044041, 35, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(MountedDreadHorn), 1044294, 1032632, 90.0, 115.0, typeof(Board), 1044041, 50, 1044351);
                 AddRes(index, typeof(PristineDreadHorn), 1032634, 1, 1053098);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(AcidProofRope), 1044294, 1074886, 80, 130.0, typeof(GreaterStrengthPotion), 1073466, 2, 1044253);
                 AddRes(index, typeof(ProtectionScroll), 1044395, 1, 1053098);
                 AddRes(index, typeof(SwitchItem), 1032127, 1, 1053098);
                 AddRecipe(index, (int)CarpRecipes.AcidProofRope);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -253,13 +238,10 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(GargishBanner), 1044294, 1095312, 94.7, 115.0, typeof(Board), 1044041, 50, 1044351);
                 AddSkill(index, SkillName.Tailoring, 75.0, 105.0);
                 AddRes(index, typeof(Cloth), 1044286, 50, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(Incubator), 1044294, 1112479, 90.0, 115.0, typeof(Board), 1044041, 100, 1044351);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(ChickenCoop), 1044294, 1112570, 90.0, 115.0, typeof(Board), 1044041, 150, 1044351);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(ExodusSummoningAlter), 1044294, 1153502, 95.0, 120.0, typeof(Board), 1044041, 100, 1044351);
                 AddSkill(index, SkillName.Magery, 75.0, 120.0);
@@ -275,12 +257,10 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(CraftableHouseItem), 1044294, 1155849, 42.1, 77.7, typeof(Board), 1044041, 5, 1044351);
                 SetData(index, CraftableItemType.DarkWoodenSignHanger);
                 SetDisplayID(index, 2967);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1044294, 1155850, 42.1, 77.7, typeof(Board), 1044041, 5, 1044351);
                 SetData(index, CraftableItemType.LightWoodenSignHanger);
                 SetDisplayID(index, 2969);
-                SetNeededExpansion(index, Expansion.TOL);
             }            
             #endregion
 
@@ -302,10 +282,8 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(ElegantLowTable), 1044291, 1030265, 80.0, 105.0, typeof(Board), 1044041, 35, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(PlainLowTable), 1044291, 1030266, 80.0, 105.0, typeof(Board), 1044041, 35, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             #region Mondain's Legacy
@@ -313,41 +291,31 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(OrnateElvenTableSouthDeed), 1044291, 1072869, 85.0, 110.0, typeof(Board), 1044041, 60, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(OrnateElvenTableEastDeed), 1044291, 1073384, 85.0, 110.0, typeof(Board), 1044041, 60, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(FancyElvenTableSouthDeed), 1044291, 1073385, 80.0, 105.0, typeof(Board), 1044041, 50, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(FancyElvenTableEastDeed), 1044291, 1073386, 80.0, 105.0, typeof(Board), 1044041, 50, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenPodium), 1044291, 1073399, 80.0, 105.0, typeof(Board), 1044041, 20, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(OrnateElvenChair), 1044291, 1072870, 80.0, 105.0, typeof(Board), 1044041, 30, 1044351);
                 AddRecipe(index, (int)CarpRecipes.OrnateElvenChair);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(BigElvenChair), 1044291, 1072872, 85.0, 110.0, typeof(Board), 1044041, 40, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenReadingChair), 1044291, 1072873, 80.0, 105.0, typeof(Board), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
             }
 
             if (Core.SA)
             {
                 index = AddCraft(typeof(TerMurStyleChair), 1044291, 1095291, 85.0, 110.0, typeof(Board), 1044041, 40, 1044351);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(TerMurStyleTable), 1044291, 1095321, 75.0, 100.0, typeof(Board), 1044041, 50, 1044351);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             index = AddCraft(typeof(UpholsteredChairDeed), 1044291, 1154173, 70.0, 110.0, typeof(Board), 1044041, 40, 1044351);
@@ -369,37 +337,26 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(PlainWoodenChest), 1044292, 1030251, 90.0, 115.0, typeof(Board), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(OrnateWoodenChest), 1044292, 1030253, 90.0, 115.0, typeof(Board), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(GildedWoodenChest), 1044292, 1030255, 90.0, 115.0, typeof(Board), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(WoodenFootLocker), 1044292, 1030257, 90.0, 115.0, typeof(Board), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(FinishedWoodenChest), 1044292, 1030259, 90.0, 115.0, typeof(Board), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(TallCabinet), 1044292, 1030261, 90.0, 115.0, typeof(Board), 1044041, 35, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(ShortCabinet), 1044292, 1030263, 90.0, 115.0, typeof(Board), 1044041, 35, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(RedArmoire), 1044292, 1030328, 90.0, 115.0, typeof(Board), 1044041, 40, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(ElegantArmoire), 1044292, 1030330, 90.0, 115.0, typeof(Board), 1044041, 40, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(MapleArmoire), 1044292, 1030332, 90.0, 115.0, typeof(Board), 1044041, 40, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(CherryArmoire), 1044292, 1030334, 90.0, 115.0, typeof(Board), 1044041, 40, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             index = AddCraft(typeof(Keg), 1044292, 1023711, 57.8, 82.8, typeof(BarrelStaves), 1044288, 3, 1044253);
@@ -413,55 +370,43 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(ArcaneBookShelfDeedSouth), 1044292, 1072871, 94.7, 119.7, typeof(Board), 1044041, 80, 1044351);
                 AddRecipe(index, (int)CarpRecipes.ArcaneBookshelfSouth);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ArcaneBookShelfDeedEast), 1044292, 1073371, 94.7, 119.7, typeof(Board), 1044041, 80, 1044351);
                 AddRecipe(index, (int)CarpRecipes.ArcaneBookshelfEast);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(OrnateElvenChestSouthDeed), 1044292, 1072862, 94.7, 119.7, typeof(Board), 1044041, 40, 1044351);
                 AddRecipe(index, (int)CarpRecipes.OrnateElvenChestSouth);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(OrnateElvenChestEastDeed), 1044292, 1073383, 94.7, 119.7, typeof(Board), 1044041, 40, 1044351);
                 AddRecipe(index, (int)CarpRecipes.OrnateElvenChestEast);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenWashBasinSouthWithDrawerDeed), 1044292, 1072865, 70.0, 95.0, typeof(Board), 1044041, 40, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenWashBasinEastWithDrawerDeed), 1044292, 1073387, 70.0, 95.0, typeof(Board), 1044041, 40, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenDresserDeedSouth), 1044292, 1072864, 75.0, 100.0, typeof(Board), 1044041, 45, 1044351);
                 AddRecipe(index, (int)CarpRecipes.ElvenDresserSouth);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenDresserDeedEast), 1044292, 1073388, 75.0, 100.0, typeof(Board), 1044041, 45, 1044351);
                 AddRecipe(index, (int)CarpRecipes.ElvenDresserEast);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(FancyElvenArmoire), 1044292, 1072866, 80.0, 105.0, typeof(Board), 1044041, 60, 1044351);
                 AddRecipe(index, (int)CarpRecipes.FancyElvenArmoire);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(SimpleElvenArmoire), 1044292, 1073401, 80.0, 105.0, typeof(Board), 1044041, 60, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(RarewoodChest), 1044292, 1073402, 80.0, 105.0, typeof(Board), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(DecorativeBox), 1044292, 1073403, 80.0, 105.0, typeof(Board), 1044041, 25, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -471,7 +416,6 @@ namespace Server.Engines.Craft
             if (Core.SA)
             {
                 index = AddCraft(typeof(GargishChest), 1044292, 1095293, 80.0, 105.0, typeof(Board), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             AddCraft(typeof(LiquorBarrel), 1044292, 1150816, 60.0, 90.0, typeof(Board), 1044041, 50, 1044351);
@@ -484,20 +428,16 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(Bokuto), 1044566, 1030227, 70.0, 95.0, typeof(Board), 1044041, 6, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(Fukiya), 1044566, 1030229, 60.0, 85.0, typeof(Board), 1044041, 6, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(Tetsubo), 1044566, 1030225, 80.0, 105.0, typeof(Board), 1044041, 10, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             #region Mondain's Legacy
             if (Core.ML)
             {
                 index = AddCraft(typeof(WildStaff), 1044566, 1031557, 63.8, 113.8, typeof(Board), 1044041, 16, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(PhantomStaff), 1044566, 1072919, 90.0, 130.0, typeof(Board), 1044041, 16, 1044351);
                 AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
@@ -505,27 +445,22 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Taint), 1032679, 10, 1053098);
                 AddRecipe(index, (int)CarpRecipes.PhantomStaff);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ArcanistsWildStaff), 1044566, 1073549, 63.8, 113.8, typeof(Board), 1044041, 16, 1044351);
                 AddRes(index, typeof(WhitePearl), 1026253, 1, 1053098);
                 AddRecipe(index, (int)CarpRecipes.ArcanistsWildStaff);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(AncientWildStaff), 1044566, 1073550, 63.8, 113.8, typeof(Board), 1044041, 16, 1044351);
                 AddRes(index, typeof(PerfectEmerald), 1026251, 1, 1053098);
                 AddRecipe(index, (int)CarpRecipes.AncientWildStaff);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ThornedWildStaff), 1044566, 1073551, 63.8, 113.8, typeof(Board), 1044041, 16, 1044351);
                 AddRes(index, typeof(FireRuby), 1026254, 1, 1053098);
                 AddRecipe(index, (int)CarpRecipes.ThornedWildStaff);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(HardenedWildStaff), 1044566, 1073552, 63.8, 113.8, typeof(Board), 1044041, 16, 1044351);
                 AddRes(index, typeof(Turquoise), 1026250, 1, 1053098);
                 AddRecipe(index, (int)CarpRecipes.HardenedWildStaff);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -534,11 +469,9 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(SerpentStoneStaff), 1044566, 1095367, 63.8, 113.8, typeof(Board), 1044041, 16, 1044351);
                 AddRes(index, typeof(EcruCitrine), 1026252, 1, 1053098);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishGnarledStaff), 1044566, 1097488, 78.9, 128.9, typeof(Board), 1044041, 16, 1044351);
                 AddRes(index, typeof(EcruCitrine), 1026252, 1, 1053098);
-                SetNeededExpansion(index, Expansion.SA);
             }
             #endregion
 
@@ -551,13 +484,11 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(BlackrockMoonstone), 1156993, 1, 1156992);
                 AddRes(index, typeof(StaffOfTheMagi), 1061600, 1, 1044253);
                 AddRecipe(index, (int)CarpRecipes.KotlBlackRod);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 /*index = AddCraft(typeof(GargishKotlBlackRod), 1044566, 1156994, 100.0, 160.0, typeof(Board), 1044041, 20, 1044351);
                 AddRes(index, typeof(BlackrockMoonstone), 1156993, 1, 1156992);
                 AddRes(index, typeof(StaffOfTheMagi), 1061600, 1, 1044253);
                 AddRecipe(index, (int)CarpRecipes.KotlBlackRod);
-                SetNeededExpansion(index, Expansion.TOL);
                 */
             }
 
@@ -569,38 +500,30 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(WoodlandChest), 1062760, 1031111, 90.0, 115.0, typeof(Board), 1044041, 20, 1044351);
                 AddRes(index, typeof(BarkFragment), 1032687, 6, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(WoodlandArms), 1062760, 1031116, 80.0, 105.0, typeof(Board), 1044041, 15, 1044351);
                 AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(WoodlandGloves), 1062760, 1031114, 85.0, 110.0, typeof(Board), 1044041, 15, 1044351);
                 AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(WoodlandLegs), 1062760, 1031115, 85.0, 110.0, typeof(Board), 1044041, 15, 1044351);
                 AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(WoodlandGorget), 1062760, 1031113, 85.0, 110.0, typeof(Board), 1044041, 15, 1044351);
                 AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(RavenHelm), 1062760, 1031121, 65.0, 115.0, typeof(Board), 1044041, 10, 1044351);
                 AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
                 AddRes(index, typeof(Feather), 1027123, 25, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(VultureHelm), 1062760, 1031122, 63.9, 113.9, typeof(Board), 1044041, 10, 1044351);
                 AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
                 AddRes(index, typeof(Feather), 1027123, 25, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(WingedHelm), 1062760, 1031123, 58.4, 108.4, typeof(Board), 1044041, 10, 1044351);
                 AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
                 AddRes(index, typeof(Feather), 1027123, 60, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(IronwoodCrown), 1062760, 1072924, 85.0, 120.0, typeof(Board), 1044041, 10, 1044351);
                 AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
@@ -608,7 +531,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
                 AddRecipe(index, (int)CarpRecipes.IronwoodCrown);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(BrambleCoat), 1062760, 1072925, 85.0, 120.0, typeof(Board), 1044041, 10, 1044351);
                 AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
@@ -616,55 +538,47 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
                 AddRecipe(index, (int)CarpRecipes.BrambleCoat);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(DarkwoodCrown), 1062760, 1073481, 85.0, 120.0, typeof(Board), 1044041, 10, 1044351);
                 AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
                 AddRes(index, typeof(Blight), 1032675, 10, 1053098);
                 AddRes(index, typeof(Taint), 1032679, 10, 1053098);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(DarkwoodChest), 1062760, 1073482, 85.0, 120.0, typeof(Board), 1044041, 20, 1044351);
                 AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
                 AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
                 AddRes(index, typeof(Muculent), 1032680, 10, 1053098);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(DarkwoodGorget), 1062760, 1073483, 85.0, 120.0, typeof(Board), 1044041, 15, 1044351);
                 AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
                 AddRes(index, typeof(Blight), 1032675, 10, 1053098);
                 AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(DarkwoodLegs), 1062760, 1073484, 85.0, 120.0, typeof(Board), 1044041, 15, 1044351);
                 AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
                 AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
                 AddRes(index, typeof(Putrefication), 1072137, 10, 1053098);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(DarkwoodPauldrons), 1062760, 1073485, 85.0, 120.0, typeof(Board), 1044041, 15, 1044351);
                 AddRes(index, typeof(EyeOfTheTravesty), 1032685, 1, 1053098);
                 AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
                 AddRes(index, typeof(Taint), 1032679, 10, 1053098);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(DarkwoodGloves), 1062760, 1073486, 85.0, 120.0, typeof(Board), 1044041, 15, 1044351);
                 AddRes(index, typeof(CapturedEssence), 1032686, 1, 1053098);
                 AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
                 AddRes(index, typeof(Muculent), 1032680, 10, 1053098);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
             #region SA
             index = AddCraft(typeof(GargishWoodenShield), 1062760, 1095768, 52.6, 77.6, typeof(Board), 1044041, 9, 1044351);
-            SetNeededExpansion(index, Expansion.SA);
             #endregion
 
             // Instruments
@@ -696,7 +610,6 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(BambooFlute), 1044293, 1030247, 80.0, 105.0, typeof(Board), 1044041, 15, 1044351);
                 AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             if (Core.SA)
@@ -704,12 +617,10 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(AudChar), 1044293, 1095315, 78.9, 103.9, typeof(Board), 1044041, 35, 1044351);
                 AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
                 AddRes(index, typeof(Granite), 1044514, 3, 1044513);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(SnakeCharmerFlute), 1044293, 1112174, 80.0, 105.0, typeof(Board), 1044041, 15, 1044351);
                 AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
                 AddRes(index, typeof(LuminescentFungi), 1073475, 3, 1044253);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             index = AddCraft(typeof(CelloDeed), 1044293, 1098390, 75.0, 105.0, typeof(Board), 1044041, 15, 1044351);
@@ -749,58 +660,48 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(ParrotPerchAddonDeed), 1044290, 1072617, 50.0, 85.0, typeof(Board), 1044041, 100, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ArcaneCircleDeed), 1044290, 1072703, 94.7, 119.7, typeof(Board), 1044041, 100, 1044351);
                 AddRes(index, typeof(BlueDiamond), 1026255, 2, 1053098);
                 AddRes(index, typeof(PerfectEmerald), 1026251, 2, 1053098);
                 AddRes(index, typeof(FireRuby), 1026254, 2, 1053098);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
 				index = AddCraft(typeof(TallElvenBedSouthDeed), 1044290, 1072858, 94.7, 119.7, typeof(Board), 1044041, 200, 1044351);
                 AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
                 AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
                 AddRecipe(index, (int)CarpRecipes.TallElvenBedSouth);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(TallElvenBedEastDeed), 1044290, 1072859, 94.7, 119.7, typeof(Board), 1044041, 200, 1044351);
                 AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
                 AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
                 AddRecipe(index, (int)CarpRecipes.TallElvenBedEast);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenBedSouthDeed), 1044290, 1072860, 94.7, 119.7, typeof(Board), 1044041, 100, 1044351);
                 AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenBedEastDeed), 1044290, 1072861, 94.7, 119.7, typeof(Board), 1044041, 100, 1044351);
                 AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenLoveseatSouthDeed), 1044290, 1072867, 80.0, 105.0, typeof(Board), 1044041, 50, 1044351);
                 SetDisplayID(index, 0x2DDF);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenLoveseatEastDeed), 1044290, 1073372, 80.0, 105.0, typeof(Board), 1044041, 50, 1044351);
                 SetDisplayID(index, 0x2DE0);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(AlchemistTableSouthDeed), 1044290, 1073396, 85.0, 110.0, typeof(Board), 1044041, 70, 1044351);
                 SetDisplayID(index, 0x2DD4);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(AlchemistTableEastDeed), 1044290, 1073397, 85.0, 110.0, typeof(Board), 1044041, 70, 1044351);
                 SetDisplayID(index, 0x2DD3);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -835,22 +736,16 @@ namespace Server.Engines.Craft
             if (Core.SA)
             {
                 index = AddCraft(typeof(GargishCouchEastDeed), 1044290, 1111776, 90.0, 115.0, typeof(Board), 1044041, 75, 1044351);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishCouchSouthDeed), 1044290, 1111775, 90.0, 115.0, typeof(Board), 1044041, 75, 1044351);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(LongTableSouthDeed), 1044290, 1111781, 90.0, 115.0, typeof(Board), 1044041, 80, 1044351);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(LongTableEastDeed), 1044290, 1111782, 90.0, 115.0, typeof(Board), 1044041, 80, 1044351);
-                SetNeededExpansion(index, Expansion.SA);
            
                 index = AddCraft(typeof(TerMurDresserEastDeed), 1044290, 1111784, 90.0, 115.0, typeof(Board), 1044041, 60, 1044351);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(TerMurDresserSouthDeed), 1044290, 1111783, 90.0, 115.0, typeof(Board), 1044041, 60, 1044351);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             index = AddCraft(typeof(RusticBenchSouthDeed), 1044290, 1150593, 94.7, 119.8, typeof(Board), 1044041, 35, 1044351);
@@ -946,12 +841,10 @@ namespace Server.Engines.Craft
             index = AddCraft(typeof(SmallDisplayCaseSouthDeed), 1044290, 1155842, 95.0, 120.0, typeof(Board), 1044041, 40, 1044351);
             AddSkill(index, SkillName.Tinkering, 75.0, 80.0);
             AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
-            SetNeededExpansion(index, Expansion.TOL);
 
             index = AddCraft(typeof(SmallDisplayCaseEastDeed), 1044290, 1155843, 95.0, 120.0, typeof(Board), 1044041, 40, 1044351);
             AddSkill(index, SkillName.Tinkering, 75.0, 80.0);
             AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
-            SetNeededExpansion(index, Expansion.TOL);
 
             index = AddCraft(typeof(FancyLoveseatNorthDeed), 1044290, 1156560, 70.0, 120.0, typeof(Board), 1044041, 80, 1044351);
             AddSkill(index, SkillName.Tailoring, 55.0, 60.0);
@@ -989,21 +882,17 @@ namespace Server.Engines.Craft
                 AddSkill(index, SkillName.Tailoring, 65.0, 85.0);
                 AddRes(index, typeof(Cloth), 1044286, 40, 1044287);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenSpinningwheelSouthDeed), 1044298, 1072878, 75.0, 100.0, typeof(Board), 1044041, 60, 1044351);
                 AddSkill(index, SkillName.Tailoring, 65.0, 85.0);
                 AddRes(index, typeof(Cloth), 1044286, 40, 1044287);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenStoveSouthDeed), 1044298, 1073394, 85.0, 110.0, typeof(Board), 1044041, 80, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenStoveEastDeed), 1044298, 1073395, 85.0, 110.0, typeof(Board), 1044041, 80, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -1048,7 +937,6 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(ElvenForgeDeed), 1111809, 1072875, 94.7, 119.7, typeof(Board), 1044041, 200, 1044351);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -1060,7 +948,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(IronIngot), 1044036, 150, 1044037);
                 AddRes(index, typeof(RelicFragment), 1031699, 1, 1044253);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.SA);
             }
             #endregion
 

--- a/Scripts/Services/Craft/DefCartography.cs
+++ b/Scripts/Services/Craft/DefCartography.cs
@@ -110,7 +110,6 @@ namespace Server.Engines.Craft
             index = AddCraft(typeof(EodonianWallMap), 1044448, 1156690, 65.0, 125.0, typeof(BlankMap), 1044449, 50, 1044450);
             AddRes(index, typeof(UnabridgedAtlasOfEodon), 1156721, 1, 1156722);
             AddRecipe(index, (int)CartographyRecipes.EodonianWallMap);
-            SetNeededExpansion(index, Expansion.TOL);
         }
 
         public int ConsumeTatteredWallMapRes(Mobile from, ConsumeType type)

--- a/Scripts/Services/Craft/DefCooking.cs
+++ b/Scripts/Services/Craft/DefCooking.cs
@@ -130,16 +130,14 @@ namespace Server.Engines.Craft
 
             if (Core.ML)
             {
-                index = this.AddCraft(typeof(CocoaButter), 1044495, 1079998, 0.0, 100.0, typeof(CocoaPulp), 1080530, 1, 1044253);
-                this.SetItemHue(index, 0x457);
-                this.SetNeededExpansion(index, Expansion.ML);
-                this.SetNeedOven(index, true);
+                index = AddCraft(typeof(CocoaButter), 1044495, 1079998, 0.0, 100.0, typeof(CocoaPulp), 1080530, 1, 1044253);
+                SetItemHue(index, 0x457);
+                SetNeedOven(index, true);
 
-                index = this.AddCraft(typeof(CocoaLiquor), 1044495, 1079999, 0.0, 100.0, typeof(CocoaPulp), 1080530, 1, 1044253);
-                this.AddRes(index, typeof(EmptyPewterBowl), 1025629, 1, 1044253);
-                this.SetItemHue(index, 0x46A);
-                this.SetNeededExpansion(index, Expansion.ML);
-                this.SetNeedOven(index, true);
+                index = AddCraft(typeof(CocoaLiquor), 1044495, 1079999, 0.0, 100.0, typeof(CocoaPulp), 1080530, 1, 1044253);
+                AddRes(index, typeof(EmptyPewterBowl), 1025629, 1, 1044253);
+                SetItemHue(index, 0x46A);
+                SetNeedOven(index, true);
             }
 
             index = AddCraft(typeof(WheatWort), 1044495, 1150275, 30.0, 100.0, typeof(Bottle), 1023854, 1, 1044253);
@@ -179,41 +177,35 @@ namespace Server.Engines.Craft
 
             if (Core.SE)
             {
-                index = this.AddCraft(typeof(GreenTea), 1044496, 1030315, 80.0, 130.0, typeof(GreenTeaBasket), 1030316, 1, 1044253);
-                this.AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-                this.SetNeededExpansion(index, Expansion.SE);
-                this.SetNeedOven(index, true);
+                index = AddCraft(typeof(GreenTea), 1044496, 1030315, 80.0, 130.0, typeof(GreenTeaBasket), 1030316, 1, 1044253);
+                AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
+                SetNeedOven(index, true);
 
-                index = this.AddCraft(typeof(WasabiClumps), 1044496, 1029451, 70.0, 120.0, typeof(BaseBeverage), 1046458, 1, 1044253);
-                this.AddRes(index, typeof(WoodenBowlOfPeas), 1025633, 3, 1044253);
-                this.SetNeededExpansion(index, Expansion.SE);
+                index = AddCraft(typeof(WasabiClumps), 1044496, 1029451, 70.0, 120.0, typeof(BaseBeverage), 1046458, 1, 1044253);
+                AddRes(index, typeof(WoodenBowlOfPeas), 1025633, 3, 1044253);
 
-                index = this.AddCraft(typeof(SushiRolls), 1044496, 1030303, 90.0, 120.0, typeof(BaseBeverage), 1046458, 1, 1044253);
-                this.AddRes(index, typeof(RawFishSteak), 1044476, 10, 1044253);
-                this.SetNeededExpansion(index, Expansion.SE);
+                index = AddCraft(typeof(SushiRolls), 1044496, 1030303, 90.0, 120.0, typeof(BaseBeverage), 1046458, 1, 1044253);
+                AddRes(index, typeof(RawFishSteak), 1044476, 10, 1044253);
 
-                index = this.AddCraft(typeof(SushiPlatter), 1044496, 1030305, 90.0, 120.0, typeof(BaseBeverage), 1046458, 1, 1044253);
-                this.AddRes(index, typeof(RawFishSteak), 1044476, 10, 1044253);
-                this.SetNeededExpansion(index, Expansion.SE);
+                index = AddCraft(typeof(SushiPlatter), 1044496, 1030305, 90.0, 120.0, typeof(BaseBeverage), 1046458, 1, 1044253);
+                AddRes(index, typeof(RawFishSteak), 1044476, 10, 1044253);
             }
 
-            index = this.AddCraft(typeof(TribalPaint), 1044496, 1040000, Core.ML ? 55.0 : 80.0, Core.ML ? 105.0 : 80.0, typeof(SackFlour), 1044468, 1, 1044253);
-            this.AddRes(index, typeof(TribalBerry), 1046460, 1, 1044253);
+            index = AddCraft(typeof(TribalPaint), 1044496, 1040000, Core.ML ? 55.0 : 80.0, Core.ML ? 105.0 : 80.0, typeof(SackFlour), 1044468, 1, 1044253);
+            AddRes(index, typeof(TribalBerry), 1046460, 1, 1044253);
 
             if (Core.SE)
             {
-                index = this.AddCraft(typeof(EggBomb), 1044496, 1030249, 90.0, 120.0, typeof(Eggs), 1044477, 1, 1044253);
-                this.AddRes(index, typeof(SackFlour), 1044468, 3, 1044253);
-                this.SetNeededExpansion(index, Expansion.SE);
+                index = AddCraft(typeof(EggBomb), 1044496, 1030249, 90.0, 120.0, typeof(Eggs), 1044477, 1, 1044253);
+                AddRes(index, typeof(SackFlour), 1044468, 3, 1044253);
             }
 
             #region Mondain's Legacy
             if (Core.ML)
             {
-                index = this.AddCraft(typeof(ParrotWafer), 1044496, 1032246, 37.5, 87.5, typeof(Dough), 1044469, 1, 1044253);
-                this.AddRes(index, typeof(JarHoney), 1044472, 1, 1044253);
-                this.AddRes(index, typeof(RawFishSteak), 1044476, 10, 1044253);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(ParrotWafer), 1044496, 1032246, 37.5, 87.5, typeof(Dough), 1044469, 1, 1044253);
+                AddRes(index, typeof(JarHoney), 1044472, 1, 1044253);
+                AddRes(index, typeof(RawFishSteak), 1044476, 10, 1044253);
             }
             #endregion
 
@@ -223,21 +215,17 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(PlantPigment), 1044496, 1112132, 75.0, 100.0, typeof(PlantClippings), 1112131, 1, 1044253);
                 AddRes(index, typeof(Bottle), 1023854, 1, 1044253);
                 SetRequireResTarget(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(NaturalDye), 1044496, 1112136, 65.0, 115.0, typeof(PlantPigment), 1112132, 1, 1044253);
                 AddRes(index, typeof(ColorFixative), 1112135, 1, 1044253);
                 SetRequireResTarget(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(ColorFixative), 1044496, 1112135, 75.0, 100.0, typeof(BaseBeverage), 1022503, 1, 1044253);
                 AddRes(index, typeof(SilverSerpentVenom), 1112173, 1, 1044253);
                 SetBeverageType(index, BeverageType.Wine);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(WoodPulp), 1044496, 1113136, 60.0, 100.0, typeof(BarkFragment), 1032687, 1, 1044253);
                 AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-                SetNeededExpansion(index, Expansion.SA);
             }
             #endregion
 
@@ -247,7 +235,6 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(Charcoal), 1044496, 1116303, 0.0, 50.0, typeof(Board), 1044041, 1, 1044351);
                 SetUseAllRes(index, true);
                 SetNeedHeat(index, true);
-                SetNeededExpansion(index, Expansion.HS);
             }
             #endregion
             /* End Preparations */
@@ -291,25 +278,21 @@ namespace Server.Engines.Craft
 
             if (Core.SE)
             {
-                index = this.AddCraft(typeof(MisoSoup), 1044497, 1030317, 60.0, 110.0, typeof(RawFishSteak), 1044476, 1, 1044253);
-                this.AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-                this.SetNeededExpansion(index, Expansion.SE);
-                this.SetNeedOven(index, true);
+                index = AddCraft(typeof(MisoSoup), 1044497, 1030317, 60.0, 110.0, typeof(RawFishSteak), 1044476, 1, 1044253);
+                AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
+                SetNeedOven(index, true);
 
-                index = this.AddCraft(typeof(WhiteMisoSoup), 1044497, 1030318, 60.0, 110.0, typeof(RawFishSteak), 1044476, 1, 1044253);
-                this.AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-                this.SetNeededExpansion(index, Expansion.SE);
-                this.SetNeedOven(index, true);
+                index = AddCraft(typeof(WhiteMisoSoup), 1044497, 1030318, 60.0, 110.0, typeof(RawFishSteak), 1044476, 1, 1044253);
+                AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
+                SetNeedOven(index, true);
 
-                index = this.AddCraft(typeof(RedMisoSoup), 1044497, 1030319, 60.0, 110.0, typeof(RawFishSteak), 1044476, 1, 1044253);
-                this.AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-                this.SetNeededExpansion(index, Expansion.SE);
-                this.SetNeedOven(index, true);
+                index = AddCraft(typeof(RedMisoSoup), 1044497, 1030319, 60.0, 110.0, typeof(RawFishSteak), 1044476, 1, 1044253);
+                AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
+                SetNeedOven(index, true);
 
-                index = this.AddCraft(typeof(AwaseMisoSoup), 1044497, 1030320, 60.0, 110.0, typeof(RawFishSteak), 1044476, 1, 1044253);
-                this.AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-                this.SetNeededExpansion(index, Expansion.SE);
-                this.SetNeedOven(index, true);
+                index = AddCraft(typeof(AwaseMisoSoup), 1044497, 1030320, 60.0, 110.0, typeof(RawFishSteak), 1044476, 1, 1044253);
+                AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
+                SetNeedOven(index, true);
             }
 
             index = this.AddCraft(typeof(GingerBreadCookie), 1044497, 1031233, 35.0, 85.0, typeof(CookieMix), 1044474, 1, 1044253);
@@ -347,11 +330,10 @@ namespace Server.Engines.Craft
             this.SetNeedHeat(index, true);
             this.SetUseAllRes(index, true);
 
-            index = this.AddCraft(typeof(BowlOfRotwormStew), 1044498, 1031706, 0.0, 100.0, typeof(RawRotwormMeat), 1031705, 1, 1044253);
-            this.SetNeedHeat(index, true);
-            this.SetUseAllRes(index, true);
-            this.AddRecipe(index, (int)CookRecipes.RotWormStew);
-            this.SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(BowlOfRotwormStew), 1044498, 1031706, 0.0, 100.0, typeof(RawRotwormMeat), 1031705, 1, 1044253);
+            SetNeedHeat(index, true);
+            SetUseAllRes(index, true);
+            AddRecipe(index, (int)CookRecipes.RotWormStew);
             /* End Barbecue */
 
             /* Begin Chocolatiering */
@@ -365,27 +347,24 @@ namespace Server.Engines.Craft
                     this.SetNeedOven(index, true);
                 }
 
-                index = this.AddCraft(typeof(DarkChocolate), 1080001, 1079994, 15.0, 100.0, typeof(SackOfSugar), 1079997, 1, 1044253);
-                this.AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
-                this.AddRes(index, typeof(CocoaLiquor), 1079999, 1, 1044253);
-                this.SetItemHue(index, 0x465);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(DarkChocolate), 1080001, 1079994, 15.0, 100.0, typeof(SackOfSugar), 1079997, 1, 1044253);
+                AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
+                AddRes(index, typeof(CocoaLiquor), 1079999, 1, 1044253);
+                SetItemHue(index, 0x465);
 
-                index = this.AddCraft(typeof(MilkChocolate), 1080001, 1079995, 32.5, 107.5, typeof(SackOfSugar), 1079997, 1, 1044253);
-                this.AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
-                this.AddRes(index, typeof(CocoaLiquor), 1079999, 1, 1044253);
-                this.AddRes(index, typeof(BaseBeverage), 1022544, 1, 1044253);
-                this.SetBeverageType(index, BeverageType.Milk);
-                this.SetItemHue(index, 0x461);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(MilkChocolate), 1080001, 1079995, 32.5, 107.5, typeof(SackOfSugar), 1079997, 1, 1044253);
+                AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
+                AddRes(index, typeof(CocoaLiquor), 1079999, 1, 1044253);
+                AddRes(index, typeof(BaseBeverage), 1022544, 1, 1044253);
+                SetBeverageType(index, BeverageType.Milk);
+                SetItemHue(index, 0x461);
 
-                index = this.AddCraft(typeof(WhiteChocolate), 1080001, 1079996, 52.5, 127.5, typeof(SackOfSugar), 1079997, 1, 1044253);
-                this.AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
-                this.AddRes(index, typeof(Vanilla), 1080000, 1, 1044253);
-                this.AddRes(index, typeof(BaseBeverage), 1022544, 1, 1044253);
-                this.SetBeverageType(index, BeverageType.Milk);
-                this.SetItemHue(index, 0x47E);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(WhiteChocolate), 1080001, 1079996, 52.5, 127.5, typeof(SackOfSugar), 1079997, 1, 1044253);
+                AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
+                AddRes(index, typeof(Vanilla), 1080000, 1, 1044253);
+                AddRes(index, typeof(BaseBeverage), 1022544, 1, 1044253);
+                SetBeverageType(index, BeverageType.Milk);
+                SetItemHue(index, 0x47E);
 
                 #region TOL
                 if (Core.TOL)
@@ -395,21 +374,18 @@ namespace Server.Engines.Craft
                     AddRes(index, typeof(CocoaLiquor), 1079999, 1, 1044253);
                     AddRecipe(index, (int)CookRecipes.DarkChocolateNutcracker);
                     SetData(index, ChocolateNutcracker.ChocolateType.Dark);
-                    SetNeededExpansion(index, Expansion.TOL);
 
                     index = AddCraft(typeof(ChocolateNutcracker), 1080001, 1156391, 32.5, 107.5, typeof(SweetCocoaButter), 1156401, 1, 1044253);
                     AddRes(index, typeof(SweetCocoaButter), 1124032, 1, 1156402);
                     AddRes(index, typeof(CocoaLiquor), 1079999, 1, 1044253);
                     AddRecipe(index, (int)CookRecipes.MilkChocolateNutcracker);
                     SetData(index, ChocolateNutcracker.ChocolateType.Milk);
-                    SetNeededExpansion(index, Expansion.TOL);
 
                     index = AddCraft(typeof(ChocolateNutcracker), 1080001, 1156392, 52.5, 127.5, typeof(SweetCocoaButter), 1156401, 1, 1044253);
                     AddRes(index, typeof(SweetCocoaButter), 1124032, 1, 1156402);
                     AddRes(index, typeof(CocoaLiquor), 1079999, 1, 1044253);
                     AddRecipe(index, (int)CookRecipes.WhiteChocolateNutcracker);
                     SetData(index, ChocolateNutcracker.ChocolateType.White);
-                    SetNeededExpansion(index, Expansion.TOL);
                 }
                 #endregion
             }
@@ -419,23 +395,19 @@ namespace Server.Engines.Craft
             /* Begin Enchanted */
             if (Core.ML)
             {
-                index = this.AddCraft(typeof(FoodEngraver), 1073108, 1072951, 75.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
-                this.AddRes(index, typeof(JarHoney), 1044472, 1, 1044253);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(FoodEngraver), 1073108, 1072951, 75.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
+                AddRes(index, typeof(JarHoney), 1044472, 1, 1044253);
 
-                index = this.AddCraft(typeof(EnchantedApple), 1073108, 1072952, 60.0, 110.0, typeof(Apple), 1044479, 1, 1044253);
-                this.AddRes(index, typeof(GreaterHealPotion), 1073467, 1, 1044253);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(EnchantedApple), 1073108, 1072952, 60.0, 110.0, typeof(Apple), 1044479, 1, 1044253);
+                AddRes(index, typeof(GreaterHealPotion), 1073467, 1, 1044253);
 
-                index = this.AddCraft(typeof(WrathGrapes), 1073108, 1072953, 95.0, 145.0, typeof(Grapes), 1073468, 1, 1044253);
-                this.AddRes(index, typeof(GreaterStrengthPotion), 1073466, 1, 1044253);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(WrathGrapes), 1073108, 1072953, 95.0, 145.0, typeof(Grapes), 1073468, 1, 1044253);
+                AddRes(index, typeof(GreaterStrengthPotion), 1073466, 1, 1044253);
 
-                index = this.AddCraft(typeof(FruitBowl), 1073108, 1072950, 55.0, 105.0, typeof(EmptyWoodenBowl), 1073472, 1, 1044253);
-                this.AddRes(index, typeof(Pear), 1044481, 3, 1044253);
-                this.AddRes(index, typeof(Apple), 1044479, 3, 1044253);
-                this.AddRes(index, typeof(Banana), 1073470, 3, 1044253);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(FruitBowl), 1073108, 1072950, 55.0, 105.0, typeof(EmptyWoodenBowl), 1073472, 1, 1044253);
+                AddRes(index, typeof(Pear), 1044481, 3, 1044253);
+                AddRes(index, typeof(Apple), 1044479, 3, 1044253);
+                AddRes(index, typeof(Banana), 1073470, 3, 1044253);
             }
             /* End Enchanted */
             #endregion

--- a/Scripts/Services/Craft/DefGlassblowing.cs
+++ b/Scripts/Services/Craft/DefGlassblowing.cs
@@ -104,55 +104,47 @@ namespace Server.Engines.Craft
 
         public override void InitCraftList()
         {
-            int index = this.AddCraft(typeof(Bottle), 1044050, 1023854, 52.5, 102.5, typeof(Sand), 1044625, 1, 1044627);
+            int index = AddCraft(typeof(Bottle), 1044050, 1023854, 52.5, 102.5, typeof(Sand), 1044625, 1, 1044627);
             this.SetUseAllRes(index, true);
 
-            this.AddCraft(typeof(SmallFlask), 1044050, 1044610, 52.5, 102.5, typeof(Sand), 1044625, 2, 1044627);
-            this.AddCraft(typeof(MediumFlask), 1044050, 1044611, 52.5, 102.5, typeof(Sand), 1044625, 3, 1044627);
-            this.AddCraft(typeof(CurvedFlask), 1044050, 1044612, 55.0, 105.0, typeof(Sand), 1044625, 2, 1044627);
-            this.AddCraft(typeof(LongFlask), 1044050, 1044613, 57.5, 107.5, typeof(Sand), 1044625, 4, 1044627);
-            this.AddCraft(typeof(LargeFlask), 1044050, 1044623, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
-            this.AddCraft(typeof(AniSmallBlueFlask), 1044050, 1044614, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
-            this.AddCraft(typeof(AniLargeVioletFlask), 1044050, 1044615, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
-            this.AddCraft(typeof(AniRedRibbedFlask), 1044050, 1044624, 60.0, 110.0, typeof(Sand), 1044625, 7, 1044627);
-            this.AddCraft(typeof(EmptyVialsWRack), 1044050, 1044616, 65.0, 115.0, typeof(Sand), 1044625, 8, 1044627);
-            this.AddCraft(typeof(FullVialsWRack), 1044050, 1044617, 65.0, 115.0, typeof(Sand), 1044625, 9, 1044627);
-            this.AddCraft(typeof(SpinningHourglass), 1044050, 1044618, 75.0, 125.0, typeof(Sand), 1044625, 10, 1044627);
+            AddCraft(typeof(SmallFlask), 1044050, 1044610, 52.5, 102.5, typeof(Sand), 1044625, 2, 1044627);
+            AddCraft(typeof(MediumFlask), 1044050, 1044611, 52.5, 102.5, typeof(Sand), 1044625, 3, 1044627);
+            AddCraft(typeof(CurvedFlask), 1044050, 1044612, 55.0, 105.0, typeof(Sand), 1044625, 2, 1044627);
+            AddCraft(typeof(LongFlask), 1044050, 1044613, 57.5, 107.5, typeof(Sand), 1044625, 4, 1044627);
+            AddCraft(typeof(LargeFlask), 1044050, 1044623, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
+            AddCraft(typeof(AniSmallBlueFlask), 1044050, 1044614, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
+            AddCraft(typeof(AniLargeVioletFlask), 1044050, 1044615, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
+            AddCraft(typeof(AniRedRibbedFlask), 1044050, 1044624, 60.0, 110.0, typeof(Sand), 1044625, 7, 1044627);
+            AddCraft(typeof(EmptyVialsWRack), 1044050, 1044616, 65.0, 115.0, typeof(Sand), 1044625, 8, 1044627);
+            AddCraft(typeof(FullVialsWRack), 1044050, 1044617, 65.0, 115.0, typeof(Sand), 1044625, 9, 1044627);
+            AddCraft(typeof(SpinningHourglass), 1044050, 1044618, 75.0, 125.0, typeof(Sand), 1044625, 10, 1044627);
 
             if (Core.SA)
             {
                 index = AddCraft(typeof(WorkableGlass), 1044050, 1154170, 55.0, 105.0, typeof(Sand), 1044625, 10, 1044627);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             if (Core.ML)
             {
-                index = this.AddCraft(typeof(HollowPrism), 1044050, 1072895, 100.0, 150.0, typeof(Sand), 1044625, 8, 1044627);
-                this.SetNeededExpansion(index, Expansion.ML);
+                index = AddCraft(typeof(HollowPrism), 1044050, 1072895, 100.0, 150.0, typeof(Sand), 1044625, 8, 1044627);
             }
 
             if (Core.SA)
             {
                 index = AddCraft(typeof(GargoyleFloorMirror), 1044050, 1095314, 75.0, 125.0, typeof(Sand), 1044625, 20, 1044627);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargoyleWallMirror), 1044050, 1095324, 70.0, 120.0, typeof(Sand), 1044625, 10, 1044627);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(SoulstoneFragment), 1044050, 1071000, 70.0, 120.0, typeof(CrystalGranules), 1112329, 2, 1044253);
                 AddRes(index, typeof(VoidEssence), 1112327, 2, 1044253);
                 SetItemHue(index, 1150);
-                SetNeededExpansion(index, Expansion.SA);
 
-                index = this.AddCraft(typeof(EmptyVenomVial), 1044050, 1112215, 52.5, 102.5, typeof(Sand), 1044625, 1, 1044627);
-                this.SetNeededExpansion(index, Expansion.SA);
+                index = AddCraft(typeof(EmptyVenomVial), 1044050, 1112215, 52.5, 102.5, typeof(Sand), 1044625, 1, 1044627);
 
                 //Glass Weapons
                 index = AddCraft(typeof(GlassSword), 1111745, 1022316, 55.0, 105.0, typeof(Sand), 1044625, 14, 1044627);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GlassStaff), 1111745, 1095368, 53.6, 103.6, typeof(Sand), 1044625, 10, 1044627);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             Repair = Core.SA;

--- a/Scripts/Services/Craft/DefInscription.cs
+++ b/Scripts/Services/Craft/DefInscription.cs
@@ -366,14 +366,12 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(BlackPearl), 1044353, 1, 1044253);
                 AddRes(index, typeof(SwitchItem), 1073464, 1, 1044253);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(RunedPrism), 1044294, 1073465, 45.0, 95.0, typeof(BlankScroll), 1044377, 1, 1044378);
                 AddRes(index, typeof(SpidersSilk), 1044360, 1, 1044253);
                 AddRes(index, typeof(BlackPearl), 1044353, 1, 1044253);
                 AddRes(index, typeof(HollowPrism), 1072895, 1, 1044253);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
             }
 
             // Runebook
@@ -411,14 +409,13 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Corruption), 1032676, 10, 1044253);
                 AddRecipe(index, (int)TinkerRecipes.ScrappersCompendium);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(SpellbookEngraver), 1044294, 1072151, 75.0, 100.0, typeof(Feather), 1044562, 1, 1044563);
                 AddRes(index, typeof(BlackPearl), 1015001, 7, 1044253);
-                SetNeededExpansion(index, Expansion.ML);
+
 
                 AddCraft(typeof(NecromancerSpellbook), 1044294, 1074909, 50.0, 100.0, typeof(BlankScroll), 1044377, 10, 1044378);
-                //	AddCraft(typeof(SpellweavingBook), 1044294, "Spellweaving book", 50.0, 100.0, typeof(BlankScroll), 1044377, 10, 1044378);
+
                 AddCraft(typeof(MysticBook), 1044294, 1031677, 50.0, 100.0, typeof(BlankScroll), 1044377, 10, 1044378);
             }
             #endregion
@@ -434,7 +431,6 @@ namespace Server.Engines.Craft
                 AddCraft(typeof(BlankScroll), 1044294, 1023636, 50.0, 100.0, typeof(WoodPulp), 1113136, 1, 1044378);
 
                 index = AddCraft(typeof(ScrollBinderDeed), 1044294, 1113135, 75.0, 125.0, typeof(WoodPulp), 1113136, 1, 1044253);
-                SetNeededExpansion(index, Expansion.SA);
                 SetItemHue(index, 1641);
 
                 index = AddCraft(typeof(GargoyleBook100), 1044294, 1113290, 60.0, 100.0, typeof(BlankScroll), 1044377, 40, 1044378);

--- a/Scripts/Services/Craft/DefMasonry.cs
+++ b/Scripts/Services/Craft/DefMasonry.cs
@@ -127,32 +127,25 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 int index = AddCraft(typeof(SmallUrn), 1044501, 1029244, 82.0, 132.0, typeof(Granite), 1044514, 3, 1044513);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(SmallTowerSculpture), 1044501, 1029242, 82.0, 132.0, typeof(Granite), 1044514, 3, 1044513);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             if (Core.SA)
             {
                 int index = AddCraft(typeof(GargoylePainting), 1044501, 1095317, 83.0, 133.0, typeof(Granite), 1044514, 3, 1044513);
-                SetNeededExpansion(index, Expansion.SA);
  
                 index = AddCraft(typeof(GargishSculpture), 1044501, 1095319, 82.0, 132.0, typeof(Granite), 1044514, 3, 1044513);
-                SetNeededExpansion(index, Expansion.SA);
  
-                index = AddCraft(typeof(GargoyleVase), 1044501, 1095322, 80.0, 126.0, typeof(Granite), 1044514, 3, 1044513);
-                SetNeededExpansion(index, Expansion.SA); 
+                index = AddCraft(typeof(GargoyleVase), 1044501, 1095322, 80.0, 126.0, typeof(Granite), 1044514, 3, 1044513); 
             }
             
             if (Core.TOL)
             {
                 int index = AddCraft(typeof(AnniversaryVaseTall), 1044501, 1156147, 60.0, 110.0, typeof(Granite), 1044514, 6, 1044513);
-                SetNeededExpansion(index, Expansion.TOL);
                 AddRecipe(index, (int)MasonryRecipes.AnniversaryVaseTall);
 
                 index = AddCraft(typeof(AnniversaryVaseShort), 1044501, 1156148, 60.0, 110.0, typeof(Granite), 1044514, 6, 1044513);
-                SetNeededExpansion(index, Expansion.TOL);
                 AddRecipe(index, (int)MasonryRecipes.AnniversaryVaseShort);                
             }
 
@@ -177,11 +170,9 @@ namespace Server.Engines.Craft
             {
                 int index = AddCraft(typeof(StoneAnvilSouthDeed), 1044290, 1072876, 78.0, 128.0, typeof(Granite), 1044514, 20, 1044513);
                 AddRecipe(index, (int)CarpRecipes.StoneAnvilSouth);
-                SetNeededExpansion(index, Expansion.ML);
 				
                 index = AddCraft(typeof(StoneAnvilEastDeed), 1044290, 1073392, 78.0, 128.0, typeof(Granite), 1044514, 20, 1044513);
                 AddRecipe(index, (int)CarpRecipes.StoneAnvilEast);
-                SetNeededExpansion(index, Expansion.ML);
             }
 
             if (Core.SA)
@@ -189,65 +180,48 @@ namespace Server.Engines.Craft
                 int index = AddCraft(typeof(LargeGargoyleBedSouthDeed), 1044290, 1111761, 76.0, 126.0, typeof(Granite), 1044514, 3, 1044513);
                 AddSkill(index, SkillName.Tailoring, 70.0, 75.0);
                 AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(LargeGargoyleBedEastDeed), 1044290, 1111762, 76.0, 126.0, typeof(Granite), 1044514, 3, 1044513);
                 AddSkill(index, SkillName.Tailoring, 70.0, 75.0);
                 AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishCotEastDeed), 1044290, 1111921, 76.0, 126.0, typeof(Granite), 1044514, 3, 1044513);
                 AddSkill(index, SkillName.Tailoring, 70.0, 75.0);
                 AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishCotSouthDeed), 1044290, 1111920, 76.0, 126.0, typeof(Granite), 1044514, 3, 1044513);
                 AddSkill(index, SkillName.Tailoring, 70.0, 75.0);
                 AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             // Stone Armor
             if (Core.SA)
             {
                 int index = AddCraft(typeof(FemaleGargishStoneArms), 1111705, 1020643, 56.3, 106.3, typeof(Granite), 1044514, 8, 1044513);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishStoneChest), 1111705, 1020645, 55.0, 105.0, typeof(Granite), 1044514, 12, 1044513);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishStoneLegs), 1111705, 1020649, 58.8, 108.8, typeof(Granite), 1044514, 10, 1044513);
-                SetNeededExpansion(index, Expansion.SA);
 
-                index = AddCraft(typeof(FemaleGargishStoneKilt), 1111705, 1020647, 48.9, 98.9, typeof(Granite), 1044514, 6, 1044513);
-                SetNeededExpansion(index, Expansion.SA);               
-
+                index = AddCraft(typeof(FemaleGargishStoneKilt), 1111705, 1020647, 48.9, 98.9, typeof(Granite), 1044514, 6, 1044513);              
 
                 index = AddCraft(typeof(GargishStoneArms), 1111705, 1020643, 56.3, 106.3, typeof(Granite), 1044514, 8, 1044513);
-                SetNeededExpansion(index, Expansion.SA);
  
                 index = AddCraft(typeof(GargishStoneChest), 1111705, 1020645, 65.0, 115.0, typeof(Granite), 1044514, 12, 1044513);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishStoneLegs), 1111705, 1020649, 58.8, 108.8, typeof(Granite), 1044514, 10, 1044513);
-                SetNeededExpansion(index, Expansion.SA);
 
-                index = AddCraft(typeof(GargishStoneKilt), 1111705, 1020647, 48.9, 98.9, typeof(Granite), 1044514, 6, 1044513);
-                SetNeededExpansion(index, Expansion.SA);               
-
+                index = AddCraft(typeof(GargishStoneKilt), 1111705, 1020647, 48.9, 98.9, typeof(Granite), 1044514, 6, 1044513);              
  
-                index = AddCraft(typeof(LargeStoneShield), 1111705, 1095773, 55.0, 105.0, typeof(Granite), 1044514, 16, 1044513);
-                SetNeededExpansion(index, Expansion.SA);               
+                index = AddCraft(typeof(LargeStoneShield), 1111705, 1095773, 55.0, 105.0, typeof(Granite), 1044514, 16, 1044513);             
 
                 index = AddCraft(typeof(GargishStoneAmulet), 1111705, 1098594, 60.0, 110.0, typeof(Granite), 1044514, 3, 1044513);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             // Stone Weapons
             if (Core.SA)
             {
                 int index = AddCraft(typeof(StoneWarSword), 1111719, 1022304, 55.0, 105.0, typeof(Granite), 1044514, 18, 1044513);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             // Stone Walls
@@ -256,62 +230,50 @@ namespace Server.Engines.Craft
                 int index = AddCraft(typeof(CraftableHouseItem), 1155792, 1155794, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, CraftableItemType.RoughWindowless);
                 SetDisplayID(index, 464);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155792, 1155797, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, CraftableItemType.RoughWindow);
                 SetDisplayID(index, 467);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155792, 1155799, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, CraftableItemType.RoughArch);
                 SetDisplayID(index, 469);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155792, 1155804, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, CraftableItemType.RoughPillar);
                 SetDisplayID(index, 474);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155792, 1155805, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, CraftableItemType.RoughRoundedArch);
                 SetDisplayID(index, 475);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155792, 1155810, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, CraftableItemType.RoughSmallArch);
                 SetDisplayID(index, 480);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155792, 1155814, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, CraftableItemType.RoughAngledPillar);
                 SetDisplayID(index, 486);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155792, 1155816, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, CraftableItemType.ShortRough);
                 SetDisplayID(index, 488);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseDoorDeed), 1155792, 1156078, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, DoorType.StoneDoor_S_In);
                 SetDisplayID(index, 804);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseDoorDeed), 1155792, 1156079, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, DoorType.StoneDoor_E_Out);
                 SetDisplayID(index, 805);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseDoorDeed), 1155792, 1156348, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, DoorType.StoneDoor_S_Out);
                 SetDisplayID(index, 804);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseDoorDeed), 1155792, 1156349, 60.0, 110.0, typeof(Granite), 1044514, 10, 1044513);
                 SetData(index, DoorType.StoneDoor_E_In);
                 SetDisplayID(index, 805);
-                SetNeededExpansion(index, Expansion.TOL);
             }
             
             // Stone Stairs
@@ -320,32 +282,26 @@ namespace Server.Engines.Craft
                 int index = AddCraft(typeof(CraftableHouseItem), 1155820, 1155821, 60.0, 110.0, typeof(Granite), 1044514, 5, 1044513);
                 SetData(index, CraftableItemType.RoughBlock);
                 SetDisplayID(index, 1928);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155820, 1155822, 60.0, 110.0, typeof(Granite), 1044514, 5, 1044513);
                 SetData(index, CraftableItemType.RoughSteps);
                 SetDisplayID(index, 1929);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155820, 1155826, 60.0, 110.0, typeof(Granite), 1044514, 5, 1044513);
                 SetData(index, CraftableItemType.RoughCornerSteps);
                 SetDisplayID(index, 1934);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155820, 1155830, 60.0, 110.0, typeof(Granite), 1044514, 5, 1044513);
                 SetData(index, CraftableItemType.RoughRoundedCornerSteps);
                 SetDisplayID(index, 1938);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155820, 1155834, 60.0, 110.0, typeof(Granite), 1044514, 5, 1044513);
                 SetData(index, CraftableItemType.RoughInsetSteps);
                 SetDisplayID(index, 1941);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155820, 1155838, 60.0, 110.0, typeof(Granite), 1044514, 5, 1044513);
                 SetData(index, CraftableItemType.RoughRoundedInsetSteps);
                 SetDisplayID(index, 1945);
-                SetNeededExpansion(index, Expansion.TOL);
             }
             
             // Stone Floors
@@ -354,17 +310,14 @@ namespace Server.Engines.Craft
                 int index = AddCraft(typeof(CraftableHouseItem), 1155877, "Light Paver", 60.0, 110.0, typeof(Granite), 1044514, 5, 1044513);
                 SetData(index, CraftableItemType.LightPaver);
                 SetDisplayID(index, 1305);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155877, "Medium Paver", 60.0, 110.0, typeof(Granite), 1044514, 5, 1044513);
                 SetData(index, CraftableItemType.MediumPaver);
                 SetDisplayID(index, 1309);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1155877, "Dark Paver", 60.0, 110.0, typeof(Granite), 1044514, 5, 1044513);
                 SetData(index, CraftableItemType.DarkPaver);
                 SetDisplayID(index, 1313);
-                SetNeededExpansion(index, Expansion.TOL);
             }
 
             MarkOption = true;

--- a/Scripts/Services/Craft/DefTailoring.cs
+++ b/Scripts/Services/Craft/DefTailoring.cs
@@ -184,11 +184,9 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(LightPowderCharge), 1044457, 1116159, 0.0, 50.0, typeof(Cloth), 1044455, 1, 1044253);
                 AddRes(index, typeof(BlackPowder), 1095826, 1, 1044253);
-                SetNeededExpansion(index, Expansion.HS);
 
                 index = AddCraft(typeof(HeavyPowderCharge), 1044457, 1116160, 0.0, 50.0, typeof(Cloth), 1044455, 1, 1044253);
                 AddRes(index, typeof(BlackPowder), 1095826, 4, 1044253);
-                SetNeededExpansion(index, Expansion.HS);
             }
 
             if (Core.SA)
@@ -196,7 +194,6 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(AbyssalCloth), 1044457, 1113350, 110.0, 160.0, typeof(Cloth), 1044455, 50, 1044253);
                 AddRes(index, typeof(CrystallineBlackrock), 1077568, 1, 1044253);
                 SetItemHue(index, 2075);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             #endregion
@@ -221,10 +218,8 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(ClothNinjaHood), 1011375, 1030202, 80.0, 105.0, typeof(Cloth), 1044455, 13, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(Kasa), 1011375, 1030211, 60.0, 85.0, typeof(Cloth), 1044455, 12, 1044287);	
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             AddCraft(typeof(OrcMask), 1011375, 1025147, 75.0, 100.0, typeof(Cloth), 1044455, 12, 1044287);
@@ -238,7 +233,6 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(ChefsToque), 1011375, 1109618, 6.2, 21.2, typeof(Cloth), 1044455, 11, 1044287);
                 AddRecipe(index, (int)TailorRecipe.ChefsToque);
-                SetNeededExpansion(index, Expansion.TOL);
             }
             #endregion
 
@@ -266,22 +260,16 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(ClothNinjaJacket), 1111747, 1030207, 75.0, 100.0, typeof(Cloth), 1044455, 12, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(Kamishimo), 1111747, 1030212, 75.0, 100.0, typeof(Cloth), 1044455, 15, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(HakamaShita), 1111747, 1030215, 40.0, 65.0, typeof(Cloth), 1044455, 14, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(MaleKimono), 1111747, 1030189, 50.0, 75.0, typeof(Cloth), 1044455, 16, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(FemaleKimono), 1111747, 1030190, 50.0, 75.0, typeof(Cloth), 1044455, 16, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(JinBaori), 1111747, 1030220, 30.0, 55.0, typeof(Cloth), 1044455, 12, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             AddCraft(typeof(ShortPants), 1111747, 1025422, 24.8, 49.8, typeof(Cloth), 1044455, 6, 1044287);
@@ -295,32 +283,24 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(Hakama), 1111747, 1030213, 50.0, 75.0, typeof(Cloth), 1044455, 16, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(TattsukeHakama), 1111747, 1030214, 50.0, 75.0, typeof(Cloth), 1044455, 16, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             #region Mondain's Legacy
             if (Core.ML)
             {
                 index = AddCraft(typeof(ElvenShirt), 1111747, 1032661, 80.0, 105.0, typeof(Cloth), 1044455, 10, 1044287);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenDarkShirt), 1111747, 1032662, 80.0, 105.0, typeof(Cloth), 1044455, 10, 1044287);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ElvenPants), 1111747, 1032665, 80.0, 105.0, typeof(Cloth), 1044455, 12, 1044287);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(MaleElvenRobe), 1111747, 1032659, 80.0, 105.0, typeof(Cloth), 1044455, 30, 1044287);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(FemaleElvenRobe), 1111747, 1032660, 80.0, 105.0, typeof(Cloth), 1044455, 30, 1044287);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(WoodlandBelt), 1111747, 1032639, 80.0, 105.0, typeof(Cloth), 1044455, 10, 1044287);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -328,17 +308,14 @@ namespace Server.Engines.Craft
             if (Core.SA)
             {
                 index = AddCraft(typeof(GargishRobe), 1111747, 1095256, 53.9, 78.9, typeof(Cloth), 1044455, 16, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishFancyRobe), 1111747, 1095258, 53.9, 78.9, typeof(Cloth), 1044455, 16, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(RobeofRite), 1111747, 1153510, 101.5, 120.0, typeof(Leather), 1044462, 6, 1044253);
                 AddRes(index, typeof(FireRuby), 1032695, 1, 1044253);
                 AddRes(index, typeof(GoldDust), 1098337, 5, 1044253);
                 AddRes(index, typeof(AbyssalCloth), 1113350, 6, 1044253);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.SA);
             }
             #endregion
 
@@ -347,23 +324,18 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(GuildedKilt), 1111747, 1109619, 82.8, 97.8, typeof(Cloth), 1044455, 8, 1044287);
                 AddRecipe(index, (int)TailorRecipe.GuildedKilt);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CheckeredKilt), 1111747, 1109620, 41.4, 56.4, typeof(Cloth), 1044455, 8, 1044287);
                 AddRecipe(index, (int)TailorRecipe.CheckeredKilt);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(FancyKilt), 1111747, 1109621, 20.7, 25.7, typeof(Cloth), 1044455, 8, 1044287);
                 AddRecipe(index, (int)TailorRecipe.FancyKilt);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(FloweredDress), 1111747, 1109622, 75.0, 90.0, typeof(Cloth), 1044455, 18, 1044287);
                 AddRecipe(index, (int)TailorRecipe.FloweredDress);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(EveningGown), 1111747, 1109625, 75, 90.0, typeof(Cloth), 1044455, 18, 1044287);
                 AddRecipe(index, (int)TailorRecipe.EveningGown);
-                SetNeededExpansion(index, Expansion.TOL);
             }
             #endregion
 
@@ -377,41 +349,34 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(Obi), 1015283, 1030219, 20.0, 45.0, typeof(Cloth), 1044455, 6, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             if (Core.ML)
             {
                 index = AddCraft(typeof(ElvenQuiver), 1015283, 1032657, 65.0, 115.0, typeof(Leather), 1044462, 28, 1044463);
                 AddRecipe(index, (int)TailorRecipe.ElvenQuiver);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(QuiverOfFire), 1015283, 1073109, 65.0, 115.0, typeof(Leather), 1044462, 28, 1044463);
                 AddRes(index, typeof(FireRuby), 1032695, 15, 1042081);
                 AddRecipe(index, (int)TailorRecipe.QuiverOfFire);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(QuiverOfIce), 1015283, 1073110, 65.0, 115.0, typeof(Leather), 1044462, 28, 1044463);
                 AddRes(index, typeof(WhitePearl), 1032694, 15, 1042081);
                 AddRecipe(index, (int)TailorRecipe.QuiverOfIce);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(QuiverOfBlight), 1015283, 1073111, 65.0, 115.0, typeof(Leather), 1044462, 28, 1044463);
                 AddRes(index, typeof(Blight), 1032675, 10, 1042081);
                 AddRecipe(index, (int)TailorRecipe.QuiverOfBlight);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(QuiverOfLightning), 1015283, 1073112, 65.0, 115.0, typeof(Leather), 1044462, 28, 1044463);
                 AddRes(index, typeof(Corruption), 1032676, 10, 1042081);
                 AddRecipe(index, (int)TailorRecipe.QuiverOfLightning);
-                SetNeededExpansion(index, Expansion.ML);
 
                 #region Mondain's Legacy
                 index = AddCraft(typeof(LeatherContainerEngraver), 1015283, 1072152, 75.0, 100.0, typeof(Bone), 1049064, 1, 1049063);
                 AddRes(index, typeof(Leather), 1044462, 6, 1044463);
                 AddRes(index, typeof(SpoolOfThread), 1073462, 2, 1073463);
                 AddRes(index, typeof(Dyes), 1024009, 6, 1044253);
-                SetNeededExpansion(index, Expansion.ML);
                 #endregion
             }
 
@@ -428,28 +393,20 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(GozaMatEastDeed), 1015283, 1030404, 55.0, 80.0, typeof(Cloth), 1044455, 25, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(GozaMatSouthDeed), 1015283, 1030405, 55.0, 80.0, typeof(Cloth), 1044455, 25, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(SquareGozaMatEastDeed), 1015283, 1030407, 55.0, 80.0, typeof(Cloth), 1044455, 25, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(SquareGozaMatSouthDeed), 1015283, 1030406, 55.0, 80.0, typeof(Cloth), 1044455, 25, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(BrocadeGozaMatEastDeed), 1015283, 1030408, 55.0, 80.0, typeof(Cloth), 1044455, 25, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
-                index = AddCraft(typeof(BrocadeGozaMatSouthDeed), 1015283, 1030409, 55.0, 80.0, typeof(Cloth), 1044455, 25, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
+                index = AddCraft(typeof(BrocadeGozaMatSouthDeed), 1015283, 1030409, 55.0, 80.0, typeof(Cloth), 1044455, 25, 1044287);;
 
                 index = AddCraft(typeof(BrocadeSquareGozaMatEastDeed), 1015283, 1030411, 55.0, 80.0, typeof(Cloth), 1044455, 25, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(BrocadeSquareGozaMatSouthDeed), 1015283, 1030410, 55.0, 80.0, typeof(Cloth), 1044455, 25, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
             }
             
             #endregion
@@ -460,7 +417,6 @@ namespace Server.Engines.Craft
             if (Core.ML)
             {
                 index = AddCraft(typeof(ElvenBoots), 1015288, 1072902, 80.0, 105.0, typeof(Leather), 1044462, 15, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -470,10 +426,8 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(NinjaTabi), 1015288, 1030210, 70.0, 95.0, typeof(Cloth), 1044455, 10, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(SamuraiTabi), 1015288, 1030209, 20.0, 45.0, typeof(Cloth), 1044455, 6, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             AddCraft(typeof(Sandals), 1015288, 1025901, 12.4, 37.4, typeof(Leather), 1044462, 4, 1044463);
@@ -493,7 +447,6 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(JesterShoes), 1015288, 1109617, 20.0, 35.0, typeof(Cloth), 1044455, 6, 1044287);
                 AddRecipe(index, (int)TailorRecipe.JesterShoes);
-                SetNeededExpansion(index, Expansion.TOL);
             }
             #endregion
 
@@ -510,7 +463,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Scourge), 1032677, 10, 1044253);
                 AddRecipe(index, (int)TailorRecipe.SpellWovenBritches);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(SongWovenMantle), 1015293, 1072931, 92.5, 117.5, typeof(Leather), 1044462, 15, 1044463);
                 AddRes(index, typeof(EyeOfTheTravesty), 1032685, 1, 1044253);
@@ -518,7 +470,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Muculent), 1032680, 10, 1044253);
                 AddRecipe(index, (int)TailorRecipe.SongWovenMantle);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(StitchersMittens), 1015293, 1072932, 92.5, 117.5, typeof(Leather), 1044462, 15, 1044463);
                 AddRes(index, typeof(CapturedEssence), 1032686, 1, 1044253);
@@ -526,7 +477,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Taint), 1032679, 10, 1044253);
                 AddRecipe(index, (int)TailorRecipe.StitchersMittens);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -540,59 +490,42 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(LeatherJingasa), 1015293, 1030177, 45.0, 70.0, typeof(Leather), 1044462, 4, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(LeatherMempo), 1015293, 1030181, 80.0, 105.0, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(LeatherDo), 1015293, 1030182, 75.0, 100.0, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(LeatherHiroSode), 1015293, 1030185, 55.0, 80.0, typeof(Leather), 1044462, 5, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(LeatherSuneate), 1015293, 1030193, 68.0, 93.0, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(LeatherHaidate), 1015293, 1030197, 68.0, 93.0, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(LeatherNinjaPants), 1015293, 1030204, 80.0, 105.0, typeof(Leather), 1044462, 13, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(LeatherNinjaJacket), 1015293, 1030206, 85.0, 110.0, typeof(Leather), 1044462, 13, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(LeatherNinjaBelt), 1015293, 1030203, 50.0, 75.0, typeof(Leather), 1044462, 5, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(LeatherNinjaMitts), 1015293, 1030205, 65.0, 90.0, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(LeatherNinjaHood), 1015293, 1030201, 90.0, 115.0, typeof(Leather), 1044462, 14, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             #region Mondain's Legacy
             if (Core.ML)
             {
                 index = AddCraft(typeof(LeafChest), 1015293, 1032667, 75.0, 100.0, typeof(Leather), 1044462, 15, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(LeafArms), 1015293, 1032670, 60.0, 85.0, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(LeafGloves), 1015293, 1032668, 60.0, 85.0, typeof(Leather), 1044462, 10, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(LeafLegs), 1015293, 1032671, 75.0, 100.0, typeof(Leather), 1044462, 15, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(LeafGorget), 1015293, 1032669, 65.0, 90.0, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(LeafTonlet), 1015293, 1032672, 70.0, 95.0, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -600,31 +533,22 @@ namespace Server.Engines.Craft
             if (Core.SA)
             {
                 index = AddCraft(typeof(GargishLeatherArms), 1015293, 1095327, 53.9, 78.9, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishLeatherChest), 1015293, 1095329, 70.5, 95.5, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishLeatherLegs), 1015293, 1095333, 66.3, 91.3, typeof(Leather), 1044462, 10, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishLeatherKilt), 1015293, 1095331, 58.0, 83.0, typeof(Leather), 1044462, 6, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishLeatherArms), 1015293, 1095327, 53.9, 78.9, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishLeatherChest), 1015293, 1095329, 70.5, 95.5, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishLeatherLegs), 1015293, 1095333, 66.3, 91.3, typeof(Leather), 1044462, 10, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishLeatherKilt), 1015293, 1095331, 58.0, 83.0, typeof(Leather), 1044462, 6, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishLeatherWingArmor), 1015293, 1096662, 65.0, 90.0, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
             }
             #endregion
 
@@ -634,47 +558,38 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(TigerPeltChest), 1015293, 1109626, 90.0, 115.0, typeof(Leather), 1044462, 8, 1044463);
                 AddRes(index, typeof(TigerPelt), 1123908, 4, 1044253);
                 AddRecipe(index, (int)TailorRecipe.TigerPeltChest);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(TigerPeltLegs), 1015293, 1109628, 90.0, 115.0, typeof(Leather), 1044462, 8, 1044463);
                 AddRes(index, typeof(TigerPelt), 1123908, 4, 1044253);
                 AddRecipe(index, (int)TailorRecipe.TigerPeltLegs);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(TigerPeltShorts), 1015293, 1109629, 90.0, 115.0, typeof(Leather), 1044462, 4, 1044463);
                 AddRes(index, typeof(TigerPelt), 1123908, 2, 1044253);
                 AddRecipe(index, (int)TailorRecipe.TigerPeltShorts);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(TigerPeltHelm), 1015293, 1109632, 90.0, 115.0, typeof(Leather), 1044462, 2, 1044463);
                 AddRes(index, typeof(TigerPelt), 1123908, 1, 1044253);
                 AddRecipe(index, (int)TailorRecipe.TigerPeltHelm);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(TigerPeltCollar), 1015293, 1109633, 90.0, 115.0, typeof(Leather), 1044462, 2, 1044463);
                 AddRes(index, typeof(TigerPelt), 1123908, 1, 1044253);
                 AddRecipe(index, (int)TailorRecipe.TigerPeltCollar);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(DragonTurtleHideChest), 1015293, 1109634, 101.5, 116.5, typeof(Leather), 1044462, 8, 1044463);
                 AddRes(index, typeof(DragonTurtleScute), 1123910, 2, 1044253);
                 AddRecipe(index, (int)TailorRecipe.DragonTurtleHideChest);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(DragonTurtleHideLegs), 1015293, 1109636, 101.5, 116.5, typeof(Leather), 1044462, 8, 1044463);
                 AddRes(index, typeof(DragonTurtleScute), 1123910, 4, 1044253);
                 AddRecipe(index, (int)TailorRecipe.DragonTurtleHideLegs);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(DragonTurtleHideHelm), 1015293, 1109637, 101.5, 116.5, typeof(Leather), 1044462, 2, 1044463);
                 AddRes(index, typeof(DragonTurtleScute), 1123910, 1, 1044253);
                 AddRecipe(index, (int)TailorRecipe.DragonTurtleHideHelm);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(DragonTurtleHideArms), 1015293, 1109638, 101.5, 116.5, typeof(Leather), 1044462, 4, 1044463);
                 AddRes(index, typeof(DragonTurtleScute), 1123910, 2, 1044253);
                 AddRecipe(index, (int)TailorRecipe.DragonTurtleHideArms);
-                SetNeededExpansion(index, Expansion.TOL);
             }
             #endregion
 
@@ -684,31 +599,22 @@ namespace Server.Engines.Craft
             if (Core.SA)
             {
                 index = AddCraft(typeof(GargishClothArmsArmor), 1111748, 1021027, 87.1, 137.1, typeof(Cloth), 1044455, 8, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishClothChestArmor), 1111748, 1021029, 94.0, 144.0, typeof(Cloth), 1044455, 8, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishClothLegsArmor), 1111748, 1021033, 91.2, 141.2, typeof(Cloth), 1044455, 10, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishClothKiltArmor), 1111748, 1021031, 82.9, 132.9, typeof(Cloth), 1044455, 6, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishClothArmsArmor), 1111748, 1021027, 87.1, 137.1, typeof(Cloth), 1044455, 8, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishClothChestArmor), 1111748, 1021029, 94.0, 144.0, typeof(Cloth), 1044455, 8, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishClothLegsArmor), 1111748, 1021033, 91.2, 141.2, typeof(Cloth), 1044455, 10, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(FemaleGargishClothKiltArmor), 1111748, 1021031, 82.9, 132.9, typeof(Cloth), 1044455, 6, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishClothWingArmor), 1111748, 1115393, 65.0, 90.0, typeof(Cloth), 1044455, 12, 1044287);
-                SetNeededExpansion(index, Expansion.SA);
             }
             #endregion
 
@@ -722,38 +628,28 @@ namespace Server.Engines.Craft
             if (Core.SE)
             {
                 index = AddCraft(typeof(StuddedMempo), 1015300, 1030216, 80.0, 105.0, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(StuddedDo), 1015300, 1030183, 95.0, 120.0, typeof(Leather), 1044462, 14, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(StuddedHiroSode), 1015300, 1030186, 85.0, 110.0, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(StuddedSuneate), 1015300, 1030194, 92.0, 117.0, typeof(Leather), 1044462, 14, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(StuddedHaidate), 1015300, 1030198, 92.0, 117.0, typeof(Leather), 1044462, 14, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             #region Mondain's Legacy
             if (Core.ML)
             {
                 index = AddCraft(typeof(HideChest), 1015300, 1032651, 85.0, 110.0, typeof(Leather), 1044462, 15, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(HidePauldrons), 1015300, 1032654, 75.0, 100.0, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(HideGloves), 1015300, 1032652, 75.0, 100.0, typeof(Leather), 1044462, 10, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(HidePants), 1015300, 1032655, 92.0, 117.0, typeof(Leather), 1044462, 15, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(HideGorget), 1015300, 1032653, 90.0, 115.0, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.ML);
             }
             #endregion
 
@@ -773,22 +669,18 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(TigerPeltBustier), 1015306, 1109627, 90.0, 115.0, typeof(Leather), 1044462, 6, 1044463);
                 AddRes(index, typeof(TigerPelt), 1123908, 3, 1044253);
                 AddRecipe(index, (int)TailorRecipe.TigerPeltBustier);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(TigerPeltLongSkirt), 1015306, 1109630, 90.0, 115.0, typeof(Leather), 1044462, 4, 1044463);
                 AddRes(index, typeof(TigerPelt), 1123908, 2, 1044253);
                 AddRecipe(index, (int)TailorRecipe.TigerPeltLongSkirt);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(TigerPeltSkirt), 1015306, 1109631, 90.0, 115.0, typeof(Leather), 1044462, 4, 1044463);
                 AddRes(index, typeof(TigerPelt), 1123908, 2, 1044253);
                 AddRecipe(index, (int)TailorRecipe.TigerPeltSkirt);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(DragonTurtleHideBustier), 1015306, 1109635, 101.5, 116.5, typeof(Leather), 1044462, 6, 1044463);
                 AddRes(index, typeof(DragonTurtleScute), 1123910, 3, 1044253);
                 AddRecipe(index, (int)TailorRecipe.DragonTurtleHideBustier);
-                SetNeededExpansion(index, Expansion.TOL);
             }
             #endregion
 
@@ -821,7 +713,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(DarkSapphire), 1032690, 5, 1044253);
                 ForceNonExceptional(index);
                 AddRecipe(index, (int)TailorRecipe.CuffsOfTheArchmage);
-                SetNeededExpansion(index, Expansion.SA);
             }
             #endregion
 

--- a/Scripts/Services/Craft/DefTinkering.cs
+++ b/Scripts/Services/Craft/DefTinkering.cs
@@ -216,16 +216,12 @@ namespace Server.Engines.Craft
             if (Core.SA)
             {
                 index = AddCraft(typeof(GargishNecklace), 1044049, 1095784, 60.0, 110.0, typeof(IronIngot), 1044036, 3, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishBracelet), 1044049, 1095785, 55.0, 105.0, typeof(IronIngot), 1044036, 3, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishRing), 1044049, 1095786, 65.0, 115.0, typeof(IronIngot), 1044036, 3, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishEarrings), 1044049, 1095787, 55.0, 105.0, typeof(IronIngot), 1044036, 3, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             AddJewelrySet(GemType.StarSapphire, typeof(StarSapphire));
@@ -244,7 +240,6 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(Nunchaku), 1044042, 1030158, 70.0, 120.0, typeof(IronIngot), 1044036, 3, 1044037);
                 AddRes(index, typeof(Board), 1044041, 8, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             AddCraft(typeof(JointingPlane), 1044042, 1024144, 0.0, 50.0, typeof(Board), 1044041, 4, 1044351);
@@ -257,11 +252,9 @@ namespace Server.Engines.Craft
             if (Core.HS)
             {
                 AddCraft(typeof(Ramrod), 1044042, 1095839, 0.0, 50.0, typeof(Board), 1044041, 8, 1044253);
-                SetNeededExpansion(index, Expansion.HS);
 
                 index = AddCraft(typeof(Swab), 1044042, 1095840, 0.0, 50.0, typeof(Cloth), 1044286, 1, 1044253);
                 AddRes(index, typeof(Board), 1044041, 4, 1044253);
-                SetNeededExpansion(index, Expansion.HS);
             }
             
             if (Core.SA)
@@ -270,73 +263,61 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(ScouringToxin), 1112292, 2, 1112326);
                 SetRequiresBasketWeaving(index);
                 SetRequireResTarget(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(RoundBasket), 1044042, 1112293, 75.0, 100.0, typeof(SoftenedReeds), 1112249, 2, 1112251);
                 AddRes(index, typeof(Shaft), 1027125, 3, 1044351);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(RoundBasketHandles), 1044042, 1112357, 75.0, 100.0, typeof(SoftenedReeds), 1112249, 2, 1112251);
                 AddRes(index, typeof(Shaft), 1027125, 3, 1044351);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(SmallBushel), 1044042, 1112337, 75.0, 100.0, typeof(SoftenedReeds), 1112249, 1, 1112251);
                 AddRes(index, typeof(Shaft), 1027125, 2, 1044351);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(PicnicBasket2), 1044042, 1023706, 75.0, 100.0, typeof(SoftenedReeds), 1112249, 1, 1112251);
                 AddRes(index, typeof(Shaft), 1027125, 2, 1044351);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(WinnowingBasket), 1044042, 1026274, 75.0, 100.0, typeof(SoftenedReeds), 1112249, 2, 1112251);
                 AddRes(index, typeof(Shaft), 1027125, 3, 1044351);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(SquareBasket), 1044042, 1112295, 75.0, 100.0, typeof(SoftenedReeds), 1112249, 2, 1112251);
                 AddRes(index, typeof(Shaft), 1027125, 3, 1044351);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(BasketCraftable), 1044042, 1022448, 75.0, 100.0, typeof(SoftenedReeds), 1112249, 2, 1112251);
                 AddRes(index, typeof(Shaft), 1027125, 3, 1044351);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(TallRoundBasket), 1044042, 1112297, 75.0, 100.0, typeof(SoftenedReeds), 1112249, 3, 1112251);
                 AddRes(index, typeof(Shaft), 1027125, 4, 1044351);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(SmallSquareBasket), 1044042, 1112296, 75.0, 100.0, typeof(SoftenedReeds), 1112249, 1, 1112251);
                 AddRes(index, typeof(Shaft), 1027125, 2, 1044351);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(TallBasket), 1044042, 1112299, 75.0, 100.0, typeof(SoftenedReeds), 1112249, 3, 1112251);
                 AddRes(index, typeof(Shaft), 1027125, 4, 1044351);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(SmallRoundBasket), 1044042, 1112298, 75.0, 100.0, typeof(SoftenedReeds), 1112249, 1, 1112251);
                 AddRes(index, typeof(Shaft), 1027125, 2, 1044351);
                 SetRequireResTarget(index);
                 SetRequiresBasketWeaving(index);
-                SetNeededExpansion(index, Expansion.SA);
             }
             #endregion
 
@@ -372,7 +353,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Springs), 1044171, 1, 1044253);
                 AddRes(index, typeof(Gears), 1044254, 2, 1044253);
                 AddRes(index, typeof(Diamond), 1062608, 1, 1044240);
-                SetNeededExpansion(index, Expansion.ML);
             }
 
             AddCraft(typeof(Pitchfork), 1044046, 1023719, 40.0, 90.0, typeof(IronIngot), 1044036, 4, 1044037);
@@ -394,7 +374,6 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(JeweledFiligree), 1044047, 1072894, 70.0, 110.0, typeof(IronIngot), 1044036, 2, 1044037);
                 AddRes(index, typeof(StarSapphire), 1044231, 1, 1044253);
                 AddRes(index, typeof(Ruby), 1044234, 1, 1044253);
-                SetNeededExpansion(index, Expansion.ML);
             }            
             #endregion
 
@@ -415,10 +394,8 @@ namespace Server.Engines.Craft
             if (Core.SA)
             {
                 index = AddCraft(typeof(GargishCleaver), 1044048, 1097478, 20.0, 70.0, typeof(IronIngot), 1044036, 3, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(GargishButcherKnife), 1044048, 1097486, 25.0, 75.0, typeof(IronIngot), 1044036, 2, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
             }
             #endregion
 
@@ -436,34 +413,27 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(ShojiLantern), 1044050, 1029404, 65.0, 115.0, typeof(IronIngot), 1044036, 10, 1044037);
                 AddRes(index, typeof(Board), 1044041, 5, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(PaperLantern), 1044050, 1029406, 65.0, 115.0, typeof(IronIngot), 1044036, 10, 1044037);
                 AddRes(index, typeof(Board), 1044041, 5, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(RoundPaperLantern), 1044050, 1029418, 65.0, 115.0, typeof(IronIngot), 1044036, 10, 1044037);
                 AddRes(index, typeof(Board), 1044041, 5, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(WindChimes), 1044050, 1030290, 80.0, 130.0, typeof(IronIngot), 1044036, 15, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
 
                 index = AddCraft(typeof(FancyWindChimes), 1044050, 1030291, 80.0, 130.0, typeof(IronIngot), 1044036, 15, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
             }
 
             if (Core.SA)
             {
                 index = AddCraft(typeof(TerMurStyleCandelabra), 1044050, 1095313, 55.0, 105.0, typeof(IronIngot), 1044036, 4, 1044037);
-                SetNeededExpansion(index, Expansion.SA);
             }
             
             if (Core.HS)
             {
                 index = AddCraft(typeof(Matches), 1044050, 1096648, 15.0, 70.0, typeof(Matchcord), 1095184, 10, 1044367);
                 AddRes(index, typeof(Board), 1044041, 4, 1044351);
-                SetNeededExpansion(index, Expansion.HS);
             }
 
             index = AddCraft(typeof(BroadcastCrystal), 1044050, 1153097, 80.0, 130.0, typeof(IronIngot), 1044036, 20, 1044037);
@@ -477,11 +447,9 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(CrystalDust), 1112328, 3, 1044253);
                 ForceNonExceptional(index);
                 SetItemHue(index, 1266);
-                SetNeededExpansion(index, Expansion.SA);
 
                 index = AddCraft(typeof(ScaleCollar), 1044050, 1112480, 50.0, 100.0, typeof(RedScales), 1112626, 4, 1053097);
                 AddRes(index, typeof(Scourge), 1032677, 1, 1044253);
-                SetNeededExpansion(index, Expansion.SA);
             }
 
             index = AddCraft(typeof(DragonLamp), 1044050, 1098404, 75.0, 125.0, typeof(IronIngot), 1044036, 8, 1044253);
@@ -504,81 +472,67 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(CraftableHouseItem), 1044050, 1155851, 40.0, 90.0, typeof(IronIngot), 1044036, 8, 1044253);
                 SetData(index, CraftableItemType.CurledMetalSignHanger);
                 SetDisplayID(index, 2971);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1044050, 1155852, 40.0, 90.0, typeof(IronIngot), 1044036, 8, 1044253);
                 SetData(index, CraftableItemType.FlourishedMetalSignHanger);
                 SetDisplayID(index, 2973);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1044050, 1155853, 40.0, 90.0, typeof(IronIngot), 1044036, 8, 1044253);
                 SetData(index, CraftableItemType.InwardCurledMetalSignHanger);
                 SetDisplayID(index, 2975);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableHouseItem), 1044050, 1155854, 40.0, 90.0, typeof(IronIngot), 1044036, 8, 1044253);
                 SetData(index, CraftableItemType.EndCurledMetalSignHanger);
                 SetDisplayID(index, 2977);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableMetalHouseDoor), 1044050, 1156080, 85.0, 135.0, typeof(IronIngot), 1044036, 50, 1044253);
                 SetData(index, DoorType.LeftMetalDoor_S_In);
                 SetDisplayID(index, 1653);
                 AddCreateItem(index, CraftableMetalHouseDoor.Create);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableMetalHouseDoor), 1044050, 1156081, 85.0, 135.0, typeof(IronIngot), 1044036, 50, 1044253);
                 SetData(index, DoorType.RightMetalDoor_S_In);
                 SetDisplayID(index, 1659);
                 AddCreateItem(index, CraftableMetalHouseDoor.Create);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableMetalHouseDoor), 1044050, 1156082, 85.0, 135.0, typeof(IronIngot), 1044036, 50, 1044253);
                 SetData(index, DoorType.LeftMetalDoor_E_Out);
                 SetDisplayID(index, 1660);
                 AddCreateItem(index, CraftableMetalHouseDoor.Create);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableMetalHouseDoor), 1044050, 1156083, 85.0, 135.0, typeof(IronIngot), 1044036, 50, 1044253);
                 SetData(index, DoorType.RightMetalDoor_E_Out);
                 SetDisplayID(index, 1663);
                 AddCreateItem(index, CraftableMetalHouseDoor.Create);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(WallSafeDeed), 1044050, 1155860, 0.0, 0.0, typeof(IronIngot), 1044036, 20, 1044253);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableMetalHouseDoor), 1044050, 1156352, 85.0, 135.0, typeof(IronIngot), 1044036, 50, 1044253);
                 SetData(index, DoorType.LeftMetalDoor_E_In);
                 SetDisplayID(index, 1660);
                 AddCreateItem(index, CraftableMetalHouseDoor.Create);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableMetalHouseDoor), 1044050, 1156353, 85.0, 135.0, typeof(IronIngot), 1044036, 50, 1044253);
                 SetData(index, DoorType.RightMetalDoor_E_In);
                 SetDisplayID(index, 1663);
                 AddCreateItem(index, CraftableMetalHouseDoor.Create);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableMetalHouseDoor), 1044050, 1156350, 85.0, 135.0, typeof(IronIngot), 1044036, 50, 1044253);
                 SetData(index, DoorType.LeftMetalDoor_S_Out);
                 SetDisplayID(index, 1653);
                 AddCreateItem(index, CraftableMetalHouseDoor.Create);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(CraftableMetalHouseDoor), 1044050, 1156351, 85.0, 135.0, typeof(IronIngot), 1044036, 50, 1044253);
                 SetData(index, DoorType.RightMetalDoor_S_Out);
                 SetDisplayID(index, 1659);
                 AddCreateItem(index, CraftableMetalHouseDoor.Create);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(KotlPowerCore), 1044050, 1124179, 85.0, 135.0, typeof(WorkableGlass), 1154170, 5, 1154171);
                 AddRes(index, typeof(CopperWire), 1026265, 5, 1150700);
                 AddRes(index, typeof(IronIngot), 1044036, 100, 1044253);
                 AddRes(index, typeof(MoonstoneCrystalShard), 1124142, 5, 1156701);
                 AddRecipe(index, (int)TinkerRecipes.KotlPowerCore);
-                SetNeededExpansion(index, Expansion.TOL);
             }
 
             index = AddCraft(typeof(WeatheredBronzeGlobeSculptureDeed), 1044050, 1156881, 85.0, 135.0, typeof(BronzeIngot), 1038039, 200, 1044253);
@@ -626,19 +580,16 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(ModifiedClockworkAssembly), 1044051, 1113031, 65.0, 115.0, typeof(ClockworkAssembly), 1073426, 1, 502910);
                 AddRes(index, typeof(PowerCrystal), 1112811, 1, 502910);
                 AddRes(index, typeof(VoidEssence), 1112327, 1, 502910);
-                SetNeededExpansion(index, Expansion.SA);
                 ForceNonExceptional(index);
 
                 index = AddCraft(typeof(ModifiedClockworkAssembly), 1044051, 1113032, 65.0, 115.0, typeof(ClockworkAssembly), 1073426, 1, 502910);
                 AddRes(index, typeof(PowerCrystal), 1112811, 1, 502910);
                 AddRes(index, typeof(VoidEssence), 1112327, 2, 502910);
-                SetNeededExpansion(index, Expansion.SA);
                 ForceNonExceptional(index);
 
                 index = AddCraft(typeof(ModifiedClockworkAssembly), 1044051, 1113033, 65.0, 115.0, typeof(ClockworkAssembly), 1073426, 1, 502910);
                 AddRes(index, typeof(PowerCrystal), 1112811, 1, 502910);
                 AddRes(index, typeof(VoidEssence), 1112327, 3, 502910);
-                SetNeededExpansion(index, Expansion.SA);
                 ForceNonExceptional(index);                
             }
 
@@ -659,13 +610,11 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(ArcanicRuneStone), 1044051, 1113352, 90.0, 140.0, typeof(CrystalShards), 1073161, 1, 1044253);
                 AddRes(index, typeof(PowerCrystal), 1112811, 5, 502910);
                 AddSkill(index, SkillName.Magery, 80.0, 85.0);
-                SetNeededExpansion(index, Expansion.SA);
                 ForceNonExceptional(index);
 
                 index = AddCraft(typeof(VoidOrb), 1044051, 1113354, 90.0, 104.3, typeof(DarkSapphire), 1032690, 1, 1044253);
                 AddSkill(index, SkillName.Magery, 80.0, 100.0);
                 AddRes(index, typeof(BlackPearl), 1015001, 50, 1044253);
-                SetNeededExpansion(index, Expansion.SA);
                 ForceNonExceptional(index);
             }
 
@@ -700,7 +649,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(AutomatonActuator), 1156997, 1, 1156999);
                 AddRes(index, typeof(StasisChamberPowerCore), 1156623, 1, 1157000);
                 AddRes(index, typeof(InoperativeAutomatonHead), 1157002, 1, 1157001);
-                SetNeededExpansion(index, Expansion.TOL);
                 AddRecipe(index, (int)TinkerRecipes.KotlAutomatonHead);
             }
             #endregion
@@ -749,42 +697,34 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(BrilliantAmberBracelet), 1073107, 1073453, 75.0, 125.0, typeof(IronIngot), 1044036, 5, 1044037);
                 AddRes(index, typeof(Amber), 1062607, 20, 1044240);
                 AddRes(index, typeof(BrilliantAmber), 1032697, 10, 1044240);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(FireRubyBracelet), 1073107, 1073454, 75.0, 125.0, typeof(IronIngot), 1044036, 5, 1044037);
                 AddRes(index, typeof(Ruby), 1062603, 20, 1044240);
                 AddRes(index, typeof(FireRuby), 1032695, 10, 1044240);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(DarkSapphireBracelet), 1073107, 1073455, 75.0, 125.0, typeof(IronIngot), 1044036, 5, 1044037);
                 AddRes(index, typeof(Sapphire), 1062602, 20, 1044240);
                 AddRes(index, typeof(DarkSapphire), 1032690, 10, 1044240);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(WhitePearlBracelet), 1073107, 1073456, 75.0, 125.0, typeof(IronIngot), 1044036, 5, 1044037);
                 AddRes(index, typeof(Tourmaline), 1062606, 20, 1044240);
                 AddRes(index, typeof(WhitePearl), 1032694, 10, 1044240);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(EcruCitrineRing), 1073107, 1073457, 75.0, 125.0, typeof(IronIngot), 1044036, 5, 1044037);
                 AddRes(index, typeof(Citrine), 1062604, 20, 1044240);
                 AddRes(index, typeof(EcruCitrine), 1032693, 10, 1044240);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(BlueDiamondRing), 1073107, 1073458, 75.0, 125.0, typeof(IronIngot), 1044036, 5, 1044037);
                 AddRes(index, typeof(Diamond), 1062608, 20, 1044240);
                 AddRes(index, typeof(BlueDiamond), 1032696, 10, 1044240);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(PerfectEmeraldRing), 1073107, 1073459, 75.0, 125.0, typeof(IronIngot), 1044036, 5, 1044037);
                 AddRes(index, typeof(Emerald), 1062601, 20, 1044240);
                 AddRes(index, typeof(PerfectEmerald), 1032692, 10, 1044240);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(TurqouiseRing), 1073107, 1073460, 75.0, 125.0, typeof(IronIngot), 1044036, 5, 1044037);
                 AddRes(index, typeof(Amethyst), 1062605, 20, 1044240);
                 AddRes(index, typeof(Turquoise), 1032691, 10, 1044240);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(ResilientBracer), 1073107, 1072933, 100.0, 125.0, typeof(IronIngot), 1044036, 2, 1044037);
                 SetMinSkillOffset(index, 25.0);
@@ -793,7 +733,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Diamond), 1062608, 50, 1044253);
                 AddRecipe(index, (int)TinkerRecipes.ResilientBracer);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
 
                 index = AddCraft(typeof(EssenceOfBattle), 1073107, 1072935, 100.0, 125.0, typeof(IronIngot), 1044036, 2, 1044037);
                 SetMinSkillOffset(index, 25.0);
@@ -802,7 +741,7 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(Ruby), 1062603, 50, 1044253);
                 AddRecipe(index, (int)TinkerRecipes.EssenceOfBattle);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
+
 
                 index = AddCraft(typeof(PendantOfTheMagi), 1073107, 1072937, 100.0, 125.0, typeof(IronIngot), 1044036, 2, 1044037);
                 SetMinSkillOffset(index, 25.0);
@@ -811,7 +750,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(StarSapphire), 1062600, 50, 1044253);
                 AddRecipe(index, (int)TinkerRecipes.PendantOfTheMagi);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
             }
 
             if (Core.TOL)
@@ -822,7 +760,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(HatOfTheMagi), 1061597, 1, 1044253);
                 AddRecipe(index, (int)TinkerRecipes.DrSpectorLenses);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.TOL);
 
                 index = AddCraft(typeof(BraceletOfPrimalConsumption), 1073107, 1157350, 100.0, 580.0, typeof(IronIngot), 1044036, 3, 1044037);
                 SetMinSkillOffset(index, 25.0);
@@ -831,7 +768,6 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(WhitePearl), 1032694, 4, 1044240);
                 AddRecipe(index, (int)TinkerRecipes.BraceletOfPrimalConsumption);
                 ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.TOL);
             }
             #endregion
 


### PR DESCRIPTION
Removed the outdated and unused ExpansionNeeded.

Since we do not have expansions people buy, or even an account property to track which expansions people have access too, or a way to enforce it, it was simply showing not needed information. Since items are enclosed in Era checks if you do not have the "Expansion" on your server you can not see it anyways.