### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Items/Consumables/TaxidermyKit.cs
+++ b/Scripts/Items/Consumables/TaxidermyKit.cs
@@ -354,6 +354,11 @@ namespace Server.Items
 
 				list.Add( 1070858, m_AnimalWeight.ToString() ); // ~1_weight~ stones
 			}
+
+            if (DateCaught != DateTime.MinValue)
+            {
+                list.Add(String.Format("[{0}]", DateCaught.ToShortDateString()));
+            }
 		}
 
 		public override void OnAosSingleClick( Mobile from )

--- a/Scripts/Items/Consumables/TaxidermyKit.cs
+++ b/Scripts/Items/Consumables/TaxidermyKit.cs
@@ -214,6 +214,7 @@ namespace Server.Items
 
                                     Mobile hunter = null;
                                     int weight = 0;
+                                    DateTime dateCaught = DateTime.MinValue;
 
                                     if ( targeted is BigFish )
                                     {
@@ -221,6 +222,7 @@ namespace Server.Items
 
                                         hunter = fish.Fisher;
                                         weight = (int)fish.Weight;
+                                        dateCaught = fish.DateCaught;
 
                                         fish.Consume();
                                     }
@@ -231,7 +233,7 @@ namespace Server.Items
 
                                         hunter = fish.Fisher;
                                         weight = (int)fish.Weight;
-                                        DateTime dateCaught = fish.DateCaught;
+                                        dateCaught = fish.DateCaught;
 
                                         from.AddToBackpack(new FishTrophyDeed(weight, hunter, dateCaught, m_Table[i].DeedNumber, m_Table[i].AddonNumber, m_Table[i].NorthID));
 
@@ -246,7 +248,7 @@ namespace Server.Items
 
                                         hunter = fish.Fisher;
                                         weight = (int)fish.Weight;
-                                        DateTime dateCaught = fish.DateCaught;
+                                        dateCaught = fish.DateCaught;
 
                                         from.AddToBackpack(new FishTrophyDeed(weight, hunter, dateCaught, m_Table[i].DeedNumber, m_Table[i].AddonNumber, m_Table[i].NorthID));
 
@@ -255,6 +257,12 @@ namespace Server.Items
                                         return;
                                     }
                                     #endregion
+                                    var deed = new TrophyDeed(m_Table[i], hunter, weight);
+
+                                    if (dateCaught != DateTime.MinValue)
+                                    {
+                                        deed.DateCaught = dateCaught;
+                                    }
 
                                     from.AddToBackpack( new TrophyDeed( m_Table[i], hunter, weight ) );
 
@@ -309,14 +317,17 @@ namespace Server.Items
 		[CommandProperty( AccessLevel.GameMaster )]
 		public int AnimalWeight{ get{ return m_AnimalWeight; } set{ m_AnimalWeight = value; InvalidateProperties(); } }
 
+        [CommandProperty(AccessLevel.GameMaster)]
+        public DateTime DateCaught { get; set; }
+
 		public override int LabelNumber{ get{ return m_AddonNumber; } }
 
 		[Constructable]
-		public TrophyAddon( Mobile from, int itemID, int westID, int northID, int deedNumber, int addonNumber ) : this( from, itemID, westID, northID, deedNumber, addonNumber, null, 0 )
+		public TrophyAddon( Mobile from, int itemID, int westID, int northID, int deedNumber, int addonNumber ) : this( from, itemID, westID, northID, deedNumber, addonNumber, null, 0, DateTime.MinValue )
 		{
 		}
 
