### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Items/Artifacts/Equipment/Armor/Sets/SetItem.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/Sets/SetItem.cs
@@ -352,6 +352,9 @@ namespace Server
 
         public static bool ResistsBonusPerPiece(ISetItem item)
         {
+            if (item.SetPhysicalBonus == 0 && item.SetFireBonus == 0 && item.SetColdBonus == 0 && item.SetPoisonBonus == 0 && item.SetEnergyBonus == 0)
+                return true;
+
             switch (item.SetID)
             {
                 default: return false;

--- a/Scripts/Items/Resource/VialOfVitriol.cs
+++ b/Scripts/Items/Resource/VialOfVitriol.cs
@@ -2,12 +2,21 @@ using System;
 
 namespace Server.Items
 {
+    [TypeAlias("Server.Items.VialVitirol")]
     public class VialOfVitriol : Item
     {
         [Constructable]
         public VialOfVitriol()
+            : this(1)
+        {
+        }
+
+        [Constructable]
+        public VialOfVitriol(int amount)
             : base(0x5722)
         {
+            Stackable = true;
+            Amount = amount;
         }
 
         public VialOfVitriol(Serial serial)
@@ -22,49 +31,6 @@ namespace Server.Items
                 return 1113331;
             }
         }// vial of vitriol
-        public override void Serialize(GenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write((int)0); // version
-        }
-
-        public override void Deserialize(GenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            int version = reader.ReadInt();
-        }
-    }
-
-    public class VialVitirol : Item
-    {
-        [Constructable]
-        public VialVitirol()
-            : this(1)
-        {
-        }
-
-        [Constructable]
-        public VialVitirol(int amount)
-            : base(0x5722)
-        {
-            this.Stackable = true;
-            this.Amount = amount;
-        }
-
-        public VialVitirol(Serial serial)
-            : base(serial)
-        {
-        }
-
-        public override int LabelNumber
-        {
-            get
-            {
-                return 1113331;
-            }
-        }// vial vitirol
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -336,12 +336,12 @@ namespace Server
             #endregion
 
             #region Pet Training
-            if (PetTrainingHelper.Enabled)
+            if (from is BaseCreature || m is BaseCreature)
             {
-                if (from is BaseCreature || m is BaseCreature)
-                {
-                    SpecialAbility.CheckCombatTrigger(from, m, ref totalDamage, type);
+                SpecialAbility.CheckCombatTrigger(from, m, ref totalDamage, type);
 
+                if (PetTrainingHelper.Enabled)
+                {
                     if (from is BaseCreature && m is BaseCreature)
                     {
                         var profile = PetTrainingHelper.GetTrainingProfile((BaseCreature)from);
@@ -358,11 +358,11 @@ namespace Server
                             profile.CheckProgress((BaseCreature)from);
                         }
                     }
-                }
 
-                if (from is BaseCreature && ((BaseCreature)from).Controlled && m.Player)
-                {
-                    totalDamage /= 2;
+                    if (from is BaseCreature && ((BaseCreature)from).Controlled && m.Player)
+                    {
+                        totalDamage /= 2;
+                    }
                 }
             }
             #endregion
@@ -2458,7 +2458,9 @@ namespace Server
                 Spell spell = context.Spell as Spell;
                 spell.GetCastSkills(out minSkill, out maxSkill);
                 if (m.Skills[spell.CastSkill].Value < minSkill)
+                {
                     TransformationSpellHelper.RemoveContext(m, context, true);
+                }
             }
             if (acontext != null)
             {

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -7783,7 +7783,7 @@ namespace Server.Mobiles
                 return;
             }
 
-            if (PetTrainingHelper.Enabled && !Summoned && _Profile != null)
+            if (!Summoned && _Profile != null)
             {
                 SpecialAbility.CheckThinkTrigger(this);
                 AreaEffect.CheckThinkTrigger(this);

--- a/Scripts/Mobiles/Normal/DemonKnight.cs
+++ b/Scripts/Mobiles/Normal/DemonKnight.cs
@@ -203,17 +203,12 @@ namespace Server.Mobiles
                     if (ran >= m_RewardTable.Length)
                     {
                         i = Loot.RandomArmorOrShieldOrWeaponOrJewelry(LootPackEntry.IsInTokuno(killer), LootPackEntry.IsMondain(killer), LootPackEntry.IsStygian(killer));
-                        RunicReforging.GenerateRandomArtifactItem(i, luck, Utility.RandomMinMax(1000, 1200));
+                        RunicReforging.GenerateRandomArtifactItem(i, luck, Utility.RandomMinMax(800, 1200));
                         NegativeAttributes attrs = RunicReforging.GetNegativeAttributes(i);
 
                         if (attrs != null)
                         {
                             attrs.Prized = 1;
-                            attrs.Brittle = 0;
-                            attrs.Massive = 0;
-                            attrs.Unwieldly = 0;
-                            attrs.Antique = 0;
-                            attrs.NoRepair = 0;
                         }
                     }
                     else

--- a/Scripts/Multis/BaseHouse.cs
+++ b/Scripts/Multis/BaseHouse.cs
@@ -4893,6 +4893,12 @@ namespace Server.Multis
                 else if (House.Release(Mobile, Item))
                 {
                     Mobile.Backpack.DropItem(Item);
+
+                    if (Item.IsLockedDown)
+                    {
+                        Item.IsLockedDown = false;
+                        Item.Movable = true;
+                    }
                 }
             }
             else

--- a/Scripts/Multis/HouseTeleporter.cs
+++ b/Scripts/Multis/HouseTeleporter.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+
 using Server.ContextMenus;
 using Server.Gumps;
 using Server.Multis;
+using Server.Mobiles;
 
 namespace Server.Items
 {
@@ -76,6 +78,11 @@ namespace Server.Items
 
         public override bool OnMoveOver(Mobile m)
         {
+            if (m is PlayerMobile && ((PlayerMobile)m).DesignContext != null)
+            {
+                return true;
+            }
+
             if (m_Target != null && !m_Target.Deleted)
             {
                 if (CheckAccess(m))

--- a/Scripts/Regions/DamagingRegion.cs
+++ b/Scripts/Regions/DamagingRegion.cs
@@ -83,7 +83,7 @@ namespace Server.Regions
 			}
 			else
 			{
-				m_Table[m] = Timer.DelayCall(TimeSpan.Zero, DamageInterval, Damage, m);
+                m_Table[m] = Timer.DelayCall(DamageInterval, DamageInterval, Damage, m);
 			}
         }
 

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -1818,7 +1818,7 @@ namespace Server.Spells
 
         protected override void OnTick()
         {
-            if (m_Mobile.Deleted || !m_Mobile.Alive || m_Mobile.Body != m_Spell.Body || (m_Mobile.Hue != m_Spell.Hue && BestialSetHelper.IsBerserk(m_Mobile)))
+            if (m_Mobile.Deleted || !m_Mobile.Alive || m_Mobile.Body != m_Spell.Body || (m_Mobile.Hue != m_Spell.Hue && !BestialSetHelper.IsBerserk(m_Mobile)))
             {
                 TransformationSpellHelper.RemoveContext(m_Mobile, true);
                 Stop();


### PR DESCRIPTION
- Berserk Set no longer gives improper Resists
- Berserk no longer knocks a player out of a transform Spell
- Vial of Vitriol now stacks
- Removed unused, mispelled vialvitrol
- Removed Era check for creature Special Ability and area effects. These were active prior to pet training helper
- Vendor rental deeds no longer stay locked down when released via retrieve context menu
- House teleporters are not longer functional during house customization
- Damage Region now uses proper interval when inflicting Damage