### PR TITLE
Towncrier message spam delay increased

### DIFF
--- a/Scripts/Mobiles/NPCs/TownCrier.cs
+++ b/Scripts/Mobiles/NPCs/TownCrier.cs
@@ -589,7 +589,7 @@ namespace Server.Mobiles
         public void ForceBeginAutoShout()
         {
             if (m_AutoShoutTimer == null)
-                m_AutoShoutTimer = Timer.DelayCall(TimeSpan.FromSeconds(5.0), TimeSpan.FromMinutes(1.0), new TimerCallback(AutoShout_Callback));
+                m_AutoShoutTimer = Timer.DelayCall(TimeSpan.FromMinutes(1.0), TimeSpan.FromMinutes(5.0), new TimerCallback(AutoShout_Callback));
         }
 
         public TownCrierEntry AddEntry(string[] lines, TimeSpan duration)
@@ -602,7 +602,7 @@ namespace Server.Mobiles
             m_Entries.Add(tce);
 
             if (m_AutoShoutTimer == null)
-                m_AutoShoutTimer = Timer.DelayCall(TimeSpan.FromSeconds(5.0), TimeSpan.FromMinutes(1.0), new TimerCallback(AutoShout_Callback));
+                m_AutoShoutTimer = Timer.DelayCall(TimeSpan.FromMinutes(1.0), TimeSpan.FromMinutes(5.0), new TimerCallback(AutoShout_Callback));
 
             return tce;
         }
@@ -615,7 +615,7 @@ namespace Server.Mobiles
             m_Entries.Add(entry);
 
             if (m_AutoShoutTimer == null)
-                m_AutoShoutTimer = Timer.DelayCall(TimeSpan.FromSeconds(5.0), TimeSpan.FromMinutes(1.0), new TimerCallback(AutoShout_Callback));
+                m_AutoShoutTimer = Timer.DelayCall(TimeSpan.FromMinutes(1.0), TimeSpan.FromMinutes(5.0), new TimerCallback(AutoShout_Callback));
         }
 
         public void RemoveEntry(TownCrierEntry tce)


### PR DESCRIPTION
I tested this on TC where they have a TC saying messages in the Brittan Commons.

On ServUO it was always 1 second to 1 minute resulting in town criers spamming the news almost none stop, very annoying.

The new delay is 1 minute to 5 minutes. As always players can simply also say new at anytime to get the latest news.