-		public TrophyAddon( Mobile from, int itemID, int westID, int northID, int deedNumber, int addonNumber, Mobile hunter, int animalWeight ) : base( itemID )
+		public TrophyAddon( Mobile from, int itemID, int westID, int northID, int deedNumber, int addonNumber, Mobile hunter, int animalWeight, DateTime dateCaught ) : base( itemID )
 		{
 			m_WestID = westID;
 			m_NorthID = northID;
@@ -325,6 +336,7 @@ namespace Server.Items
 
 			m_Hunter = hunter;
 			m_AnimalWeight = animalWeight;
+            DateCaught = dateCaught;
 
 			Movable = false;
 
@@ -383,7 +395,9 @@ namespace Server.Items
 		{
 			base.Serialize( writer );
 
-			writer.Write( (int) 1 ); // version
+			writer.Write( (int) 2 ); // version
+
+            writer.Write(DateCaught);
 
 			writer.Write( (Mobile) m_Hunter );
 			writer.Write( (int) m_AnimalWeight );
@@ -394,32 +408,37 @@ namespace Server.Items
 			writer.Write( (int) m_AddonNumber );
 		}
 
-		public override void Deserialize( GenericReader reader )
-		{
-			base.Deserialize( reader );
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
 
-			int version = reader.ReadInt();
+            int version = reader.ReadInt();
 
-			switch ( version )
-			{
-				case 1:
-				{
-					m_Hunter = reader.ReadMobile();
-					m_AnimalWeight = reader.ReadInt();
-					goto case 0;
-				}
-				case 0:
-				{
-					m_WestID = reader.ReadInt();
-					m_NorthID = reader.ReadInt();
-					m_DeedNumber = reader.ReadInt();
-					m_AddonNumber = reader.ReadInt();
-					break;
-				}
-			}
+            switch (version)
+            {
+                case 2:
+                    {
+                        DateCaught = reader.ReadDateTime();
+                        goto case 1;
+                    }
+                case 1:
+                    {
+                        m_Hunter = reader.ReadMobile();
+                        m_AnimalWeight = reader.ReadInt();
+                        goto case 0;
+                    }
+                case 0:
+                    {
+                        m_WestID = reader.ReadInt();
+                        m_NorthID = reader.ReadInt();
+                        m_DeedNumber = reader.ReadInt();
+                        m_AddonNumber = reader.ReadInt();
+                        break;
+                    }
+            }
 
-			Timer.DelayCall( TimeSpan.Zero, new TimerCallback( FixMovingCrate ) );
-		}
+            Timer.DelayCall(TimeSpan.Zero, new TimerCallback(FixMovingCrate));
+        }
 
 		private void FixMovingCrate()
 		{
@@ -446,7 +465,7 @@ namespace Server.Items
 
 		public Item Deed
 		{
-			get{ return new TrophyDeed( m_WestID, m_NorthID, m_DeedNumber, m_AddonNumber, m_Hunter, m_AnimalWeight ); }
+			get{ return new TrophyDeed( m_WestID, m_NorthID, m_DeedNumber, m_AddonNumber, m_Hunter, m_AnimalWeight, DateCaught ); }
 		}
 
 		void IChopable.OnChop(Mobile user)
@@ -502,14 +521,18 @@ namespace Server.Items
 		[CommandProperty( AccessLevel.GameMaster )]
 		public int AnimalWeight{ get{ return m_AnimalWeight; } set{ m_AnimalWeight = value; InvalidateProperties(); } }
 
+        [CommandProperty(AccessLevel.GameMaster)]
+        public DateTime DateCaught { get; set; }
+
 		public override int LabelNumber{ get{ return m_DeedNumber; } }
 
 		[Constructable]
-		public TrophyDeed( int westID, int northID, int deedNumber, int addonNumber ) : this( westID, northID, deedNumber, addonNumber, null, 0 )
+        public TrophyDeed(int westID, int northID, int deedNumber, int addonNumber)
+            : this(westID, northID, deedNumber, addonNumber, null, 0, DateTime.MinValue)
 		{
 		}
 
-		public TrophyDeed( int westID, int northID, int deedNumber, int addonNumber, Mobile hunter, int animalWeight ) : base( 0x14F0 )
+		public TrophyDeed( int westID, int northID, int deedNumber, int addonNumber, Mobile hunter, int animalWeight, DateTime dateCaught ) : base( 0x14F0 )
 		{
 			m_WestID = westID;
 			m_NorthID = northID;
@@ -517,10 +540,11 @@ namespace Server.Items
 			m_AddonNumber = addonNumber;
 			m_Hunter = hunter;
 			m_AnimalWeight = animalWeight;
+            DateCaught = dateCaught;
 		}
 
         public TrophyDeed( TaxidermyKit.TrophyInfo info, Mobile hunter, int animalWeight )
-            : this( info.NorthID + 7, info.NorthID, info.DeedNumber, info.AddonNumber, hunter, animalWeight )
+            : this( info.NorthID + 7, info.NorthID, info.DeedNumber, info.AddonNumber, hunter, animalWeight, DateTime.MinValue )
         {
         }
 
@@ -545,7 +569,9 @@ namespace Server.Items
 		{
 			base.Serialize( writer );
 
-			writer.Write( (int) 1 ); // version
+			writer.Write( (int) 2 ); // version
+
+            writer.Write(DateCaught);
 
 			writer.Write( (Mobile) m_Hunter );
 			writer.Write( (int) m_AnimalWeight );
@@ -562,23 +588,28 @@ namespace Server.Items
 
 			int version = reader.ReadInt();
 
-			switch ( version )
-			{
-				case 1:
-				{
-					m_Hunter = reader.ReadMobile();
-					m_AnimalWeight = reader.ReadInt();
-					goto case 0;
-				}
-				case 0:
-				{
-					m_WestID = reader.ReadInt();
-					m_NorthID = reader.ReadInt();
-					m_DeedNumber = reader.ReadInt();
-					m_AddonNumber = reader.ReadInt();
-					break;
-				}
-			}
+            switch (version)
+            {
+                case 2:
+                    {
+                        DateCaught = reader.ReadDateTime();
+                        goto case 1;
+                    }
+                case 1:
+                    {
+                        m_Hunter = reader.ReadMobile();
+                        m_AnimalWeight = reader.ReadInt();
+                        goto case 0;
+                    }
+                case 0:
+                    {
+                        m_WestID = reader.ReadInt();
+                        m_NorthID = reader.ReadInt();
+                        m_DeedNumber = reader.ReadInt();
+                        m_AddonNumber = reader.ReadInt();
+                        break;
+                    }
+            }
 		}
 
 		public override void OnDoubleClick( Mobile from )
@@ -617,7 +648,7 @@ namespace Server.Items
 
 					if ( itemID > 0 )
 					{
-                        Item trophy = new TrophyAddon(from, itemID, m_WestID, m_NorthID, m_DeedNumber, m_AddonNumber, m_Hunter, m_AnimalWeight);
+                        Item trophy = new TrophyAddon(from, itemID, m_WestID, m_NorthID, m_DeedNumber, m_AddonNumber, m_Hunter, m_AnimalWeight, DateCaught);
 
                         if (m_DeedNumber == 1113567)
                             trophy.Hue = 1645;

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -6883,6 +6883,10 @@ namespace Server.Mobiles
 
         public virtual void OnAfterTame(Mobile tamer)
         {
+            if (StatLossAfterTame)
+            {
+                AnimalTaming.ScaleStats(this, 0.5);
+            }
         }
 
         public override void OnRegionChange(Region Old, Region New)

--- a/Scripts/Mobiles/Normal/Beetle.cs
+++ b/Scripts/Mobiles/Normal/Beetle.cs
@@ -190,7 +190,12 @@ namespace Server.Mobiles
 
         public override void OnAfterTame(Mobile tamer)
         {
-            SetInt(500);
+            base.OnAfterTame(tamer);
+
+            if (PetTrainingHelper.Enabled)
+            {
+                SetInt(500);
+            }
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/CuSidhe.cs
+++ b/Scripts/Mobiles/Normal/CuSidhe.cs
@@ -122,6 +122,25 @@ namespace Server.Mobiles
             AddLoot(LootPack.AosFilthyRich, 5);
         }
 
+        public override void OnAfterTame(Mobile tamer)
+        {
+            if (PetTrainingHelper.Enabled)
+            {
+                RawStr = (int)Math.Max(1, RawStr * 0.5);
+                RawDex = (int)Math.Max(1, RawDex * 0.5);
+
+                HitsMaxSeed = RawStr;
+                Hits = RawStr;
+
+                StamMaxSeed = RawDex;
+                Stam = RawDex;
+            }
+            else
+            {
+                base.OnAfterTame(tamer);
+            }
+        }
+
         public override void OnDoubleClick(Mobile from)
         {
             if (from.Race != Race.Elf && from == ControlMaster && from.IsPlayer())

--- a/Scripts/Mobiles/Normal/DemonKnight.cs
+++ b/Scripts/Mobiles/Normal/DemonKnight.cs
@@ -203,17 +203,12 @@ namespace Server.Mobiles
                     if (ran >= m_RewardTable.Length)
                     {
                         i = Loot.RandomArmorOrShieldOrWeaponOrJewelry(LootPackEntry.IsInTokuno(killer), LootPackEntry.IsMondain(killer), LootPackEntry.IsStygian(killer));
-                        RunicReforging.GenerateRandomArtifactItem(i, luck, Utility.RandomMinMax(1000, 1200));
+                        RunicReforging.GenerateRandomArtifactItem(i, luck, Utility.RandomMinMax(800, 1200));
                         NegativeAttributes attrs = RunicReforging.GetNegativeAttributes(i);
 
                         if (attrs != null)
                         {
                             attrs.Prized = 1;
-                            attrs.Brittle = 0;
-                            attrs.Massive = 0;
-                            attrs.Unwieldly = 0;
-                            attrs.Antique = 0;
-                            attrs.NoRepair = 0;
                         }
                     }
                     else

--- a/Scripts/Mobiles/Normal/FireBeetle.cs
+++ b/Scripts/Mobiles/Normal/FireBeetle.cs
@@ -151,7 +151,12 @@ namespace Server.Mobiles
 
         public override void OnAfterTame(Mobile tamer)
         {
-            SetInt(500);
+            base.OnAfterTame(tamer);
+
+            if (PetTrainingHelper.Enabled)
+            {
+                SetInt(500);
+            }
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/FrostDragon.cs
+++ b/Scripts/Mobiles/Normal/FrostDragon.cs
@@ -61,6 +61,8 @@ namespace Server.Mobiles
         public override void OnAfterTame(Mobile tamer)
         {
             Title = null;
+
+            base.OnAfterTame(tamer);
         }
 
         public override bool CanAngerOnTame { get { return true; } }

--- a/Scripts/Mobiles/Normal/GiantIceWorm.cs
+++ b/Scripts/Mobiles/Normal/GiantIceWorm.cs
@@ -78,6 +78,9 @@ namespace Server.Mobiles
                 return FoodType.Meat;
             }
         }
+
+        public override bool StatLossAfterTame { get { return true; } }
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Mobiles/Normal/Hiryu.cs
+++ b/Scripts/Mobiles/Normal/Hiryu.cs
@@ -135,6 +135,25 @@ namespace Server.Mobiles
             AddLoot(LootPack.Gems, 4);
         }
 
+        public override void OnAfterTame(Mobile tamer)
+        {
+            if (PetTrainingHelper.Enabled)
+            {
+                RawStr = (int)Math.Max(1, RawStr * 0.5);
+                RawDex = (int)Math.Max(1, RawDex * 0.5);
+
+                HitsMaxSeed = RawStr;
+                Hits = RawStr;
+
+                StamMaxSeed = RawDex;
+                Stam = RawDex;
+            }
+            else
+            {
+                base.OnAfterTame(tamer);
+            }
+        }
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Mobiles/Normal/SabertoothedTiger.cs
+++ b/Scripts/Mobiles/Normal/SabertoothedTiger.cs
@@ -59,19 +59,26 @@ namespace Server.Mobiles
         public override HideType HideType { get { return HideType.Regular; } }
         public override int Meat { get { return 3; } }
         public override FoodType FavoriteFood { get { return FoodType.Meat; } }
-
+        public override bool StatLossAfterTame { get { return true; } }
         public override bool CanAngerOnTame { get { return true; } }
 
-        public override void OnAfterTame(Mobile master)
+        public override void OnAfterTame(Mobile tamer)
         {
-            int intel = RawInt;
-            int mana = ManaMax;
+            if (PetTrainingHelper.Enabled)
+            {
+                RawStr = (int)Math.Max(1, RawStr * 0.5);
+                RawDex = (int)Math.Max(1, RawDex * 0.5);
 
-            // UO Stratics say they keep their intelligence. Crappy but hey!
-            Server.SkillHandlers.AnimalTaming.ScaleStats(this, 0.5);
+                HitsMaxSeed = RawStr;
+                Hits = RawStr;
 
-            SetInt(intel);
-            SetMana(mana);
+                StamMaxSeed = RawDex;
+                Stam = RawDex;
+            }
+            else
+            {
+                base.OnAfterTame(tamer);
+            }
         }
 
         public override void GenerateLoot()

--- a/Scripts/Services/Expansions/Time Of Legends/Mobiles/Dimetrosaur.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Mobiles/Dimetrosaur.cs
@@ -86,7 +86,11 @@ namespace Server.Mobiles
 
         public override void OnAfterTame(Mobile tamer)
         {
-            SetHits(HitsMax / 4);
+            int hits = HitsMax;
+
+            base.OnAfterTame(tamer);
+
+            SetHits(hits / 4);
         }
 
         public override bool CanAngerOnTame { get { return true; } }

--- a/Scripts/Services/ExploringTheDeep/Mobiles/Paralithode.cs
+++ b/Scripts/Services/ExploringTheDeep/Mobiles/Paralithode.cs
@@ -78,6 +78,8 @@ namespace Server.Mobiles
 
             CantWalk = false;
             Hidden = false;
+
+            base.OnAfterTame(tamer);
         }
 
         private class HideTimer : Timer

