### PR TITLE
Fixes a MAJOR issue with rune books. 

### DIFF
--- a/Scripts/Gumps/RunebookGump.cs
+++ b/Scripts/Gumps/RunebookGump.cs
@@ -332,7 +332,7 @@ namespace Server.Gumps
             }
             else if (buttonID == 1) // Rename book
             {
-                if (m_Book.CheckAccess(from))
+                if (m_Book.CheckAccess(from) && m_Book.Movable != false)
                 {
                     from.Prompt = new InternalPrompt(m_Book);
                 }
@@ -391,7 +391,7 @@ namespace Server.Gumps
                                 }
                             case 8: // Drop rune
                                 {
-                                    if (m_Book.CheckAccess(from))
+                                    if (m_Book.CheckAccess(from) && m_Book.Movable != false)
                                     {
                                         m_Book.DropRune(from, e, index);
 

--- a/Scripts/Items/Artifacts/Equipment/Armor/SummonersKilt.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/SummonersKilt.cs
@@ -4,6 +4,8 @@ namespace Server.Items
 {
     public class SummonersKilt : GargishClothKilt
 	{
+		public Server.Engines.Craft.CraftSystem RepairSystem { get { return Server.Engines.Craft.DefTailoring.CraftSystem; } }
+		
 		public override bool IsArtifact { get { return true; } }
 		public override int LabelNumber { get { return 1113540; } } // Summoner's Kilt
 		

--- a/Scripts/Items/Books/RunicAtlas.cs
+++ b/Scripts/Items/Books/RunicAtlas.cs
@@ -360,7 +360,7 @@ namespace Server.Items
 
         public void RenameBook()
         {
-            if (Atlas.CheckAccess(User) || User.AccessLevel >= AccessLevel.GameMaster)
+            if (Atlas.CheckAccess(User) && Atlas.Movable != false || User.AccessLevel >= AccessLevel.GameMaster)
             {
                 User.Prompt = new InternalPrompt(Atlas);
             }
@@ -393,7 +393,7 @@ namespace Server.Items
 
         private void DropRune()
         {
-            if (Atlas.CheckAccess(User) || User.AccessLevel >= AccessLevel.GameMaster)
+            if (Atlas.CheckAccess(User)&& Atlas.Movable != false || User.AccessLevel >= AccessLevel.GameMaster)
             {
                 Atlas.DropRune(User, Atlas.Entries[Selected], Selected);
                 Refresh();

--- a/Scripts/Items/Books/RunicAtlas.cs
+++ b/Scripts/Items/Books/RunicAtlas.cs
@@ -393,7 +393,7 @@ namespace Server.Items
 
         private void DropRune()
         {
-            if (Atlas.CheckAccess(User)&& Atlas.Movable != false || User.AccessLevel >= AccessLevel.GameMaster)
+            if (Atlas.CheckAccess(User) && Atlas.Movable != false || User.AccessLevel >= AccessLevel.GameMaster)
             {
                 Atlas.DropRune(User, Atlas.Entries[Selected], Selected);
                 Refresh();


### PR DESCRIPTION
Bug Fixes

1. This PR addresses a major issue with Runebooks and the Runic Atlas where ANYONE with access to a locked down runebook could drop all the runes and rename the book.

Public runebook libraries have the access set to Everyone, so everyone can use them (obviously) there was NEVER a check to see if the item was locked down. This fixes that by making sure Movable != true

This way it could also come in handy for staff created runebooks that are locked down in the world.

2. Allows the Summoners Kilt to be repaired.
A lot of the Gargoyle clothing items need to be fixed. 