### PR TITLE
Update BaseHealer.cs

### DIFF
--- a/Scripts/Mobiles/NPCs/BaseHealer.cs
+++ b/Scripts/Mobiles/NPCs/BaseHealer.cs
@@ -146,7 +146,7 @@ namespace Server.Mobiles
 
         public override void OnMovement(Mobile m, Point3D oldLocation)
         {
-            if (!m.Frozen && DateTime.UtcNow >= this.m_NextResurrect && this.InRange(m, 4) && !this.InRange(oldLocation, 4) && this.InLOS(m))
+            if (!m.Frozen && DateTime.UtcNow >= this.m_NextResurrect && this.InRange(m, 2) && !this.InRange(oldLocation, 2) && this.InLOS(m))
             {
                 if (!m.Alive)
                 {


### PR DESCRIPTION
A common issue on ServUO for years is a dead player will enter a healer shop and since the healer was within 4 tiles it would not rez them no matter now many times they entered and left the door. (door blocking LOS) setting it down to 2 will help in many town healer spawn setups.