### PR TITLE
Bug fixes *Requires Core Re-Compile*

### DIFF
--- a/Scripts/Items/Equipment/Armor/ArmorEnums.cs
+++ b/Scripts/Items/Equipment/Armor/ArmorEnums.cs
@@ -45,7 +45,9 @@ namespace Server.Items
         Ringmail,
         Chainmail,
         Plate,
-        Dragon	// On OSI, Dragon is seen and considered its own type.
+        Dragon,
+        Wood,
+        Stone,
     }
 
     public enum ArmorMeditationAllowance

--- a/Scripts/Items/Equipment/Armor/BaseArmor.cs
+++ b/Scripts/Items/Equipment/Armor/BaseArmor.cs
@@ -583,21 +583,78 @@ namespace Server.Items
 
         public static int GetInherentLowerManaCost(Mobile from)
         {
+            if (!Core.SA)
+            {
+                return 0;
+            }
+
             int toReduce = 0;
 
             foreach (BaseArmor armor in from.Items.OfType<BaseArmor>())
             {
-                if (armor.ArmorAttributes.MageArmor > 0 || armor is WoodlandArms || armor is WoodlandChest || armor is WoodlandGloves || armor is WoodlandLegs || armor is WoodlandGorget || armor is BaseShield)
+                if (armor.ArmorAttributes.MageArmor > 0 || armor.MaterialType == ArmorMaterialType.Wood || armor is BaseShield)
                     continue;
 
-                else if (armor.MaterialType == ArmorMaterialType.Studded || armor.MaterialType == ArmorMaterialType.Bone ||
-                    armor is GargishStoneKilt || armor is GargishStoneLegs || armor is GargishStoneChest || armor is GargishStoneArms || armor is FemaleGargishStoneKilt || armor is FemaleGargishStoneLegs || armor is FemaleGargishStoneChest || armor is FemaleGargishStoneArms || armor is GargishStoneAmulet) 
-                    toReduce += 3;
-                else if (armor.MaterialType >= ArmorMaterialType.Ringmail)
-                    toReduce += 1;
+                switch (armor.MaterialType)
+                {
+                    case ArmorMaterialType.Studded:
+                    case ArmorMaterialType.Bone:
+                    case ArmorMaterialType.Stone:
+                        toReduce += 3;
+                        break;
+                    case ArmorMaterialType.Ringmail:
+                    case ArmorMaterialType.Chainmail:
+                    case ArmorMaterialType.Plate:
+                    case ArmorMaterialType.Dragon:
+                        toReduce += 1;
+                        break;
+                }
             }
 
             return Math.Min(15, toReduce);
+        }
+
+        public static double GetInherentStaminaLossReduction(Mobile from)
+        {
+            if (!Core.SA)
+            {
+                return 0.0;
+            }
+
+            double toReduce = 0.0;
+
+            var list = new List<double>();
+
+            foreach (var armor in from.Items.OfType<BaseArmor>())
+            {
+                switch (armor.MaterialType)
+                {
+                    case ArmorMaterialType.Cloth:
+                    case ArmorMaterialType.Leather:
+                        list.Insert(0, .1);
+                        break;
+                    case ArmorMaterialType.Wood:
+                    case ArmorMaterialType.Stone:
+                    case ArmorMaterialType.Studded:
+                    case ArmorMaterialType.Bone:
+                        list.Add(.5);
+                        break;
+                    case ArmorMaterialType.Ringmail:
+                    case ArmorMaterialType.Chainmail:
+                    case ArmorMaterialType.Plate:
+                    case ArmorMaterialType.Dragon:
+                        list.Insert(0, 1);
+                        break;
+                }
+            }
+
+            for (int i = 0; i < 5 && i < list.Count; i++)
+            {
+                toReduce += list[i];
+            }
+
+            ColUtility.Free(list);
+            return toReduce;
         }
         #endregion
 

