### PR TITLE
Update DefTailoring.cs

### DIFF
--- a/Scripts/Misc/Titles.cs
+++ b/Scripts/Misc/Titles.cs
@@ -238,6 +238,7 @@ namespace Server.Misc
                 {
                     if (((PlayerMobile)beheld).CurrentChampTitle != null)
                         title.AppendFormat(((PlayerMobile)beheld).CurrentChampTitle);
+                    else if (beheld is BaseVendor) title.AppendFormat(" {0}", customTitle);
                 }
 				else if (info.Harrower > 0)
                     title.AppendFormat(": {0} of Evil", HarrowerTitles[Math.Min(HarrowerTitles.Length, info.Harrower) - 1]);

--- a/Scripts/Services/Craft/Core/CraftSystem.cs
+++ b/Scripts/Services/Craft/Core/CraftSystem.cs
@@ -390,12 +390,6 @@ namespace Server.Engines.Craft
             craftItem.NeedMill = needMill;
         }
 
-        public void SetNeededExpansion(int index, Expansion expansion)
-        {
-            CraftItem craftItem = m_CraftItems.GetAt(index);
-            craftItem.RequiredExpansion = expansion;
-        }
-
         public void SetNeededThemePack(int index, ThemePack pack)
         {
             CraftItem craftItem = m_CraftItems.GetAt(index);

--- a/Scripts/Services/Craft/DefTailoring.cs
+++ b/Scripts/Services/Craft/DefTailoring.cs
@@ -376,7 +376,7 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(LeatherContainerEngraver), 1015283, 1072152, 75.0, 100.0, typeof(Bone), 1049064, 1, 1049063);
                 AddRes(index, typeof(Leather), 1044462, 6, 1044463);
                 AddRes(index, typeof(SpoolOfThread), 1073462, 2, 1073463);
-                AddRes(index, typeof(Dyes), 1024009, 6, 1044253);
+                AddRes(index, typeof(Dyes), 1024009, 1, 1044253);
                 #endregion
             }
 


### PR DESCRIPTION
https://www.servuo.com/threads/leather-container-engraving-tool-takes-6-dye-should-take-only-1.9955/
https://www.servuo.com/threads/npcs-and-titles.9946/

NPC vendors now show their titles on their paperdolls per EA.
Leather Container Engraving Tool now correctly only takes 1 dye.
Removed no longer used Expansion tag from CraftSystem.
