### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Gumps/AddCustomizableMessageGump.cs
+++ b/Scripts/Gumps/AddCustomizableMessageGump.cs
@@ -1,0 +1,130 @@
+using System;
+
+using Server;
+using Server.Gumps;
+using Server.Mobiles;
+using Server.ContextMenus;
+
+namespace Server.Items
+{
+    public interface ICustomizableMessageItem
+    {
+        string[] Lines { get; set; }
+    }
+
+    public class AddCustomizableMessageGump : BaseGump
+    {
+        private ICustomizableMessageItem _MessageItem;
+
+        public AddCustomizableMessageGump(PlayerMobile pm, ICustomizableMessageItem item)
+            : base(pm, 100, 100)
+        {
+            _MessageItem = item;
+        }
+
+        public override void AddGumpLayout()
+        {
+            string line1 = String.Empty;
+            string line2 = String.Empty;
+            string line3 = String.Empty;
+
+            if (_MessageItem.Lines != null)
+            {
+                if (_MessageItem.Lines.Length > 0)
+                    line1 = _MessageItem.Lines[0];
+
+                if (_MessageItem.Lines.Length > 1)
+                    line2 = _MessageItem.Lines[1];
+
+                if (_MessageItem.Lines.Length > 2)
+                    line3 = _MessageItem.Lines[2];
+            }
+
+            AddPage(0);
+
+            AddBackground(0, 0, 420, 320, 0x2454);
+            AddHtmlLocalized(10, 10, 400, 18, 1114513, "#1151680", 0x4000, false, false); // Add Message
+            AddHtmlLocalized(10, 37, 400, 90, 1151681, 0x14AA, false, false); // Enter up to three lines of personallized text.  you may enter up to 25 characters per line.
+            
+            AddHtmlLocalized(10, 136, 400, 16, 1150296, 0x14AA, false, false); // Line 1:
+            AddBackground(10, 152, 400, 22, 0x2486);
+            AddTextEntry(12, 154, 396, 18, 0x9C2, 0, line1, 25);
+            
+            AddHtmlLocalized(10, 178, 400, 16, 1150297, 0x14AA, false, false); // Line 2:
+            AddBackground(10, 194, 400, 22, 0x2486);
+            AddTextEntry(12, 196, 396, 18, 0x9C2, 1, line2, 25);
+            
+            AddHtmlLocalized(10, 220, 400, 16, 1150298, 0x14AA, false, false); // Line 3:
+            AddBackground(10, 236, 400, 22, 0x2486);
+            AddTextEntry(12, 238, 396, 18, 0x9C2, 2, line3, 25);
+            
+            AddButton(10, 290, 0xFAB, 0xFAC, 1, GumpButtonType.Reply, 0);
+            AddHtmlLocalized(50, 290, 100, 20, 1150299, 0x10, false, false); // ACCEPT
+
+            AddButton(380, 290, 0xFB4, 0xFB5, 0, GumpButtonType.Reply, 0);
+            AddHtmlLocalized(270, 290, 100, 20, 1114514, "#1150300 ", 0x10, false, false); // CANCEL
+        }
+
+        public override void OnResponse(RelayInfo info)
+        {
+            if (info.ButtonID == 1)
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    if (_MessageItem.Lines.Length <= i)
+                    {
+                        break;
+                    }
+
+                    TextRelay text = info.GetTextEntry(i);
+                    string s = text.Text;
+
+                    if (s.Length > 25)
+                        s = s.Substring(0, 25);
+
+                    _MessageItem.Lines[i] = s;
+                }
+
+                if (_MessageItem is BaseAddon)
+                {
+                    foreach (var comp in ((BaseAddon)_MessageItem).Components)
+                    {
+                        comp.InvalidateProperties();
+                    }
+                }
+                else if (_MessageItem is Item)
+                {
+                    ((Item)_MessageItem).InvalidateProperties();
+                }
+            }
+        }
+    }
+
+    public class EditSign : ContextMenuEntry
+    {
+        private ICustomizableMessageItem _MessageItem;
+        private PlayerMobile _From;
+
+        public EditSign(ICustomizableMessageItem messageItem, PlayerMobile from)
+            : base(1151817) // Edit Sign
+        {
+            _MessageItem = messageItem;
+            _From = from;
+        }
+
+        public override void OnClick()
+        {
+            if (_MessageItem is Item)
+            {
+                if (_MessageItem is BaseAddon || ((Item)_MessageItem).IsChildOf(_From.Backpack))
+                {
+                    BaseGump.SendGump(new AddCustomizableMessageGump(_From, _MessageItem));
+                }
+                else
+                {
+                    _From.SendLocalizedMessage(1116249); // That must be in your backpack for you to use it.
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Items/Addons/BaseAddon.cs
+++ b/Scripts/Items/Addons/BaseAddon.cs
@@ -13,8 +13,7 @@ namespace Server.Items
 		NotInHouse,
 		DoorTooClose,
 		NoWall,
-		DoorsNotClosed,
-		BadHouse
+		DoorsNotClosed
 	}
 
 	public interface IAddon : IEntity, IChopable
@@ -79,9 +78,13 @@ namespace Server.Items
 			}
 		}
 
-		public virtual bool RetainDeedHue { get { return false; } }
-
-		public virtual bool RestrictToClassicHouses { get { return false; } }
+		public virtual bool RetainDeedHue
+        { 
+            get 
+            {
+                return Hue != 0 && CraftResources.GetHue(Resource) != Hue;
+            }
+        }
 
 		public virtual void OnChop(Mobile from)
 		{
@@ -127,6 +130,8 @@ namespace Server.Items
 					else
 						deed.Hue = 0;
 
+                    deed.IsReDeed = true;
+
 					from.AddToBackpack(deed);
 				}
 			}
