### PR TITLE
Shadowguard Boss spawn fix.

### DIFF
--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Bosses.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Bosses.cs
@@ -76,7 +76,7 @@ namespace Server.Engines.Shadowguard
 
 		public override void OnGotMeleeAttack(Mobile m)
 		{
-            if (CanSummon && !(m is GreaterDragon) && _NextSummon < DateTime.UtcNow)
+            if (m is PlayerMobile && CanSummon && !(m is GreaterDragon) && _NextSummon < DateTime.UtcNow)
 				Summon();
 				
 			base.OnGotMeleeAttack(m);
@@ -84,7 +84,7 @@ namespace Server.Engines.Shadowguard
 		
 		public override void OnDamagedBySpell(Mobile m)
 		{
-            if (CanSummon && !(m is GreaterDragon) && _NextSummon < DateTime.UtcNow)
+            if (m is PlayerMobile && CanSummon && !(m is GreaterDragon) && _NextSummon < DateTime.UtcNow)
 				Summon();
 				
 			base.OnDamagedBySpell(m);


### PR DESCRIPTION
* As with all bosses in Shadowguard, additional creatures are only spawned if the player has hit Juo'nar a set amount of times. 

reference : http://www.uoguide.com/Juo%27nar