### PR TITLE
Bug Fix for The Sewing Kit can make strange items.

### DIFF
--- a/Scripts/Services/Craft/Core/CraftGumpItem.cs
+++ b/Scripts/Services/Craft/Core/CraftGumpItem.cs
@@ -293,6 +293,12 @@ namespace Server.Engines.Craft
                     }
                 case 1: // Make Button
                     {
+                        if (m_CraftItem.TryCraft != null)
+                        {
+                            m_CraftItem.TryCraft(m_From, m_CraftItem, m_Tool);
+                            return;
+                        }
+                        
                         int num = m_CraftSystem.CanCraft(m_From, m_Tool, m_CraftItem.ItemType);
 
                         if (num > 0)


### PR DESCRIPTION
The Sewing Kit can make strange items named "Combine Cloth" and "Cut-Up Cloth" if you push the button on "CraftGumpItem" (not on "CraftGump") to make it.
By the way there is similar code in "CraftGump.cs" line 475.