### PR TITLE
Bug fixes *Requires Core Re-Compile*

### DIFF
--- a/Scripts/Gumps/ConfirmHouseResize.cs
+++ b/Scripts/Gumps/ConfirmHouseResize.cs
@@ -99,7 +99,7 @@ namespace Server.Gumps
                         {
                             if (m_House.Price > 0)
                             {
-                                if (Core.TOL)
+                                if (!Core.TOL)
                                 {
                                     toGive = new BankCheck(m_House.Price);
                                 }

--- a/Scripts/Items/Addons/HitchingPost.cs
+++ b/Scripts/Items/Addons/HitchingPost.cs
@@ -373,7 +373,10 @@ namespace Server.Items
 
                     from.Stabled.Add(pet);
 
-                    UsesRemaining -= 1;
+                    if (m_Replica)
+                    {
+                        UsesRemaining -= 1;
+                    }
 
                     from.SendLocalizedMessage(502679); // Very well, thy pet is stabled. Thou mayst recover it by saying 'claim' to me. In one real world week, I shall sell it off if it is not claimed!
                 }

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/DragonJadeEarrings.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/DragonJadeEarrings.cs
@@ -2,15 +2,19 @@ using System;
 
 namespace Server.Items
 {
-    public class DragonJadeEarrings : GoldEarrings
+    public class DragonJadeEarrings : GargishEarrings
 	{
 		public override bool IsArtifact { get { return true; } }
 		public override int LabelNumber { get { return 1113720; } } // Dragon Jade Earrings
-		
+
+        public override int BasePhysicalResistance { get { return 9; } }
+        public override int BaseFireResistance { get { return 16; } }
+        public override int BaseColdResistance { get { return 5; } }
+        public override int BasePoisonResistance { get { return 13; } }
+        public override int BaseEnergyResistance { get { return 3; } }
+
         [Constructable]
         public DragonJadeEarrings()
-            : base(0x4213)
-	
         {
             Hue = 2129;
             Attributes.BonusDex = 5;
@@ -18,11 +22,6 @@ namespace Server.Items
             Attributes.RegenHits = 2;
             Attributes.RegenStam = 3;
             Attributes.LowerManaCost = 5;
-            Resistances.Physical = 9;
-            Resistances.Fire = 16;
-            Resistances.Cold = 5;
-            Resistances.Poison = 13;
-            Resistances.Energy = 3;
 	        AbsorptionAttributes.EaterFire = 10;
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/ObsidianEarrings.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/ObsidianEarrings.cs
@@ -2,24 +2,24 @@ using System;
 
 namespace Server.Items
 {
-    public class ObsidianEarrings : GoldEarrings // Should be Gargish Earrings 
+    public class ObsidianEarrings : GargishEarrings
 	{
 		public override bool IsArtifact { get { return true; } }
 		public override int LabelNumber { get { return 1113820; } } // Obsidian Earrings
-		
+
+        public override int BasePhysicalResistance { get { return 4; } }
+        public override int BaseFireResistance { get { return 10; } }
+        public override int BaseColdResistance { get { return 10; } }
+        public override int BasePoisonResistance { get { return 3; } }
+        public override int BaseEnergyResistance { get { return 13; } }
+
         [Constructable]
         public ObsidianEarrings()
-            : base()
         {	
             Attributes.BonusMana = 8;
             Attributes.RegenMana = 2;
             Attributes.RegenStam = 2;
             Attributes.SpellDamage = 8;
-            Resistances.Physical = 4;
-            Resistances.Fire = 10;
-            Resistances.Cold = 10;
-            Resistances.Poison = 3;
-            Resistances.Energy = 13;
             AbsorptionAttributes.CastingFocus = 4;
         }
 

--- a/Scripts/Items/Consumables/CommodityDeed.cs
+++ b/Scripts/Items/Consumables/CommodityDeed.cs
@@ -103,12 +103,12 @@ namespace Server.Items
         public CommodityDeed(Item commodity)
             : base(0x14F0)
         {
-            this.Weight = 1.0;
-            this.Hue = 0x47;
+            Weight = 1.0;
+            Hue = 0x47;
 
-            this.m_Commodity = commodity;
+            m_Commodity = commodity;
 
-            this.LootType = LootType.Blessed;
+            LootType = LootType.Blessed;
         }
 
         [Constructable]
@@ -127,25 +127,27 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Commodity;
+                return m_Commodity;
             }
         }
         public override int LabelNumber
         {
             get
             {
-                return this.m_Commodity == null ? 1047016 : 1047017;
+                return m_Commodity == null ? 1047016 : 1047017;
             }
         }
         public bool SetCommodity(Item item)
         {
-            this.InvalidateProperties();
+            InvalidateProperties();
 
-            if (this.m_Commodity == null && item is ICommodity && ((ICommodity)item).IsDeedable)
+            if (m_Commodity == null && item is ICommodity && ((ICommodity)item).IsDeedable)
             {
-                this.m_Commodity = item;
-                this.m_Commodity.Internalize();
-                this.InvalidateProperties();
+                m_Commodity = item;
+                m_Commodity.Internalize();
+                Hue = 0x592;
+
+                InvalidateProperties();
 
                 return true;
             }
@@ -161,7 +163,7 @@ namespace Server.Items
 
             writer.Write((int)1); // version
 
-            writer.Write(this.m_Commodity);
+            writer.Write(m_Commodity);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -170,15 +172,15 @@ namespace Server.Items
 
             int version = reader.ReadInt();
 
-            this.m_Commodity = reader.ReadItem();
+            m_Commodity = reader.ReadItem();
 
             switch ( version )
             {
                 case 0:
                     {
-                        if (this.m_Commodity != null)
+                        if (m_Commodity != null)
                         {
-                            this.Hue = 0x592;
+                            Hue = 0x592;
                         }
                         break;
                     }
@@ -187,8 +189,8 @@ namespace Server.Items
 
         public override void OnDelete()
         {
-            if (this.m_Commodity != null)
-                this.m_Commodity.Delete();
+            if (m_Commodity != null)
+                m_Commodity.Delete();
 
             base.OnDelete();
         }
@@ -209,7 +211,7 @@ namespace Server.Items
                         args = String.Format("#{0}\t{1}", m_Commodity.LabelNumber, m_Commodity.Amount);
                 }
                 else
-                    args = String.Format("{0}\t{1}", this.m_Commodity.Name, this.m_Commodity.Amount);
+                    args = String.Format("{0}\t{1}", m_Commodity.Name, m_Commodity.Amount);
                 
                 list.Add(1060658, args); // ~1_val~: ~2_val~
             }
@@ -247,19 +249,19 @@ namespace Server.Items
 
             BankBox box = from.FindBankNoCreate();
             CommodityDeedBox cox = CommodityDeedBox.Find(this);
-            GalleonHold hold = this.RootParent as GalleonHold;
+            GalleonHold hold = RootParent as GalleonHold;
 
             // Veteran Rewards mods
-            if (this.m_Commodity != null)
+            if (m_Commodity != null)
             {
-                if (box != null && this.IsChildOf(box))
+                if (box != null && IsChildOf(box))
                 {
                     number = 1047031; // The commodity has been redeemed.
 
-                    box.DropItem(this.m_Commodity);
+                    box.DropItem(m_Commodity);
 
-                    this.m_Commodity = null;
-                    this.Delete();
+                    m_Commodity = null;
+                    Delete();
                 }
                 else if (cox != null)
                 {
@@ -267,10 +269,10 @@ namespace Server.Items
                     {
                         number = 1047031; // The commodity has been redeemed.
 
-                        cox.DropItem(this.m_Commodity);
+                        cox.DropItem(m_Commodity);
 
-                        this.m_Commodity = null;
-                        this.Delete();
+                        m_Commodity = null;
+                        Delete();
                     }
                     else
                         number = 1080525; // The commodity deed box must be secured before you can use it.
@@ -300,7 +302,7 @@ namespace Server.Items
             {
                 number = 1080525; // The commodity deed box must be secured before you can use it.
             }
-            else if ((box == null || !this.IsChildOf(box)) && cox == null && hold == null)
+            else if ((box == null || !IsChildOf(box)) && cox == null && hold == null)
             {
                 if (Core.ML)
                 {
@@ -327,34 +329,33 @@ namespace Server.Items
             public InternalTarget(CommodityDeed deed)
                 : base(3, false, TargetFlags.None)
             {
-                this.m_Deed = deed;
+                m_Deed = deed;
             }
 
             protected override void OnTarget(Mobile from, object targeted)
             {
-                if (this.m_Deed.Deleted)
+                if (m_Deed.Deleted)
                     return;
 
                 int number;
 
-                if (this.m_Deed.Commodity != null)
+                if (m_Deed.Commodity != null)
                 {
                     number = 1047028; // The commodity deed has already been filled.
                 }
                 else if (targeted is Item)
                 {
                     BankBox box = from.FindBankNoCreate();
-                    CommodityDeedBox cox = CommodityDeedBox.Find(this.m_Deed);
+                    CommodityDeedBox cox = CommodityDeedBox.Find(m_Deed);
                     GalleonHold hold = ((Item)targeted).RootParent as GalleonHold;
 
                     // Veteran Rewards mods
-                    if (box != null && this.m_Deed.IsChildOf(box) && ((Item)targeted).IsChildOf(box) ||
+                    if (box != null && m_Deed.IsChildOf(box) && ((Item)targeted).IsChildOf(box) ||
                         (cox != null && cox.IsSecure && ((Item)targeted).IsChildOf(cox)) ||
                         hold != null)
                     {
-                        if (this.m_Deed.SetCommodity((Item)targeted))
+                        if (m_Deed.SetCommodity((Item)targeted))
                         {
-                            this.m_Deed.Hue = 0x592;
                             number = 1047030; // The commodity deed has been filled.
                         }
                         else

--- a/Scripts/Items/Consumables/Cooking.cs
+++ b/Scripts/Items/Consumables/Cooking.cs
@@ -434,33 +434,9 @@ namespace Server.Items
 
     // ********** SackFlour **********
     [TypeAlias("Server.Items.SackFlourOpen")]
-    public class SackFlour : Item, IHasQuantity, IQuality
+    public class SackFlour : Item, IQuality
     {
-        private int m_Quantity;
         private ItemQuality _Quality;
-
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int Quantity
-        {
-            get
-            {
-                return m_Quantity;
-            }
-            set
-            {
-                if (value < 0)
-                    value = 0;
-                else if (value > 20)
-                    value = 20;
-
-                m_Quantity = value;
-
-                if (m_Quantity == 0)
-                    Delete();
-                else if (m_Quantity < 20 && (ItemID == 0x1039 || ItemID == 0x1045))
-                    ++ItemID;
-            }
-        }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public ItemQuality Quality { get { return _Quality; } set { _Quality = value; InvalidateProperties(); } }
@@ -469,10 +445,45 @@ namespace Server.Items
 
         [Constructable]
         public SackFlour()
+            : this(1)
+        {
+        }
+
+        [Constructable]
+        public SackFlour(int amount)
             : base(0x1039)
         {
             Weight = 5.0;
-            m_Quantity = 20;
+
+            Stackable = true;
+            Amount = amount;
+        }
+
+        public override void OnDoubleClick(Mobile from)
+        {
+            if (!Movable)
+                return;
+
+            var flour = new SackFlourOpen();
+            flour.Location = Location;
+
+            if (Parent is Container)
+            {
+                ((Container)Parent).DropItem(flour);
+            }
+            else
+            {
+                flour.MoveToWorld(GetWorldLocation(), Map);
+            }
+
+            if (Amount > 1)
+            {
+                Amount--;
+            }
+            else
+            {
+                Delete();
+            }
         }
 
         public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, ITool tool, CraftItem craftItem, int resHue)
@@ -501,11 +512,9 @@ namespace Server.Items
         {
             base.Serialize(writer);
 
-            writer.Write((int)3); // version
+            writer.Write((int)4); // version
 
             writer.Write((int)_Quality);
-
-            writer.Write((int)m_Quantity);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -516,52 +525,27 @@ namespace Server.Items
 
             switch ( version )
             {
+                case 4:
+                    _Quality = (ItemQuality)reader.ReadInt();
+                    break;
                 case 3:
-                    {
-                        _Quality = (ItemQuality)reader.ReadInt();
-                        goto case 2;
-                    }
-                case 2:
-                case 1:
-                    {
-                        m_Quantity = reader.ReadInt();
-                        break;
-                    }
-                case 0:
-                    {
-                        m_Quantity = 20;
-                        break;
-                    }
+                    _Quality = (ItemQuality)reader.ReadInt();
+                    reader.ReadInt();
+                    Stackable = true;
+                    break;
             }
-
-            if (version < 2 && Weight == 1.0)
-                Weight = 5.0;
-        }
-
-        public override void OnDoubleClick(Mobile from)
-        {
-            if (!Movable)
-                return;
-
-            if ((ItemID == 0x1039 || ItemID == 0x1045))
-                ++ItemID;
-            #if false
-			Delete();
-			from.AddToBackpack( new SackFlourOpen() );
-            #endif
         }
     }
 
-    #if false
 	// ********** SackFlourOpen **********
 	public class SackFlourOpen : Item
 	{
 		public override int LabelNumber{ get{ return 1024166; } } // open sack of flour
 
 		[Constructable]
-		public SackFlourOpen() : base(UtilityItem.RandomChoice( 0x1046, 0x103a ))
+		public SackFlourOpen() : base(0x103A)
 		{
-			Weight = 1.0;
+			Weight = 4.0;
 		}
 
 		public SackFlourOpen( Serial serial ) : base( serial )
@@ -581,55 +565,7 @@ namespace Server.Items
 
 			int version = reader.ReadInt();
 		}
-
-		public override void OnDoubleClick( Mobile from )
-		{
-			if ( !Movable )
-				return;
-
-			from.Target = new InternalTarget( this );
-		}
-
-		private class InternalTarget : Target
-		{
-			private SackFlourOpen m_Item;
-
-			public InternalTarget( SackFlourOpen item ) : base( 1, false, TargetFlags.None )
-			{
-				m_Item = item;
-			}
-
-			protected override void OnTarget( Mobile from, object targeted )
-			{
-				if ( m_Item.Deleted ) return;
-
-				if ( targeted is WoodenBowl )
-				{
-					m_Item.Delete();
-					((WoodenBowl)targeted).Delete();
-
-					from.AddToBackpack( new BowlFlour() );
-				}
-				else if ( targeted is TribalBerry )
-				{
-					if ( from.Skills[SkillName.Cooking].Base >= 80.0 )
-					{
-						m_Item.Delete();
-						((TribalBerry)targeted).Delete();
-
-						from.AddToBackpack( new TribalPaint() );
-
-						from.SendLocalizedMessage( 1042002 ); // You combine the berry and the flour into the tribal paint worn by the savages.
-					}
-					else
-					{
-						from.SendLocalizedMessage( 1042003 ); // You don't have the cooking skill to create the body paint.
-					}
-				}
-			}
-		}
 	}
-    #endif
 
     // ********** Eggshells **********
     public class Eggshells : Item

--- a/Scripts/Items/Decorative/Easle.cs
+++ b/Scripts/Items/Decorative/Easle.cs
@@ -8,7 +8,7 @@ namespace Server.Items
     {
         [Constructable]
         public EasleSouth()
-            : base(0xF65)
+            : base(0xF66)
         {
             Weight = 25.0;
         }
@@ -21,7 +21,7 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -29,9 +29,9 @@ namespace Server.Items
             base.Deserialize(reader);
             int version = reader.ReadInt();
 
-            if (Weight == 10.0)
+            if (version == 0)
             {
-                Weight = 25.0;
+                ItemID = 0xF66;
             }
         }
     }
@@ -41,7 +41,7 @@ namespace Server.Items
     {
         [Constructable]
         public EasleEast()
-            : base(0xF67)
+            : base(0xF68)
         {
             Weight = 25.0;
         }
@@ -54,13 +54,18 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            if (version == 0)
+            {
+                ItemID = 0xF68;
+            }
         }
     }
 
@@ -69,7 +74,7 @@ namespace Server.Items
     {
         [Constructable]
         public EasleNorth()
-            : base(0xF69)
+            : base(0xF6A)
         {
             Weight = 25.0;
         }
@@ -82,13 +87,18 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            if (version == 0)
+            {
+                ItemID = 0xF6A;
+            }
         }
     }
 }

--- a/Scripts/Items/Functional/StrangeContraption.cs
+++ b/Scripts/Items/Functional/StrangeContraption.cs
@@ -1,0 +1,226 @@
+using System;
+using Server.ContextMenus;
+using Server.Engines.Quests.Collector;
+using Server.Engines.Quests.Hag;
+using Server.Network;
+using System.Collections.Generic;
+using Server.Gumps;
+
+namespace Server.Items
+{
+    public class StrangeContraptionComponent : AddonComponent
+    {
+        public override bool ForceShowProperties { get { return true; } }
+        
+        public StrangeContraptionComponent(int id, int hue = 0)
+            : base(id)
+        {
+            Name = "a strange contraption";
+            Hue = hue;
+        }
+
+        public StrangeContraptionComponent(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)
+        {
+            base.GetContextMenuEntries(from, list);
+
+            if (ItemID == 6434)
+            {
+                list.Add(new DeviceEntry(from, this));
+            }
+        }
+
+        private class DeviceEntry : ContextMenuEntry
+        {
+            private readonly Mobile m_Mobile;
+            private readonly AddonComponent m_Component;
+
+            public DeviceEntry(Mobile mobile, AddonComponent c)
+                : base(3006190, 16) // Appraise for Cleanup
+            {
+                m_Mobile = mobile;
+                m_Component = c;
+            }
+
+            public bool CanDrop(Mobile m)
+            {
+                if (!StrangeContraptionAddon.Table.ContainsKey(m))
+                    return true;
+
+                if (StrangeContraptionAddon.Table[m] < DateTime.UtcNow)
+                {
+                    StrangeContraptionAddon.Table.Remove(m);
+                    return true;
+                }
+                else
+                {
+                    m.SendLocalizedMessage(1060001); // You throw the switch, but the mechanism cannot be engaged again so soon.
+                }
+
+                return false;
+            }
+
+            public override void OnClick()
+            {
+                if (m_Mobile.InRange(m_Component.Location, 2))
+                {
+                    if (CanDrop(m_Mobile))
+                    {
+                        Container pack = m_Mobile.Backpack as Container;
+
+                        if (pack == null)
+                            return;
+
+                        Item pmc = pack.FindItemByType(typeof(PlagueBeastMutationCore));
+                        Item obs = pack.FindItemByType(typeof(Obsidian));
+                        Item mb = pack.FindItemByType(typeof(MoonfireBrew));
+
+                        if (pmc != null && obs != null && mb != null)
+                        {
+                            m_Mobile.PlaySound(0x21E);
+                            m_Mobile.SendLocalizedMessage(1055143); // You add the required ingredients and activate the contraption. It rumbles and smokes and then falls silent. The water shines for a brief moment, and you feel confident that it is now much less tainted then before. 
+                            m_Mobile.Karma += 500;
+
+                            pmc.Delete();
+                            obs.Delete();
+                            mb.Delete();
+
+                            StrangeContraptionAddon.Table[m_Mobile] = DateTime.UtcNow + TimeSpan.FromHours(1);
+                        }
+                        else
+                        {
+                            m_Mobile.SendLocalizedMessage(1055142, "", 0x59); // You do not have the necessary ingredients. The contraptions rumbles angrily but does nothing.
+                        }
+                    }                    
+                }
+                else
+                {
+                    m_Mobile.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1019045); // I can't reach that.
+                }
+            }
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0); // Version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+        }
+    }
+
+    public class StrangeContraptionAddon : BaseAddon
+    {
+        public static StrangeContraptionAddon InstanceTram { get; set; }
+        public static StrangeContraptionAddon InstanceFel { get; set; }
+
+        public static void Initialize()
+        {
+            if (Core.T2A)
+            {
+                if (InstanceTram == null)
+                {
+                    StrangeContraptionAddon item = new StrangeContraptionAddon();
+                    item.MoveToWorld(new Point3D(5668, 1925, 0), Map.Trammel);
+                }
+
+                if (InstanceFel == null)
+                {
+                    StrangeContraptionAddon item = new StrangeContraptionAddon();
+                    item.MoveToWorld(new Point3D(5668, 1925, 0), Map.Felucca);
+                }
+            }
+        }
+
+        public static Dictionary<Mobile, DateTime> Table = new Dictionary<Mobile, DateTime>();
+
+        public StrangeContraptionAddon()
+        {
+            // Table
+            AddComponent(new AddonComponent(2923), 1, 2, 1);
+            AddComponent(new AddonComponent(2924), 1, 1, 1);
+
+            // Book
+            AddComponent(new AddonComponent(0x0FF4), 1, 2, 7);
+
+            // Water
+            AddComponent(new AddonComponent(6063), -1, 0, 1);
+            AddComponent(new AddonComponent(6066), 0, 0, 1);
+            AddComponent(new AddonComponent(6064), -1, 1, 1);
+            AddComponent(new AddonComponent(6065), 0, 1, 1);
+
+            AddComponent(new StrangeContraptionComponent(4758), 0, -1, 1);
+            AddComponent(new StrangeContraptionComponent(4758), 0, 0, 1);
+            AddComponent(new StrangeContraptionComponent(2813), 2, 0, 19);
+            AddComponent(new StrangeContraptionComponent(2815), 1, 0, 19);
+            AddComponent(new StrangeContraptionComponent(2816), 2, 0, 16);
+            AddComponent(new StrangeContraptionComponent(2818), 1, 0, 16);
+            AddComponent(new StrangeContraptionComponent(4715), 1, 0, 1);
+            AddComponent(new StrangeContraptionComponent(2643), 1, 0, 3);
+            AddComponent(new StrangeContraptionComponent(6434), 2, 0, 1);
+            AddComponent(new StrangeContraptionComponent(4758, 1545), -1, 0, 0);
+            AddComponent(new StrangeContraptionComponent(4272, 1545), - 1, 0, 1);
+            AddComponent(new StrangeContraptionComponent(6039, 999), 2, 0, 20);
+            AddComponent(new StrangeContraptionComponent(6040, 999), 1, 0, 20);
+        }
+
+        public override void OnComponentUsed(AddonComponent comp, Mobile from)
+        {
+            if (comp.ItemID == 0x0FF4)
+            {
+                if (!from.InRange(comp.GetWorldLocation(), 2))
+                {
+                    from.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1019045); // I can't reach that.
+                }
+                else
+                {
+                    Gump g = new Gump(35, 70);
+                    g.AddImage(0, 0, 500);
+                    g.AddHtmlLocalized(40, 17, 150, 220, 1055141, false, false);
+                    from.SendGump(g);
+                }
+            }
+        }
+
+        public StrangeContraptionAddon(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+
+            if (Core.T2A)
+            {
+                if (Map == Map.Trammel)
+                {
+                    InstanceTram = this;
+                }
+                else if (Map == Map.Felucca)
+                {
+                    InstanceFel = this;
+                }
+            }
+            else
+            {
+                Delete();
+            }
+        }
+    }
+}

--- a/Scripts/Misc/Notoriety.cs
+++ b/Scripts/Misc/Notoriety.cs
@@ -87,11 +87,6 @@ namespace Server.Misc
 			}
 			#endregion
 
-			#region Mondain's Legacy
-			if (target is Gregorio)
-				return false;
-			#endregion
-
 			if (map != null && (map.Rules & MapRules.BeneficialRestrictions) == 0)
 				return true; // In felucca, anything goes
 
@@ -127,17 +122,6 @@ namespace Server.Misc
 
 			if (from == null || target == null || from.IsStaff() || target.IsStaff())
 				return true;
-
-			#region Mondain's Legacy
-			if (target is Gregorio)
-			{
-				if (Gregorio.IsMurderer(from))
-					return true;
-
-				from.SendLocalizedMessage(1075456); // You are not allowed to damage this NPC unless your on the Guilty Quest
-				return false;
-			}
-			#endregion
 
 			var map = from.Map;
 
@@ -411,18 +395,8 @@ namespace Server.Misc
 					return Notoriety.Murderer;
 			}
 
-			#region Mondain's Legacy
-			if (target is Gregorio)
-			{
-				if (Gregorio.IsMurderer(source))
-					return Notoriety.Murderer;
-
-				return Notoriety.Innocent;
-			}
-
 			if (source.Player && target is BaseEscort)
 				return Notoriety.Innocent;
-			#endregion
 
 			if (target.Criminal)
 				return Notoriety.Criminal;

--- a/Scripts/Misc/Poison.cs
+++ b/Scripts/Misc/Poison.cs
@@ -242,6 +242,7 @@ namespace Server
                 }
 
                 IHonorTarget honorTarget = m_Mobile as IHonorTarget;
+
                 if (honorTarget != null && honorTarget.ReceivedHonorContext != null)
                     honorTarget.ReceivedHonorContext.OnTargetPoisoned();
 
@@ -268,6 +269,11 @@ namespace Server
                 #endregion
 
                 AOS.Damage(m_Mobile, m_From, damage, 0, 0, 0, 100, 0);
+
+                if (damage > 0)
+                {
+                    m_Mobile.RevealingAction();
+                }
 
                 if ((m_Index % m_Poison.m_MessageInterval) == 0)
                     m_Mobile.OnPoisoned(m_From, m_Poison, m_Poison);

--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -2986,7 +2986,7 @@ namespace Server.Mobiles
 						}
 
 						// Don't ignore hostile mobiles
