### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Gumps/ReportMurderer.cs
+++ b/Scripts/Gumps/ReportMurderer.cs
@@ -82,7 +82,11 @@ namespace Server.Gumps
                 Titles.AwardKarma(g, karmaAward, true);
 
                 Server.Items.XmlQuest.RegisterKill(m, g);
-                EventSink.InvokePlayerMurdered(new PlayerMurderedEventArgs(g, m));
+
+                if (killers.Contains(g))
+                {
+                    EventSink.InvokePlayerMurdered(new PlayerMurderedEventArgs(g, m));
+                }
             }
 
             if (m is PlayerMobile && ((PlayerMobile)m).NpcGuild == NpcGuild.ThievesGuild)

--- a/Scripts/Items/Internal/ItemInterfaces.cs
+++ b/Scripts/Items/Internal/ItemInterfaces.cs
@@ -31,7 +31,7 @@ namespace Server.Items
         bool PlayerConstructed { get; }
     }
 
-    public interface IResource : IQuality
+    public interface IResource
     {
         CraftResource Resource { get; set; }
     }

--- a/Scripts/Items/Resource/Board.cs
+++ b/Scripts/Items/Resource/Board.cs
@@ -3,7 +3,7 @@ using System;
 namespace Server.Items
 {
     [FlipableAttribute( 0x1BD7, 0x1BDA )]
-	public class BaseWoodBoard : Item, ICommodity
+	public class BaseWoodBoard : Item, ICommodity, IResource
 	{
 		private CraftResource m_Resource;
 

--- a/Scripts/Items/Resource/Ingots.cs
+++ b/Scripts/Items/Resource/Ingots.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Server.Items
 {
-    public abstract class BaseIngot : Item, ICommodity
+    public abstract class BaseIngot : Item, ICommodity, IResource
     {
         protected virtual CraftResource DefaultResource { get { return CraftResource.Iron; } }
 
@@ -15,11 +15,11 @@ namespace Server.Items
         public BaseIngot(CraftResource resource, int amount)
             : base(0x1BF2)
         {
-            this.Stackable = true;
-            this.Amount = amount;
-            this.Hue = CraftResources.GetHue(resource);
+            Stackable = true;
+            Amount = amount;
+            Hue = CraftResources.GetHue(resource);
 
-            this.m_Resource = resource;
+            m_Resource = resource;
         }
 
         public BaseIngot(Serial serial)
@@ -32,12 +32,12 @@ namespace Server.Items
         {
             get
             {
-                return this.m_Resource;
+                return m_Resource;
             }
             set
             {
-                this.m_Resource = value;
-                this.InvalidateProperties();
+                m_Resource = value;
+                InvalidateProperties();
             }
         }
         public override double DefaultWeight
@@ -51,8 +51,8 @@ namespace Server.Items
         {
             get
             {
-                if (this.m_Resource >= CraftResource.DullCopper && this.m_Resource <= CraftResource.Valorite)
-                    return 1042684 + (int)(this.m_Resource - CraftResource.DullCopper);
+                if (m_Resource >= CraftResource.DullCopper && m_Resource <= CraftResource.Valorite)
+                    return 1042684 + (int)(m_Resource - CraftResource.DullCopper);
 
                 return 1042692;
             }
@@ -61,7 +61,7 @@ namespace Server.Items
         {
             get
             {
-                return this.LabelNumber;
+                return LabelNumber;
             }
         }
         bool ICommodity.IsDeedable
@@ -77,7 +77,7 @@ namespace Server.Items
 
             writer.Write((int)1); // version
 
-            writer.Write((int)this.m_Resource);
+            writer.Write((int)m_Resource);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -89,12 +89,12 @@ namespace Server.Items
             switch ( version )
             {
                 case 2: // Reset from Resource System
-                    this.m_Resource = this.DefaultResource;
+                    m_Resource = DefaultResource;
                     reader.ReadString();
                     break;
                 case 1:
                     {
-                        this.m_Resource = (CraftResource)reader.ReadInt();
+                        m_Resource = (CraftResource)reader.ReadInt();
                         break;
                     }
                 case 0:
@@ -135,7 +135,7 @@ namespace Server.Items
                                 break;
                         }
 
-                        this.m_Resource = CraftResources.GetFromOreInfo(info);
+                        m_Resource = CraftResources.GetFromOreInfo(info);
                         break;
                     }
             }
@@ -143,8 +143,8 @@ namespace Server.Items
 
         public override void AddNameProperty(ObjectPropertyList list)
         {
-            if (this.Amount > 1)
-                list.Add(1050039, "{0}\t#{1}", this.Amount, 1027154); // ~1_NUMBER~ ~2_ITEMNAME~
+            if (Amount > 1)
+                list.Add(1050039, "{0}\t#{1}", Amount, 1027154); // ~1_NUMBER~ ~2_ITEMNAME~
             else
                 list.Add(1027154); // ingots
         }
@@ -153,14 +153,14 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            if (!CraftResources.IsStandard(this.m_Resource))
+            if (!CraftResources.IsStandard(m_Resource))
             {
-                int num = CraftResources.GetLocalizationNumber(this.m_Resource);
+                int num = CraftResources.GetLocalizationNumber(m_Resource);
 
                 if (num > 0)
                     list.Add(num);
                 else
-                    list.Add(CraftResources.GetName(this.m_Resource));
+                    list.Add(CraftResources.GetName(m_Resource));
             }
         }
     }

--- a/Scripts/Items/Resource/Log.cs
+++ b/Scripts/Items/Resource/Log.cs
@@ -3,7 +3,7 @@ using System;
 namespace Server.Items
 {
 	[FlipableAttribute( 0x1bdd, 0x1be0 )]
-	public class BaseLog : Item, ICommodity, IAxe
+	public class BaseLog : Item, ICommodity, IAxe, IResource
 	{
 		private CraftResource m_Resource;
 

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -428,7 +428,7 @@ namespace Server
             {
                 if (context.Type == typeof(WraithFormSpell))
                 {
-                    int manaLeech = AOS.Scale(damageGiven, Math.Min(target.Mana, (5 + (int)((15 * from.Skills.SpiritSpeak.Value) / 100)))); // Wraith form gives 5-20% mana leech
+                    int manaLeech = AOS.Scale(damageGiven, Math.Min(target.Mana, (int)from.Skills.SpiritSpeak.Value / 5)); // Wraith form gives 5-20% mana leech
 
                     if (manaLeech != 0)
                     {

--- a/Scripts/Multis/Boats/BaseBoat.cs
+++ b/Scripts/Multis/Boats/BaseBoat.cs
@@ -1827,7 +1827,9 @@ namespace Server.Multis
                 NoMoveHS = true;
 
                 foreach (var e in toMove)
+                {
                     e.NoMoveHS = true;
+                }
 
                 // packet created
                 MoveBoatHS smooth = new MoveBoatHS(this, d, clientSpeed, xOffset, yOffset);
@@ -2193,7 +2195,7 @@ namespace Server.Multis
             return false;
         }
 
-        public IEnumerable<IEntity> GetEntitiesOnBoard()
+        public virtual IEnumerable<IEntity> GetEntitiesOnBoard()
         {
             Map map = Map;
 

--- a/Scripts/Multis/Boats/BaseBoatDeed.cs
+++ b/Scripts/Multis/Boats/BaseBoatDeed.cs
@@ -81,7 +81,7 @@ namespace Server.Multis
 			{
 				from.SendLocalizedMessage( 1010567, null, 0x25 ); // You may not place a boat from this location.
 			}
-            else if (Core.HS && BaseBoat.HasBoat(from))
+            else if (Core.HS && BaseBoat.HasBoat(from) && !(this is RowBoatDeed))
             {
                 from.SendLocalizedMessage(1116758); //You already have a ship deployed!
             }

--- a/Scripts/Multis/Boats/TillerMan.cs
+++ b/Scripts/Multis/Boats/TillerMan.cs
@@ -9,6 +9,8 @@ namespace Server.Items
 {
 	public class TillerMan : Item
 	{
+        public virtual bool Babbles { get { return true; } }
+
 		private BaseBoat m_Boat;
         public BaseBoat Boat { get { return m_Boat; } }
 
@@ -124,10 +126,13 @@ namespace Server.Items
 
         public void Babble()
         {
-            PublicOverheadMessage(MessageType.Regular, 0x3B2, 1114137, RandomBabbleArgs());
-            // Ar! Did I ever tell thee about the time I was in ~1_CITY~ and I met ~2_GENDER~ ~3_STORY~ Anyway, 'tis a dull story.
+            if (Babbles)
+            {
+                PublicOverheadMessage(MessageType.Regular, 0x3B2, 1114137, RandomBabbleArgs());
+                // Ar! Did I ever tell thee about the time I was in ~1_CITY~ and I met ~2_GENDER~ ~3_STORY~ Anyway, 'tis a dull story.
 
-            _NextBabble = DateTime.UtcNow + TimeSpan.FromMinutes(Utility.RandomMinMax(3, 10));
+                _NextBabble = DateTime.UtcNow + TimeSpan.FromMinutes(Utility.RandomMinMax(3, 10));
+            }
         }
 
         private string RandomBabbleArgs()

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Controller.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Controller.cs
@@ -17,12 +17,12 @@ namespace Server.Engines.Shadowguard
     [Flags]
     public enum EncounterType
     {
-        Bar = 0x00000001,
-        Orchard = 0x00000002,
-        Armory = 0x00000004,
-        Fountain = 0x00000008,
-        Belfry = 0x00000010,
-        Roof = 0x00000020,
+        Bar         = 0x00000001,
+        Orchard     = 0x00000002,
+        Armory      = 0x00000004,
+        Fountain    = 0x00000008,
+        Belfry      = 0x00000010,
+        Roof        = 0x00000020,
 
         Required = Bar | Orchard | Armory | Fountain | Belfry
     }
@@ -140,19 +140,7 @@ namespace Server.Engines.Shadowguard
             if(Table == null)
                 return;
 
-            Party p = Party.Get(m);
-
-            if (p != null)
-            {
-                foreach (PartyMemberInfo info in p.Members)
-                {
-                    Mobile mobile = info.Mobile;
-
-                    if (Table.ContainsKey(mobile))
-                        Table.Remove(mobile);
-                }
-            }
-            else if (Table.ContainsKey(m))
+            if (Table.ContainsKey(m))
             {
                 Table.Remove(m);
             }
@@ -168,23 +156,9 @@ namespace Server.Engines.Shadowguard
 
             if (!expired)
             {
-                Mobile m = encounter.PartyLeader;
-
-                if (m == null)
-                    return;
-
-                Party p = Party.Get(m);
-
-                if (p != null)
+                foreach (var pm in encounter.Region.GetEnumeratedMobiles().OfType<PlayerMobile>())
                 {
-                    foreach (PartyMemberInfo info in p.Members)
-                    {
-                        AddToTable(info.Mobile, encounter.Encounter);
-                    }
-                }
-                else
-                {
-                    AddToTable(m, encounter.Encounter);
+                    AddToTable(pm, encounter.Encounter);
                 }
             }
         }

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Encounters.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Encounters.cs
@@ -1421,7 +1421,10 @@ namespace Server.Engines.Shadowguard
         {
             base.CompleteEncounter();
 
-            Controller.CompleteRoof(PartyLeader);
+            foreach (var pm in Region.GetEnumeratedMobiles().OfType<PlayerMobile>())
+            {
+                Controller.CompleteRoof(pm);
+            }
         }
 
 		public override void OnCreatureKilled(BaseCreature bc)
@@ -1449,7 +1452,12 @@ namespace Server.Engines.Shadowguard
             if (m == null)
                 return;
 
-            Party p = Party.Get(m);
+            foreach (var pm in Region.GetEnumeratedMobiles().OfType<PlayerMobile>())
+            {
+                pm.AddRewardTitle(1156318); // Destroyer of the Time Rift
+            }
+
+            /*Party p = Party.Get(m);
 
             if (p != null)
             {
@@ -1460,7 +1468,7 @@ namespace Server.Engines.Shadowguard
                 }
             }
             else if (m is PlayerMobile)
-                ((PlayerMobile)m).AddRewardTitle(1156318); // Destroyer of the Time Rift
+                ((PlayerMobile)m).AddRewardTitle(1156318); // Destroyer of the Time Rift*/
         }
 		
 		public override void ClearItems()

--- a/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/VoidPoolController.cs
+++ b/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/VoidPoolController.cs
@@ -244,26 +244,6 @@ namespace Server.Engines.VoidPool
             int toSpawn = (int)Math.Ceiling(Math.Max(5, Math.Sqrt(Wave) * 2) * 1.5);
 			List<BaseCreature> creatures = new List<BaseCreature>();
 
-            var gate1 = new VoidPoolGate();
-            gate1.MoveToWorld(StartPoint1, Map);
-            Effects.PlaySound(StartPoint1, Map, 0x20E);
-
-            var gate2 = new VoidPoolGate();
-            gate2.MoveToWorld(StartPoint2, Map);
-            Effects.PlaySound(StartPoint2, Map, 0x20E);
-
-            Timer.DelayCall(TimeSpan.FromSeconds(toSpawn * .80), () =>
-            {
-                Effects.SendLocationParticles(EffectItem.Create(gate1.Location, gate1.Map, EffectItem.DefaultDuration), 0x376A, 9, 20, 5042);
-                Effects.PlaySound(gate1.GetWorldLocation(), gate1.Map, 0x201);
-
-                Effects.SendLocationParticles(EffectItem.Create(gate2.Location, gate2.Map, EffectItem.DefaultDuration), 0x376A, 9, 20, 5042);
-                Effects.PlaySound(gate2.GetWorldLocation(), gate2.Map, 0x201);
-
-                gate1.Delete();
-                gate2.Delete();
-            });
-
             for (int i = 0; i < toSpawn; i++)
 			{
 				Point3D start = i % 2 == 0 ? StartPoint1 : StartPoint2;
@@ -316,8 +296,28 @@ namespace Server.Engines.VoidPool
 					});
 				}
 			}
-			
-			Waves.Add(new WaveInfo(Wave, creatures));
+
+            var gate1 = new VoidPoolGate();
+            gate1.MoveToWorld(StartPoint1, Map);
+            Effects.PlaySound(StartPoint1, Map, 0x20E);
+
+            var gate2 = new VoidPoolGate();
+            gate2.MoveToWorld(StartPoint2, Map);
+            Effects.PlaySound(StartPoint2, Map, 0x20E);
+
+            Timer.DelayCall(TimeSpan.FromSeconds(toSpawn * .80), () =>
+            {
+                Effects.SendLocationParticles(EffectItem.Create(gate1.Location, gate1.Map, EffectItem.DefaultDuration), 0x376A, 9, 20, 5042);
+                Effects.PlaySound(gate1.GetWorldLocation(), gate1.Map, 0x201);
+
+                Effects.SendLocationParticles(EffectItem.Create(gate2.Location, gate2.Map, EffectItem.DefaultDuration), 0x376A, 9, 20, 5042);
+                Effects.PlaySound(gate2.GetWorldLocation(), gate2.Map, 0x201);
+
+                gate1.Delete();
+                gate2.Delete();
+            });
+
+            Waves.Add(new WaveInfo(Wave, creatures));
 			NextWave = GetNextWaveTime();
 		}
 

--- a/Scripts/Services/Vendor Searching/VendorSearch.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearch.cs
@@ -61,6 +61,11 @@ namespace Server.Engines.VendorSearching
 			
 			Item item = vitem.Item;
 
+            if (item is CommodityDeed && ((CommodityDeed)item).Commodity != null)
+            {
+                item = ((CommodityDeed)item).Commodity;
+            }
+
             if (searchCriteria.MinPrice > -1 && vitem.Price < searchCriteria.MinPrice)
 				return false;
 
@@ -69,7 +74,25 @@ namespace Server.Engines.VendorSearching
 			
 			if (!String.IsNullOrEmpty(searchCriteria.SearchName))
 			{
-				string name = GetItemName(item);
+                string name;
+
+                if (item is CommodityDeed && ((CommodityDeed)item).Commodity is ICommodity)
+                {
+                    var commodity = (ICommodity)((CommodityDeed)item).Commodity;
+
+                    if (!String.IsNullOrEmpty(commodity.Description.String))
+                    {
+                        name = commodity.Description.String;
+                    }
+                    else
+                    {
+                        name = StringList.GetString(commodity.Description.Number);
+                    }
+                }
+                else
+                {
+                    name = GetItemName(item);
+                }
 				
 				if(name == null)
 				{
@@ -379,6 +402,38 @@ namespace Server.Engines.VendorSearching
 
         private static bool CheckKeyword(string searchstring, Item item)
         {
+            if (item is CommodityDeed && ((CommodityDeed)item).Commodity != null)
+            {
+                item = ((CommodityDeed)item).Commodity;
+            }
+
+            if (item is IResource)
+            {
+                var resName = CraftResources.GetName(((IResource)item).Resource);
+
+                if (resName.ToLower().IndexOf(searchstring.ToLower()) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            if (item is ICommodity)
+            {
+                var commodity = (ICommodity)item;
+
+                string name = commodity.Description.String;
+
+                if (String.IsNullOrEmpty(name) && commodity.Description.Number > 0)
+                {
+                    name = StringList.GetString(commodity.Description.Number);
+                }
+
+                if (!String.IsNullOrEmpty(name) && name.ToLower().IndexOf(searchstring.ToLower()) >= 0)
+                {
+                    return true;
+                }
+            }
+
             return Keywords.ContainsKey(searchstring.ToLower()) && Keywords[searchstring.ToLower()] == item.GetType();
         }
 
@@ -593,6 +648,8 @@ namespace Server.Engines.VendorSearching
 
             //read number property from the packet data
             number = (uint)(data[index++] << 24 | data[index++] << 16 | data[index++] << 8 | data[index++]);
+
+            Console.WriteLine("{1} Number: {0}", number, item);
 
             //reset the length property
             ushort length = 0;

--- a/Scripts/Spells/Mysticism/SpellDefinitions/CleansingWindsSpell.cs
+++ b/Scripts/Spells/Mysticism/SpellDefinitions/CleansingWindsSpell.cs
@@ -89,7 +89,6 @@ namespace Server.Spells.Mysticism
                     // Cleansing Winds will not heal the target after removing mortal wound.
                     if (MortalStrike.IsWounded(target))
                     {
-                        MortalStrike.EndWound(target);
                         toHealMod = 0;
                     }
 
@@ -205,6 +204,12 @@ namespace Server.Spells.Mysticism
             {
                 WeakenSpell.RemoveEffects(m);
                 curseLevel += 1;
+            }
+
+            if (MortalStrike.IsWounded(m))
+            {
+                MortalStrike.EndWound(m);
+                curseLevel += 2;
             }
 
             BuffInfo.RemoveBuff(m, BuffIcon.Clumsy);

--- a/Scripts/Spells/Necromancy/WraithForm.cs
+++ b/Scripts/Spells/Necromancy/WraithForm.cs
@@ -95,7 +95,7 @@ namespace Server.Spells.Necromancy
             m.PlaySound(0x17F);
             m.FixedParticles(0x374A, 1, 15, 9902, 1108, 4, EffectLayer.Waist);
 
-            int manadrain = (int)(5 + ((15 * m.Skills.SpiritSpeak.Value) / 100));
+            int manadrain = (int)(m.Skills.SpiritSpeak.Value / 5);
 
             BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.WraithForm, 1060524, 1153829, String.Format("15\t5\t5\t{0}", manadrain)));
         }

--- a/Scripts/Spells/Spellweaving/Wildfire.cs
+++ b/Scripts/Spells/Spellweaving/Wildfire.cs
@@ -176,10 +176,10 @@ namespace Server.Spells.Spellweaving
                 {
                     m_Owner.DoHarmful(m);
 
-                    if (m_Owner.Map.CanFit(m.Location, 12, true, false))
-                        new FireItem(m_LifeSpan).MoveToWorld(m.Location, m.Map);
+                    if (m_Map.CanFit(m.Location, 12, true, false))
+                        new FireItem(m_LifeSpan).MoveToWorld(m.Location, m_Map);
 
-                    Effects.PlaySound(m.Location, m.Map, 0x5CF);
+                    Effects.PlaySound(m.Location, m_Map, 0x5CF);
                     double sdiBonus = (double)AosAttributes.GetValue(m_Owner, AosAttribute.SpellDamage) / 100;
 
                     if (m is PlayerMobile && sdiBonus > .15)


### PR DESCRIPTION
- Added IResource interface to Ingots and Boards/Logs
- Fixed Mana Leech Formula, per EA
- Rowboats can now be placed when another ship is in the world
- Rowboat display issue fixed when Moving
- Fixed shadowguard exploit when party is disbanded inside the roof encoutner
- Shadowguard now uses region mobiles for tasks such as messaging, death checks, credit, etc as opposed to a party check in the event party disbands
- Fixed issue where void pool cretaures were leaking to internal Map
- Enchanted apple now removes Mortal Wound
- Fixed (hopefully) crash anomaly in Wildfire
- Vendor search now searches properly for commodity deeded items