### PR TITLE
Bug Fixes

### DIFF
--- a/Data/bodyTable.cfg
+++ b/Data/bodyTable.cfg
@@ -616,7 +616,6 @@
 1469	Equipment
 1476	Equipment
 1477	Equipment
-1486	Equipment
 1490	Equipment
 1492	Equipment
 1521	Equipment
@@ -1245,3 +1244,21 @@
 1481	Equipment	#	EQUIP_Female_H_Mask_Khal_Ankur
 1482	Equipment	#	EQUIP_Male_G_Necklace_Khal_Ankur
 1483	Equipment	#	EQUIP_Female_G_Necklace_Khal_Ankur
+1486	Equipment	#	EQUIP_Whip_1H_Blunt
+1488	Equipment	#	EQUIP_Gargoyle_Whip_1H_Blunt
+1490	Equipment	#	EQUIP_Whip_1H_Pierce
+1492	Equipment	#	EQUIP_Gargoyle_Whip_1H_Pierce
+1494	Equipment	#	EQUIP_Whip_1H_Slash
+1496	Equipment	#	EQUIP_Gargoyle_Whip_1H_Slash
+1498	Equipment	#	EQUIP_Male_Boots_Holiday
+1499	Equipment	#	EQUIP_Female_Boots_Holiday
+1500	Equipment	#	EQUIP_Male_Hat_Santa
+1501	Equipment	#	EQUIP_Female_Hat_Santa
+1502	Equipment	#	GARGOYLE_Talons_Holiday_Male
+1503	Equipment	#	GARGOYLE_Talons_Holiday_Female
+1504 	Equipment	#	Gargoyle Earrings - NO ANIMATION - PLACEHOLDER FOR PAPERDOLL - Male - Holiday	
+1505	Equipment	#	Gargoyle Earrings - NO ANIMATION - PLACEHOLDER FOR PAPERDOLL - Female - Holiday
+1506	Equipment	#	EQUIP_H_Male_Parrot_Epaulets- NO ANIMATION - PLACEHOLDER FOR PAPERDOLL 
+1507	Equipment	#	EQUIP_H_Female_Parrot_Epaulets - NO ANIMATION - PLACEHOLDER FOR PAPERDOLL 
+1508	Equipment	#	Gargoyle_Male_Parrot_Epaulets - NO ANIMATION - PLACEHOLDER FOR PAPERDOLL 
+1509	Equipment	#	Gargoyle_Female_Parrot_Epaulets- NO ANIMATION - PLACEHOLDER FOR PAPERDOLL

