### PR TITLE
Update Thunderstorm.cs

### DIFF
--- a/Scripts/Spells/Spellweaving/Thunderstorm.cs
+++ b/Scripts/Spells/Spellweaving/Thunderstorm.cs
@@ -85,7 +85,7 @@ namespace Server.Spells.Spellweaving
 
                 TimeSpan duration = TimeSpan.FromSeconds(5 + FocusLevel);
 
-                foreach (var m in AcquireIndirectTargets(Caster.Location, 2 + FocusLevel).OfType<Mobile>())
+                foreach (var m in AcquireIndirectTargets(Caster.Location, 3 + FocusLevel).OfType<Mobile>())
                 {
                     Caster.DoHarmful(m);
 


### PR DESCRIPTION
Current Thunderstorm range is up to 8 if we don't include caster's tile.

UOGuide says range is up to 10 tiles from caster (I guess this includes caster's tile): http://www.uoguide.com/Thunderstorm

stratics says Area of Effect: 3 tile radius (+1 per Focus level) (I guess this doesn't include caster's tile because it says area of effect) https://stratics.com/w/index.php?title=UO:Thunderstorm

Our code should be AcquireIndirectTargets(Caster.Location, 3 + FocusLevel)