--- a/Scripts/Items/Equipment/Armor/BaseArmor.cs
+++ b/Scripts/Items/Equipment/Armor/BaseArmor.cs
@@ -622,39 +622,39 @@ namespace Server.Items
             }
 
             double toReduce = 0.0;
+            int count = 0;
 
-            var list = new List<double>();
-
-            foreach (var armor in from.Items.OfType<BaseArmor>())
+            foreach (var armor in from.Items.OfType<BaseArmor>().OrderBy(arm => -GetArmorRatingReduction(arm)))
             {
-                switch (armor.MaterialType)
-                {
-                    case ArmorMaterialType.Cloth:
-                    case ArmorMaterialType.Leather:
-                        list.Insert(0, .1);
-                        break;
-                    case ArmorMaterialType.Wood:
-                    case ArmorMaterialType.Stone:
-                    case ArmorMaterialType.Studded:
-                    case ArmorMaterialType.Bone:
-                        list.Add(.5);
-                        break;
-                    case ArmorMaterialType.Ringmail:
-                    case ArmorMaterialType.Chainmail:
-                    case ArmorMaterialType.Plate:
-                    case ArmorMaterialType.Dragon:
-                        list.Insert(0, 1);
-                        break;
-                }
+                if (count == 5)
+                    break;
+
+                toReduce += GetArmorRatingReduction(armor);
+                count++;
             }
 
-            for (int i = 0; i < 5 && i < list.Count; i++)
-            {
-                toReduce += list[i];
-            }
-
-            ColUtility.Free(list);
             return toReduce;
+        }
+
+        public static double GetArmorRatingReduction(BaseArmor armor)
+        {
+            switch (armor.MaterialType)
+            {
+                default: return 0.0;
+                case ArmorMaterialType.Cloth:
+                case ArmorMaterialType.Leather:
+                    return .1;
+                case ArmorMaterialType.Wood:
+                case ArmorMaterialType.Stone:
+                case ArmorMaterialType.Studded:
+                case ArmorMaterialType.Bone:
+                    return .5;
+                case ArmorMaterialType.Ringmail:
+                case ArmorMaterialType.Chainmail:
+                case ArmorMaterialType.Plate:
+                case ArmorMaterialType.Dragon:
+                    return 1.0;
+            }
         }
         #endregion
 

--- a/Scripts/Items/Equipment/Armor/FemaleGargishStoneArms.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishStoneArms.cs
@@ -34,7 +34,7 @@ namespace Server.Items
 
         public override int AosStrReq { get { return 40; } }
 
-        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Plate; } }
+        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Stone; } }
 
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }

--- a/Scripts/Items/Equipment/Armor/FemaleGargishStoneChest.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishStoneChest.cs
@@ -34,7 +34,7 @@ namespace Server.Items
 
         public override int AosStrReq { get { return 40; } }
 
-        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Plate; } }
+        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Stone; } }
 
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }

--- a/Scripts/Items/Equipment/Armor/FemaleGargishStoneKilt.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishStoneKilt.cs
@@ -34,7 +34,7 @@ namespace Server.Items
 
         public override int AosStrReq { get { return 40; } }
 
-        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Plate; } }
+        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Stone; } }
 
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }

--- a/Scripts/Items/Equipment/Armor/FemaleGargishStoneLegs.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleGargishStoneLegs.cs
@@ -34,7 +34,7 @@ namespace Server.Items
 
         public override int AosStrReq { get { return 40; } }
 
-        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Plate; } }
+        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Stone; } }
 
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }

--- a/Scripts/Items/Equipment/Armor/FemaleWoodlandChest.cs
+++ b/Scripts/Items/Equipment/Armor/FemaleWoodlandChest.cs
@@ -99,7 +99,7 @@ namespace Server.Items
         {
             get
             {
-                return ArmorMaterialType.Plate;
+                return ArmorMaterialType.Wood;
             }
         }
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Items/Equipment/Armor/GargishStoneArms.cs
+++ b/Scripts/Items/Equipment/Armor/GargishStoneArms.cs
@@ -35,7 +35,7 @@ namespace Server.Items
 
         public override int AosStrReq { get { return 40; } }
 
