### PR TITLE
Update Fishing.cs

### DIFF
--- a/Scripts/Skills/Fishing.cs
+++ b/Scripts/Skills/Fishing.cs
@@ -1043,7 +1043,7 @@ namespace Server.Engines.Harvest
             Type newType = null;
 
             double skillBase = from.Skills[SkillName.Fishing].Base;
-            double skillValue = Math.Min(100.0, from.Skills[SkillName.Fishing].Value);
+            double skillValue = Math.Min(120.0, from.Skills[SkillName.Fishing].Value);
 
             //Same method as mutate entries
             for (int i = 0; i < m_LavaMutateTable.Length; ++i)


### PR DESCRIPTION
Was not taking into account skill level above 100. Since lava items only existed when 120 powerscrolls came out for fishing no Era check is needed.