-						if (!IsHostile(m))
+						if (!IsHostile(m, acqType))
 						{
 							// Ignore anyone if we don't want enemies
 							if (!bFacFoe)
@@ -3019,14 +3019,14 @@ namespace Server.Mobiles
 			return (m_Mobile.FocusMob != null);
 		}
 
-		public bool IsHostile(Mobile from)
+		public virtual bool IsHostile(Mobile from, FightMode mode)
 		{
 			if (m_Mobile.Combatant == from || from.Combatant == m_Mobile)
 			{
 				return true;
 			}
 
-			var count = Math.Max(m_Mobile.Aggressors.Count, m_Mobile.Aggressed.Count);
+            /*var count = Math.Max(m_Mobile.Aggressors.Count, m_Mobile.Aggressed.Count);
 
 			if (count > 0)
 			{
@@ -3042,7 +3042,7 @@ namespace Server.Mobiles
 						return true;
 					}
 				}
-			}
+			}*/
 
 			return false;
 		}

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -1315,11 +1315,6 @@ namespace Server.Mobiles
             }
         }
 
-        /*
-        Solen Style, override me for other mobiles/items:
-        kappa+acidslime, grizzles+whatever, etc.
-        */
-
         public virtual Item NewHarmfulItem()
         {
             return new PoolOfAcid(TimeSpan.FromSeconds(10), 30, 30);
@@ -7352,15 +7347,9 @@ namespace Server.Mobiles
 
             for (int i = 0; i < 10; i++)
             {
-                int x = from.X + Utility.Random(range);
-                int y = from.Y + Utility.Random(range);
+                int x = from.X + Utility.RandomMinMax(-range, range);
+                int y = from.Y + Utility.RandomMinMax(-range, range);
                 int z = map.GetAverageZ(x, y);
-
-                if (Utility.RandomBool())
-                    x *= -1;
-
-                if (Utility.RandomBool())
-                    y *= -1;
 
                 Point3D p = new Point3D(x, y, from.Z);
 

--- a/Scripts/Mobiles/Normal/Gregorio.cs
+++ b/Scripts/Mobiles/Normal/Gregorio.cs
@@ -10,31 +10,31 @@ namespace Server.Mobiles
         public Gregorio()
             : base(AIType.AI_Melee, FightMode.Aggressor, 10, 1, 0.2, 0.4)
         { 
-            this.Race = Race.Human;
-            this.Name = "Gregorio";
-            this.Title = "the brigand";
+            Race = Race.Human;
+            Name = "Gregorio";
+            Title = "the brigand";
 			
-            this.InitBody();
-            this.InitOutfit();
+            InitBody();
+            InitOutfit();
 			
-            this.SetStr(86, 100);
-            this.SetDex(81, 95);
-            this.SetInt(61, 75);
+            SetStr(86, 100);
+            SetDex(81, 95);
+            SetInt(61, 75);
 
-            this.SetDamage(15, 27);
+            SetDamage(15, 27);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 10, 15);
-            this.SetResistance(ResistanceType.Fire, 10, 15);
-            this.SetResistance(ResistanceType.Poison, 10, 15);
-            this.SetResistance(ResistanceType.Energy, 10, 15);
+            SetResistance(ResistanceType.Physical, 10, 15);
+            SetResistance(ResistanceType.Fire, 10, 15);
+            SetResistance(ResistanceType.Poison, 10, 15);
+            SetResistance(ResistanceType.Energy, 10, 15);
 
-            this.SetSkill(SkillName.MagicResist, 25.0, 50.0);
-            this.SetSkill(SkillName.Tactics, 80.0, 100.0);
-            this.SetSkill(SkillName.Wrestling, 80.0, 100.0);	
+            SetSkill(SkillName.MagicResist, 25.0, 50.0);
+            SetSkill(SkillName.Tactics, 80.0, 100.0);
+            SetSkill(SkillName.Wrestling, 80.0, 100.0);	
 			
-            this.PackGold(50, 150);
+            PackGold(50, 150);
         }
 
         public Gregorio(Serial serial)
@@ -42,46 +42,82 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool InitialInnocent
+        /*public override bool InitialInnocent
         {
             get
             {
                 return true;
             }
-        }
-        public static bool IsMurderer(Mobile from)
-        { 
-            if (from != null && from is PlayerMobile)
-            {
-                BaseQuest quest = QuestHelper.GetQuest((PlayerMobile)from, typeof(GuiltyQuest));
+        }*/
 
-                if (quest != null)
-                    return !quest.Completed;
+        public override bool AlwaysMurderer { get { return true; } }
+
+        public override int Damage(int amount, Mobile from, bool informMount, bool checkDisrupt)
+        {
+            if (from is BaseCreature && ((BaseCreature)from).GetMaster() is PlayerMobile)
+                from = ((BaseCreature)from).GetMaster();
+
+            if (from is PlayerMobile)
+            {
+                var pm = (PlayerMobile)from;
+
+                BaseQuest quest = QuestHelper.GetQuest(pm, typeof(GuiltyQuest));
+
+                if (quest != null && !quest.Completed)
+                {
+                    return base.Damage(amount, from, informMount, checkDisrupt);
+                }
             }
-				
+
+            from.SendLocalizedMessage(1075456); // You are not allowed to damage this NPC unless your on the Guilty Quest
+            return 0;
+        }
+
+        public override bool CanBeHarmedBy(Mobile from, bool message)
+        {
+            if (from is BaseCreature && ((BaseCreature)from).GetMaster() is PlayerMobile)
+                from = ((BaseCreature)from).GetMaster();
+
+            if (from is PlayerMobile)
+            {
+                var pm = (PlayerMobile)from;
+
+                BaseQuest quest = QuestHelper.GetQuest(pm, typeof(GuiltyQuest));
+
+                if (quest != null && !quest.Completed)
+                {
+                    return base.CanBeHarmedBy(from, message);
+                }
+            }
+
+            if (message)
+            {
+                from.SendLocalizedMessage(1075456); // You are not allowed to damage this NPC unless your on the Guilty Quest
+            }
+
             return false;
         }
 
-        public virtual void InitBody()
+        public void InitBody()
         {
-            this.InitStats(100, 100, 25);
+            InitStats(100, 100, 25);
 				
-            this.Hue = 0x8412;
-            this.Female = false;		
+            Hue = 0x8412;
+            Female = false;		
 			
-            this.HairItemID = 0x203C;
-            this.HairHue = 0x47A;
-            this.FacialHairItemID = 0x204D;
-            this.FacialHairHue = 0x47A;
+            HairItemID = 0x203C;
+            HairHue = 0x47A;
+            FacialHairItemID = 0x204D;
+            FacialHairHue = 0x47A;
         }
 
-        public virtual void InitOutfit()
+        public void InitOutfit()
         { 
-            this.AddItem(new Sandals(0x75E));
-            this.AddItem(new Shirt());
-            this.AddItem(new ShortPants(0x66C));
-            this.AddItem(new SkullCap(0x649));
-            this.AddItem(new Pitchfork());
+            AddItem(new Sandals(0x75E));
+            AddItem(new Shirt());
+            AddItem(new ShortPants(0x66C));
+            AddItem(new SkullCap(0x649));
+            AddItem(new Pitchfork());
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/InterredGrizzle .cs
+++ b/Scripts/Mobiles/Normal/InterredGrizzle .cs
@@ -69,44 +69,15 @@ namespace Server.Mobiles
 
         public override void OnDamage(int amount, Mobile from, bool willKill)
         {
-            if (Utility.RandomDouble() < 0.3)
-                this.DropOoze();
+            if (Utility.RandomDouble() < 0.04)
+                SpillAcid(null, Utility.RandomMinMax(1, 3));
 
             base.OnDamage(amount, from, willKill);
         }
 
-        public virtual void DropOoze()
+        public override Item NewHarmfulItem()
         {
-            int amount = Utility.RandomMinMax(1, 3);
-
-            for (int i = 0; i < amount; i++)
-            {
-                Item ooze = new InfernalOoze(false, Utility.RandomMinMax(6, 10));
-                Point3D p = new Point3D(this.Location);
-
-                for (int j = 0; j < 5; j++)
-                {
-                    p = this.GetSpawnPosition(2);
-                    bool found = false;
-
-                    foreach (Item item in this.Map.GetItemsInRange(p, 0))
-                        if (item is InfernalOoze)
-                        {
-                            found = true;
-                            break;
-                        }
-
-                    if (!found)
-                        break;
-                }
-
-                ooze.MoveToWorld(p, this.Map);
-            }
-
-            if (this.Combatant is Mobile)
-            {
-                ((Mobile)this.Combatant).SendLocalizedMessage(1070820); // The creature spills a pool of acidic slime!
-            }
+            return new InfernalOoze(this, false, Utility.RandomMinMax(6, 10));
         }
 
         public override int GetAngerSound()

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -601,6 +601,7 @@
     <Compile Include="Items\Decorative\FlamingScarecrow.cs" />
     <Compile Include="Items\Decorative\SilverSaplingReplica.cs" />
     <Compile Include="Items\Decorative\ValentineBear.cs" />
+    <Compile Include="Items\Functional\StrangeContraption.cs" />
     <Compile Include="Items\Resource\FocusingGemOfVirtueBane.cs" />
     <Compile Include="Items\Functional\SerpentsJawbone.cs" />
     <Compile Include="Items\Internal\ItemSockets\Caddellite.cs" />

--- a/Scripts/Services/Craft/DefCooking.cs
+++ b/Scripts/Services/Craft/DefCooking.cs
@@ -126,13 +126,13 @@ namespace Server.Engines.Craft
             index = AddCraft(typeof(SackFlour), 1044495, 1024153, 0.0, 100.0, typeof(WheatSheaf), 1044489, 2, 1044490);
             SetNeedMill(index, true);
 
-            index = AddCraft(typeof(Dough), 1044495, 1024157, 0.0, 100.0, typeof(SackFlour), 1044468, 1, 1044253);
+            index = AddCraft(typeof(Dough), 1044495, 1024157, 0.0, 100.0, typeof(SackFlourOpen), 1044468, 1, 1151092);
             AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
 
             index = AddCraft(typeof(SweetDough), 1044495, 1041340, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
             AddRes(index, typeof(JarHoney), 1044472, 1, 1044253);
 
-            index = AddCraft(typeof(CakeMix), 1044495, 1041002, 0.0, 100.0, typeof(SackFlour), 1044468, 1, 1044253);
+            index = AddCraft(typeof(CakeMix), 1044495, 1041002, 0.0, 100.0, typeof(SackFlourOpen), 1044468, 1, 1151092);
             AddRes(index, typeof(SweetDough), 1044475, 1, 1044253);
 
             index = AddCraft(typeof(CookieMix), 1044495, 1024159, 0.0, 100.0, typeof(JarHoney), 1044472, 1, 1044253);
@@ -152,7 +152,7 @@ namespace Server.Engines.Craft
 
             index = AddCraft(typeof(WheatWort), 1044495, 1150275, 30.0, 100.0, typeof(Bottle), 1023854, 1, 1044253);
             AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-            AddRes(index, typeof(SackFlour), 1044468, 1, 1044253);
+            AddRes(index, typeof(SackFlourOpen), 1044468, 1, 1151092);
             SetItemHue(index, 1281);
             #endregion
 
@@ -198,13 +198,13 @@ namespace Server.Engines.Craft
                 AddRes(index, typeof(RawFishSteak), 1044476, 10, 1044253);
             }
 
-            index = AddCraft(typeof(TribalPaint), 1044496, 1040000, Core.ML ? 55.0 : 80.0, Core.ML ? 105.0 : 80.0, typeof(SackFlour), 1044468, 1, 1044253);
+            index = AddCraft(typeof(TribalPaint), 1044496, 1040000, Core.ML ? 55.0 : 80.0, Core.ML ? 105.0 : 80.0, typeof(SackFlourOpen), 1044468, 1, 1151092);
             AddRes(index, typeof(TribalBerry), 1046460, 1, 1044253);
 
             if (Core.SE)
             {
                 index = AddCraft(typeof(EggBomb), 1044496, 1030249, 90.0, 120.0, typeof(Eggs), 1044477, 1, 1044253);
-                AddRes(index, typeof(SackFlour), 1044468, 3, 1044253);
+                AddRes(index, typeof(SackFlourOpen), 1044468, 3, 1151092);
             }
 
             #region Mondain's Legacy

--- a/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Region.cs
+++ b/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Region.cs
@@ -1,6 +1,8 @@
-using Server;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+
+using Server;
 using Server.Mobiles;
 using Server.Items;
 using Server.Spells;
@@ -12,7 +14,8 @@ namespace Server.Engines.VoidPool
 	{
 		private static Rectangle2D[] Bounds = new Rectangle2D[]
 		{
-			new Rectangle2D(5383, 1948, 234, 95),
+            new Rectangle2D(5383, 1960, 236, 80),
+			new Rectangle2D(5429, 1948, 12, 10),
 		};
 		
 		public VoidPoolController Controller { get; private set; }
@@ -24,26 +27,34 @@ namespace Server.Engines.VoidPool
 		
 		public void SendRegionMessage(int localization)
 		{
-			List<Mobile> list = GetPlayers();
-			list.ForEach(m => m.SendLocalizedMessage(localization));
-			list.Clear();
-			list.TrimExcess();
+            foreach (var m in GetEnumeratedMobiles().Where(m => m.Player))
+            {
+                m.SendLocalizedMessage(localization);
+            }
 		}
-		
-		public void SendRegionMessage(int localization, string args)
+
+        public void SendRegionMessage(int localization, int hue)
+        {
+            foreach (var m in GetEnumeratedMobiles().Where(m => m.Player))
+            {
+                m.SendLocalizedMessage(localization, "", hue);
+            }
+        }
+
+        public void SendRegionMessage(int localization, string args)
 		{
-			List<Mobile> list = GetPlayers();
-			list.ForEach(m => m.SendLocalizedMessage(localization, args));
-			list.Clear();
-			list.TrimExcess();
-		}
+            foreach (var m in GetEnumeratedMobiles().Where(m => m.Player))
+            {
+                m.SendLocalizedMessage(localization, args);
+            }
+        }
 
         public void SendRegionMessage(string message)
         {
-            List<Mobile> list = GetPlayers();
-            list.ForEach(m => m.SendMessage(0x25, message));
-            list.Clear();
-            list.TrimExcess();
+            foreach (var m in GetEnumeratedMobiles().Where(m => m.Player))
+            {
+                m.SendMessage(0x25, message);
+            }
         }
 		
 		public override void OnDeath(Mobile m)

--- a/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/VoidPoolController.cs
+++ b/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/VoidPoolController.cs
@@ -208,7 +208,7 @@ namespace Server.Engines.VoidPool
 				CurrentScore = new Dictionary<Mobile, long>();
 				Waves = new List<WaveInfo>();
 				
-				Region.SendRegionMessage(1152527); // The battle for the Void Pool is beginning now!
+				Region.SendRegionMessage(1152527, 0x2B); // The battle for the Void Pool is beginning now!
 
                 if (WaypointACount != WaypointsA.Count || WaypointBCount != WaypointsB.Count)
                     Generate.AddWaypoints();
@@ -244,7 +244,27 @@ namespace Server.Engines.VoidPool
             int toSpawn = (int)Math.Ceiling(Math.Max(5, Math.Sqrt(Wave) * 2) * 1.5);
 			List<BaseCreature> creatures = new List<BaseCreature>();
 
-			for(int i = 0; i < toSpawn; i++)
+            var gate1 = new VoidPoolGate();
+            gate1.MoveToWorld(StartPoint1, Map);
+            Effects.PlaySound(StartPoint1, Map, 0x20E);
+
+            var gate2 = new VoidPoolGate();
+            gate2.MoveToWorld(StartPoint2, Map);
+            Effects.PlaySound(StartPoint2, Map, 0x20E);
+
+            Timer.DelayCall(TimeSpan.FromSeconds(toSpawn * .80), () =>
+            {
+                Effects.SendLocationParticles(EffectItem.Create(gate1.Location, gate1.Map, EffectItem.DefaultDuration), 0x376A, 9, 20, 5042);
+                Effects.PlaySound(gate1.GetWorldLocation(), gate1.Map, 0x201);
+
+                Effects.SendLocationParticles(EffectItem.Create(gate2.Location, gate2.Map, EffectItem.DefaultDuration), 0x376A, 9, 20, 5042);
+                Effects.PlaySound(gate2.GetWorldLocation(), gate2.Map, 0x201);
+
+                gate1.Delete();
+                gate2.Delete();
+            });
+
+            for (int i = 0; i < toSpawn; i++)
 			{
 				Point3D start = i % 2 == 0 ? StartPoint1 : StartPoint2;
 				
@@ -671,6 +691,7 @@ namespace Server.Engines.VoidPool
                     WaypointsB = new List<WayPoint>();
 
                     Active = reader.ReadBool();
+                    NextStart = DateTime.UtcNow;
 
                     int counta = reader.ReadInt();
                     int countb = reader.ReadInt();
@@ -702,6 +723,34 @@ namespace Server.Engines.VoidPool
             Timer.DelayCall(TimeSpan.FromSeconds(10), () => { ClearSpawn(); ClearSpawners(); } );
         }
 	}
+
+    public class VoidPoolGate : Static
+    {
+        public VoidPoolGate()
+            : base(0xF6C)
+        {
+            Light = LightType.Circle300;
+        }
+
+        public VoidPoolGate(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+
+            Delete();
+        }
+    }
 }
 
 /*

--- a/Scripts/Spells/Skill Masteries/CombatTraining.cs
+++ b/Scripts/Spells/Skill Masteries/CombatTraining.cs
@@ -70,7 +70,7 @@ namespace Server.Spells.SkillMasteries
         {
         }
 
-        public override bool CheckCast()
+        public override bool Cast()
         {
             CombatTrainingSpell spell = GetSpell(Caster, typeof(CombatTrainingSpell)) as CombatTrainingSpell;
 
@@ -80,6 +80,11 @@ namespace Server.Spells.SkillMasteries
                 return false;
             }
 
+            return base.Cast();
+        }
+
+        public override bool CheckCast()
+        {
             if (Caster is PlayerMobile && ((PlayerMobile)Caster).AllFollowers == null || ((PlayerMobile)Caster).AllFollowers.Count == 0)
             {
                 Caster.SendLocalizedMessage(1156112); // This ability requires you to have pets.

--- a/Scripts/Spells/Skill Masteries/Core/SelectMasteryGump.cs
+++ b/Scripts/Spells/Skill Masteries/Core/SelectMasteryGump.cs
@@ -62,7 +62,7 @@ namespace Server.Gumps
                 User.Skills.CurrentMastery = SkillName.Alchemy;
                 MasteryInfo.OnMasteryChanged(User, current);
             }
-            else if (User.Skills[n].Value >= MasteryInfo.MinSkillRequirement)
+            else if (User.Skills[n].Base >= MasteryInfo.MinSkillRequirement)
             {
                 User.SendLocalizedMessage(1155886, User.Skills[n].Info.Name); // Your active skill mastery is now set to ~1_MasterySkill~!
                 User.Skills.CurrentMastery = n;

--- a/Scripts/VendorInfo/VendorInventory.cs
+++ b/Scripts/VendorInfo/VendorInventory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Server.Multis;
+using Server.Accounting;
 
 namespace Server.Mobiles
 {
@@ -181,10 +182,17 @@ namespace Server.Mobiles
                 {
                     if (m_Inventory.Gold > 0)
                     {
-                        if (house.MovingCrate == null)
-                            house.MovingCrate = new MovingCrate(house);
+                        if (AccountGold.Enabled && m_Inventory.Owner != null)
+                        {
+                            Banker.Deposit(m_Inventory.Owner, m_Inventory.Gold, true);
+                        }
+                        else
+                        {
+                            if (house.MovingCrate == null)
+                                house.MovingCrate = new MovingCrate(house);
 
-                        Banker.Deposit(house.MovingCrate, m_Inventory.Gold);
+                            Banker.Deposit(house.MovingCrate, m_Inventory.Gold);
+                        }
                     }
 
                     foreach (Item item in m_Inventory.Items)

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -8008,6 +8008,10 @@ namespace Server
 
                     return false;
                 }
+                else if (!((Mobile)target).CanBeHarmedBy(this, message))
+                {
+                    return false;
+                }
             }
 
 			if (target == this)
@@ -8029,6 +8033,11 @@ namespace Server
 
 			return true;
 		}
+
+        public virtual bool CanBeHarmedBy(Mobile from, bool message)
+        {
+            return true;
+        }
 
 		public virtual bool IsHarmfulCriminal(IDamageable target)
 		{


### PR DESCRIPTION
- Only Hitching Post Replica now consumes charges on stable and Claim
- Dragon Jade Earrings and Obsidian Earrings now derive from BaseArmor as they should. This will cause all existing items to delete.
- Sack of Flour now stacks and unstacks when dbl clicked properly, per EA
- Crafting with flour now requires an open sack of flour, per EA
- Fixed Craftable Easle to show proper ItemID
- Gregorio is now red, and can only be attacked if you have the Guilty QuestArrow
- Creatures no longer auto-target players if they invis/Hide
- Interred Grizzle now utilizes SpillAcid method in BaseCreature as it should have
- Fixed issue where grizzle acid would remain in effect after it deleted or the mobile moved off
- Fixed issue where bank checks were being generated after a vendor was dismissed
- Fixed Void Pool region where spawn would start prematurely
- Combat training no longer makes mana check to deactivate
- Skill Mastery usage now depends on Real Skill
- Poison Damage now reveals

Addition: *Requires Core Re-Compile*
- Added Strange Contraption to Solen Hives - Thanks!
- Added CanBeHarmedBy(Mobile, bool) method to Mobile.cs, so we're not klunking up Notoriety.cs