### PR TITLE
Update PetTrainingHelper.cs

### DIFF
--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -964,7 +964,7 @@ namespace Server.Mobiles
         #region Training Helpers
         public static bool CanControl(Mobile m, BaseCreature bc, TrainingProfile trainProfile)
         {
-            return m.Skills[SkillName.AnimalTaming].Value >= bc.CurrentTameSkill + trainProfile.GetRequirementIncrease(!trainProfile.HasIncreasedControlSlot);
+            return m.Skills[SkillName.AnimalTaming].Value >= bc.CurrentTameSkill + trainProfile.GetRequirementIncrease(trainProfile.HasIncreasedControlSlot);
             /*double skill = m.Skills[SkillName.AnimalTaming].Value;
 
             if (trainProfile.HasIncreasedControlSlot)


### PR DESCRIPTION
We can not see the button on gump of AnimalLore for many pets to start training.
e.g.) Why do we need high skill of Animal Taming 117.1 (95.1+22) to start training (to see the button) a unicorn even now?