### PR TITLE
Costume fixes

### DIFF
--- a/Scripts/Items/Equipment/Suits/BaseCostume.cs
+++ b/Scripts/Items/Equipment/Suits/BaseCostume.cs
@@ -7,7 +7,7 @@ using System.Collections;
 namespace Server.Items
 {
     [FlipableAttribute(0x19BC, 0x19BD)]
-    public partial class BaseCostume : BaseShield, IDyable
+    public partial class BaseCostume : BaseShield
     {
         public bool m_Transformed;
         private int m_Body = 0;

--- a/Scripts/Items/Equipment/Suits/WolfSpiderCostume.cs
+++ b/Scripts/Items/Equipment/Suits/WolfSpiderCostume.cs
@@ -8,7 +8,7 @@ namespace Server.Items
 		[Constructable]
 		public WolfSpiderCostume() : base( )
 		{
-            this.CostumeBody = 376;
+            CostumeBody = 736;
 		}
 		
 		public override int LabelNumber

--- a/Scripts/Items/Equipment/Talismans/TalismanSlayer.cs
+++ b/Scripts/Items/Equipment/Talismans/TalismanSlayer.cs
@@ -85,8 +85,7 @@ namespace Server.Items
                     typeof(DesertOstard),   typeof(Eagle),
                     typeof(ForestOstard),   typeof(FrenziedOstard),
                     typeof(Phoenix),        typeof(Pyre),
-                    typeof(Swoop),          typeof(Saliva),
-                    typeof(Harpy),          typeof(StoneHarpy)
+                    typeof(Swoop),          typeof(Saliva)
                 };
 
             m_Table[TalismanSlayerName.Ice] = new Type[]


### PR DESCRIPTION
1. Wolf spider costume had an invalid bodyvalue resulting in players appearing to be "invisible".

2. BaseCostume should not be IDyable.