### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Services/Harvest/HarvestSystem.cs
+++ b/Scripts/Services/Harvest/HarvestSystem.cs
@@ -779,7 +779,7 @@ namespace Server
                 return false;
             }
 			
-			if (item is CommodityDeedBox || item is ChinaCabinet || item is PieSafe item is AcademicBookCase)
+			if (item is CommodityDeedBox || item is ChinaCabinet || item is PieSafe item || is AcademicBookCase)
 			{
 				return false;
 			}

--- a/Scripts/Services/Harvest/HarvestSystem.cs
+++ b/Scripts/Services/Harvest/HarvestSystem.cs
@@ -778,6 +778,11 @@ namespace Server
             {
                 return false;
             }
+			
+			if (item is CommodityDeedBox || item is ChinaCabinet || item is PieSafe)
+			{
+				return false;
+			}
 
             if (item.GetType().IsDefined(typeof(FurnitureAttribute), false))
             {

--- a/Scripts/Services/Harvest/HarvestSystem.cs
+++ b/Scripts/Services/Harvest/HarvestSystem.cs
@@ -779,7 +779,7 @@ namespace Server
                 return false;
             }
 			
-			if (item is CommodityDeedBox || item is ChinaCabinet || item is PieSafe item || is AcademicBookCase)
+			if (item is CommodityDeedBox || item is ChinaCabinet || item is PieSafe || item is AcademicBookCase || item is JewelryBox || item is WoodenBookcase || item is Countertop)
 			{
 				return false;
 			}

--- a/Scripts/Services/Harvest/HarvestSystem.cs
+++ b/Scripts/Services/Harvest/HarvestSystem.cs
@@ -779,7 +779,7 @@ namespace Server
                 return false;
             }
 			
-			if (item is CommodityDeedBox || item is ChinaCabinet || item is PieSafe)
+			if (item is CommodityDeedBox || item is ChinaCabinet || item is PieSafe item is AcademicBookCase)
 			{
 				return false;
 			}


### PR DESCRIPTION
Fixes an issue where players could accidently use an axe to destroy Commodity Deed Boxes, the new China Cabinet, and Pie Safe. None of these should be able to be destroyed like that.