@@ -141,10 +146,12 @@ namespace Server.Items
 		public virtual BaseAddonDeed GetDeed()
 		{
 			var deed = Deed;
+
 			if (deed != null)
 			{
 				deed.Resource = Resource;
 			}
+
 			return deed;
 		}
 
@@ -193,9 +200,6 @@ namespace Server.Items
 
 			if (house != null)
 			{
-				if (RestrictToClassicHouses && house is HouseFoundation)
-					return AddonFitResult.BadHouse;
-
 				var doors = house.Doors;
 
 				for (var i = 0; i < doors.Count; ++i)

--- a/Scripts/Items/Addons/BaseAddonDeed.cs
+++ b/Scripts/Items/Addons/BaseAddonDeed.cs
@@ -9,6 +9,7 @@ namespace Server.Items
     public abstract class BaseAddonDeed : Item, ICraftable
     {
         private CraftResource m_Resource;
+        private bool m_ReDeed;
 
         public BaseAddonDeed()
             : base(0x14F0)
@@ -46,11 +47,37 @@ namespace Server.Items
                 }
             }
         }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public bool IsReDeed
+        {
+            get { return m_ReDeed; }
+            set 
+            {
+                m_ReDeed = value;
+
+                if (UseCraftResource)
+                {
+                    if (m_ReDeed && ItemID == 0x14F0)
+                    {
+                        ItemID = 0x14EF;
+                    }
+                    else if (!m_ReDeed && ItemID == 0x14EF)
+                    {
+                        ItemID = 0x14F0;
+                    }
+                }
+            }
+        }
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
 
-            writer.Write(1); // version
+            writer.Write(2); // version
+
+            // Version 2
+            writer.Write(m_ReDeed);
 
             // Version 1
             writer.Write((int)m_Resource);
@@ -64,6 +91,11 @@ namespace Server.Items
 
             switch (version)
             {
+                case 2:
+                    {
+                        m_ReDeed = reader.ReadBool();
+                        goto case 1;
+                    }
                 case 1:
                     {
                         m_Resource = (CraftResource)reader.ReadInt();
@@ -71,8 +103,10 @@ namespace Server.Items
                     }
             }
 
-            if (Weight == 0.0)
-                Weight = 1.0;
+            if (version == 1 && UseCraftResource && Hue == 0 && m_Resource != CraftResource.None)
+            {
+                Hue = CraftResources.GetHue(m_Resource);
+            }
         }
 
         public override void OnDoubleClick(Mobile from)
@@ -107,10 +141,10 @@ namespace Server.Items
 
             CraftContext context = craftSystem.GetContext(from);
 
-			if (context != null && context.DoNotColor)
-				this.Hue = 0;
-			else
-				this.Hue = resHue;
+            if (context != null && context.DoNotColor)
+                Hue = 0;
+            else if (Hue == 0)
+                Hue = resHue;
 
             return quality;
         }
@@ -149,7 +183,7 @@ namespace Server.Items
                     {
                         addon.Resource = m_Deed.Resource;
 
-                        if (addon.RetainDeedHue)
+                        if (addon.RetainDeedHue || (m_Deed.Hue != 0 && CraftResources.GetHue(m_Deed.Resource) != m_Deed.Hue))
                             addon.Hue = m_Deed.Hue;
 
                         addon.MoveToWorld(new Point3D(p), map);

--- a/Scripts/Items/Addons/LoomEastAddon.cs
+++ b/Scripts/Items/Addons/LoomEastAddon.cs
@@ -5,7 +5,6 @@ namespace Server.Items
     public interface ILoom
     {
         int Phase { get; set; }
-        int Hue { get; set; }
     }
 
     public class LoomEastAddon : BaseAddon, ILoom

--- a/Scripts/Items/Artifacts/Consumables/BasePigmentsOfTokuno.cs
+++ b/Scripts/Items/Artifacts/Consumables/BasePigmentsOfTokuno.cs
@@ -138,6 +138,9 @@ namespace Server.Items
             if (i.IsArtifact)
                 return true;
 
+            if (i is BaseAddonDeed && ((BaseAddonDeed)i).UseCraftResource && !((BaseAddonDeed)i).IsReDeed && ((BaseAddonDeed)i).Resource != CraftResource.None)
+                return true;
+
             return false;
         }
 

--- a/Scripts/Items/Decorative/CustomizableRoundedDoorMat.cs
+++ b/Scripts/Items/Decorative/CustomizableRoundedDoorMat.cs
@@ -1,15 +1,20 @@
 using System;
 using System.Collections.Generic;
 using Server.ContextMenus;
-using Server.Gumps;
 using Server.Multis;
