### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Encounters.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Encounters.cs
@@ -1364,7 +1364,10 @@ namespace Server.Engines.Shadowguard
 	
 	public class RoofEncounter : ShadowguardEncounter
 	{
+        [CommandProperty(AccessLevel.GameMaster)]
 		public ShadowguardBoss CurrentBoss { get; set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
         public LadyMinax Minax { get; set; }
 		
 		public List<Type> Bosses { get; set; }
@@ -1456,19 +1459,6 @@ namespace Server.Engines.Shadowguard
             {
                 pm.AddRewardTitle(1156318); // Destroyer of the Time Rift
             }
-
-            /*Party p = Party.Get(m);
-
-            if (p != null)
-            {
-                foreach (PartyMemberInfo info in p.Members)
-                {
-                    if (info.Mobile is PlayerMobile && info.Mobile.Region.IsPartOf<ShadowguardRegion>())
-                        ((PlayerMobile)info.Mobile).AddRewardTitle(1156318); // Destroyer of the Time Rift
-                }
-            }
-            else if (m is PlayerMobile)
-                ((PlayerMobile)m).AddRewardTitle(1156318); // Destroyer of the Time Rift*/
         }
 		
 		public override void ClearItems()
@@ -1555,8 +1545,10 @@ namespace Server.Engines.Shadowguard
                     Bosses.Add(boss);
             }
 
-            if (CurrentBoss == null)
-                Reset();
+            if (CurrentBoss == null && !Completed)
+            {
+                Completed = true;
+            }
         }
 	}
 }

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/ShadowguardInstance.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/ShadowguardInstance.cs
@@ -31,6 +31,11 @@ namespace Server.Engines.Shadowguard
         [CommandProperty(AccessLevel.GameMaster)]
         public bool IsRoof { get { return Index >= 13; } }
 
+        public override string ToString()
+        {
+            return "...";
+        }
+
         public ShadowguardInstance(ShadowguardController controller, Point3D center, Rectangle2D bounds, int index)
         {
             Controller = controller;

--- a/Scripts/Spells/Base/MagerySpell.cs
+++ b/Scripts/Spells/Base/MagerySpell.cs
@@ -17,7 +17,7 @@ namespace Server.Spells
         {
             get
             {
-                return TimeSpan.FromSeconds((3 + (int)Circle) * CastDelaySecondsPerTick);
+                return TimeSpan.FromSeconds((4 + (int)Circle) * CastDelaySecondsPerTick);
             }
         }
         public override bool ConsumeReagents()

--- a/Scripts/Spells/Mysticism/MysticSpell.cs
+++ b/Scripts/Spells/Mysticism/MysticSpell.cs
@@ -15,7 +15,7 @@ namespace Server.Spells.Mysticism
 
         private static int[] m_ManaTable = new int[] { 4, 6, 9, 11, 14, 20, 40, 50 };
 
-        public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds(0.5 + 0.25 * (int)Circle); } }
+        public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds((4 + (int)Circle) * CastDelaySecondsPerTick); } }
         public override double CastDelayFastScalar { get { return 1.0; } }
 
         public double ChanceOffset { get { return Caster is Server.Mobiles.PlayerMobile ? 20.0 : 30.0; } }

--- a/Scripts/Spells/Necromancy/AnimateDeadSpell.cs
+++ b/Scripts/Spells/Necromancy/AnimateDeadSpell.cs
@@ -21,7 +21,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(1.5);
+                return TimeSpan.FromSeconds(1.75);
             }
         }
 

--- a/Scripts/Spells/Necromancy/BloodOathSpell.cs
+++ b/Scripts/Spells/Necromancy/BloodOathSpell.cs
@@ -24,7 +24,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(1.5);
+                return TimeSpan.FromSeconds(1.75);
             }
         }
         public override double RequiredSkill

--- a/Scripts/Spells/Necromancy/CorpseSkin.cs
+++ b/Scripts/Spells/Necromancy/CorpseSkin.cs
@@ -25,7 +25,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(1.5);
+                return TimeSpan.FromSeconds(1.75);
             }
         }
         public override double RequiredSkill

--- a/Scripts/Spells/Necromancy/CurseWeapon.cs
+++ b/Scripts/Spells/Necromancy/CurseWeapon.cs
@@ -23,7 +23,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(0.75);
+                return TimeSpan.FromSeconds(1.0);
             }
         }
         public override double RequiredSkill