-        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Plate; } }
+        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Stone; } }
 
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }

--- a/Scripts/Items/Equipment/Armor/GargishStoneChest.cs
+++ b/Scripts/Items/Equipment/Armor/GargishStoneChest.cs
@@ -35,7 +35,7 @@ namespace Server.Items
 
         public override int AosStrReq { get { return 40; } }
 
-        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Plate; } }
+        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Stone; } }
 
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }

--- a/Scripts/Items/Equipment/Armor/GargishStoneKilt.cs
+++ b/Scripts/Items/Equipment/Armor/GargishStoneKilt.cs
@@ -35,7 +35,7 @@ namespace Server.Items
 
         public override int AosStrReq { get { return 40; } }
 
-        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Plate; } }
+        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Stone; } }
 
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }

--- a/Scripts/Items/Equipment/Armor/GargishStoneLegs.cs
+++ b/Scripts/Items/Equipment/Armor/GargishStoneLegs.cs
@@ -35,7 +35,7 @@ namespace Server.Items
 
         public override int AosStrReq { get { return 40; } }
 
-        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Plate; } }
+        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Stone; } }
 
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }

--- a/Scripts/Items/Equipment/Armor/WoodlandArms.cs
+++ b/Scripts/Items/Equipment/Armor/WoodlandArms.cs
@@ -91,7 +91,7 @@ namespace Server.Items
         {
             get
             {
-                return ArmorMaterialType.Plate;
+                return ArmorMaterialType.Wood;
             }
         }
         public override Race RequiredRace

--- a/Scripts/Items/Equipment/Armor/WoodlandChest.cs
+++ b/Scripts/Items/Equipment/Armor/WoodlandChest.cs
@@ -91,7 +91,7 @@ namespace Server.Items
         {
             get
             {
-                return ArmorMaterialType.Plate;
+                return ArmorMaterialType.Wood;
             }
         }
         public override Race RequiredRace

--- a/Scripts/Items/Equipment/Armor/WoodlandGloves.cs
+++ b/Scripts/Items/Equipment/Armor/WoodlandGloves.cs
@@ -91,7 +91,7 @@ namespace Server.Items
         {
             get
             {
-                return ArmorMaterialType.Plate;
+                return ArmorMaterialType.Wood;
             }
         }
         public override Race RequiredRace

--- a/Scripts/Items/Equipment/Armor/WoodlandGorget.cs
+++ b/Scripts/Items/Equipment/Armor/WoodlandGorget.cs
@@ -90,7 +90,7 @@ namespace Server.Items
         {
             get
             {
-                return ArmorMaterialType.Plate;
+                return ArmorMaterialType.Wood;
             }
         }
         public override Race RequiredRace

--- a/Scripts/Items/Equipment/Armor/WoodlandLegs.cs
+++ b/Scripts/Items/Equipment/Armor/WoodlandLegs.cs
@@ -91,7 +91,7 @@ namespace Server.Items
         {
             get
             {
-                return ArmorMaterialType.Plate;
+                return ArmorMaterialType.Wood;
             }
         }
         public override Race RequiredRace

--- a/Scripts/Items/Equipment/Jewelry/GargishNecklace.cs
+++ b/Scripts/Items/Equipment/Jewelry/GargishNecklace.cs
@@ -88,7 +88,7 @@ namespace Server.Items
 
     public class GargishStoneAmulet : GargishNecklace
     {
-        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Plate; } }
+        public override ArmorMaterialType MaterialType { get { return ArmorMaterialType.Stone; } }
         public override int AosStrReq { get { return 40; } }
         public override int OldStrReq { get { return 20; } }
 

