### PR TITLE
Persistence now causes server crash when an exception is thrown.

### DIFF
--- a/Scripts/Services/PointsSystems/PointsSystem.cs
+++ b/Scripts/Services/PointsSystems/PointsSystem.cs
@@ -299,45 +299,36 @@ namespace Server.Engines.Points
         }
 
         public static void OnLoad()
-		{
-			Persistence.Deserialize(
-				FilePath,
-				reader =>
-				{
-					int version = reader.ReadInt();
+        {
+            Persistence.Deserialize(
+                FilePath,
+                reader =>
+                {
+                    int version = reader.ReadInt();
 
                     if (version < 2)
                         reader.ReadBool();
 
-                    List<PointsType> loaded = new List<PointsType>();
+                    PointsType loaded = PointsType.None;
 
-					int count = reader.ReadInt();
-					for(int i = 0; i < count; i++)
-					{
+                    int count = reader.ReadInt();
+                    for (int i = 0; i < count; i++)
+                    {
                         try
                         {
                             PointsType type = (PointsType)reader.ReadInt();
+                            loaded = type;
                             PointsSystem s = GetSystemInstance(type);
 
                             s.Deserialize(reader);
-
-                            if (!loaded.Contains(type))
-                                loaded.Add(type);
                         }
                         catch (Exception e)
                         {
-                            foreach (var success in loaded)
-                                Console.WriteLine("[Points System] Successfully Loaded: {0}", success.ToString());
-
-                            loaded.Clear();
-
-                            throw new Exception(String.Format("[Points System]: {0}", e));
+                            throw new Exception(String.Format("Points System Failed Load: {0} Last Loaded...", loaded.ToString()));
                         }
-					}
-
-                    loaded.Clear();
-				});
-		}
+                    }
+                });
+        }
 
         public static List<PointsSystem> Systems { get; set; }
 

--- a/Server/Persistence/Persistence.cs
+++ b/Server/Persistence/Persistence.cs
@@ -88,32 +88,32 @@ namespace Server
 				
 			file.Refresh();
 
-			using (var fs = file.OpenRead())
-			{
-				var reader = new BinaryFileReader(new BinaryReader(fs));
+            using (var fs = file.OpenRead())
+            {
+                var reader = new BinaryFileReader(new BinaryReader(fs));
 
-				try
-				{
-					deserializer(reader);
-				}
-				catch (EndOfStreamException eos)
-				{
-					if (file.Length > 0)
-					{
-						Console.WriteLine("[Persistence]: {0}", eos);
-					}
-				}
-				catch (Exception e)
-				{
-					Utility.PushColor(ConsoleColor.Red);
-					Console.WriteLine("[Persistence]: {0}", e);
-					Utility.PopColor();
-				}
-				finally
-				{
-					reader.Close();
-				}
-			}
+                try
+                {
+                    deserializer(reader);
+                }
+                catch (EndOfStreamException eos)
+                {
+                    if (file.Length > 0)
+                    {
+                        throw new Exception(String.Format("[Persistance]: {0}", eos));
+                    }
+                }
+                catch (Exception e)
+                {
+                    Utility.WriteConsoleColor(ConsoleColor.Red, "[Persistance]: An error was encountered while loading a saved object");
+
+                    throw new Exception(String.Format("[Persistance]: {0}", e));
+                }
+                finally
+                {
+                    reader.Close();
+                }
+            }
 		}
 	}
 }


### PR DESCRIPTION
- This prevents unnoticed data corruption and forces shard owners to fix serialize/deserialize issues and not pissing players off

*REQUIRES CORE RE-COMPILE*