### PR TITLE
Update PowderOfFortKeg.cs

### DIFF
--- a/Scripts/Services/BulkOrders/Items/PowderOfFortKeg.cs
+++ b/Scripts/Services/BulkOrders/Items/PowderOfFortKeg.cs
@@ -16,7 +16,7 @@ namespace Server.Items
 
         [Constructable]
         public PowderOfFortKeg()
-            : this(250)
+            : this(0)
         {
         }
 


### PR DESCRIPTION
POF kegs should come EMPTY they are just meant to hold POFs.

Right now it is 700 points for a FULL keg that comes with 250 charges vs the blacksmith one for 450 points that comes with 10 charges lol. These have secretly been getting farmed for months, for that very reason.