--- a/Scripts/Items/Equipment/Talismans/BaseTalisman.cs
+++ b/Scripts/Items/Equipment/Talismans/BaseTalisman.cs
@@ -1290,6 +1290,7 @@ namespace Server.Items
             return Utility.RandomList(m_ItemIDs);
         }
 
+        public static Type[] Summons { get { return m_Summons; } }
         private static readonly Type[] m_Summons = new Type[]
         {
             typeof(SummonedAntLion),
@@ -1314,6 +1315,7 @@ namespace Server.Items
             typeof(Bandage),
         };
 
+        public static int[] SummonLabels { get { return m_SummonLabels; } }
         private static readonly int[] m_SummonLabels = new int[]
         {
             1075211, // Ant Lion
@@ -1367,6 +1369,7 @@ namespace Server.Items
             return TalismanRemoval.None;
         }
 
+        public static Type[] Killers { get { return m_Killers; } }
         private static readonly Type[] m_Killers = new Type[]
         {
             typeof(OrcBomber), typeof(OrcBrute), typeof(Sewerrat), typeof(Rat), typeof(GiantRat),
@@ -1385,6 +1388,7 @@ namespace Server.Items
             // TODO Meraktus, Tormented Minotaur, Minotaur
         };
 
+        public static int[] KillerLabels { get { return m_KillerLabels; } }
         private static readonly int[] m_KillerLabels = new int[]
         {
             1072413, 1072414, 1072418, 1072419, 1072420,
@@ -1432,6 +1436,7 @@ namespace Server.Items
             return new TalismanAttribute(m_Killers[num], m_KillerLabels[num], Utility.RandomMinMax(5, 60));
         }
 
+        public static SkillName[] SkillsOld { get { return m_SkillsOld; } }
         private static readonly SkillName[] m_SkillsOld = new SkillName[]
         {
             SkillName.Alchemy,
@@ -1445,6 +1450,7 @@ namespace Server.Items
             SkillName.Tinkering,
         };
 
+        public static TalismanSkill[] Skills { get { return m_Skills; } }
         private static readonly TalismanSkill[] m_Skills = new TalismanSkill[]
         {
             TalismanSkill.Alchemy,

--- a/Scripts/Misc/RegenRates.cs
+++ b/Scripts/Misc/RegenRates.cs
@@ -86,11 +86,18 @@ namespace Server.Misc
 
             CheckBonusSkill(from, from.Stam, from.StamMax, SkillName.Focus);
 
-            int points = (int)(from.Skills[SkillName.Focus].Value * 0.1);
+            int bonus = (int)(from.Skills[SkillName.Focus].Value * 0.1);
 
-            points += StamRegen(from);
+            bonus += StamRegen(from);
 
-            return TimeSpan.FromSeconds(1.0 / (0.1 * (2 + points)));
+            if (Core.SA)
+            {
+                return TimeSpan.FromSeconds(1.0 / (1.42 + (bonus / 100)));
+            }
+            else
+            {
+                return TimeSpan.FromSeconds(1.0 / (0.1 * (2 + bonus)));
+            }
         }
 
         private static TimeSpan Mobile_ManaRegenRate(Mobile from)

--- a/Scripts/Misc/WeightOverloading.cs
+++ b/Scripts/Misc/WeightOverloading.cs
@@ -82,7 +82,7 @@ namespace Server.Misc
                 return;
             }
 
-            int maxWeight = from.MaxWeigh + OverloadAllowance;
+            int maxWeight = from.MaxWeight + OverloadAllowance;
             int overWeight = (Mobile.BodyWeight + from.TotalWeight) - maxWeight;
 
             if (overWeight > 0)
@@ -140,7 +140,7 @@ namespace Server.Misc
             if (!m.Player || !m.Alive || m.IsStaff())
                 return false;
 
-            return ((Mobile.BodyWeight + m.TotalWeight) > (m.MaxWeigh + OverloadAllowance));
+            return ((Mobile.BodyWeight + m.TotalWeight) > (m.MaxWeight + OverloadAllowance));
         }
     }
 }

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -2358,8 +2358,6 @@ namespace Server.Mobiles
                 Confidence.StopRegenerating(this);
             }
 