--- a/Scripts/Spells/Necromancy/EvilOmen.cs
+++ b/Scripts/Spells/Necromancy/EvilOmen.cs
@@ -26,7 +26,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(0.75);
+                return TimeSpan.FromSeconds(1.0);
             }
         }
         public override double RequiredSkill

--- a/Scripts/Spells/Necromancy/HorrificBeast.cs
+++ b/Scripts/Spells/Necromancy/HorrificBeast.cs
@@ -19,7 +19,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(2.0);
+                return TimeSpan.FromSeconds(2.25);
             }
         }
         public override double RequiredSkill

--- a/Scripts/Spells/Necromancy/LichForm.cs
+++ b/Scripts/Spells/Necromancy/LichForm.cs
@@ -21,7 +21,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(2.0);
+                return TimeSpan.FromSeconds(2.25);
             }
         }
         public override double RequiredSkill

--- a/Scripts/Spells/Necromancy/MindRot.cs
+++ b/Scripts/Spells/Necromancy/MindRot.cs
@@ -24,7 +24,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(1.5);
+                return TimeSpan.FromSeconds(1.75);
             }
         }
         public override double RequiredSkill

--- a/Scripts/Spells/Necromancy/PainSpike.cs
+++ b/Scripts/Spells/Necromancy/PainSpike.cs
@@ -27,7 +27,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(1.0);
+                return TimeSpan.FromSeconds(1.25);
             }
         }
         public override double RequiredSkill

--- a/Scripts/Spells/Necromancy/PoisonStrike.cs
+++ b/Scripts/Spells/Necromancy/PoisonStrike.cs
@@ -26,7 +26,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds((Core.ML ? 1.75 : 1.5));
+                return TimeSpan.FromSeconds((Core.ML ? 2.0 : 1.5));
             }
         }
         public override double RequiredSkill
@@ -94,7 +94,7 @@ namespace Server.Spells.Necromancy
                 {
                     sdiBonus = (double)AosAttributes.GetValue(Caster, AosAttribute.SpellDamage) / 100;
 
-                    // PvP spell damage increase cap of 15% from an item’s magic property in Publish 33(SE)
+                    // PvP spell damage increase cap of 15% from an itemâ€™s magic property in Publish 33(SE)
                     if (m is PlayerMobile && Caster.Player && sdiBonus > 15)
                         sdiBonus = 15;
                 }

--- a/Scripts/Spells/Necromancy/Strangle.cs
+++ b/Scripts/Spells/Necromancy/Strangle.cs
@@ -23,7 +23,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(2.0);
+                return TimeSpan.FromSeconds(2.25);
             }
         }
         public override double RequiredSkill

--- a/Scripts/Spells/Necromancy/SummonFamiliar.cs
+++ b/Scripts/Spells/Necromancy/SummonFamiliar.cs
@@ -20,7 +20,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(2.0);
+                return TimeSpan.FromSeconds(2.25);
             }
         }
 

--- a/Scripts/Spells/Necromancy/VampiricEmbrace.cs
+++ b/Scripts/Spells/Necromancy/VampiricEmbrace.cs
@@ -21,7 +21,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(2.0);
+                return TimeSpan.FromSeconds(2.25);
             }
         }
         public override double RequiredSkill

--- a/Scripts/Spells/Necromancy/VengefulSpirit.cs
+++ b/Scripts/Spells/Necromancy/VengefulSpirit.cs
@@ -22,7 +22,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(2.0);
+                return TimeSpan.FromSeconds(2.25);
             }
         }
         public override double RequiredSkill

--- a/Scripts/Spells/Necromancy/WraithForm.cs
+++ b/Scripts/Spells/Necromancy/WraithForm.cs
@@ -21,7 +21,7 @@ namespace Server.Spells.Necromancy
         {
             get
             {
-                return TimeSpan.FromSeconds(2.0);
+                return TimeSpan.FromSeconds(2.25);
             }
         }
         public override double RequiredSkill


### PR DESCRIPTION
Cast TImes;
This is per EA. Times were off on ServUO by 1 spell circle for magery and mysticism. Most necro spells were off by .25 seconds. All verified on EA.

Shadowguard now saves properly to prevent hung encounters on server restart