-using Server.Network;
+using Server.Mobiles;
+using Server.Gumps;
 
 namespace Server.Items
 {
+    public interface ICustomizableMessage
+    {
+        string[] Lines { get; set; }
+    }
+
     [Furniture]
     [FlipableAttribute(0x4790, 0x4791)]
-    public class CustomizableRoundedDoorMat : Item, IDyable
+    public class CustomizableRoundedDoorMat : Item, IDyable, ICustomizableMessageItem
     {
         public string[] Lines { get; set; }
 
@@ -35,7 +40,8 @@ namespace Server.Items
         {
             if (IsChildOf(from.Backpack))
             {
-                from.SendGump(new AddMessageGump(this));
+                if(from is PlayerMobile)
+                    BaseGump.SendGump(new AddCustomizableMessageGump((PlayerMobile)from, this));
             }
             else
             {
@@ -70,34 +76,9 @@ namespace Server.Items
 
             BaseHouse house = BaseHouse.FindHouseAt(from);
 
-            if (house != null && house.IsCoOwner(from))
+            if (house != null && house.IsCoOwner(from) && from is PlayerMobile)
             {
-                list.Add(new EditSign(this, from));
-            }
-        }
-
-        private class EditSign : ContextMenuEntry
-        {
-            private readonly CustomizableRoundedDoorMat Mat;
-            private readonly Mobile _From;
-
-            public EditSign(CustomizableRoundedDoorMat mat, Mobile from)
-                : base(1151817) // Edit Sign
-            {
-                Mat = mat;
-                _From = from;
-            }
-
-            public override void OnClick()
-            {
-                if (Mat.IsChildOf(_From.Backpack))
-                {
-                    _From.SendGump(new AddMessageGump(Mat));
-                }
-                else
-                {
-                    _From.SendLocalizedMessage(1116249); // That must be in your backpack for you to use it.
-                }               
+                list.Add(new EditSign(this, (PlayerMobile)from));
             }
         }
 
@@ -121,62 +102,6 @@ namespace Server.Items
 
             for (int i = 0; i < Lines.Length; i++)
                 Lines[i] = reader.ReadString();
-        }
-
-        private class AddMessageGump : Gump
-        {
-            private readonly CustomizableRoundedDoorMat Mat;
-
-            public AddMessageGump(CustomizableRoundedDoorMat mat)
-                : base(100, 100)
-            {
-                Mat = mat;
-
-                string line1 = "";
-                string line2 = "";
-                string line3 = "";
-
-                if (Mat.Lines != null && Mat.Lines.Length > 0)
-                {
-                    line1 = Mat.Lines[0];
-                    line2 = Mat.Lines[1];
-                    line3 = Mat.Lines[2];
-                }
-
-                AddPage(0);
-
-                AddBackground(0, 0, 420, 320, 0x2454);
-                AddHtmlLocalized(10, 10, 400, 18, 1114513, "#1151680", 0x4000, false, false); // <DIV ALIGN=CENTER>~1_TOKEN~</DIV>
-                AddHtmlLocalized(10, 37, 400, 90, 1151681, 0x14AA, false, false); // Enter up to three lines of personallized text.  you may enter up to 25 characters per line.
-                AddHtmlLocalized(10, 136, 400, 16, 1150296, 0x14AA, false, false); // Line 1:
-                AddBackground(10, 152, 400, 22, 0x2486);
-                AddTextEntry(12, 154, 396, 18, 0x9C2, 0, line1, 25);
-                AddHtmlLocalized(10, 178, 400, 16, 1150297, 0x14AA, false, false); // Line 2:
-                AddBackground(10, 194, 400, 22, 0x2486);
-                AddTextEntry(12, 196, 396, 18, 0x9C2, 1, line2, 25);
-                AddHtmlLocalized(10, 220, 400, 16, 1150298, 0x14AA, false, false); // Line 3:
-                AddBackground(10, 236, 400, 22, 0x2486);
-                AddTextEntry(12, 238, 396, 18, 0x9C2, 2, line3, 25);
-                AddButton(10, 290, 0xFAB, 0xFAC, 1, GumpButtonType.Reply, 0);
-                AddHtmlLocalized(50, 290, 100, 20, 1150299, 0x10, false, false); // ACCEPT
-                AddButton(380, 290, 0xFB4, 0xFB5, 0, GumpButtonType.Reply, 0);
-                AddHtmlLocalized(270, 290, 100, 20, 1114514, "#1150300 ", 0x10, false, false); // <DIV ALIGN=RIGHT>~1_TOKEN~</DIV>
-            }
-
-            public override void OnResponse(NetState sender, RelayInfo info)
-            {
-                if (info.ButtonID == 1)
-                {
-                    for (int i = 0; i < 3; i++)
-                    {
-                        TextRelay text = info.GetTextEntry(i);
-                        string s = text.Text.Substring(0, 25);
-                        Mat.Lines[i] = s;
-                    }
-
-                    Mat.InvalidateProperties();
-                }
-            }
         }
     }
 }

--- a/Scripts/Items/Decorative/CustomizableSquaredDoorMat.cs
+++ b/Scripts/Items/Decorative/CustomizableSquaredDoorMat.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Collections.Generic;
 using Server.ContextMenus;
-using Server.Gumps;
 using Server.Multis;