-            WeightOverloading.FatigueOnDamage(this, amount);
-
             InhumanSpeech speechType = SpeechType;
 
             if (speechType != null && !willKill)

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -1772,12 +1772,11 @@ namespace Server.Mobiles
 		{
 			if (AccessLevel < AccessLevel.GameMaster && item.IsChildOf(Backpack))
 			{
-				int maxWeight = WeightOverloading.GetMaxWeight(this);
 				int curWeight = BodyWeight + TotalWeight;
 
-				if (curWeight > maxWeight)
+                if (curWeight > MaxWeight)
 				{
-					SendLocalizedMessage(1019035, true, String.Format(" : {0} / {1}", curWeight, maxWeight));
+                    SendLocalizedMessage(1019035, true, String.Format(" : {0} / {1}", curWeight, MaxWeight));
 				}
 			}
 		}

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -3605,8 +3605,6 @@ namespace Server.Mobiles
 				Confidence.StopRegenerating(this);
 			}
 
-			WeightOverloading.FatigueOnDamage(this, amount);
-
 			if (m_ReceivedHonorContext != null)
 			{
 				m_ReceivedHonorContext.OnTargetDamaged(from, amount);

--- a/Scripts/Services/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/RunicReforging/RunicReforging.cs
@@ -990,6 +990,8 @@ namespace Server.Items
 		private static Dictionary<Type, CraftSystem> m_AllowableTable = new Dictionary<Type, CraftSystem>();
 		private static Dictionary<int, NamedInfoCol[][]> m_PrefixSuffixInfo = new Dictionary<int, NamedInfoCol[][]>();
 
+        public static Dictionary<int, NamedInfoCol[][]> PrefixSuffixInfo { get { return m_PrefixSuffixInfo; } }
+
         public static void Initialize()
         {
             m_AllowableTable[typeof(LeatherGlovesOfMining)] = DefTailoring.CraftSystem;
@@ -2876,11 +2878,17 @@ namespace Server.Items
             return 1;
         }
 
-        public static List<object> m_MeleeWeaponList;
-        public static List<object> m_RangedWeaponList;
-        public static List<object> m_ArmorList;
-        public static List<object> m_JewelList;
-        public static List<object> m_ShieldList;
+        public static List<object> MeleeWeaponList { get { return m_MeleeWeaponList; } }
+        public static List<object> RangedWeaponList { get { return m_RangedWeaponList; } }
+        public static List<object> ArmorList { get { return m_ArmorList; } }
+        public static List<object> JewelList { get { return m_JewelList; } }
+        public static List<object> ShieldList { get { return m_ShieldList; } }
+
+        private static List<object> m_MeleeWeaponList;
+        private static List<object> m_RangedWeaponList;
+        private static List<object> m_ArmorList;
+        private static List<object> m_JewelList;
+        private static List<object> m_ShieldList;
 
         private static object[] m_WeaponBasic = new object[]
 		{

--- a/Scripts/Services/Vendor Searching/VendorSearch.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearch.cs
@@ -1048,7 +1048,8 @@ namespace Server.Engines.VendorSearching
             ExtendedWeaponAttribute,
             NegativeAttribute,
             SlayerName,
-            String
+            String,
+            TalismanSlayerName
         }
 
         public object Attribute { get; set; }
@@ -1104,6 +1105,7 @@ namespace Server.Engines.VendorSearching
                 case 8: writer.Write((int)(NegativeAttribute)Attribute); break;
                 case 9: writer.Write((int)(SlayerName)Attribute); break;
                 case 10: writer.Write((string)Attribute); break;
+                case 11: writer.Write((int)(TalismanSlayerName)Attribute); break;
             }
         }
 