--- a/Scripts/Gumps/Guilds/New Guild System/GuildRosterGump.cs
+++ b/Scripts/Gumps/Guilds/New Guild System/GuildRosterGump.cs
@@ -122,30 +122,33 @@ namespace Server.Guilds
         public GuildRosterGump(PlayerMobile pm, Guild g, IComparer<PlayerMobile> currentComparer, bool ascending, string filter, int startNumber)
             : base(pm, g, Utility.SafeConvertList<Mobile, PlayerMobile>(g.Members), currentComparer, ascending, filter, startNumber, m_Fields)
         {
-            this.PopulateGump();
+            PopulateGump();
         }
 
         public override void PopulateGump()
         {
             base.PopulateGump();
 
-            this.AddHtmlLocalized(266, 43, 110, 26, 1062974, 0xF, false, false); // Guild Roster
+            AddHtmlLocalized(266, 43, 110, 26, 1062974, 0xF, false, false); // Guild Roster
         }
 
         public override void DrawEndingEntry(int itemNumber)
         {
-            this.AddBackground(225, 148 + itemNumber * 28, 150, 26, 0x2486);
-            this.AddButton(230, 153 + itemNumber * 28, 0x845, 0x846, 8, GumpButtonType.Reply, 0);
-            this.AddHtmlLocalized(255, 151 + itemNumber * 28, 110, 26, 1062992, 0x0, false, false); // Invite Player
+            AddBackground(225, 148 + itemNumber * 28, 150, 26, 0x2486);
+            AddButton(230, 153 + itemNumber * 28, 0x845, 0x846, 8, GumpButtonType.Reply, 0);
+            AddHtmlLocalized(255, 151 + itemNumber * 28, 110, 26, 1062992, 0x0, false, false); // Invite Player
         }
 
         protected override TextDefinition[] GetValuesFor(PlayerMobile pm, int aryLength)
         {
             TextDefinition[] defs = new TextDefinition[aryLength];
 
-            string name = String.Format("{0}{1}", pm.Name, (this.player.GuildFealty == pm && this.player.GuildFealty != this.guild.Leader) ? " *" : "");
+            string name = String.Format("{0} {1}{2}", 
+                pm.Name, 
+                Engines.VvV.ViceVsVirtueSystem.IsVvV(pm) ? "VvV" : "",
+                (player.GuildFealty == pm && player.GuildFealty != guild.Leader) ? " *" : "");
 
-            if (pm == this.player)
+            if (pm == player)
                 name = Color(name, 0x006600);
             else if (pm.NetState != null)
                 name = Color(name, 0x000066);
@@ -182,7 +185,7 @@ namespace Server.Guilds
 
             PlayerMobile pm = sender.Mobile as PlayerMobile;
 
-            if (pm == null || !IsMember(pm, this.guild))
+            if (pm == null || !IsMember(pm, guild))
                 return;
 
             if (info.ButtonID == 8)
@@ -190,7 +193,7 @@ namespace Server.Guilds
                 if (pm.GuildRank.GetFlag(RankFlags.CanInvitePlayer))
                 {
                     pm.SendLocalizedMessage(1063048); // Whom do you wish to invite into your guild?
-                    pm.BeginTarget(-1, false, Targeting.TargetFlags.None, new TargetStateCallback(InvitePlayer_Callback), this.guild);
+                    pm.BeginTarget(-1, false, Targeting.TargetFlags.None, new TargetStateCallback(InvitePlayer_Callback), guild);
                 }
                 else
                     pm.SendLocalizedMessage(503301); // You don't have permission to do that.
@@ -210,7 +213,7 @@ namespace Server.Guilds
             Faction guildFaction = (guildState == null ? null : guildState.Faction);
             Faction targetFaction = (targetState == null ? null : targetState.Faction);
 
-            if (pm == null || !IsMember(pm, this.guild) || !pm.GuildRank.GetFlag(RankFlags.CanInvitePlayer))
+            if (pm == null || !IsMember(pm, guild) || !pm.GuildRank.GetFlag(RankFlags.CanInvitePlayer))
             {
                 pm.SendLocalizedMessage(503301); // You don't have permission to do that.
             }
@@ -257,7 +260,7 @@ namespace Server.Guilds
             else
             {
                 pm.SendLocalizedMessage(1063053, targ.Name); // You invite ~1_val~ to join your guild.
-                targ.SendGump(new GuildInvitationRequest(targ, this.guild, pm));
+                targ.SendGump(new GuildInvitationRequest(targ, guild, pm));
             }
         }
     }

--- a/Scripts/Items/Books/SpecialScrollBooks/ScrollOfAlacrityBook.cs
+++ b/Scripts/Items/Books/SpecialScrollBooks/ScrollOfAlacrityBook.cs
@@ -9,7 +9,7 @@ namespace Server.Items
     [Flipable(0x9981, 0x9982)]
     public class ScrollOfAlacrityBook : BaseSpecialScrollBook
     {
-        public override Type ScrollType { get { return typeof(ScrollofAlacrity); } }
+        public override Type ScrollType { get { return typeof(ScrollOfAlacrity); } }
         public override int LabelNumber { get { return 1154321; } } // Scrolls of Alacrity Book
         public override int BadDropMessage { get { return 1154323; } } // This book only holds Scrolls of Alacrity.
         public override int DropMessage { get { return 1154326; } }    // You add the scroll to your Scrolls of Alacrity book.

--- a/Scripts/Items/Books/SpecialScrollBooks/ScrollOfTranscendenceBook.cs
+++ b/Scripts/Items/Books/SpecialScrollBooks/ScrollOfTranscendenceBook.cs
@@ -9,7 +9,7 @@ namespace Server.Items
     [Flipable(0x577E, 0x577F)]
     public class ScrollOfTranscendenceBook : BaseSpecialScrollBook
     {
-        public override Type ScrollType { get { return typeof(ScrollofTranscendence); } }
+        public override Type ScrollType { get { return typeof(ScrollOfTranscendence); } }
         public override int LabelNumber { get { return 1151679; } } // Scrolls of Transcendence Book
         public override int BadDropMessage { get { return 1151677; } } // This book only holds Scrolls of Transcendence.
         public override int DropMessage { get { return 1151674; } }    // You add the scroll to your Scrolls of Transcendence book.

--- a/Scripts/Items/Consumables/ScrollBinderDeed.cs
+++ b/Scripts/Items/Consumables/ScrollBinderDeed.cs
@@ -161,9 +161,9 @@ namespace Server.Items
                                 from.PlaySound(0x249);
 							}
 						}
