### PR TITLE
Summoners Kilt could not be repaired

### DIFF
--- a/Scripts/Items/Artifacts/Equipment/Armor/SummonersKilt.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/SummonersKilt.cs
@@ -4,6 +4,8 @@ namespace Server.Items
 {
     public class SummonersKilt : GargishClothKilt
 	{
+		public Server.Engines.Craft.CraftSystem RepairSystem { get { return Server.Engines.Craft.DefTailoring.CraftSystem; } }
+		
 		public override bool IsArtifact { get { return true; } }
 		public override int LabelNumber { get { return 1113540; } } // Summoner's Kilt
 		


### PR DESCRIPTION
now it can be repaired.

If someone has time, it is a little beyond me, the OuterLegs.cs Gargoyle items portion seems all messed up.