### PR TITLE
Pet control chance fix:

### DIFF
--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -737,37 +737,14 @@ namespace Server.Mobiles
 
         public void AdjustTameRequirements()
         {
-            CurrentTameSkill = CalculateCurrentTameSkill(ControlSlots);
-        }
-
-        public double CalculateCurrentTameSkill(int currentControlSlots)
-        {
-            double minSkill = Math.Ceiling(MinTameSkill);
-            double current = 0;
-
-            if (currentControlSlots <= ControlSlotsMin)
+            if (ControlSlots <= ControlSlotsMin)
             {
-                current = MinTameSkill;
+                CurrentTameSkill = MinTameSkill;
             }
-            else if (MinTameSkill < 108) // Currently, with increased control slots, taming skill does not seem to pass 108.0
+            else
             {
-                if (MinTameSkill <= 0)
-                {
-                    current = Math.Ceiling(Math.Min(108.0, Math.Max(0, CurrentTameSkill) + (Math.Abs(minSkill) * .7)));
-                }
-                else
-                {
-                    double level = currentControlSlots - ControlSlotsMin;
-                    double levelFactor = (double)(1 + (ControlSlotsMax - ControlSlotsMin)) / minSkill;
-
-                    current = Math.Ceiling(Math.Min(108.0, minSkill + (minSkill * ((levelFactor * 7) * level))));
-                }
+                CurrentTameSkill = ((ControlSlots - ControlSlotsMin) * 21) + 1;
             }
-
-            if (current < MinTameSkill)
-                current = MinTameSkill;
-
-            return current;
         }
         #endregion
 
@@ -4066,12 +4043,19 @@ namespace Server.Mobiles
             {
                 double skill = m_dMinTameSkill;
 
-                m_dMinTameSkill = value;
-
-                if (skill != m_dMinTameSkill)
+                if (skill != value)
                 {
-                    m_CurrentTameSkill = value;
-                    AdjustTameRequirements();
+                    m_dMinTameSkill = value;
+                    var adjusted = CurrentTameSkill - skill;
+
+                    if (adjusted > 0)
+                    {
+                        m_CurrentTameSkill = value + adjusted;
+                    }
+                    else
+                    {
+                        m_CurrentTameSkill = value;
+                    }
                 }
             } 
         }

--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -964,14 +964,15 @@ namespace Server.Mobiles
         #region Training Helpers
         public static bool CanControl(Mobile m, BaseCreature bc, TrainingProfile trainProfile)
         {
-            double skill = m.Skills[SkillName.AnimalTaming].Value;
+            return m.Skills[SkillName.AnimalTaming].Value >= bc.CurrentTameSkill + trainProfile.GetRequirementIncrease(!trainProfile.HasIncreasedControlSlot);
+            /*double skill = m.Skills[SkillName.AnimalTaming].Value;
 
             if (trainProfile.HasIncreasedControlSlot)
             {
                 return skill >= bc.CalculateCurrentTameSkill(bc.ControlSlots);
             }
 
-            return skill >= bc.CalculateCurrentTameSkill(bc.ControlSlots + 1);
+            return skill >= bc.CalculateCurrentTameSkill(bc.ControlSlots + 1);*/
         }
 
         public static int GetTrainingCapTotal(PetStat stat)


### PR DESCRIPTION
- Per EA, control tame requirement as follows:
1st train of any level, requirement increases by 21. Subsequent level changes increase requirement by 22. Subsequent training increases requirement by 3 (2 for subsequent trains, per level).