### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Addons/WashBasin.cs
+++ b/Scripts/Items/Addons/WashBasin.cs
@@ -130,7 +130,7 @@ namespace Server.Items
 
     public class WashBasinDeed : BaseAddonDeed, IRewardOption
     {
-        public override int LabelNumber { get { return 1158881; } } // Water Wheel
+        public override int LabelNumber { get { return 1158966; } } // Wash Basin
         
         public override BaseAddon Addon
         {

--- a/Scripts/Items/Consumables/EngravingTools.cs
+++ b/Scripts/Items/Consumables/EngravingTools.cs
@@ -415,6 +415,12 @@ namespace Server.Items
                     return;
 
                 Mobile from = state.Mobile;
+				
+				if (!m_Tool.IsChildOf(from.Backpack))
+				{
+				from.SendLocalizedMessage(1062334); // This item must be in your backpack to be used.
+					return;
+				}
 
                 if (info.ButtonID == 1)
                 {


### PR DESCRIPTION
1. Fixes a cliloc error.
2. Fixes an issue where all engraving tools can be used once the gump is up, even if the item is not in the players backpack.