### PR TITLE
Despicable Quiver

### DIFF
--- a/Scripts/Items/Artifacts/DespiseArtifacts.cs
+++ b/Scripts/Items/Artifacts/DespiseArtifacts.cs
@@ -134,6 +134,7 @@ namespace Server.Items
 			SkillBonuses.SetValues( 0, SkillName.Archery, 5.0 );
 			Attributes.ReflectPhysical = 5;
 			Attributes.AttackChance = 5;
+            LowerAmmoCost = 20;
 			
 			switch(Utility.Random(5))
 			{

--- a/Scripts/Items/Artifacts/DespiseArtifacts.cs
+++ b/Scripts/Items/Artifacts/DespiseArtifacts.cs
@@ -134,7 +134,7 @@ namespace Server.Items
 			SkillBonuses.SetValues( 0, SkillName.Archery, 5.0 );
 			Attributes.ReflectPhysical = 5;
 			Attributes.AttackChance = 5;
-            LowerAmmoCost = 20;
+            LowerAmmoCost = 30;
 			
 			switch(Utility.Random(5))
 			{


### PR DESCRIPTION
The Despicable Quiver was missing its 30% Lower Ammo Cost attribute.

https://uo.com/wiki/ultima-online-wiki/items/artifact-collections/artifacts-despise/