### PR TITLE
Crash Fix + other fixes

### DIFF
--- a/Scripts/Services/MiniChampionSystem/MiniChampionSpawn.cs
+++ b/Scripts/Services/MiniChampionSystem/MiniChampionSpawn.cs
@@ -21,7 +21,10 @@ namespace Server.Engines.MiniChamps
         [Description("MiniChampion Generator")]
         public static void GenStoneRuins_OnCommand(CommandEventArgs e)
         {
-            Controllers.ForEach(x => x.Delete());
+            foreach (var controller in Controllers)
+            {
+                controller.Delete();
+            }
 
             Map map = Map.TerMur;
 
@@ -200,8 +203,7 @@ namespace Server.Engines.MiniChamps
             m_Level = 0;
 
             ClearSpawn();
-            Despawns.ForEach(x => x.Delete());
-            Despawns.Clear();
+            Despawn();
 
             if (m_Timer != null)
                 m_Timer.Stop();
@@ -212,6 +214,16 @@ namespace Server.Engines.MiniChamps
                 m_RestartTimer.Stop();
 
             m_RestartTimer = null;
+        }
+
+        public void Despawn()
+        {
+            foreach (var toDespawn in Despawns)
+            {
+                toDespawn.Delete();
+            }
+
+            Despawns.Clear();
         }
 
         public void OnSlice()
@@ -242,7 +254,14 @@ namespace Server.Engines.MiniChamps
 
             if (m_Active)
             {
-                Spawn.ForEach(x => changed |= x.Respawn());
+                foreach (var spawn in Spawn)
+                {
+                    if (spawn.Respawn() && !changed)
+                    {
+                        changed = true;
+                    }
+                }
+                //Spawn.ForEach(x => changed |= x.Respawn());
             }
 
             if (done || changed)
@@ -253,10 +272,13 @@ namespace Server.Engines.MiniChamps
 
         public void ClearSpawn()
         {
-            Spawn.ForEach(x =>
+            foreach (var spawn in Spawn)
             {
-                x.Creatures.ForEach(y => Despawns.Add(y));
-            });
+                foreach (var creature in spawn.Creatures)
+                {
+                    Despawns.Add(creature);
+                }
+            }
 
             Spawn.Clear();
         }
@@ -274,7 +296,11 @@ namespace Server.Engines.MiniChamps
                     MinotaurShouts();
                 }
 
-                levelInfo.Types.ToList().ForEach(x => Spawn.Add(new MiniChampSpawnInfo(this, x)));
+                //levelInfo.Types.ToList().ForEach(x => Spawn.Add(new MiniChampSpawnInfo(this, x)));
+                foreach(var type in levelInfo.Types)
+                {
+                    Spawn.Add(new MiniChampSpawnInfo(this, type));
+                }
             }
             else // begin restart
             {

--- a/Scripts/Spells/Skill Masteries/FistsOfFury.cs
+++ b/Scripts/Spells/Skill Masteries/FistsOfFury.cs
@@ -75,7 +75,7 @@ namespace Server.Spells.SkillMasteries
                 defender.SendLocalizedMessage(1155979); // You may not wield a weapon and use this ability.
                 Expire(defender);
             }
-            else if (defender.InRange(attacker.Location, 2))
+            else if (defender.InRange(attacker.Location, 2) && !UnderEffects(attacker))
             {
                 if (_Table == null)
                     _Table = new Dictionary<Mobile, FistsOfFuryContext>();
@@ -103,7 +103,7 @@ namespace Server.Spells.SkillMasteries
 
         public override void OnHit(Mobile attacker, Mobile defender, int damage)
         {
-            if (_Table == null || _Table.Count == 0 || !_Table.ContainsKey(attacker))
+            if (!UnderEffects(attacker))
                 return;
 
             if (_Table[attacker].Target == defender)
@@ -129,6 +129,11 @@ namespace Server.Spells.SkillMasteries
         public override void OnClearMove(Mobile from)
         {
             BuffInfo.RemoveBuff(from, BuffIcon.FistsOfFury);
+        }
+
+        private bool UnderEffects(Mobile from)
+        {
+            return _Table != null && _Table.ContainsKey(from);
         }
 
         public class FistsOfFuryContext

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -7920,17 +7920,7 @@ namespace Server
 
 			if (newRegion != oldRegion)
 			{
-				if (oldRegion != null)
-				{
-					oldRegion.OnExit(this);
-				}
-				
 				m_Region = newRegion;
-
-				if (newRegion != null)
-				{
-					newRegion.OnEnter(this);
-				}
 
 				Region.OnRegionChange(this, oldRegion, newRegion);
 


### PR DESCRIPTION
- One more attempt at Mini Champ System bug where champ doesnt spawn and the system gets hung up
- Removed redundant OnEnter/OnExit methods in Region/Mobile:

@Vorspire
Here is the problem with the Region issue.  I can see why the redundant checks were added, so it would be called at the appropriate timing, ie OnExit called before the new region was set to the mobile, and OnEnter begin called aferwards.  The problem is, in Region.cs, it is needed there to be called during the appropriate child/parent regions as well.  This will need to be looked into in the near future.