### PR TITLE
Abyss Reaver

### DIFF
--- a/Scripts/Items/Artifacts/Equipment/Weapons/AbyssReaver.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/AbyssReaver.cs
@@ -5,11 +5,10 @@ namespace Server.Items
     public class AbyssReaver : Cyclone
 	{
 		public override bool IsArtifact { get { return true; } }
-    public override int LabelNumber { get { return 1112694; } } // Abyss Reaver
+        public override int LabelNumber { get { return 1112694; } } // Abyss Reaver
 
         [Constructable]
         public AbyssReaver()
-            : base(0x901)
         {
             SkillBonuses.SetValues(0, SkillName.Throwing, Utility.RandomMinMax(5, 10));
             Attributes.WeaponDamage = Utility.RandomMinMax(25, 35);

--- a/Scripts/Mobiles/Bosses/StygianDragon.cs
+++ b/Scripts/Mobiles/Bosses/StygianDragon.cs
@@ -125,6 +125,9 @@ namespace Server.Mobiles
             base.OnDeath(c);
 
             c.DropItem(new StygianDragonHead());
+			
+			if ( Paragon.ChestChance > Utility.RandomDouble() )
+            c.DropItem( new ParagonChest( Name, TreasureMapLevel ) );
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Named/MasterJonath.cs
+++ b/Scripts/Mobiles/Named/MasterJonath.cs
@@ -9,43 +9,43 @@ namespace Server.Mobiles
         [Constructable]
         public MasterJonath()
         {
-            this.Name = "Master Jonath";
-            this.Hue = 0x455;
+            Name = "Master Jonath";
+            Hue = 0x455;
 
-            this.SetStr(109, 131);
-            this.SetDex(98, 110);
-            this.SetInt(232, 259);
+            SetStr(109, 131);
+            SetDex(98, 110);
+            SetInt(232, 259);
 
-            this.SetHits(766, 920);
+            SetHits(766, 920);
 
-            this.SetDamage(10, 15);
+            SetDamage(10, 15);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 55, 60);
-            this.SetResistance(ResistanceType.Fire, 43, 49);
-            this.SetResistance(ResistanceType.Cold, 45, 80);
-            this.SetResistance(ResistanceType.Poison, 41, 45);
-            this.SetResistance(ResistanceType.Energy, 54, 55);
+            SetResistance(ResistanceType.Physical, 55, 60);
+            SetResistance(ResistanceType.Fire, 43, 49);
+            SetResistance(ResistanceType.Cold, 45, 80);
+            SetResistance(ResistanceType.Poison, 41, 45);
+            SetResistance(ResistanceType.Energy, 54, 55);
 
-            this.SetSkill(SkillName.Wrestling, 80.5, 88.6);
-            this.SetSkill(SkillName.Tactics, 88.5, 95.1);
-            this.SetSkill(SkillName.MagicResist, 102.7, 102.9);
-            this.SetSkill(SkillName.Magery, 100.0, 106.6);
-            this.SetSkill(SkillName.EvalInt, 99.6, 106.9);
-            this.SetSkill(SkillName.Necromancy, 100.0, 106.6);
-            this.SetSkill(SkillName.SpiritSpeak, 99.6, 106.9);
+            SetSkill(SkillName.Wrestling, 80.5, 88.6);
+            SetSkill(SkillName.Tactics, 88.5, 95.1);
+            SetSkill(SkillName.MagicResist, 102.7, 102.9);
+            SetSkill(SkillName.Magery, 100.0, 106.6);
+            SetSkill(SkillName.EvalInt, 99.6, 106.9);
+            SetSkill(SkillName.Necromancy, 100.0, 106.6);
+            SetSkill(SkillName.SpiritSpeak, 99.6, 106.9);
 
-            this.Fame = 18000;
-            this.Karma = -18000;
+            Fame = 18000;
+            Karma = -18000;
 
-            this.PackReg(7);
-            this.PackReg(7);
-            this.PackReg(8);
+            PackReg(7);
+            PackReg(7);
+            PackReg(8);
 
             for (int i = 0; i < Utility.RandomMinMax(0, 1); i++)
             {
-                this.PackItem(Loot.RandomScroll(0, Loot.ArcanistScrollTypes.Length, SpellbookType.Arcanist));
+                PackItem(Loot.RandomScroll(0, Loot.ArcanistScrollTypes.Length, SpellbookType.Arcanist));
             }
         }
 
@@ -63,19 +63,8 @@ namespace Server.Mobiles
 
             if ( Utility.RandomDouble() < 0.15 )
             c.DropItem( new DisintegratingThesisNotes() );
-
-            if ( Paragon.ChestChance > Utility.RandomDouble() )
-            c.DropItem( new ParagonChest( Name, TreasureMapLevel ) );
-
         }
 
-        /*public override bool GivesMLMinorArtifact
-        {
-            get
-            {
-                return true;
-            }
-        }*/
         public override int TreasureMapLevel
         {
             get

--- a/Scripts/Mobiles/Named/Rend.cs
+++ b/Scripts/Mobiles/Named/Rend.cs
@@ -54,6 +54,14 @@ namespace Server.Mobiles
         public override bool HasBreath{ get{ return true; } } // fire breath enabled
         public override double BreathDamageScalar{ get{ return 0.06; } }
         public override bool GivesMLMinorArtifact{get{ return true; } }
+		
+		public override void OnDeath( Container c )
+        {
+            base.OnDeath( c );
+
+            if ( Paragon.ChestChance > Utility.RandomDouble() )
+            c.DropItem( new ParagonChest( Name, TreasureMapLevel ) );
+        }
         
         public override void GenerateLoot()
         {


### PR DESCRIPTION
When awarded as a quest reward it did not appear because it could not actually be constructed in-game. This fixes that.