### PR TITLE
Update HouseSign.cs

### DIFF
--- a/Scripts/Multis/HouseSign.cs
+++ b/Scripts/Multis/HouseSign.cs
@@ -202,6 +202,7 @@ namespace Server.Multis
                 }
             }
 
+            InvalidateProperties();
             ShowSign(from);
         }
 


### PR DESCRIPTION
When players change their name and perform some actions sometimes there is a delay in the house sign updating. This simply updates the sign when someone double clicks on it and it passes all the checks.