@@ -1122,6 +1124,7 @@ namespace Server.Engines.VendorSearching
                 case 8: Attribute = (NegativeAttribute)reader.ReadInt(); break;
                 case 9: Attribute = (SlayerName)reader.ReadInt(); break;
                 case 10: Attribute = reader.ReadString(); break;
+                case 11: Attribute = (TalismanSlayerName)reader.ReadInt(); break;
             }
         }
 
@@ -1153,6 +1156,9 @@ namespace Server.Engines.VendorSearching
 
             if (o is SlayerName)
                 return (int)AttributeID.SlayerName;
+
+            if (o is TalismanSlayerName)
+                return (int)AttributeID.TalismanSlayerName;
 
             if (o is string)
                 return (int)AttributeID.String;

--- a/Scripts/Skills/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Skills/Imbuing/Core/Imbuing.cs
@@ -1782,7 +1782,7 @@ namespace Server.SkillHandlers
             m_Table[217] = new ImbuingDefinition(SAAbsorptionAttribute.ResonanceEnergy,     1154658, 140, null, null, null, 20, 1, 1152391);
             m_Table[218] = new ImbuingDefinition(SAAbsorptionAttribute.ResonanceKinetic,    1154659, 140, null, null, null, 20, 1, 1152391);
 
-            m_Table[219] = new ImbuingDefinition(SAAbsorptionAttribute.CastingFocus,        1154659, 140, null, null, null, 20, 1, 1116535);
+            m_Table[219] = new ImbuingDefinition(SAAbsorptionAttribute.CastingFocus,        1116535, 140, null, null, null, 20, 1, 1116535);
 
             m_Table[220] = new ImbuingDefinition(AosArmorAttribute.ReactiveParalyze,        1154660, 140, null, null, null, 1, 1,  1152400);
             m_Table[221] = new ImbuingDefinition(AosArmorAttribute.SoulCharge,              1116536, 140, null, null, null, 20, 1, 1152391);

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -1438,15 +1438,22 @@ namespace Server.Spells
                 if (target is BaseCreature)
                     ((BaseCreature)target).AlterSpellDamageFrom(from, ref iDamage);
 
-                WeightOverloading.DFA = dfa;
                 DamageType dtype = spell != null ? spell.SpellDamageType : DamageType.Spell;
+
+                if (target != null)
+                {
+                    target.DFA = dfa;
+                }
 
                 int damageGiven = AOS.Damage(damageable, from, iDamage, phys, fire, cold, pois, nrgy, chaos, direct, dtype);
 
                 if(target != null)
                     Spells.Mysticism.SpellPlagueSpell.OnMobileDamaged(target);
 
-                WeightOverloading.DFA = DFAlgorithm.Standard;
+                if (target != null && target.DFA != DFAlgorithm.Standard)
+                {
+                    target.DFA = DFAlgorithm.Standard;
+                }
 
                 NegativeAttributes.OnCombatAction(from);
 
@@ -1579,12 +1586,19 @@ namespace Server.Spells
                 if (m_Target is BaseCreature && m_From != null)
                     ((BaseCreature)m_Target).AlterSpellDamageFrom(m_From, ref m_Damage);
 
-                WeightOverloading.DFA = m_DFA;
                 DamageType dtype = m_Spell != null ? m_Spell.SpellDamageType : DamageType.Spell;
+
+                if (target != null)
+                {
+                    target.DFA = m_DFA;
+                }
 
                 int damageGiven = AOS.Damage(m_Target, m_From, m_Damage, m_Phys, m_Fire, m_Cold, m_Pois, m_Nrgy, m_Chaos, m_Direct, dtype);
 
