### PR TITLE
Gargoyle Necklaces and Earrings

### DIFF
--- a/Scripts/Services/Craft/Core/Enhance.cs
+++ b/Scripts/Services/Craft/Core/Enhance.cs
@@ -53,6 +53,9 @@ namespace Server.Engines.Craft
         {
             if (item == null)
                 return EnhanceResult.BadItem;
+			
+			if (item is GargishNecklace || item is GargishEarrings)
+                return EnhanceResult.BadItem;
 
             if (!item.IsChildOf(from.Backpack))
                 return EnhanceResult.NotInBackpack;


### PR DESCRIPTION
These items should NOT be able to be enhanced. Confirmed on EA. Although they take up jewelry slots they already have resists and allow gargoyles to really go over cap in resists, compared to any other race. Enhancing just furthers that advantage.

https://stratics.com/threads/enhancing-gargoyle-jewelry.267417/
https://community.stratics.com/threads/wasted-a-forged-metal-tool-charge-on-a-gargoyle-amulet.328672/