### PR TITLE
Bug Fixes

### DIFF
--- a/Data/Locations/termur.xml
+++ b/Data/Locations/termur.xml
@@ -14,7 +14,7 @@
                 </parent>
 		<parent name="Dungeons">
 			<parent name="Tomb of Kings">
-				<child name="Enterance" x="997" y="3843" z="-41" />
+				<child name="Entrance" x="997" y="3843" z="-41" />
 				<child name="Gate to Stygian Abyss" x="38" y="29" z="0" />
 			</parent>
 			<parent name="Stygian Abyss">
@@ -39,7 +39,7 @@
 				<child name="Sutek the Mage" x="924" y="595" z="-14" />
 			</parent>
 			<parent name="Underworld">
-				<child name="Enterance" x="1128" y="1211" z="-2" />
+				<child name="Entrance" x="1128" y="1211" z="-2" />
 			</parent>
 		</parent>
 		<parent name="Sites">

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -2194,9 +2194,11 @@ namespace Server.Mobiles
         {
             get
             {
+                int value = Str;
+
                 if (m_HitsMax > 0)
                 {
-                    int value = m_HitsMax + GetStatOffset(StatType.Str);
+                    value = m_HitsMax + GetStatOffset(StatType.Str);
 
                     if (value < 1)
                     {
@@ -2206,11 +2208,16 @@ namespace Server.Mobiles
                     {
                         value = 1000000;
                     }
-
-                    return value;
                 }
 
-                return Str;
+                // Skill Masteries
+                if (Core.TOL)
+                {
+                    value += ToughnessSpell.GetHPBonus(this);
+                    value += InvigorateSpell.GetHPBonus(this);
+                }
+
+                return value;
             }
         }
 

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -2001,8 +2001,11 @@ namespace Server.Mobiles
 					}
 
                     // Skill Masteries
-                    if(Core.TOL)
+                    if (Core.TOL)
+                    {
                         strOffs += ToughnessSpell.GetHPBonus(this);
+                        strOffs += InvigorateSpell.GetHPBonus(this);
+                    }
 				}
 				else
 				{

--- a/Scripts/Services/ViceVsVirtue/Gumps/ConfirmSignupGump.cs
+++ b/Scripts/Services/ViceVsVirtue/Gumps/ConfirmSignupGump.cs
@@ -20,12 +20,20 @@ namespace Server.Engines.VvV
             AddBackground(0, 0, 360, 300, 83);
 
             AddHtmlLocalized(0, 25, 360, 20, 1154645, "#1155565",0xFFFF, false, false); // Vice vs Virtue Signup
-            AddHtmlLocalized(10, 55, 340, 210, 1155566, 0xFFFF, false, false);
-            /*Greetings! You are about to join Vice vs Virtue! VvV is an exhilarating Player vs Player 
-             * experience that you can have fun with whether you have hours or only a few minutes to 
-             * jump into the action!  Be forewarned, once you join VvV you will be freely attackable 
-             * by other VvV participants in non-consensual PvP facets.<br><br>Will you answer the call
-             * and lead your guild to victory?*/
+
+            if (ViceVsVirtueSystem.EnhancedRules)
+            {
+                AddHtml(10, 55, 340, 165, _EnhancedRulesMessage, false, true);
+            }
+            else
+            {
+                AddHtmlLocalized(10, 55, 340, 210, 1155566, 0xFFFF, false, false);
+                /*Greetings! You are about to join Vice vs Virtue! VvV is an exhilarating Player vs Player 
+                 * experience that you can have fun with whether you have hours or only a few minutes to 
+                 * jump into the action!  Be forewarned, once you join VvV you will be freely attackable 
+                 * by other VvV participants in non-consensual PvP facets.<br><br>Will you answer the call
+                 * and lead your guild to victory?*/
+            }
 
             AddButton(115, 230, 0x2622, 0x2623, 1, GumpButtonType.Reply, 0);
             AddHtmlLocalized(140, 230, 150, 20, 1155567, 0xFFFF, false, false); // Learn more about VvV!
@@ -36,6 +44,14 @@ namespace Server.Engines.VvV
             AddButton(325, 268, 0xFB1, 0xFB3, 0, GumpButtonType.Reply, 0);
             AddHtml(285, 268, 100, 20, "<basefont color=#FFFFFF>Cancel", false, false);
         }
+
+        private string _EnhancedRulesMessage =
+            "<basefont color=#FFFFFF>Greetings! You are about to join Vice vs Virtue! VvV is an exhilarating Player vs Player" +
+            " experience that you can have fun with whether you have hours or only a few minutes to" +
+            " jump into the action!  Be forewarned, once you join VvV you will be freely attackable" +
+            " by other VvV participants in <b>any</b> facet.<br><br>Will you answer the call" +
+            " and lead your guild to victory? Please note the slightly different enhanced rules that you may not be used to:<br><br>" +
+            "- VvV Combat on any facet<br>- Reduced silver during town battles when uncontested<br>- Combat travel restrictions when in VvV Combat Zone";
 
         public override void OnResponse(NetState state, RelayInfo info)
         {

--- a/Scripts/Spells/Skill Masteries/BardSpells/invigorate.cs
+++ b/Scripts/Spells/Skill Masteries/BardSpells/invigorate.cs
@@ -139,5 +139,15 @@ namespace Server.Spells.SkillMasteries
 		{
             return m_HPBonus;
 		}
+
+        public static int GetHPBonus(Mobile m)
+        {
+            var spell = SkillMasterySpell.GetSpellForParty(m, typeof(InvigorateSpell));
+
+            if (spell != null)
+                return spell.StatBonus();
+
+            return 0;
+        }
 	}
 }

--- a/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
+++ b/Scripts/Spells/Skill Masteries/Core/SkillMasterySpell.cs
@@ -1145,12 +1145,6 @@ namespace Server.Spells.SkillMasteries
                     if (spell != null)
                         value += spell.PropertyBonus();
                     break;
-                case AosAttribute.BonusHits:
-                    spell = SkillMasterySpell.GetSpellForParty(m, typeof(InvigorateSpell));
-
-                    if (spell != null)
-                        value += spell.StatBonus();
-                    break;
                 case AosAttribute.WeaponDamage:
                     spell = SkillMasterySpell.GetSpellForParty(m, typeof(InspireSpell));
 


### PR DESCRIPTION
- Fixed Typo in Data/Locations
- Invigorate HP bonus now goes over cap, per EA
- Added extra information to VvV signup gump when using Enhanced Rules
- VvV Enhanced Rules: Added a small amount of silver award to enemy kills. You will not earn silver for any account matching IP's to reduce abuse. You can only gain silver 5 times in a 3 hour period from a player. Each kill for that player halves the silver earned each time, so 20, 10, 5, 2, 1, 0.