### PR TITLE
* pub 103 - The Hovering Wisp fix.

### DIFF
--- a/Scripts/Services/Craft/DefAlchemy.cs
+++ b/Scripts/Services/Craft/DefAlchemy.cs
@@ -295,8 +295,10 @@ namespace Server.Engines.Craft
 
             if (Core.ML)
             {
-                index = AddCraft(typeof(HoveringWisp), 1116353, 1072881, 65.0, 115.0, typeof(CapturedEssence), 1032686, 4, 1044253);
-                AddRecipe(index, (int)TinkerRecipes.HoveringWisp);
+                index = AddCraft(typeof(HoveringWisp), 1116353, 1072881, 75.0, 125.0, typeof(CapturedEssence), 1032686, 4, 1044253);
+
+                if (!Core.TOL) // Removed at OSI Publish 103
+                    AddRecipe(index, (int)TinkerRecipes.HoveringWisp);
             }
 
             if (Core.SA)

--- a/Scripts/Services/Craft/DefTinkering.cs
+++ b/Scripts/Services/Craft/DefTinkering.cs
@@ -16,7 +16,7 @@ namespace Server.Engines.Craft
         PendantOfTheMagi = 451,
         ResilientBracer = 452,
         ScrappersCompendium = 453,
-        HoveringWisp = 454,
+        HoveringWisp = 454, // Removed at OSI Publish 103
 
         KotlPowerCore = 455,
 

--- a/Scripts/Services/MondainsLegacyQuests/BaseReward.cs
+++ b/Scripts/Services/MondainsLegacyQuests/BaseReward.cs
@@ -154,8 +154,19 @@ namespace Server.Engines.Quests
 
 		public static Item TinkerRecipe()
 		{
-            return GetRecipe(new int[] { 400, 401, 402, 450, 451, 452, 453, 454 });
-		}
+            RecipeScroll recipes;
+
+            if (Core.TOL)
+            {
+                recipes = GetRecipe(new int[] { 400, 401, 402, 450, 451, 452, 453 });
+            }
+            else
+            {
+                recipes = GetRecipe(new int[] { 400, 401, 402, 450, 451, 452, 453, 454 });
+            }
+
+            return recipes;
+        }
 
 		public static Item CarpRecipe()
 		{


### PR DESCRIPTION
* The Hovering Wisp no longer requires a recipe to craft, and recipes are no longer available as Heartwood Quest rewards.