-						else if (targeted is ScrollofTranscendence)
+						else if (targeted is ScrollOfTranscendence)
 						{
-							ScrollofTranscendence sot = (ScrollofTranscendence)targeted;
+							ScrollOfTranscendence sot = (ScrollOfTranscendence)targeted;
 							
 							m_Skill = sot.Skill;
 							m_BinderType = BinderType.SOT;
@@ -247,9 +247,9 @@ namespace Server.Items
 					}
 				case BinderType.SOT:
 					{
-						if(targeted is ScrollofTranscendence)
+						if(targeted is ScrollOfTranscendence)
 						{
-							ScrollofTranscendence sot = (ScrollofTranscendence)targeted;
+							ScrollOfTranscendence sot = (ScrollOfTranscendence)targeted;
 							
 							if(sot.Skill == m_Skill)
 							{
@@ -257,7 +257,7 @@ namespace Server.Items
 								
 								if(newValue == m_Needed)
 								{
-									GiveItem(from, new ScrollofTranscendence(m_Skill, m_Needed));
+									GiveItem(from, new ScrollOfTranscendence(m_Skill, m_Needed));
 									from.SendLocalizedMessage(1113145); //You've completed your binding and received an upgraded version of your scroll!
 									Delete();
 								}
@@ -313,13 +313,13 @@ namespace Server.Items
 		{
 			private double m_Value;
 			private int m_Needed;
-			private ScrollofTranscendence m_Scroll;
+			private ScrollOfTranscendence m_Scroll;
 			private ScrollBinderDeed m_Binder;
 			
 			//public override int TitleNumber{ get{ return 1075083; } }
             public override int LabelNumber { get { return 1113147; } }
 			
-			public BinderWarningGump(double value, ScrollBinderDeed binder, ScrollofTranscendence scroll, int needed)
+			public BinderWarningGump(double value, ScrollBinderDeed binder, ScrollOfTranscendence scroll, int needed)
 			{
 				m_Value = value;
 				m_Needed = needed;
@@ -331,7 +331,7 @@ namespace Server.Items
 			{		
 				if(m_Scroll != null && m_Binder != null)
 				{
-					m_Binder.GiveItem(from, new ScrollofTranscendence(m_Scroll.Skill, m_Needed));
+					m_Binder.GiveItem(from, new ScrollOfTranscendence(m_Scroll.Skill, m_Needed));
 					m_Scroll.Delete();
 					m_Binder.Delete();
                     from.PlaySound(0x249);
@@ -375,7 +375,7 @@ namespace Server.Items
                     writer.Write((int)1);
                 if (check is StatCapScroll)
                     writer.Write((int)2);
-                if (check is ScrollofTranscendence)
+                if (check is ScrollOfTranscendence)
                     writer.Write((int)3);
             }
             else
@@ -442,7 +442,7 @@ namespace Server.Items
                                     }
                                 case 3:
                                     {
-                                        check = new ScrollofTranscendence(m_skillname, m_skillvalue);
+                                        check = new ScrollOfTranscendence(m_skillname, m_skillvalue);
                                         break;
                                     }
                             }

--- a/Scripts/Items/Consumables/ScrollofAlacrity.cs
+++ b/Scripts/Items/Consumables/ScrollofAlacrity.cs
@@ -5,7 +5,8 @@ using Server.Mobiles;
 
 namespace Server.Items
 {
-    public class ScrollofAlacrity : SpecialScroll
+    [TypeAlias("Server.Items.ScrollofAlacrity")]
+    public class ScrollOfAlacrity : SpecialScroll
     {
         public override int LabelNumber
         {
@@ -33,20 +34,20 @@ namespace Server.Items
             }
         }
 
-        public ScrollofAlacrity()
+        public ScrollOfAlacrity()
             : this(SkillName.Alchemy)
         {
         }
 		
         [Constructable]
-        public ScrollofAlacrity(SkillName skill)
+        public ScrollOfAlacrity(SkillName skill)
             : base(skill, 0.0)
         {
             ItemID = 0x14EF;
             Hue = 1195;
         }
 
-        public ScrollofAlacrity(Serial serial)
+        public ScrollOfAlacrity(Serial serial)
             : base(serial)
         {
         }
@@ -151,9 +152,9 @@ namespace Server.Items
             return true;
         }
 
-        public static ScrollofAlacrity CreateRandom()
+        public static ScrollOfAlacrity CreateRandom()
         {
-            return new ScrollofAlacrity((SkillName)SkillInfo.Table[Utility.Random(SkillInfo.Table.Length)].SkillID);
+            return new ScrollOfAlacrity((SkillName)SkillInfo.Table[Utility.Random(SkillInfo.Table.Length)].SkillID);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Items/Consumables/ScrollofTranscendence.cs
+++ b/Scripts/Items/Consumables/ScrollofTranscendence.cs
@@ -4,7 +4,8 @@ using Server.Accounting;
 
 namespace Server.Items
 {
-    public class ScrollofTranscendence : SpecialScroll, IAccountRestricted
+    [TypeAlias("Server.Items.ScrollofTranscendence")]
+    public class ScrollOfTranscendence : SpecialScroll, IAccountRestricted
     {
         public override int LabelNumber
         {
@@ -32,30 +33,30 @@ namespace Server.Items
             }
         }
 
-        public static ScrollofTranscendence CreateRandom(int min, int max)
+        public static ScrollOfTranscendence CreateRandom(int min, int max)
         {
             SkillName skill = (SkillName)Utility.Random(SkillInfo.Table.Length);
 
-            return new ScrollofTranscendence(skill, Utility.RandomMinMax(min, max) * 0.1);
+            return new ScrollOfTranscendence(skill, Utility.RandomMinMax(min, max) * 0.1);
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public string Account { get; set; }
 
-        public ScrollofTranscendence()
+        public ScrollOfTranscendence()
             : this(SkillName.Alchemy, 0.0)
         {
         }
 		
         [Constructable]
-        public ScrollofTranscendence(SkillName skill, double value)
+        public ScrollOfTranscendence(SkillName skill, double value)
             : base(skill, value)
         {
             ItemID = 0x14EF;
             Hue = 0x490;
         }
 
-        public ScrollofTranscendence(Serial serial)
+        public ScrollOfTranscendence(Serial serial)
             : base(serial)
         {
         }

--- a/Scripts/Items/Consumables/SpecialScroll.cs
+++ b/Scripts/Items/Consumables/SpecialScroll.cs
@@ -149,7 +149,7 @@ namespace Server.Items
                         else
                             this.m_Skill = SkillName.Alchemy;
 
-                        if (this is ScrollofAlacrity)
+                        if (this is ScrollOfAlacrity)
                             this.m_Value = 0.0;
                         else if (this is StatCapScroll)
                             this.m_Value = (double)reader.ReadInt();

--- a/Scripts/Items/Containers/TreasureMapChest.cs
+++ b/Scripts/Items/Containers/TreasureMapChest.cs
@@ -523,12 +523,12 @@ namespace Server.Items
                 default:
                 case 0: special = new CreepingVine(); break;
                 case 1: special = new MessageInABottle(); break;
-                case 2: special = new ScrollofAlacrity(PowerScroll.Skills[Utility.Random(PowerScroll.Skills.Count)]); break;
+                case 2: special = new ScrollOfAlacrity(PowerScroll.Skills[Utility.Random(PowerScroll.Skills.Count)]); break;
                 case 3: special = new Skeletonkey(); break;
                 case 4: special = new TastyTreat(5); break;
                 case 5: special = new TreasureMap(Utility.RandomMinMax(level, Math.Min(7, level + 1)), map); break;
                 case 6: special = GetRandomRecipe(); break;
-                case 7: special = ScrollofTranscendence.CreateRandom(1, 5); break;
+                case 7: special = ScrollOfTranscendence.CreateRandom(1, 5); break;
             }
 
             return special;

--- a/Scripts/Items/Decorative/Chairs.cs
+++ b/Scripts/Items/Decorative/Chairs.cs
@@ -266,7 +266,7 @@ namespace Server.Items
 
     [Furniture]
     [Flipable(0x4023, 0x4024)]
-    public class TerMurStyleChair : Item
+    public class TerMurStyleChair : CraftableFurniture
     {
         public override int LabelNumber { get { return 1095291; } } // Ter-Mur style chair
 

--- a/Scripts/Items/Functional/PrimevalLichPuzzle.cs
+++ b/Scripts/Items/Functional/PrimevalLichPuzzle.cs
@@ -498,7 +498,7 @@ namespace Server.Engines.CannedEvil
             switch ( Utility.Random(1) )
             {
                 case 0:
-                    item = ScrollofTranscendence.CreateRandom(10, 10);
+                    item = ScrollOfTranscendence.CreateRandom(10, 10);
                     break;
                 case 1:
                     // black bone container

--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -146,6 +146,11 @@ namespace Server.Mobiles
 			{
 				if (!m_Mobile.Deleted && m_Mobile.Controlled && m_From.CheckAlive())
 				{
+                    if (m_From.Hidden)
+                    {
+                        m_From.RevealingAction();
+                    }
+
 					if (m_Mobile.IsDeadPet && (m_Order == OrderType.Guard || m_Order == OrderType.Attack ||
 											   m_Order == OrderType.Transfer || m_Order == OrderType.Drop))
 					{
@@ -1224,7 +1229,7 @@ namespace Server.Mobiles
 			switch (m_Mobile.ControlOrder)
 			{
 				case OrderType.None:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.Home = m_Mobile.Location;
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
@@ -1232,14 +1237,14 @@ namespace Server.Mobiles
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Come:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = FollowSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Drop:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = true;
@@ -1247,10 +1252,10 @@ namespace Server.Mobiles
 					break;
 				case OrderType.Friend:
 				case OrderType.Unfriend:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					break;
 				case OrderType.Guard:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = FollowSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = true;
@@ -1260,7 +1265,7 @@ namespace Server.Mobiles
 					m_Mobile.ControlMaster.SendLocalizedMessage(1049671, petname); //~1_PETNAME~ is now guarding you.
 					break;
 				case OrderType.Attack:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 
@@ -1268,28 +1273,28 @@ namespace Server.Mobiles
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Patrol:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Release:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Stay:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Stop:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.Home = m_Mobile.Location;
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
@@ -1297,7 +1302,7 @@ namespace Server.Mobiles
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Follow:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = FollowSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 
@@ -1305,7 +1310,7 @@ namespace Server.Mobiles
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Transfer:
-					m_Mobile.ControlMaster.RevealingAction();
+					//m_Mobile.ControlMaster.RevealingAction();
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 

--- a/Scripts/Mobiles/Bosses/Navery/Navrey.cs
+++ b/Scripts/Mobiles/Bosses/Navery/Navrey.cs
@@ -123,7 +123,7 @@ namespace Server.Mobiles
                 c.AddItem(new UntranslatedAncientTome());
 
             if (0.1 >= Utility.RandomDouble())
-                c.AddItem(ScrollofTranscendence.CreateRandom(30, 30));
+                c.AddItem(ScrollOfTranscendence.CreateRandom(30, 30));
 
             if (0.1 >= Utility.RandomDouble())
                 c.AddItem(new TatteredAncientScroll());

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -1636,7 +1636,7 @@ namespace Server.Mobiles
             if (pm.AcceleratedStart > DateTime.UtcNow)
 			{
 				pm.AcceleratedStart = DateTime.UtcNow;
-				ScrollofAlacrity.AlacrityEnd(pm);
+                ScrollOfAlacrity.AlacrityEnd(pm);
 			}
 			#endregion
 
@@ -2813,6 +2813,9 @@ namespace Server.Mobiles
 
         private bool DisplayInItemInsuranceGump(Item item)
         {
+            if (item.Parent is LockableContainer && ((LockableContainer)item.Parent).Locked)
+                return false;
+
             return ((item.Visible || AccessLevel >= AccessLevel.GameMaster) && (item.Insured || CanInsure(item)));
         }
 
@@ -3367,7 +3370,10 @@ namespace Server.Mobiles
 
 			if (msgNum == 1154111)
 			{
-				SendLocalizedMessage(msgNum, RawName);
+                if (to != null)
+                {
+                    SendLocalizedMessage(msgNum, to.Name);
+                }
 			}
 			else
 			{

--- a/Scripts/Quests/Eodon/Valley of One Quest/Creatures.cs
+++ b/Scripts/Quests/Eodon/Valley of One Quest/Creatures.cs
@@ -58,6 +58,7 @@ namespace Server.Mobiles
         public override bool UseSmartAI { get { return true; } }
         public override bool ReacquireOnMovement { get { return true; } }
         public override bool AttacksFocus { get { return true; } }
+        public override bool CanFlee { get { return false; } }
 
         // Missing Tail Swipe Ability
 

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -7330,10 +7330,10 @@
     <Compile Include="Items\Consumables\PowerScroll.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Items\Consumables\ScrollofAlacrity.cs">
+    <Compile Include="Items\Consumables\ScrollOfAlacrity.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Items\Consumables\ScrollofTranscendence.cs">
+    <Compile Include="Items\Consumables\ScrollOfTranscendence.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Items\Consumables\SpecialScroll.cs">

--- a/Scripts/Services/ChampionSystem/ChampionSpawn.cs
+++ b/Scripts/Services/ChampionSystem/ChampionSpawn.cs
@@ -488,14 +488,14 @@ namespace Server.Engines.CannedEvil
         }
 
         #region Scroll of Transcendence
-        private ScrollofTranscendence CreateRandomSoT(bool felucca)
+        private ScrollOfTranscendence CreateRandomSoT(bool felucca)
         {
             int level = Utility.RandomMinMax(1, 5);
 			
             if (felucca)
                 level += 5;
 
-            return ScrollofTranscendence.CreateRandom(level, level);
+            return ScrollOfTranscendence.CreateRandom(level, level);
         }
 
         #endregion
@@ -505,7 +505,7 @@ namespace Server.Engines.CannedEvil
             if (scroll == null || killer == null)	//sanity
                 return;
 
-            if (scroll is ScrollofTranscendence)
+            if (scroll is ScrollOfTranscendence)
                 killer.SendLocalizedMessage(1094936); // You have received a Scroll of Transcendence!
             else
                 killer.SendLocalizedMessage(1049524); // You have received a scroll of power!
@@ -648,7 +648,7 @@ namespace Server.Engines.CannedEvil
 
                                         if (Utility.RandomDouble() < ChampionSystem.TranscendenceChance)
                                         {
-                                            ScrollofTranscendence SoTF = CreateRandomSoT(true);
+                                            ScrollOfTranscendence SoTF = CreateRandomSoT(true);
                                             GiveScrollTo(pm, (SpecialScroll)SoTF);
                                         }
                                         else
@@ -664,7 +664,7 @@ namespace Server.Engines.CannedEvil
                                     if (Utility.RandomDouble() < 0.0015)
                                     {
                                         killer.SendLocalizedMessage(1094936); // You have received a Scroll of Transcendence!
-                                        ScrollofTranscendence SoTT = CreateRandomSoT(false);
+                                        ScrollOfTranscendence SoTT = CreateRandomSoT(false);
                                         killer.AddToBackpack(SoTT);
                                     }
                                 }

--- a/Scripts/Services/City Loyalty System/Trading/Mobiles/Slim.cs
+++ b/Scripts/Services/City Loyalty System/Trading/Mobiles/Slim.cs
@@ -138,7 +138,7 @@ namespace Server.Engines.CityLoyalty
                     RunicReforging.GenerateRandomItem(item, 0, min, max, this.Map);
                     return item;
                 case 2:
-                    return ScrollofTranscendence.CreateRandom(1, 10);
+                    return ScrollOfTranscendence.CreateRandom(1, 10);
             }
         }
 

--- a/Scripts/Services/City Loyalty System/Trading/Mobiles/TradeMinister.cs
+++ b/Scripts/Services/City Loyalty System/Trading/Mobiles/TradeMinister.cs
@@ -179,7 +179,7 @@ namespace Server.Engines.CityLoyalty
                 {
                     default:
                     case 1: return RandomResource(entry);
-                    case 2: return ScrollofTranscendence.CreateRandom(1, 10);
+                    case 2: return ScrollOfTranscendence.CreateRandom(1, 10);
                 }
             }
         }

--- a/Scripts/Services/CleanUpBritannia/CleanUpBritanniaRewards.cs
+++ b/Scripts/Services/CleanUpBritannia/CleanUpBritanniaRewards.cs
@@ -77,7 +77,7 @@ namespace Server.Engines.CleanUpBritannia
             Rewards.Add(new CollectionItem(typeof(Bamboo), 0x246D, 1029324, 0, 15000));
 
             Rewards.Add(new CollectionItem(typeof(HorseBardingDeed), 0x14EF, 1080212, 0, 20000));
-            Rewards.Add(new CollectionItem(typeof(ScrollofAlacrity), 0x14EF, 1078604, 1195, 20000));
+            Rewards.Add(new CollectionItem(typeof(ScrollOfAlacrity), 0x14EF, 1078604, 1195, 20000));
 
             Rewards.Add(new CollectionItem(typeof(SnakeSkinBoots), 0x170B, 1151224, 0x7D9, 20000));
             Rewards.Add(new CollectionItem(typeof(BootsOfTheLavaLizard), 0x170B, 1151223, 0x674, 20000));

--- a/Scripts/Services/CleanUpBritannia/Gumps.cs
+++ b/Scripts/Services/CleanUpBritannia/Gumps.cs
@@ -34,9 +34,9 @@ namespace Server.Engines.CleanUpBritannia
 
         public override void OnItemCreated(Item item)
         {
-            if (item is ScrollofAlacrity)
+            if (item is ScrollOfAlacrity)
             {
-                ((ScrollofAlacrity)item).Skill = (SkillName)Utility.Random(SkillInfo.Table.Length);
+                ((ScrollOfAlacrity)item).Skill = (SkillName)Utility.Random(SkillInfo.Table.Length);
             }
 
             item.InvalidateProperties();

--- a/Scripts/Services/PointsSystems/CleanUpBritanniaData.cs
+++ b/Scripts/Services/PointsSystems/CleanUpBritanniaData.cs
@@ -101,7 +101,7 @@ namespace Server.Engines.Points
                     else if (ps.Value == 120)
                         points = 2500;
                 }
-                else if (item is ScrollofTranscendence)
+                else if (item is ScrollOfTranscendence)
                 {
                     SpecialScroll sot = (SpecialScroll)item;
 

--- a/Scripts/Services/ViceVsVirtue/Gumps/RewardGump.cs
+++ b/Scripts/Services/ViceVsVirtue/Gumps/RewardGump.cs
@@ -67,9 +67,9 @@ namespace Server.Engines.VvV
             {
                 item = Activator.CreateInstance(citem.Type, citem.Hue) as Item;
             }
-            else if (citem.Type == typeof(ScrollofTranscendence))
+            else if (citem.Type == typeof(ScrollOfTranscendence))
             {
-                item = ScrollofTranscendence.CreateRandom(10, 10);
+                item = ScrollOfTranscendence.CreateRandom(10, 10);
             }
             else
                 item = Activator.CreateInstance(citem.Type) as Item;

--- a/Scripts/Services/ViceVsVirtue/VvVRewards.cs
+++ b/Scripts/Services/ViceVsVirtue/VvVRewards.cs
@@ -50,7 +50,7 @@ namespace Server.Engines.VvV
             Rewards.Add(new CollectionItem(typeof(ManaSpike), 2308, 1155508, 0, 1000));            // Mana Spike
 
             Rewards.Add(new CollectionItem(typeof(ForgedRoyalPardon), 18098, 1155524, 0, 10000));        // Royal Forged Pardon
-            Rewards.Add(new CollectionItem(typeof(ScrollofTranscendence), 5360, 1094934, 0x490, 10000));   // Scroll of Transcendence
+            Rewards.Add(new CollectionItem(typeof(ScrollOfTranscendence), 5360, 1094934, 0x490, 10000));   // Scroll of Transcendence
 
             Rewards.Add(new CollectionItem(typeof(VvVRobe), 9859, 1155532, ViceVsVirtueSystem.VirtueHue, 5000)); // virtue robe
             Rewards.Add(new CollectionItem(typeof(VvVRobe), 9859, 1155533, ViceVsVirtueSystem.ViceHue, 5000)); // virtue robe

--- a/Scripts/Skills/DetectHidden.cs
+++ b/Scripts/Skills/DetectHidden.cs
@@ -181,7 +181,7 @@ namespace Server.SkillHandlers
             eable.Free();
         }
 
-        private static bool CanDetect(Mobile src, Mobile target)
+        public static bool CanDetect(Mobile src, Mobile target)
         {
             if (src.Map == null || target.Map == null || !src.CanBeHarmful(target, false))
                 return false;

--- a/Scripts/Spells/Sixth/Reveal.cs
+++ b/Scripts/Spells/Sixth/Reveal.cs
@@ -26,35 +26,35 @@ namespace Server.Spells.Sixth
         }
         public override void OnCast()
         {
-            this.Caster.Target = new InternalTarget(this);
+            Caster.Target = new InternalTarget(this);
         }
 
         public void Target(IPoint3D p)
         {
-            if (!this.Caster.CanSee(p))
+            if (!Caster.CanSee(p))
             {
-                this.Caster.SendLocalizedMessage(500237); // Target can not be seen.
+                Caster.SendLocalizedMessage(500237); // Target can not be seen.
             }
-            else if (this.CheckSequence())
+            else if (CheckSequence())
             {
-                SpellHelper.Turn(this.Caster, p);
+                SpellHelper.Turn(Caster, p);
 
                 SpellHelper.GetSurfaceTop(ref p);
 
                 List<Mobile> targets = new List<Mobile>();
 
-                Map map = this.Caster.Map;
+                Map map = Caster.Map;
 
                 if (map != null)
                 {
-                    IPooledEnumerable eable = map.GetMobilesInRange(new Point3D(p), 1 + (int)(this.Caster.Skills[SkillName.Magery].Value / 20.0));
+                    IPooledEnumerable eable = map.GetMobilesInRange(new Point3D(p), 1 + (int)(Caster.Skills[SkillName.Magery].Value / 20.0));
 
                     foreach (Mobile m in eable)
                     {
-                        if (m is Mobiles.ShadowKnight && (m.X != p.X || m.Y != p.Y))
+                        if ((m is Mobiles.ShadowKnight && (m.X != p.X || m.Y != p.Y)) || !SkillHandlers.DetectHidden.CanDetect(Caster, m))
                             continue;
 
-                        if (m.Hidden && (m.IsPlayer() || this.Caster.AccessLevel > m.AccessLevel) && CheckDifficulty(this.Caster, m))
+                        if (m.Hidden && (m.IsPlayer() || Caster.AccessLevel > m.AccessLevel) && CheckDifficulty(Caster, m))
                             targets.Add(m);
                     }
 
@@ -70,9 +70,11 @@ namespace Server.Spells.Sixth
                     m.FixedParticles(0x375A, 9, 20, 5049, EffectLayer.Head);
                     m.PlaySound(0x1FD);
                 }
+
+                ColUtility.Free(targets);
             }
 
-            this.FinishSequence();
+            FinishSequence();
         }
 
         // Reveal uses magery and detect hidden vs. hide and stealth 
@@ -104,7 +106,7 @@ namespace Server.Spells.Sixth
             public InternalTarget(RevealSpell owner)
                 : base(Core.ML ? 10 : 12, true, TargetFlags.None)
             {
-                this.m_Owner = owner;
+                m_Owner = owner;
             }
 
             protected override void OnTarget(Mobile from, object o)
@@ -112,12 +114,12 @@ namespace Server.Spells.Sixth
                 IPoint3D p = o as IPoint3D;
 
                 if (p != null)
-                    this.m_Owner.Target(p);
+                    m_Owner.Target(p);
             }
 
             protected override void OnTargetFinish(Mobile from)
             {
-                this.m_Owner.FinishSequence();
+                m_Owner.FinishSequence();
             }
         }
     }


### PR DESCRIPTION
- VvV now appears after player name in guild roster (guild gump)
- Changed Type Name for ScrollofAlacrity to ScrollOfAlacrity
- Changed Type Name for ScrollofTranscendence to ScrollOfTranscendence
- Removed unused code from BaseExplosionPotion. It now uses LOS for hitting targets
- TerMurStyleChair now retains resource hue when crafted
- Players no longer become reveales when their pet performs various actions. They only get revealed when they give commands via context menu and typed commands
- Locked container contents no longer show on Item Insurance Menu
- TRex no longer flees
- Detect Hidden Spell no longer reveals blues in tram, it now follows same rules as the skill

Updated Body Table with new wearables