-using Server.Network;
+using Server.Mobiles;
+using Server.Gumps;
 
 namespace Server.Items
 {
-    public class CustomizableSquaredDoorMatAddon : BaseAddon
+    public class CustomizableSquaredDoorMatAddon : BaseAddon, ICustomizableMessageItem
     {
         public string[] Lines { get; set; }
 
@@ -95,27 +95,9 @@ namespace Server.Items
 
             BaseHouse house = BaseHouse.FindHouseAt(from);
 
-            if (house != null && house.IsCoOwner(from))
+            if (house != null && house.IsCoOwner(from) && from is PlayerMobile)
             {
-                list.Add(new EditSign((CustomizableSquaredDoorMatAddon)Addon, from));
-            }
-        }
-
-        private class EditSign : ContextMenuEntry
-        {
-            private readonly CustomizableSquaredDoorMatAddon Addon;
-            private readonly Mobile _From;
-
-            public EditSign(CustomizableSquaredDoorMatAddon addon, Mobile from)
-                : base(1151817) // Edit Sign
-            {
-                Addon = addon;
-                _From = from;
-            }
-
-            public override void OnClick()
-            {
-                _From.SendGump(new AddMessageGump(Addon));
+                list.Add(new EditSign((CustomizableSquaredDoorMatAddon)Addon, (PlayerMobile)from));
             }
         }
 
@@ -134,62 +116,6 @@ namespace Server.Items
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
-        }
-
-        private class AddMessageGump : Gump
-        {
-            private readonly CustomizableSquaredDoorMatAddon Addon;
-
-            public AddMessageGump(CustomizableSquaredDoorMatAddon addon)
-                : base(100, 100)
-            {
-                Addon = addon;
-
-                string line1 = "";
-                string line2 = "";
-                string line3 = "";
-
-                if (Addon.Lines != null && Addon.Lines.Length > 0)
-                {
-                    line1 = Addon.Lines[0];
-                    line2 = Addon.Lines[1];
-                    line3 = Addon.Lines[2];
-                }
-
-                AddPage(0);
-
-                AddBackground(0, 0, 420, 320, 0x2454);
-                AddHtmlLocalized(10, 10, 400, 18, 1114513, "#1151680", 0x4000, false, false); // <DIV ALIGN=CENTER>~1_TOKEN~</DIV>
-                AddHtmlLocalized(10, 37, 400, 90, 1151681, 0x14AA, false, false); // Enter up to three lines of personallized text.  you may enter up to 25 characters per line.
-                AddHtmlLocalized(10, 136, 400, 16, 1150296, 0x14AA, false, false); // Line 1:
-                AddBackground(10, 152, 400, 22, 0x2486);
-                AddTextEntry(12, 154, 396, 18, 0x9C2, 0, line1, 25);
-                AddHtmlLocalized(10, 178, 400, 16, 1150297, 0x14AA, false, false); // Line 2:
-                AddBackground(10, 194, 400, 22, 0x2486);
-                AddTextEntry(12, 196, 396, 18, 0x9C2, 1, line2, 25);
-                AddHtmlLocalized(10, 220, 400, 16, 1150298, 0x14AA, false, false); // Line 3:
-                AddBackground(10, 236, 400, 22, 0x2486);
-                AddTextEntry(12, 238, 396, 18, 0x9C2, 2, line3, 25);
-                AddButton(10, 290, 0xFAB, 0xFAC, 1, GumpButtonType.Reply, 0);
-                AddHtmlLocalized(50, 290, 100, 20, 1150299, 0x10, false, false); // ACCEPT
-                AddButton(380, 290, 0xFB4, 0xFB5, 0, GumpButtonType.Reply, 0);
-                AddHtmlLocalized(270, 290, 100, 20, 1114514, "#1150300 ", 0x10, false, false); // <DIV ALIGN=RIGHT>~1_TOKEN~</DIV>
-            }
-
-            public override void OnResponse(NetState sender, RelayInfo info)
-            {
-                if (info.ButtonID == 1)
-                {
-                    for (int i = 0; i < 3; i++)
-                    {
-                        TextRelay text = info.GetTextEntry(i);
-                        string s = text.Text.Substring(0, 25);
-                        Addon.Lines[i] = s;
-                    }
-
-                    Addon.UpdateProperties();
-                }
-            }
         }
     }
 

--- a/Scripts/Items/Decorative/CustomizableWallSign.cs
+++ b/Scripts/Items/Decorative/CustomizableWallSign.cs
@@ -1,14 +1,14 @@
 using System;
 using System.Collections.Generic;
 using Server.ContextMenus;
-using Server.Gumps;
 using Server.Multis;
-using Server.Network;
+using Server.Mobiles;
+using Server.Gumps;
 
 namespace Server.Items
 {
     [FlipableAttribute(0x4B20, 0x4B21)]
-    public class CustomizableWallSign : Item
+    public class CustomizableWallSign : Item, ICustomizableMessageItem
     {
         public string[] Lines { get; set; }
 
@@ -24,7 +24,8 @@ namespace Server.Items
         {
             if (IsChildOf(from.Backpack))
             {
-                from.SendGump(new AddMessageGump(this));
+                if(from is PlayerMobile)
+                    BaseGump.SendGump(new AddCustomizableMessageGump((PlayerMobile)from, this));
             }
             else
             {
@@ -59,34 +60,9 @@ namespace Server.Items
 
             BaseHouse house = BaseHouse.FindHouseAt(from);
 
-            if (house != null && house.IsCoOwner(from))
+            if (house != null && house.IsCoOwner(from) && from is PlayerMobile)
             {
-                list.Add(new EditSign(this, from));
-            }
-        }
-
-        private class EditSign : ContextMenuEntry
-        {
-            private readonly CustomizableWallSign Sign;
-            private readonly Mobile _From;
-
-            public EditSign(CustomizableWallSign sign, Mobile from)
-                : base(1151817) // Edit Sign
-            {
-                Sign = sign;
-                _From = from;
-            }
-
-            public override void OnClick()
-            {
-                if (Sign.IsChildOf(_From.Backpack))
-                {
-                    _From.SendGump(new AddMessageGump(Sign));
-                }
-                else
-                {
-                    _From.SendLocalizedMessage(1116249); // That must be in your backpack for you to use it.
-                }               
+                list.Add(new EditSign(this, (PlayerMobile)from));
             }
         }
 
@@ -110,62 +86,6 @@ namespace Server.Items
 
             for (int i = 0; i < Lines.Length; i++)
                 Lines[i] = reader.ReadString();
-        }
-
-        private class AddMessageGump : Gump
-        {
-            private readonly CustomizableWallSign Sign;
-
-            public AddMessageGump(CustomizableWallSign sign)
-                : base(100, 100)
-            {
-                Sign = sign;
-
-                string line1 = "";
-                string line2 = "";
-                string line3 = "";
-
-                if (Sign.Lines != null && Sign.Lines.Length > 0)
-                {
-                    line1 = Sign.Lines[0];
-                    line2 = Sign.Lines[1];
-                    line3 = Sign.Lines[2];
-                }
-
-                AddPage(0);
-
-                AddBackground(0, 0, 420, 320, 0x2454);
-                AddHtmlLocalized(10, 10, 400, 18, 1114513, "#1151680", 0x4000, false, false); // <DIV ALIGN=CENTER>~1_TOKEN~</DIV>
-                AddHtmlLocalized(10, 37, 400, 90, 1151681, 0x14AA, false, false); // Enter up to three lines of personallized text.  you may enter up to 25 characters per line.
-                AddHtmlLocalized(10, 136, 400, 16, 1150296, 0x14AA, false, false); // Line 1:
-                AddBackground(10, 152, 400, 22, 0x2486);
-                AddTextEntry(12, 154, 396, 18, 0x9C2, 0, line1, 25);
-                AddHtmlLocalized(10, 178, 400, 16, 1150297, 0x14AA, false, false); // Line 2:
-                AddBackground(10, 194, 400, 22, 0x2486);
-                AddTextEntry(12, 196, 396, 18, 0x9C2, 1, line2, 25);
-                AddHtmlLocalized(10, 220, 400, 16, 1150298, 0x14AA, false, false); // Line 3:
-                AddBackground(10, 236, 400, 22, 0x2486);
-                AddTextEntry(12, 238, 396, 18, 0x9C2, 2, line3, 25);
-                AddButton(10, 290, 0xFAB, 0xFAC, 1, GumpButtonType.Reply, 0);
-                AddHtmlLocalized(50, 290, 100, 20, 1150299, 0x10, false, false); // ACCEPT
-                AddButton(380, 290, 0xFB4, 0xFB5, 0, GumpButtonType.Reply, 0);
-                AddHtmlLocalized(270, 290, 100, 20, 1114514, "#1150300 ", 0x10, false, false); // <DIV ALIGN=RIGHT>~1_TOKEN~</DIV>
-            }
-
-            public override void OnResponse(NetState sender, RelayInfo info)
-            {
-                if (info.ButtonID == 1)
-                {
-                    for (int i = 0; i < 3; i++)
-                    {
-                        TextRelay text = info.GetTextEntry(i);
-                        string s = text.Text.Substring(0, 25);
-                        Sign.Lines[i] = s;
-                    }
-
-                    Sign.InvalidateProperties();
-                }
-            }
         }
     }
 }

