### PR TITLE
Type Cache

### DIFF
--- a/Scripts/Commands/Add.cs
+++ b/Scripts/Commands/Add.cs
@@ -530,7 +530,7 @@ namespace Server.Commands
 
         public static bool IsEntity(Type t)
         {
-            return m_EntityType.IsAssignableFrom(t);
+            return t != null && t.GetInterface(m_EntityType.Name) != null;
         }
 
         public static bool IsConstructable(ConstructorInfo ctor, AccessLevel accessLevel)

--- a/Scripts/Gumps/AddGump.cs
+++ b/Scripts/Gumps/AddGump.cs
@@ -95,7 +95,12 @@ namespace Server.Gumps
             types = ScriptCompiler.GetTypeCache(Core.Assembly).Types;
             Match(match, types, results);
 
-            results.Sort(new TypeNameComparer());
+            results.RemoveAll(t => t == null);
+
+            if (results.Count > 1)
+            {
+                results.Sort((l, r) => Insensitive.Compare(l.Name, r.Name));
+            }
 
             return results;
         }
@@ -189,7 +194,7 @@ namespace Server.Gumps
             {
                 Type t = types[i];
 
-                if ((typeofMobile.IsAssignableFrom(t) || typeofItem.IsAssignableFrom(t)) && t.Name.ToLower().IndexOf(match) >= 0 && !results.Contains(t))
+                if ((typeofMobile.IsAssignableFrom(t) || typeofItem.IsAssignableFrom(t)) && Insensitive.Contains(t.Name, match) && !results.Contains(t))
                 {
                     ConstructorInfo[] ctors = t.GetConstructors();
 
@@ -241,14 +246,6 @@ namespace Server.Gumps
             {
                 if (cancelType == TargetCancelType.Canceled)
                     from.SendGump(new AddGump(from, this.m_SearchString, this.m_Page, this.m_SearchResults, true));
-            }
-        }
-
-        private class TypeNameComparer : IComparer<Type>
-        {
-            public int Compare(Type x, Type y)
-            {
-                return x.Name.CompareTo(y.Name);
             }
         }
     }

--- a/Scripts/Items/Consumables/Cooking.cs
+++ b/Scripts/Items/Consumables/Cooking.cs
@@ -433,7 +433,6 @@ namespace Server.Items
     }
 
     // ********** SackFlour **********
-    [TypeAlias("Server.Items.SackFlourOpen")]
     public class SackFlour : Item, IQuality
     {
         private ItemQuality _Quality;


### PR DESCRIPTION
Type cache; Fix issues with conflicting type names by implementing nested caching for types.

Type sorting; Types implementing IEntity will always take priority when performing lookups.

[Add command; Check for IEntity implementation using Type.GetInterface instead of Type.IsAssignableFrom.

SackFlour; Removed redundant TypeAliasAttribute.
(TypeAliasAttribute should only be used when the aliased type no longer exists)