### PR TITLE
Coagulated Legs had the wrong weight.

### DIFF
--- a/Scripts/Items/Quest/CoagulatedLegs.cs
+++ b/Scripts/Items/Quest/CoagulatedLegs.cs
@@ -8,7 +8,7 @@ namespace Server.Items
         public CoagulatedLegs()
             : base(0x1CDF)
         {
-            this.Weight = 30.0;
+            this.Weight = 1;
         }
 
         public CoagulatedLegs(Serial serial)


### PR DESCRIPTION
Confirmed on EA. Just like all the other peerless keys these ones weigh 1 stone, not 30.