### PR TITLE
Update RemoveTrap.cs

### DIFF
--- a/Scripts/Skills/RemoveTrap.cs
+++ b/Scripts/Skills/RemoveTrap.cs
@@ -67,6 +67,7 @@ namespace Server.SkillHandlers
                         targ.TrapPower = 0;
                         targ.TrapLevel = 0;
                         targ.TrapType = Server.Items.TrapType.None;
+                        targ.InvalidateProperties();
                         from.SendLocalizedMessage(502377); // You successfully render the trap harmless
                     }
                     else


### PR DESCRIPTION
In certain situations if the target was marked as [trapped] it would not invalidate the property right away. This fixes that.