-                WeightOverloading.DFA = DFAlgorithm.Standard;
+                if (target != null && target.DFA != DFAlgorithm.Standard)
+                {
+                    target.DFA = DFAlgorithm.Standard;
+                }
 
                 if (m_Target is BaseCreature && m_From != null)
                 {

--- a/Scripts/Spells/Mysticism/SpellDefinitions/SpellPlague.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/SpellPlague.cs
@@ -141,7 +141,7 @@ namespace Server.Spells.Mysticism
             damage *= (100 + sdiBonus);
             damage /= 100;
 
-            SpellHelper.Damage(null, TimeSpan.Zero, from, caster, damage, 0, 0, 0, 0, 0, Server.Misc.DFAlgorithm.Standard, 100, 0);
+            SpellHelper.Damage(null, TimeSpan.Zero, from, caster, damage, 0, 0, 0, 0, 0, DFAlgorithm.Standard, 100, 0);
         }
 
         public static void RemoveFromList(Mobile from)

--- a/Scripts/Spells/Necromancy/PainSpike.cs
+++ b/Scripts/Spells/Necromancy/PainSpike.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+
+using Server;
 using Server.Targeting;
 using Server.Spells.SkillMasteries;
 
@@ -107,10 +109,10 @@ namespace Server.Spells.Necromancy
 
             BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.PainSpike, 1075667, t.Expires - DateTime.UtcNow, m, Convert.ToString((int)damage)));
 
-            Misc.WeightOverloading.DFA = Misc.DFAlgorithm.PainSpike;
+            m.DFA = DFAlgorithm.PainSpike;
             AOS.Damage(m, Caster, (int)damage, 0, 0, 0, 0, 0, 0, 100);
             AOS.DoLeech((int)damage, Caster, m);
-            Misc.WeightOverloading.DFA = Misc.DFAlgorithm.Standard;
+            m.DFA = DFAlgorithm.Standard;
 
             HarmfulSpell(m);
         }

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -485,6 +485,12 @@ namespace Server
         Pillage = 14,
         Spawn = 15
     }
+
+    public enum DFAlgorithm
+    {
+        Standard,
+        PainSpike
+    }
 	#endregion
 
 	[Serializable]
@@ -512,6 +518,8 @@ namespace Server
 	public delegate bool AllowBeneficialHandler(Mobile from, Mobile target);
 
 	public delegate bool AllowHarmfulHandler(Mobile from, IDamageable target);
+
+    public delegate void FatigueHandler(Mobile m, int damage, DFAlgorithm df);
 
 	public delegate Container CreateCorpseHandler(
 		Mobile from, HairInfo hair, FacialHairInfo facialhair, List<Item> initialContent, List<Item> equipedItems);
@@ -609,8 +617,9 @@ namespace Server
 
 		#region Handlers
 		public static AllowBeneficialHandler AllowBeneficialHandler { get; set; }
-
 		public static AllowHarmfulHandler AllowHarmfulHandler { get; set; }
+
+        public static FatigueHandler FatigueHandler { get; set; }
 
 		private static SkillCheckTargetHandler m_SkillCheckTargetHandler;
 		private static SkillCheckLocationHandler m_SkillCheckLocationHandler;
@@ -859,6 +868,8 @@ namespace Server
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool CharacterOut { get; set; }
+
+        public DFAlgorithm DFA { get; set; } 
 
         protected virtual void OnRaceChange(Race oldRace)
 		{ }
@@ -5632,6 +5643,8 @@ namespace Server
 				else
 				{
 					Hits = newHits;
+
+                    FatigueHandler(this, amount, DFA);
 				}
 			}
 


### PR DESCRIPTION
- Core.SA+ speeds up stamina regen rate, per EA. It used to be 24 stam per minute, is now 85 per minute. Significant increase!
- Added Wood and Stone armor to ArmorEnum MaterialType
- Added inherent stamina loss reduction, per EA (Core.SA)
- Added Core.SA to inherent lower mana cost regarding Armor
- Removed static DFAlgorithm property and added it to Mobile.cs as an instance property. This would have cause potential issues where the wrong stam loss was given out on damage
- Added public assessors to BaseTalisman killer/protection lists and RunicReforging property lists
- Added previously omitted TalismanSlayerName to Vendor Search Criteria serialization
- Fixed Casting Focus cliloc in Imbuing.cs, this was giving the wrong label in vendor search