--- a/Scripts/Items/Equipment/Armor/BaseArmor.cs
+++ b/Scripts/Items/Equipment/Armor/BaseArmor.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace Server.Items
 {
-    public abstract class BaseArmor : Item, IScissorable, IFactionItem, ICraftable, IWearableDurability, IResource, ISetItem, IVvVItem, IOwnerRestricted, ITalismanProtection, IEngravable, IArtifact
+    public abstract class BaseArmor : Item, IScissorable, IFactionItem, ICraftable, IWearableDurability, IResource, ISetItem, IVvVItem, IOwnerRestricted, ITalismanProtection, IEngravable, IArtifact, ICombatEquipment
     {
         #region Factions
         private FactionItem m_FactionState;

--- a/Scripts/Items/Equipment/Clothing/BaseClothing.cs
+++ b/Scripts/Items/Equipment/Clothing/BaseClothing.cs
@@ -15,7 +15,7 @@ namespace Server.Items
         int MaxArcaneCharges { get; set; }
     }
 
-    public abstract class BaseClothing : Item, IDyable, IScissorable, IFactionItem, ICraftable, IWearableDurability, IResource, ISetItem, IVvVItem, IOwnerRestricted, IArtifact
+    public abstract class BaseClothing : Item, IDyable, IScissorable, IFactionItem, ICraftable, IWearableDurability, IResource, ISetItem, IVvVItem, IOwnerRestricted, IArtifact, ICombatEquipment
     {
         #region Factions
         private FactionItem m_FactionState;

--- a/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
+++ b/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
@@ -21,7 +21,7 @@ namespace Server.Items
         Diamond
     }
 
-    public abstract class BaseJewel : Item, ICraftable, ISetItem, IWearableDurability, IResource, IVvVItem, IOwnerRestricted, ITalismanProtection, IFactionItem, IArtifact
+    public abstract class BaseJewel : Item, ICraftable, ISetItem, IWearableDurability, IResource, IVvVItem, IOwnerRestricted, ITalismanProtection, IFactionItem, IArtifact, ICombatEquipment
     {
         #region Factions
         private FactionItem m_FactionState;

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -30,7 +30,7 @@ namespace Server.Items
 		SlayerName Slayer2 { get; set; }
 	}
 
-    public abstract class BaseWeapon : Item, IWeapon, IFactionItem, IUsesRemaining, ICraftable, ISlayer, IDurability, ISetItem, IVvVItem, IOwnerRestricted, IResource, IArtifact
+    public abstract class BaseWeapon : Item, IWeapon, IFactionItem, IUsesRemaining, ICraftable, ISlayer, IDurability, ISetItem, IVvVItem, IOwnerRestricted, IResource, IArtifact, ICombatEquipment
 	{
 		#region Damage Helpers
 		public static BaseWeapon GetDamageOutput(Mobile wielder, out int min, out int max)

--- a/Scripts/Items/Internal/ItemInterfaces.cs
+++ b/Scripts/Items/Internal/ItemInterfaces.cs
@@ -41,6 +41,20 @@ namespace Server.Items
         bool CanBeSeenBy(PlayerMobile m);
     }
 
+    public interface IImbuableEquipement
+    {
+        int TimesImbued { get; set; }
+        bool IsImbued { get; set; }
+    }
+
+    public interface ICombatEquipment : IImbuableEquipement
+    {
+        ItemPower ItemPower { get; set; }
+        ReforgedPrefix ReforgedPrefix { get; set; }
+        ReforgedSuffix ReforgedSuffix { get; set; }
+        bool PlayerConstructed { get; set; }
+    }
+
     public enum ItemQuality
     {
         Low,

--- a/Scripts/Items/Resource/YarnsAndThreads.cs
+++ b/Scripts/Items/Resource/YarnsAndThreads.cs
@@ -91,7 +91,6 @@ namespace Server.Items
                     else if (loom.Phase < 4)
                     {
                         m_Material.Consume();
-                        loom.Hue = m_Material.Hue;
 
                         if (targeted is Item)
                             ((Item)targeted).SendLocalizedMessageTo(from, 1010001 + loom.Phase++);
@@ -103,7 +102,6 @@ namespace Server.Items
 
                         m_Material.Consume();
                         loom.Phase = 0;
-                        loom.Hue = 0;
                         from.SendLocalizedMessage(500368); // You create some cloth and put it in your backpack.
                         from.AddToBackpack(create);
                     }

--- a/Scripts/Mobiles/NPCs/Gervis.cs
+++ b/Scripts/Mobiles/NPCs/Gervis.cs
@@ -8,9 +8,9 @@ namespace Server.Engines.Quests
         public BatteredBucklersQuest()
             : base()
         { 
-            this.AddObjective(new ObtainObjective(typeof(Buckler), "buckler", 10, 0x1B73));
+            AddObjective(new ObtainObjective(typeof(Buckler), "buckler", 10, 0x1B73));
 						
-            this.AddReward(new BaseReward(typeof(SmithsSatchel), 1074282)); // Craftsman's Satchel
+            AddReward(new BaseReward(typeof(SmithsSatchel), 1074282)); // Craftsman's Satchel
         }
 
         /* Battered Bucklers */
@@ -78,7 +78,7 @@ namespace Server.Engines.Quests
         public Gervis()
             : base("Gervis", "the blacksmith trainer")
         { 
-            this.SetSkill(SkillName.Blacksmith, 65.0, 88.0);
+            SetSkill(SkillName.Blacksmith, 65.0, 88.0);
         }
 
         public Gervis(Serial serial)
@@ -98,31 +98,31 @@ namespace Server.Engines.Quests
         }
         public override void InitBody()
         {
-            this.InitStats(100, 100, 25);
+            InitStats(100, 100, 25);
 			
-            this.Female = false;
-            this.CantWalk = true;
-            this.Race = Race.Human;
+            Female = false;
+            CantWalk = true;
+            Race = Race.Human;
 			
-            this.Hue = 0x83F5;
-            this.HairItemID = 0x203B;
-            this.HairHue = 0x5EC;
+            Hue = 0x83F5;
+            HairItemID = 0x203B;
+            HairHue = 0x5EC;
         }
 
         public override void InitOutfit()
         {
-            this.AddItem(new Backpack());			
-            this.AddItem(new SmithHammer());
-            this.AddItem(new Boots(0x3B2));
-            this.AddItem(new ShortPants(0x1BB));
-            this.AddItem(new Shirt(0x71F));
-            this.AddItem(new FullApron(0x3B2));
+            AddItem(new Backpack());			
+            AddItem(new SmithHammer());
+            AddItem(new Boots(0x3B2));
+            AddItem(new ShortPants(0x1BB));
+            AddItem(new Shirt(0x71F));
+            AddItem(new FullApron(0x3B2));
 			
             Item item;
 			
             item = new LeatherGloves();
             item.Hue = 0x3B2;
-            this.AddItem(item);
+            AddItem(item);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -146,10 +146,10 @@ namespace Server.Engines.Quests
         public SmithsSatchel()
             : base()
         {
-            this.Hue = BaseReward.SatchelHue();
+            Hue = BaseReward.SatchelHue();
 			
-            this.AddItem(new IronIngot(10));
-            this.AddItem(new SmithHammer());
+            DropItem(new IronIngot(10));
+            DropItem(new SmithHammer());
         }
 
         public SmithsSatchel(Serial serial)

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -289,6 +289,7 @@
     <Compile Include="Deprecated\ScribeStone.cs" />
     <Compile Include="Deprecated\SmithStone.cs" />
     <Compile Include="Deprecated\TailorStone.cs" />
+    <Compile Include="Gumps\AddCustomizableMessageGump.cs" />
     <Compile Include="Gumps\AddDoorGump.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Scripts/Services/City Loyalty System/CityDefinition.cs
+++ b/Scripts/Services/City Loyalty System/CityDefinition.cs
@@ -46,7 +46,7 @@ namespace Server.Engines.CityLoyalty
             {
                 if (_Region == null)
                 {
-                    _Region = Region.Regions.FirstOrDefault(r => r.Name == Name && r.Map == Map.Trammel);
+                    _Region = Region.Regions.FirstOrDefault(r => r.Name == Name && r.Map == CityLoyaltySystem.SystemMap);
 
                     if(_Region == null)
                         Console.WriteLine("WARNING: Region for {0} not found!", Name);

--- a/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
+++ b/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
@@ -98,6 +98,7 @@ namespace Server.Engines.CityLoyalty
         public static readonly int AnnouncementPeriod = Config.Get("CityLoyalty.AnnouncementPeriod", 48);
 
         public static readonly TimeSpan LoveAtrophyDuration = TimeSpan.FromHours(40);
+        public static Map SystemMap { get { return Siege.SiegeShard ? Map.Felucca : Map.Trammel; } }
 
         public override TextDefinition Name { get { return new TextDefinition(String.Format("{0}", this.City.ToString())); } }
         public override bool AutoAdd { get { return false; } }
@@ -1277,12 +1278,12 @@ namespace Server.Engines.CityLoyalty
                 Timer.DelayCall(TimeSpan.FromSeconds(10), () =>
                     {
                         Board = new CityMessageBoard(City, 0xA0C5);
-                        Board.MoveToWorld(Definition.BoardLocation, Map.Trammel);
+                        Board.MoveToWorld(Definition.BoardLocation, SystemMap);
                         Console.WriteLine("City Message Board for {0} Converted!", City.ToString());
                         /*if (Board != null)
                         {
                             //Board.ItemID = 0xA0C5;
-                            //board.MoveToWorld(Definition.BoardLocation, Map.Trammel);
+                            //board.MoveToWorld(Definition.BoardLocation, SystemMap);
 
 
                             Console.WriteLine("City Message Board for {0} Converted!", City.ToString());

--- a/Scripts/Services/City Loyalty System/Setup.cs
+++ b/Scripts/Services/City Loyalty System/Setup.cs
@@ -95,7 +95,7 @@ namespace Server.Engines.CityLoyalty
                     if (!HasType(sys, minister.GetType()))
                     {
                         sys.Minister = minister;
-                        minister.MoveToWorld(sys.Definition.TradeMinisterLocation, Map.Trammel);
+                        minister.MoveToWorld(sys.Definition.TradeMinisterLocation, CityLoyaltySystem.SystemMap);
                     }
                     else
                         minister.Delete();
@@ -103,7 +103,7 @@ namespace Server.Engines.CityLoyalty
                     if (!HasType(sys, herald.GetType()))
                     {
                         sys.Herald = herald;
-                        herald.MoveToWorld(sys.Definition.HeraldLocation, Map.Trammel);
+                        herald.MoveToWorld(sys.Definition.HeraldLocation, CityLoyaltySystem.SystemMap);
                     }
                     else
                         herald.Delete();
@@ -111,7 +111,7 @@ namespace Server.Engines.CityLoyalty
                     if (!HasType(sys, capt.GetType()))
                     {
                         sys.Captain = capt;
-                        capt.MoveToWorld(sys.Definition.GuardsmanLocation, Map.Trammel);
+                        capt.MoveToWorld(sys.Definition.GuardsmanLocation, CityLoyaltySystem.SystemMap);
                     }
                     else
                         capt.Delete();
@@ -119,29 +119,29 @@ namespace Server.Engines.CityLoyalty
                     if (!HasType(sys, stone.GetType()))
                     {
                         sys.Stone = stone;
-                        stone.MoveToWorld(sys.Definition.StoneLocation, Map.Trammel);
+                        stone.MoveToWorld(sys.Definition.StoneLocation, CityLoyaltySystem.SystemMap);
                     }
                     else
                         stone.Delete();
 
                     if (!HasType(sys, itemdonation.GetType()))
-                        itemdonation.MoveToWorld(new Point3D(sys.Definition.TradeMinisterLocation.X, sys.Definition.TradeMinisterLocation.Y - 1, sys.Definition.TradeMinisterLocation.Z), Map.Trammel);
+                        itemdonation.MoveToWorld(new Point3D(sys.Definition.TradeMinisterLocation.X, sys.Definition.TradeMinisterLocation.Y - 1, sys.Definition.TradeMinisterLocation.Z), CityLoyaltySystem.SystemMap);
                     else
                         itemdonation.Delete();
 
                     if (!HasType(sys, petdonation.GetType()))
-                        petdonation.MoveToWorld(new Point3D(sys.Definition.TradeMinisterLocation.X, sys.Definition.TradeMinisterLocation.Y - 2, sys.Definition.TradeMinisterLocation.Z), Map.Trammel);
+                        petdonation.MoveToWorld(new Point3D(sys.Definition.TradeMinisterLocation.X, sys.Definition.TradeMinisterLocation.Y - 2, sys.Definition.TradeMinisterLocation.Z), CityLoyaltySystem.SystemMap);
                     else
                         petdonation.Delete();
 
                     if (!HasType(sys, box.GetType()))
-                        box.MoveToWorld(new Point3D(sys.Definition.GuardsmanLocation.X, sys.Definition.GuardsmanLocation.Y - 1, sys.Definition.GuardsmanLocation.Z), Map.Trammel);
+                        box.MoveToWorld(new Point3D(sys.Definition.GuardsmanLocation.X, sys.Definition.GuardsmanLocation.Y - 1, sys.Definition.GuardsmanLocation.Z), CityLoyaltySystem.SystemMap);
                     else
                         box.Delete();
 
                     if (!HasType(sys, board.GetType()))
                     {
-                        board.MoveToWorld(sys.Definition.BoardLocation, Map.Trammel);
+                        board.MoveToWorld(sys.Definition.BoardLocation, CityLoyaltySystem.SystemMap);
                         sys.Board = board;
                     }
                     else

--- a/Scripts/Services/HuntmasterChallenge/HuntingSystem.cs
+++ b/Scripts/Services/HuntmasterChallenge/HuntingSystem.cs
@@ -23,10 +23,10 @@ namespace Server.Engines.HuntsmasterChallenge
         private Timer m_Timer;
 		
 		[CommandProperty(AccessLevel.GameMaster)]
-		public DateTime SeasonBegins { get { return m_SeasonBegins; } }
+        public DateTime SeasonBegins { get { return m_SeasonBegins; } set { m_SeasonBegins = value; } }
 		
 		[CommandProperty(AccessLevel.GameMaster)]
-		public DateTime SeasonEnds { get { return m_SeasonEnds; } }
+        public DateTime SeasonEnds { get { return m_SeasonEnds; } set { m_SeasonEnds = value; } }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public int BonusIndex { get { return m_BonusIndex; } }
@@ -273,9 +273,11 @@ namespace Server.Engines.HuntsmasterChallenge
 			
 			m_Leaders.Clear();
 			
-			m_SeasonBegins = DateTime.Now;
-            DateTime ends = DateTime.Now + TimeSpan.FromDays(30);
+			var now = DateTime.Now;
+            var ends = DateTime.Now + TimeSpan.FromDays(30);
+
 			m_SeasonEnds = new DateTime(ends.Year, ends.Month, 1, 0, 0, 0);
+            m_SeasonBegins = new DateTime(now.Year, now.Month, 1, 0, 0, 0);
 
             HuntingDisplayTrophy.InvalidateDisplayTrophies();
 		}

--- a/Scripts/Services/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/RunicReforging/RunicReforging.cs
@@ -2347,14 +2347,10 @@ namespace Server.Items
         {
             ItemPower ip = GetItemPower(item, Imbuing.GetTotalWeight(item), Imbuing.GetTotalMods(item), playermade);
 
-            if (item is BaseWeapon)
-                ((BaseWeapon)item).ItemPower = ip;
-            else if (item is BaseArmor)
-                ((BaseArmor)item).ItemPower = ip;
-            else if (item is BaseJewel)
-                ((BaseJewel)item).ItemPower = ip;
-            else if (item is BaseClothing)
-                ((BaseClothing)item).ItemPower = ip;
+            if (item is ICombatEquipment)
+            {
+                ((ICombatEquipment)item).ItemPower = ip;
+            }
 
             return ip;
         }

--- a/Scripts/Skills/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Skills/Imbuing/Core/Imbuing.cs
@@ -2077,6 +2077,10 @@ namespace Server.SkillHandlers
                 {
                     max = GetPropRange((BaseWeapon)item, (AosWeaponAttribute)attr)[1];
                 }
+                else if (item is BaseWeapon && mod >= 3 && mod <= 5)
+                {
+                    max = 9;
+                }
                 else if (item is BaseJewel && attr is AosAttribute && (AosAttribute)attr == AosAttribute.WeaponDamage)
                 {
                     max = 25;
@@ -2346,14 +2350,10 @@ namespace Server.SkillHandlers
 
         public static int TimesImbued(Item item)
         {
-            if (item is BaseWeapon)
-                return ((BaseWeapon)item).TimesImbued;
-            if (item is BaseArmor)
-                return ((BaseArmor)item).TimesImbued;
-            if (item is BaseJewel)
-                return ((BaseJewel)item).TimesImbued;
-            if (item is BaseHat)
-                return ((BaseHat)item).TimesImbued;
+            if (item is IImbuableEquipement)
+            {
+                return ((IImbuableEquipement)item).TimesImbued;
+            }
 
             return 0;
         }

--- a/Scripts/Spells/Skill Masteries/Onslaught.cs
+++ b/Scripts/Spells/Skill Masteries/Onslaught.cs
@@ -15,7 +15,6 @@ namespace Server.Spells.SkillMasteries
 
         public override SkillName MoveSkill { get { return SkillName.Swords; } }
         public override TextDefinition AbilityMessage { get { return new TextDefinition(1156007); } } // *You ready an onslaught!*
-        public override TimeSpan CooldownPeriod { get { return TimeSpan.FromSeconds(5); } }
 
         public OnslaughtSpell()
         {
@@ -29,12 +28,7 @@ namespace Server.Spells.SkillMasteries
                 return false;
             }
 
-            bool validate = base.Validate(from);
-
-            if (!validate)
-                return false;
-
-            return CheckMana(from, true);
+            return base.Validate(from);
         }
 
         public override void OnUse(Mobile from)
@@ -42,12 +36,13 @@ namespace Server.Spells.SkillMasteries
             from.PlaySound(0x1EC);
 
             from.FixedEffect(0x3779, 10, 20, 1372, 0);
-
-            AddToCooldown(from);
         }
 
         public override void OnHit(Mobile attacker, Mobile defender, int damage)
         {
+            if (!Validate(attacker) || !CheckMana(attacker, true))
+                return;
+
             BaseWeapon weapon = attacker.Weapon as BaseWeapon;
 
             if (weapon != null && !HasOnslaught(attacker, defender))

--- a/Server/Network/PacketHandlers.cs
+++ b/Server/Network/PacketHandlers.cs
@@ -1724,7 +1724,7 @@ namespace Server.Network
 
 		public static void LookReq(NetState state, PacketReader pvSrc)
 		{
-			if (state.Mobile != null && (state.Mobile.ViewOPL || state.Expansion < Expansion.AOS))
+			if (state.Mobile != null)
 			{
 				HandleSingleClick(state.Mobile, World.FindEntity(pvSrc.ReadInt32()));
 			}
@@ -2220,12 +2220,17 @@ namespace Server.Network
 		{
 			var target = World.FindEntity(pvSrc.ReadInt32());
 
-			if (target != null && ObjectPropertyList.Enabled && !state.Mobile.ViewOPL)
-			{
-				HandleSingleClick(state.Mobile, target);
-			}
-
-			ContextMenu.Display(state.Mobile, target);
+            if (target != null && ObjectPropertyList.Enabled)
+            {
+                if (!state.Mobile.ViewOPL)
+                {
+                    HandleSingleClick(state.Mobile, target);
+                }
+                else
+                {
+                    ContextMenu.Display(state.Mobile, target);
+                }
+            }
 		}
 
 		public static void CloseStatus(NetState state, PacketReader pvSrc)


### PR DESCRIPTION
- Fixed addon deeds that retain hue from the craft resources.
- You can now, per EA, dye the above mentioned addon deeds with natural dyes and tokuno dyes
- Addon Deeds now face opposite direction once re-deed. Any of the above mentioned deeds will not be able to be dyed any longer once re-deeded, per EA
- Consolidated Custom Sign Entry gumps to one gump and context menu entry
- Fixed sign gump Crash
- Added IImbueableEquipment and ICombatEquipment for convenient accessors of certain properties, ie ItemPower, TimesImbued, Etc.
- Onslaught no longer uses mana on initial use, and no longer has a cooldown per EA
- Regen on items have had their max intensity adjusted to give the proper item weight
- Huntsmaster challenge new season will now auto correct the season start and end date
- City Loyalty System will not setup in fel for siege shards

- Fixed context menu entries from appearing on pre-aos shards *Requires core recompile*