--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -1719,11 +1719,6 @@ namespace Server.Mobiles
                                     AnimalTaming.ScaleSkills(bc, 0.90);
                                 }
 
-                                if (bc.StatLossAfterTame)
-                                {
-                                    AnimalTaming.ScaleStats(bc, 0.50);
-                                }
-
                                 Timer.DelayCall(TimeSpan.FromSeconds(.25), () =>
                                 {
                                     bc.PrivateOverheadMessage(Server.Network.MessageType.Regular, 0x3B2, 502799, m.NetState);

--- a/Scripts/Services/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/RunicReforging/RunicReforging.cs
@@ -1908,7 +1908,12 @@ namespace Server.Items
 
                 ApplyReforgedProperties(item, prefix, suffix, false, budget, perclow, perchigh, mods, luckchance);
 
-                int addonbudget = TryApplyRandomDisadvantage(item);
+                int addonbudget = 0;
+
+                if (!artifact)
+                {
+                    addonbudget = TryApplyRandomDisadvantage(item);
+                }
 
                 if (addonbudget > 0)
                 {

--- a/Scripts/Skills/AnimalTaming.cs
+++ b/Scripts/Skills/AnimalTaming.cs
@@ -426,11 +426,6 @@ namespace Server.SkillHandlers
 								{
 									ScaleSkills(m_Creature, 0.90); // 90% of original skills
 								}
-
-								if (m_Creature.StatLossAfterTame)
-								{
-									ScaleStats(m_Creature, 0.50);
-								}
 							}
 
 							if (alreadyOwned)


### PR DESCRIPTION
- StatLossOnTame is now handled, for most creatures, in OnAfterTame. Since Pet Training, it has become more of a pain keeping up with all the different stat loss types. This way, the individual stat losses can be easier handled in the respective creatures' scripts.
- date caught now added to big fish trophy
- DOOM RIG Artifacts no longer get disadvantage, only Prized