### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Items/Addons/Banner.cs
+++ b/Scripts/Items/Addons/Banner.cs
@@ -14,8 +14,8 @@ namespace Server.Items
         public Banner(int itemID)
             : base(itemID)
         { 
-            this.LootType = LootType.Blessed;
-            this.Movable = false;
+            LootType = LootType.Blessed;
+            Movable = false;
         }
 
         public Banner(Serial serial)
@@ -35,7 +35,7 @@ namespace Server.Items
             get
             { 
                 BannerDeed deed = new BannerDeed();
-                deed.IsRewardItem = this.m_IsRewardItem;
+                deed.IsRewardItem = m_IsRewardItem;
 
                 return deed;	
             }
@@ -45,26 +45,26 @@ namespace Server.Items
         {
             get
             {
-                return this.m_IsRewardItem;
+                return m_IsRewardItem;
             }
             set
             {
-                this.m_IsRewardItem = value;
-                this.InvalidateProperties();
+                m_IsRewardItem = value;
+                InvalidateProperties();
             }
         }
         public bool FacingSouth
         {
             get
             {
-                return (this.ItemID & 0x1) == 0;
+                return (ItemID & 0x1) == 0;
             }
         }
         public override void GetProperties(ObjectPropertyList list)
         {
             base.GetProperties(list);
 			
-            if (Core.ML && this.m_IsRewardItem)
+            if (Core.ML && m_IsRewardItem)
                 list.Add(1076218); // 2nd Year Veteran Reward
         }
 
@@ -75,7 +75,7 @@ namespace Server.Items
 
         public override void OnDoubleClick(Mobile from)
         {
-            if (from.InRange(this.Location, 2))
+            if (from.InRange(Location, 2))
             {
                 BaseHouse house = BaseHouse.FindHouseAt(this);  
 				
@@ -97,7 +97,7 @@ namespace Server.Items
 
             writer.WriteEncodedInt(0); // version
 			
-            writer.Write((bool)this.m_IsRewardItem);
+            writer.Write((bool)m_IsRewardItem);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -106,25 +106,25 @@ namespace Server.Items
 
             int version = reader.ReadEncodedInt();
 			
-            this.m_IsRewardItem = reader.ReadBool();
+            m_IsRewardItem = reader.ReadBool();
         }
 
         public bool Dye(Mobile from, DyeTub sender)
         {
-            if (this.Deleted)
+            if (Deleted)
                 return false;
 
-            this.Hue = sender.DyedHue;
+            Hue = sender.DyedHue;
 
             return true;
         }
 
         public bool CouldFit(IPoint3D p, Map map)
         { 
-            if (map == null || !map.CanFit(p.X, p.Y, p.Z, this.ItemData.Height))
+            if (map == null || !map.CanFit(p.X, p.Y, p.Z, ItemData.Height))
                 return false;
 				
-            if (this.FacingSouth)
+            if (FacingSouth)
                 return BaseAddon.IsWall(p.X, p.Y - 1, p.Z, map); // north wall
             else
                 return BaseAddon.IsWall(p.X - 1, p.Y, p.Z, map); // west wall
@@ -138,8 +138,8 @@ namespace Server.Items
         public BannerDeed()
             : base(0x14F0)
         { 
-            this.LootType = LootType.Blessed;
-            this.Weight = 1.0;
+            LootType = LootType.Blessed;
+            Weight = 1.0;
         }
 
         public BannerDeed(Serial serial)
@@ -159,28 +159,28 @@ namespace Server.Items
         {
             get
             {
-                return this.m_IsRewardItem;
+                return m_IsRewardItem;
             }
             set
             {
-                this.m_IsRewardItem = value;
-                this.InvalidateProperties();
+                m_IsRewardItem = value;
+                InvalidateProperties();
             }
         }
         public override void GetProperties(ObjectPropertyList list)
         {
             base.GetProperties(list);
 			
-            if (this.m_IsRewardItem)
+            if (m_IsRewardItem)
                 list.Add(1076218); // 2nd Year Veteran Reward
         }
 
         public override void OnDoubleClick(Mobile from)
         { 
-            if (this.m_IsRewardItem && !RewardSystem.CheckIsUsableBy(from, this, null))
+            if (m_IsRewardItem && !RewardSystem.CheckIsUsableBy(from, this, null))
                 return;
 		
-            if (this.IsChildOf(from.Backpack))
+            if (IsChildOf(from.Backpack))
             {
                 BaseHouse house = BaseHouse.FindHouseAt(from);
 
@@ -190,7 +190,7 @@ namespace Server.Items
                     from.SendGump(new InternalGump(this));
                 }
                 else
-                    from.SendLocalizedMessage(502092); // You must be in your house to do this.
+                    from.SendLocalizedMessage(502092); // You must be in your house to do 
             }
             else
                 from.SendLocalizedMessage(1042038); // You must have the object in your backpack to use it.          	
@@ -202,7 +202,7 @@ namespace Server.Items
 
             writer.WriteEncodedInt(0); // version
 			
-            writer.Write((bool)this.m_IsRewardItem);
+            writer.Write((bool)m_IsRewardItem);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -211,7 +211,7 @@ namespace Server.Items
 
             int version = reader.ReadEncodedInt();
 			
-            this.m_IsRewardItem = reader.ReadBool();
+            m_IsRewardItem = reader.ReadBool();
         }
 
         private class InternalGump : Gump
@@ -222,41 +222,44 @@ namespace Server.Items
             public InternalGump(BannerDeed banner)
                 : base(100, 200)
             {
-                this.m_Banner = banner;
+                m_Banner = banner;
 				
-                this.Closable = true;
-                this.Disposable = true;
-                this.Dragable = true;
-                this.Resizable = false;
+                Closable = true;
+                Disposable = true;
+                Dragable = true;
+                Resizable = false;
 				
-                this.AddPage(0);
+                AddPage(0);
 
-                this.AddBackground(25, 0, 520, 230, 0xA28);				
-                this.AddLabel(70, 12, 0x3E3, "Choose a Banner:");
+                AddBackground(25, 0, 520, 230, 0xA28);				
+                AddLabel(70, 12, 0x3E3, "Choose a Banner:");
 
                 int itemID = Start;
 
-                for (int i = 1; i <= 4; i++)
+                for (int i = 1; i <= 5; i++)
                 {
-                    this.AddPage(i);
+                    AddPage(i);
 
                     for (int j = 0; j < 8; j++, itemID += 2)
                     {
-                        this.AddItem(50 + 60 * j, 70, itemID);
-                        this.AddButton(50 + 60 * j, 50, 0x845, 0x846, itemID, GumpButtonType.Reply, 0);
+                        AddItem(50 + 60 * j, 70, itemID);
+                        AddButton(50 + 60 * j, 50, 0x845, 0x846, itemID, GumpButtonType.Reply, 0);
+
+                        if (itemID >= End)
+                            break;
                     }
 
                     if (i > 1)
-                        this.AddButton(75, 198, 0x8AF, 0x8AF, 0, GumpButtonType.Page, i - 1);
+                        AddButton(75, 198, 0x8AF, 0x8AF, 0, GumpButtonType.Page, i - 1);
 
-                    if (i < 4)
-                        this.AddButton(475, 198, 0x8B0, 0x8B0, 0, GumpButtonType.Page, i + 1);
+                    if (i < 5)
+                        AddButton(475, 198, 0x8B0, 0x8B0, 0, GumpButtonType.Page, i + 1);
                 }
             }
 
             public override void OnResponse(NetState sender, RelayInfo info)
             {
-                if (this.m_Banner == null || this.m_Banner.Deleted)
+                if (m_Banner == null || m_Banner.Deleted)
                     return;		
 				
                 Mobile m = sender.Mobile;	
@@ -266,7 +269,7 @@ namespace Server.Items
                     if ((info.ButtonID & 0x1) == 0)
                     {
                         m.SendLocalizedMessage(1042037); // Where would you like to place this banner?
-                        m.Target = new InternalTarget(this.m_Banner, info.ButtonID);
+                        m.Target = new InternalTarget(m_Banner, info.ButtonID);
                     }
                 }
             }
@@ -279,16 +282,16 @@ namespace Server.Items
             public InternalTarget(BannerDeed banner, int itemID)
                 : base(-1, true, TargetFlags.None)
             {
-                this.m_Banner = banner;
-                this.m_ItemID = itemID;
+                m_Banner = banner;
+                m_ItemID = itemID;
             }
 
             protected override void OnTarget(Mobile from, object targeted)
             {
-                if (this.m_Banner == null || this.m_Banner.Deleted)
+                if (m_Banner == null || m_Banner.Deleted)
                     return;
 					
-                if (this.m_Banner.IsChildOf(from.Backpack))
+                if (m_Banner.IsChildOf(from.Backpack))
                 {
                     BaseHouse house = BaseHouse.FindHouseAt(from);
 
@@ -301,7 +304,7 @@ namespace Server.Items
                             return;
 							
                         Point3D p3d = new Point3D(p);
-                        ItemData id = TileData.ItemTable[this.m_ItemID & TileData.MaxItemValue];
+                        ItemData id = TileData.ItemTable[m_ItemID & TileData.MaxItemValue];
 						
                         if (map.CanFit(p3d, id.Height))
                         {
@@ -315,23 +318,23 @@ namespace Server.Items
                                 if (north && west)
                                 {
                                     from.CloseGump(typeof(FacingGump));
-                                    from.SendGump(new FacingGump(this.m_Banner, this.m_ItemID, p3d, house));
+                                    from.SendGump(new FacingGump(m_Banner, m_ItemID, p3d, house));
                                 }
                                 else if (north || west)
                                 {
                                     Banner banner = null;
 									
                                     if (north)
-                                        banner = new Banner(this.m_ItemID);
+                                        banner = new Banner(m_ItemID);
                                     else if (west)
-                                        banner = new Banner(this.m_ItemID + 1);
+                                        banner = new Banner(m_ItemID + 1);
 										
                                     house.Addons[banner] = from;
 
-                                    banner.IsRewardItem = this.m_Banner.IsRewardItem;
+                                    banner.IsRewardItem = m_Banner.IsRewardItem;
                                     banner.MoveToWorld(p3d, map);
 
-                                    this.m_Banner.Delete();
+                                    m_Banner.Delete();
                                 }
                                 else
                                     from.SendLocalizedMessage(1042039); // The banner must be placed next to a wall.								
@@ -343,7 +346,7 @@ namespace Server.Items
                             from.SendLocalizedMessage(500269); // You cannot build that there.		
                     }
                     else
-                        from.SendLocalizedMessage(502092); // You must be in your house to do this.
+                        from.SendLocalizedMessage(502092); // You must be in your house to do 
                 }
                 else
                     from.SendLocalizedMessage(1042038); // You must have the object in your backpack to use it.     
@@ -358,25 +361,25 @@ namespace Server.Items
                 public FacingGump(BannerDeed banner, int itemID, Point3D location, BaseHouse house)
                     : base(150, 50)
                 {
-                    this.m_Banner = banner;
-                    this.m_ItemID = itemID;
-                    this.m_Location = location;
-                    this.m_House = house;
+                    m_Banner = banner;
+                    m_ItemID = itemID;
+                    m_Location = location;
+                    m_House = house;
 				
-                    this.Closable = true;
-                    this.Disposable = true;
-                    this.Dragable = true;
-                    this.Resizable = false;
+                    Closable = true;
+                    Disposable = true;
+                    Dragable = true;
+                    Resizable = false;
 
-                    this.AddPage(0);
+                    AddPage(0);
 
-                    this.AddBackground(0, 0, 300, 150, 0xA28);
+                    AddBackground(0, 0, 300, 150, 0xA28);
 
-                    this.AddItem(90, 30, itemID + 1);
-                    this.AddItem(180, 30, itemID);
+                    AddItem(90, 30, itemID + 1);
+                    AddItem(180, 30, itemID);
 
-                    this.AddButton(50, 35, 0x868, 0x869, (int)Buttons.East, GumpButtonType.Reply, 0);
-                    this.AddButton(145, 35, 0x868, 0x869, (int)Buttons.South, GumpButtonType.Reply, 0);
+                    AddButton(50, 35, 0x868, 0x869, (int)Buttons.East, GumpButtonType.Reply, 0);
+                    AddButton(145, 35, 0x868, 0x869, (int)Buttons.South, GumpButtonType.Reply, 0);
                 }
 
                 private enum Buttons
@@ -387,24 +390,24 @@ namespace Server.Items
                 }
                 public override void OnResponse(NetState sender, RelayInfo info)
                 {
-                    if (this.m_Banner == null || this.m_Banner.Deleted || this.m_House == null)
+                    if (m_Banner == null || m_Banner.Deleted || m_House == null)
                         return;		
 					
                     Banner banner = null;	
 				
                     if (info.ButtonID == (int)Buttons.East)
-                        banner = new Banner(this.m_ItemID + 1);
+                        banner = new Banner(m_ItemID + 1);
                     if (info.ButtonID == (int)Buttons.South)
-                        banner = new Banner(this.m_ItemID);
+                        banner = new Banner(m_ItemID);
 						
                     if (banner != null)
                     {
-                        this.m_House.Addons[banner] = sender.Mobile;
+                        m_House.Addons[banner] = sender.Mobile;
 
-                        banner.IsRewardItem = this.m_Banner.IsRewardItem;
-                        banner.MoveToWorld(this.m_Location, sender.Mobile.Map);
+                        banner.IsRewardItem = m_Banner.IsRewardItem;
+                        banner.MoveToWorld(m_Location, sender.Mobile.Map);
 
-                        this.m_Banner.Delete();
+                        m_Banner.Delete();
                     }
                 }
             }

--- a/Scripts/Items/Addons/WallBanner.cs
+++ b/Scripts/Items/Addons/WallBanner.cs
@@ -28,14 +28,14 @@ namespace Server.Items
         {
             get
             {
-                return this.East ? new Point3D(-1, 0, 0) : new Point3D(0, -1, 0);
+                return East ? new Point3D(-1, 0, 0) : new Point3D(0, -1, 0);
             }
         }
         public bool East
         {
             get
             {
-                return ((WallBanner)this.Addon).East;
+                return ((WallBanner)Addon).East;
             }
         }
         public override void Serialize(GenericWriter writer)
@@ -54,11 +54,11 @@ namespace Server.Items
 
         public bool Dye(Mobile from, DyeTub sender)
         {
-            if (this.Deleted)
+            if (Deleted)
                 return false;
 
-            if (this.Addon != null)
-                this.Addon.Hue = sender.DyedHue;
+            if (Addon != null)
+                Addon.Hue = sender.DyedHue;
 
             return true;
         }
@@ -72,145 +72,145 @@ namespace Server.Items
         public WallBanner(int bannerID)
             : base()
         {
-            this.m_East = ((bannerID % 2) == 1);
+            m_East = ((bannerID % 2) == 1);
 
             switch ( bannerID )
             {
                 case 1: 
-                    this.AddComponent(new WallBannerComponent(0x161F), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x161E), 0, 1, 0);
-                    this.AddComponent(new WallBannerComponent(0x161D), 0, 2, 0);
+                    AddComponent(new WallBannerComponent(0x161F), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x161E), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x161D), 0, 2, 0);
                     break;
                 case 2: 
-                    this.AddComponent(new WallBannerComponent(0x1586), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1587), 1, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1588), 2, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1586), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1587), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1588), 2, 0, 0);
                     break;
                 case 3: 
-                    this.AddComponent(new WallBannerComponent(0x1622), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1621), 0, 1, 0);
-                    this.AddComponent(new WallBannerComponent(0x1620), 0, 2, 0);
+                    AddComponent(new WallBannerComponent(0x1622), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1621), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x1620), 0, 2, 0);
                     break;
                 case 4: 
-                    this.AddComponent(new WallBannerComponent(0x1589), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x158A), 1, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x158B), 2, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1589), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x158A), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x158B), 2, 0, 0);
                     break;
                 case 5: 
-                    this.AddComponent(new WallBannerComponent(0x1625), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1624), 0, 1, 0);
-                    this.AddComponent(new WallBannerComponent(0x1623), 0, 2, 0);
+                    AddComponent(new WallBannerComponent(0x1625), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1624), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x1623), 0, 2, 0);
                     break;
                 case 6: 
-                    this.AddComponent(new WallBannerComponent(0x158C), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x158D), 1, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x158E), 2, 0, 0);
+                    AddComponent(new WallBannerComponent(0x158C), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x158D), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x158E), 2, 0, 0);
                     break;
                 case 7: 
-                    this.AddComponent(new WallBannerComponent(0x1628), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1627), 0, 1, 0);
-                    this.AddComponent(new WallBannerComponent(0x1626), 0, 2, 0);
+                    AddComponent(new WallBannerComponent(0x1628), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1627), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x1626), 0, 2, 0);
                     break;
                 case 8: 
-                    this.AddComponent(new WallBannerComponent(0x1590), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1591), 1, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x158F), 2, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1590), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1591), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x158F), 2, 0, 0);
                     break;
                 case 9: 
-                    this.AddComponent(new WallBannerComponent(0x162A), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1629), 0, 1, 0);
-                    this.AddComponent(new WallBannerComponent(0x1626), 0, 2, 0);
+                    AddComponent(new WallBannerComponent(0x162A), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1629), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x1626), 0, 2, 0);
                     break;
                 case 10: 
-                    this.AddComponent(new WallBannerComponent(0x1592), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1593), 1, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x158F), 2, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1592), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1593), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x158F), 2, 0, 0);
                     break;
                 case 11: 
-                    this.AddComponent(new WallBannerComponent(0x162D), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x162C), 0, 1, 0);
-                    this.AddComponent(new WallBannerComponent(0x162B), 0, 2, 0);
+                    AddComponent(new WallBannerComponent(0x162D), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x162C), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x162B), 0, 2, 0);
                     break;
                 case 12: 
-                    this.AddComponent(new WallBannerComponent(0x1594), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1595), 1, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1596), 2, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1594), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1595), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1596), 2, 0, 0);
                     break;
                 case 13: 
-                    this.AddComponent(new WallBannerComponent(0x1632), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1631), 0, 1, 0);
-                    this.AddComponent(new WallBannerComponent(0x162E), 0, 2, 0);
+                    AddComponent(new WallBannerComponent(0x1632), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1631), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x162E), 0, 2, 0);
                     break;
                 case 14: 
-                    this.AddComponent(new WallBannerComponent(0x1598), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x159B), 1, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x159C), 2, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1598), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x159B), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x159C), 2, 0, 0);
                     break;
                 case 15: 
-                    this.AddComponent(new WallBannerComponent(0x1633), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1630), 0, 1, 0);
-                    this.AddComponent(new WallBannerComponent(0x162F), 0, 2, 0);
+                    AddComponent(new WallBannerComponent(0x1633), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1630), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x162F), 0, 2, 0);
                     break;
                 case 16: 
-                    this.AddComponent(new WallBannerComponent(0x1599), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x159A), 1, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x159D), 2, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1599), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x159A), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x159D), 2, 0, 0);
                     break;
                 case 17: 
-                    this.AddComponent(new WallBannerComponent(0x1610), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x160F), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x1610), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x160F), 0, 1, 0);
                     break;
                 case 18: 
-                    this.AddComponent(new WallBannerComponent(0x15A0), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x15A1), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15A0), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15A1), 1, 0, 0);
                     break;
                 case 19: 
-                    this.AddComponent(new WallBannerComponent(0x1612), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1611), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x1612), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1611), 0, 1, 0);
                     break;
                 case 20: 
-                    this.AddComponent(new WallBannerComponent(0x15A2), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x15A3), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15A2), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15A3), 1, 0, 0);
                     break;
                 case 21: 
-                    this.AddComponent(new WallBannerComponent(0x1614), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1613), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x1614), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1613), 0, 1, 0);
                     break;
                 case 22: 
-                    this.AddComponent(new WallBannerComponent(0x15A4), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x15A5), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15A4), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15A5), 1, 0, 0);
                     break;
                 case 23: 
-                    this.AddComponent(new WallBannerComponent(0x1616), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1615), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x1616), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1615), 0, 1, 0);
                     break;
                 case 24: 
-                    this.AddComponent(new WallBannerComponent(0x15A6), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x15A7), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15A6), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15A7), 1, 0, 0);
                     break;
                 case 25: 
-                    this.AddComponent(new WallBannerComponent(0x1618), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1617), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x1618), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1617), 0, 1, 0);
                     break;
                 case 26: 
-                    this.AddComponent(new WallBannerComponent(0x15A8), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x15A9), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15A8), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15A9), 1, 0, 0);
                     break;
                 case 27: 
-                    this.AddComponent(new WallBannerComponent(0x161A), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x1619), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x161A), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x1619), 0, 1, 0);
                     break;
                 case 28: 
-                    this.AddComponent(new WallBannerComponent(0x15AA), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x15AB), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15AA), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15AB), 1, 0, 0);
                     break;
                 case 29: 
-                    this.AddComponent(new WallBannerComponent(0x161C), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x161B), 0, 1, 0);
+                    AddComponent(new WallBannerComponent(0x161C), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x161B), 0, 1, 0);
                     break;
                 case 30: 
-                    this.AddComponent(new WallBannerComponent(0x15AC), 0, 0, 0);
-                    this.AddComponent(new WallBannerComponent(0x15AD), 1, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15AC), 0, 0, 0);
+                    AddComponent(new WallBannerComponent(0x15AD), 1, 0, 0);
                     break;
             }
         }
@@ -225,7 +225,7 @@ namespace Server.Items
             get
             { 
                 WallBannerDeed deed = new WallBannerDeed();
-                deed.IsRewardItem = this.m_IsRewardItem;
+                deed.IsRewardItem = m_IsRewardItem;
 
                 return deed;	
             }
@@ -235,12 +235,12 @@ namespace Server.Items
         {
             get
             {
-                return this.m_IsRewardItem;
+                return m_IsRewardItem;
             }
             set
             {
-                this.m_IsRewardItem = value;
-                this.InvalidateProperties();
+                m_IsRewardItem = value;
+                InvalidateProperties();
             }
         }
         [CommandProperty(AccessLevel.GameMaster)]
@@ -248,12 +248,12 @@ namespace Server.Items
         {
             get
             {
-                return this.m_East;
+                return m_East;
             }
             set
             {
-                this.m_IsRewardItem = value;
-                this.InvalidateProperties();
+                m_IsRewardItem = value;
+                InvalidateProperties();
             }
         }
         public override void Serialize(GenericWriter writer)
@@ -262,8 +262,8 @@ namespace Server.Items
 
             writer.WriteEncodedInt(0); // version
 			
-            writer.Write((bool)this.m_East);
-            writer.Write((bool)this.m_IsRewardItem);
+            writer.Write((bool)m_East);
+            writer.Write((bool)m_IsRewardItem);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -272,8 +272,8 @@ namespace Server.Items
 
             int version = reader.ReadEncodedInt();
 			
-            this.m_East = reader.ReadBool();
-            this.m_IsRewardItem = reader.ReadBool();
+            m_East = reader.ReadBool();
+            m_IsRewardItem = reader.ReadBool();
         }
     }
 
@@ -285,7 +285,7 @@ namespace Server.Items
         public WallBannerDeed()
             : base()
         { 
-            this.LootType = LootType.Blessed;
+            LootType = LootType.Blessed;
         }
 
         public WallBannerDeed(Serial serial)
@@ -304,8 +304,8 @@ namespace Server.Items
         {
             get
             {
-                WallBanner addon = new WallBanner(this.m_BannerID);
-                addon.IsRewardItem = this.m_IsRewardItem;
+                WallBanner addon = new WallBanner(m_BannerID);
+                addon.IsRewardItem = m_IsRewardItem;
 
                 return addon;
             }
@@ -315,28 +315,28 @@ namespace Server.Items
         {
             get
             {
-                return this.m_IsRewardItem;
+                return m_IsRewardItem;
             }
             set
             {
-                this.m_IsRewardItem = value;
-                this.InvalidateProperties();
+                m_IsRewardItem = value;
+                InvalidateProperties();
             }
         }
         public override void GetProperties(ObjectPropertyList list)
         {
             base.GetProperties(list);
 			
-            if (this.m_IsRewardItem)
+            if (m_IsRewardItem)
                 list.Add(1076225); // 9th Year Veteran Reward
         }
 
         public override void OnDoubleClick(Mobile from)
         { 
-            if (this.m_IsRewardItem && !RewardSystem.CheckIsUsableBy(from, this, null))
+            if (m_IsRewardItem && !RewardSystem.CheckIsUsableBy(from, this, null))
                 return;
 		
-            if (this.IsChildOf(from.Backpack))
+            if (IsChildOf(from.Backpack))
             {
                 from.CloseGump(typeof(InternalGump));
                 from.SendGump(new InternalGump(this));
@@ -347,7 +347,7 @@ namespace Server.Items
 
         public void Use(Mobile m, int bannerID)
         {
-            this.m_BannerID = bannerID;
+            m_BannerID = bannerID;
 		
             base.OnDoubleClick(m);
         }
@@ -358,7 +358,7 @@ namespace Server.Items
 
             writer.WriteEncodedInt(0); // version
 			
-            writer.Write((bool)this.m_IsRewardItem);
+            writer.Write((bool)m_IsRewardItem);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -367,7 +367,7 @@ namespace Server.Items
 
             int version = reader.ReadEncodedInt();
 			
-            this.m_IsRewardItem = reader.ReadBool();
+            m_IsRewardItem = reader.ReadBool();
         }
 
         private class InternalGump : Gump
@@ -376,153 +376,153 @@ namespace Server.Items
             public InternalGump(WallBannerDeed WallBanner)
                 : base(150, 50)
             {
-                this.m_WallBanner = WallBanner;
+                m_WallBanner = WallBanner;
 				
-                this.Closable = true;
-                this.Disposable = true;
-                this.Dragable = true;
-                this.Resizable = false;
+                Closable = true;
+                Disposable = true;
+                Dragable = true;
+                Resizable = false;
 				
-                this.AddBackground(25, 0, 500, 265, 0xA28);
-                this.AddLabel(70, 12, 0x3E3, "Choose a Wall Banner:");
+                AddBackground(25, 0, 500, 265, 0xA28);
+                AddLabel(70, 12, 0x3E3, "Choose a Wall Banner:");
 
-                this.AddPage(1);
+                AddPage(1);
 
-                this.AddItem(55, 110, 0x161D);
-                this.AddItem(75, 90, 0x161E);
-                this.AddItem(95, 70, 0x161F);
-                this.AddButton(70, 50, 0x845, 0x846, 1, GumpButtonType.Reply, 0);
-                this.AddItem(105, 70, 0x1586);
-                this.AddItem(125, 90, 0x1587);
-                this.AddItem(145, 110, 0x1588);
-                this.AddButton(145, 50, 0x845, 0x846, 2, GumpButtonType.Reply, 0);
-                this.AddItem(200, 110, 0x1620);
-                this.AddItem(220, 90, 0x1621);
-                this.AddItem(240, 70, 0x1622);
-                this.AddButton(220, 50, 0x845, 0x846, 3, GumpButtonType.Reply, 0);
-                this.AddItem(250, 70, 0x1589);
-                this.AddItem(270, 90, 0x158A);
-                this.AddItem(290, 110, 0x158B);
-                this.AddButton(300, 50, 0x845, 0x846, 4, GumpButtonType.Reply, 0);
-                this.AddItem(350, 110, 0x1623);
-                this.AddItem(370, 90, 0x1624);
-                this.AddItem(390, 70, 0x1625);
-                this.AddButton(365, 50, 0x845, 0x846, 5, GumpButtonType.Reply, 0);
-                this.AddItem(400, 70, 0x158C);
-                this.AddItem(420, 90, 0x158D);
-                this.AddItem(440, 110, 0x158E);
-                this.AddButton(445, 50, 0x845, 0x846, 6, GumpButtonType.Reply, 0);
-                this.AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 2);
+                AddItem(55, 110, 0x161D);
+                AddItem(75, 90, 0x161E);
+                AddItem(95, 70, 0x161F);
+                AddButton(70, 50, 0x845, 0x846, 1, GumpButtonType.Reply, 0);
+                AddItem(105, 70, 0x1586);
+                AddItem(125, 90, 0x1587);
+                AddItem(145, 110, 0x1588);
+                AddButton(145, 50, 0x845, 0x846, 2, GumpButtonType.Reply, 0);
+                AddItem(200, 110, 0x1620);
+                AddItem(220, 90, 0x1621);
+                AddItem(240, 70, 0x1622);
+                AddButton(220, 50, 0x845, 0x846, 3, GumpButtonType.Reply, 0);
+                AddItem(250, 70, 0x1589);
+                AddItem(270, 90, 0x158A);
+                AddItem(290, 110, 0x158B);
+                AddButton(300, 50, 0x845, 0x846, 4, GumpButtonType.Reply, 0);
+                AddItem(350, 110, 0x1623);
+                AddItem(370, 90, 0x1624);
+                AddItem(390, 70, 0x1625);
+                AddButton(365, 50, 0x845, 0x846, 5, GumpButtonType.Reply, 0);
+                AddItem(400, 70, 0x158C);
+                AddItem(420, 90, 0x158D);
+                AddItem(440, 110, 0x158E);
+                AddButton(445, 50, 0x845, 0x846, 6, GumpButtonType.Reply, 0);
+                AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 2);
 
-                this.AddPage(2);
+                AddPage(2);
 
-                this.AddItem(52, 110, 0x1626);
-                this.AddItem(72, 90, 0x1627);
-                this.AddItem(95, 70, 0x1628);
-                this.AddButton(70, 50, 0x845, 0x846, 7, GumpButtonType.Reply, 0);
-                this.AddItem(105, 70, 0x1590);
-                this.AddItem(125, 90, 0x1591);
-                this.AddItem(145, 110, 0x158F);
-                this.AddButton(145, 50, 0x845, 0x846, 8, GumpButtonType.Reply, 0);
-                this.AddItem(197, 110, 0x1626);
-                this.AddItem(217, 90, 0x1629);
-                this.AddItem(240, 70, 0x162A);
-                this.AddButton(220, 50, 0x845, 0x846, 9, GumpButtonType.Reply, 0);
-                this.AddItem(250, 70, 0x1592);
-                this.AddItem(270, 90, 0x1593);
-                this.AddItem(290, 110, 0x158F);
-                this.AddButton(300, 50, 0x845, 0x846, 10, GumpButtonType.Reply, 0);
-                this.AddItem(340, 110, 0x162B);
-                this.AddItem(363, 90, 0x162C);
-                this.AddItem(385, 70, 0x162D);
-                this.AddButton(365, 50, 0x845, 0x846, 11, GumpButtonType.Reply, 0);
-                this.AddItem(395, 70, 0x1594);
-                this.AddItem(417, 90, 0x1595);
-                this.AddItem(439, 111, 0x1596);
-                this.AddButton(445, 50, 0x845, 0x846, 12, GumpButtonType.Reply, 0);
-                this.AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 1);
-                this.AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 3);
+                AddItem(52, 110, 0x1626);
+                AddItem(72, 90, 0x1627);
+                AddItem(95, 70, 0x1628);
+                AddButton(70, 50, 0x845, 0x846, 7, GumpButtonType.Reply, 0);
+                AddItem(105, 70, 0x1590);
+                AddItem(125, 90, 0x1591);
+                AddItem(145, 110, 0x158F);
+                AddButton(145, 50, 0x845, 0x846, 8, GumpButtonType.Reply, 0);
+                AddItem(197, 110, 0x1626);
+                AddItem(217, 90, 0x1629);
+                AddItem(240, 70, 0x162A);
+                AddButton(220, 50, 0x845, 0x846, 9, GumpButtonType.Reply, 0);
+                AddItem(250, 70, 0x1592);
+                AddItem(270, 90, 0x1593);
+                AddItem(290, 110, 0x158F);
+                AddButton(300, 50, 0x845, 0x846, 10, GumpButtonType.Reply, 0);
+                AddItem(340, 110, 0x162B);
+                AddItem(363, 90, 0x162C);
+                AddItem(385, 70, 0x162D);
+                AddButton(365, 50, 0x845, 0x846, 11, GumpButtonType.Reply, 0);
+                AddItem(395, 70, 0x1594);
+                AddItem(417, 90, 0x1595);
+                AddItem(439, 111, 0x1596);
+                AddButton(445, 50, 0x845, 0x846, 12, GumpButtonType.Reply, 0);
+                AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 1);
+                AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 3);
 
-                this.AddPage(3);
+                AddPage(3);
 
-                this.AddItem(55, 110, 0x162E);
-                this.AddItem(75, 93, 0x1631);
-                this.AddItem(95, 70, 0x1632);
-                this.AddButton(70, 50, 0x845, 0x846, 13, GumpButtonType.Reply, 0);
-                this.AddItem(118, 70, 0x1598);
-                this.AddItem(138, 94, 0x159B);
-                this.AddItem(159, 113, 0x159C);
-                this.AddButton(160, 50, 0x845, 0x846, 14, GumpButtonType.Reply, 0);
-                this.AddItem(219, 111, 0x162F);
-                this.AddItem(238, 94, 0x1630);
-                this.AddItem(258, 70, 0x1633);
-                this.AddButton(240, 50, 0x845, 0x846, 15, GumpButtonType.Reply, 0);
-                this.AddItem(279, 70, 0x1599);
-                this.AddItem(298, 93, 0x159A);
-                this.AddItem(319, 113, 0x159D);
-                this.AddButton(320, 50, 0x845, 0x846, 16, GumpButtonType.Reply, 0);
-                this.AddItem(380, 90, 0x160F);
-                this.AddItem(400, 70, 0x1610);
-                this.AddButton(390, 50, 0x845, 0x846, 17, GumpButtonType.Reply, 0);
-                this.AddItem(420, 70, 0x15A0);
-                this.AddItem(440, 90, 0x15A1);
-                this.AddButton(455, 50, 0x845, 0x846, 18, GumpButtonType.Reply, 0);
-                this.AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 2);
-                this.AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 4);
+                AddItem(55, 110, 0x162E);
+                AddItem(75, 93, 0x1631);
+                AddItem(95, 70, 0x1632);
+                AddButton(70, 50, 0x845, 0x846, 13, GumpButtonType.Reply, 0);
+                AddItem(118, 70, 0x1598);
+                AddItem(138, 94, 0x159B);
+                AddItem(159, 113, 0x159C);
+                AddButton(160, 50, 0x845, 0x846, 14, GumpButtonType.Reply, 0);
+                AddItem(219, 111, 0x162F);
+                AddItem(238, 94, 0x1630);
+                AddItem(258, 70, 0x1633);
+                AddButton(240, 50, 0x845, 0x846, 15, GumpButtonType.Reply, 0);
+                AddItem(279, 70, 0x1599);
+                AddItem(298, 93, 0x159A);
+                AddItem(319, 113, 0x159D);
+                AddButton(320, 50, 0x845, 0x846, 16, GumpButtonType.Reply, 0);
+                AddItem(380, 90, 0x160F);
+                AddItem(400, 70, 0x1610);
+                AddButton(390, 50, 0x845, 0x846, 17, GumpButtonType.Reply, 0);
+                AddItem(420, 70, 0x15A0);
+                AddItem(440, 90, 0x15A1);
+                AddButton(455, 50, 0x845, 0x846, 18, GumpButtonType.Reply, 0);
+                AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 2);
+                AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 4);
 
-                this.AddPage(4);
+                AddPage(4);
 
-                this.AddItem(55, 90, 0x1611);
-                this.AddItem(75, 70, 0x1612);
-                this.AddButton(70, 50, 0x845, 0x846, 19, GumpButtonType.Reply, 0);
-                this.AddItem(105, 70, 0x15A2);
-                this.AddItem(125, 90, 0x15A3);
-                this.AddButton(145, 50, 0x845, 0x846, 20, GumpButtonType.Reply, 0);
-                this.AddItem(200, 84, 0x1613);
-                this.AddItem(220, 70, 0x1614);
-                this.AddButton(215, 50, 0x845, 0x846, 21, GumpButtonType.Reply, 0);
-                this.AddItem(250, 70, 0x15A4);
-                this.AddItem(270, 84, 0x15A5);
-                this.AddButton(290, 50, 0x845, 0x846, 22, GumpButtonType.Reply, 0);
-                this.AddItem(350, 90, 0x1615);
-                this.AddItem(370, 70, 0x1616);
-                this.AddButton(365, 50, 0x845, 0x846, 23, GumpButtonType.Reply, 0);
-                this.AddItem(400, 70, 0x15A6);
-                this.AddItem(420, 90, 0x15A7);
-                this.AddButton(445, 50, 0x845, 0x846, 24, GumpButtonType.Reply, 0);
-                this.AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 3);
-                this.AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 5);
+                AddItem(55, 90, 0x1611);
+                AddItem(75, 70, 0x1612);
+                AddButton(70, 50, 0x845, 0x846, 19, GumpButtonType.Reply, 0);
+                AddItem(105, 70, 0x15A2);
+                AddItem(125, 90, 0x15A3);
+                AddButton(145, 50, 0x845, 0x846, 20, GumpButtonType.Reply, 0);
+                AddItem(200, 84, 0x1613);
+                AddItem(220, 70, 0x1614);
+                AddButton(215, 50, 0x845, 0x846, 21, GumpButtonType.Reply, 0);
+                AddItem(250, 70, 0x15A4);
+                AddItem(270, 84, 0x15A5);
+                AddButton(290, 50, 0x845, 0x846, 22, GumpButtonType.Reply, 0);
+                AddItem(350, 90, 0x1615);
+                AddItem(370, 70, 0x1616);
+                AddButton(365, 50, 0x845, 0x846, 23, GumpButtonType.Reply, 0);
+                AddItem(400, 70, 0x15A6);
+                AddItem(420, 90, 0x15A7);
+                AddButton(445, 50, 0x845, 0x846, 24, GumpButtonType.Reply, 0);
+                AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 3);
+                AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 5);
 
-                this.AddPage(5);
+                AddPage(5);
 
-                this.AddItem(55, 90, 0x1617);
-                this.AddItem(77, 70, 0x1618);
-                this.AddButton(70, 50, 0x845, 0x846, 25, GumpButtonType.Reply, 0);
-                this.AddItem(105, 70, 0x15A8);
-                this.AddItem(127, 90, 0x15A9);
-                this.AddButton(145, 50, 0x845, 0x846, 26, GumpButtonType.Reply, 0);
-                this.AddItem(200, 90, 0x1619);
-                this.AddItem(222, 70, 0x161A);
-                this.AddButton(220, 50, 0x845, 0x846, 27, GumpButtonType.Reply, 0);
-                this.AddItem(250, 70, 0x15AA);
-                this.AddItem(272, 90, 0x15AB);
-                this.AddButton(300, 50, 0x845, 0x846, 28, GumpButtonType.Reply, 0);
-                this.AddItem(350, 90, 0x161B);
-                this.AddItem(372, 70, 0x161C);
-                this.AddButton(365, 50, 0x845, 0x846, 29, GumpButtonType.Reply, 0);
-                this.AddItem(400, 70, 0x15AC);
-                this.AddItem(422, 90, 0x15AD);
-                this.AddButton(445, 50, 0x845, 0x846, 30, GumpButtonType.Reply, 0);
-                this.AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 4);
+                AddItem(55, 90, 0x1617);
+                AddItem(77, 70, 0x1618);
+                AddButton(70, 50, 0x845, 0x846, 25, GumpButtonType.Reply, 0);
+                AddItem(105, 70, 0x15A8);
+                AddItem(127, 90, 0x15A9);
+                AddButton(145, 50, 0x845, 0x846, 26, GumpButtonType.Reply, 0);
+                AddItem(200, 90, 0x1619);
+                AddItem(222, 70, 0x161A);
+                AddButton(220, 50, 0x845, 0x846, 27, GumpButtonType.Reply, 0);
+                AddItem(250, 70, 0x15AA);
+                AddItem(272, 90, 0x15AB);
+                AddButton(300, 50, 0x845, 0x846, 28, GumpButtonType.Reply, 0);
+                AddItem(350, 90, 0x161B);
+                AddItem(372, 70, 0x161C);
+                AddButton(365, 50, 0x845, 0x846, 29, GumpButtonType.Reply, 0);
+                AddItem(400, 70, 0x15AC);
+                AddItem(422, 90, 0x15AD);
+                AddButton(445, 50, 0x845, 0x846, 30, GumpButtonType.Reply, 0);
+                AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 4);
             }
 
             public override void OnResponse(NetState sender, RelayInfo info)
             {
-                if (this.m_WallBanner == null || this.m_WallBanner.Deleted)
+                if (m_WallBanner == null || m_WallBanner.Deleted)
                     return;
 
                 if (info.ButtonID > 0 && info.ButtonID < 31)
-                    this.m_WallBanner.Use(sender.Mobile, info.ButtonID);
+                    m_WallBanner.Use(sender.Mobile, info.ButtonID);
             }
         }
     }

--- a/Scripts/Items/Consumables/TaxidermyKit.cs
+++ b/Scripts/Items/Consumables/TaxidermyKit.cs
@@ -182,10 +182,10 @@ namespace Server.Items
                             {
                                 string name = lic.KillEntry.Owner != null ? lic.KillEntry.Owner.Name : from.Name;
 
-                                if (!info.RequiresWall || info.Complex)
+                                if (info.Complex)
                                     from.AddToBackpack(new HuntTrophyAddonDeed(name, index, lic.KillEntry.Measurement, lic.KillEntry.DateKilled.ToShortDateString(), lic.KillEntry.Location));
                                 else
-                                    from.AddToBackpack(new HuntTrophyDeed(name, index, lic.KillEntry.Measurement, lic.KillEntry.DateKilled.ToShortDateString(), lic.KillEntry.Location));
+                                    from.AddToBackpack(new HuntTrophy(name, index, lic.KillEntry.Measurement, lic.KillEntry.DateKilled.ToShortDateString(), lic.KillEntry.Location));
 
                                 lic.ProducedTrophy = true;
                                 m_Kit.Delete();

--- a/Scripts/Items/StoreBought/VirtueShield.cs
+++ b/Scripts/Items/StoreBought/VirtueShield.cs
@@ -13,8 +13,10 @@ namespace Server.Items
 
         public override bool CanBeWornByGargoyles { get { return true; } }
         public override int LabelNumber { get { return 1109616; } } // Virtue Shield
-		
-		public override bool IsArtifact { get { return true; } }
+
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+        public override bool IsArtifact { get { return true; } }
 
         [Constructable]
         public VirtueShield()
@@ -48,7 +50,7 @@ namespace Server.Items
         {
             base.Serialize(writer);
 
-            writer.Write((int)0);
+            writer.Write((int)1);
         }
 
         public override void Deserialize(GenericReader reader)
@@ -56,6 +58,11 @@ namespace Server.Items
             base.Deserialize(reader);
 
             int version = reader.ReadInt();
+
+            if (version == 0)
+            {
+                HitPoints = MaxHitPoints = 255;
+            }
         }
     }
 }

--- a/Scripts/Mobiles/Normal/ParoxysmusSwampDragon.cs
+++ b/Scripts/Mobiles/Normal/ParoxysmusSwampDragon.cs
@@ -9,6 +9,8 @@ namespace Server.Mobiles
         public ParoxysmusSwampDragon()
             : base()
         {
+            Name = "Chief Paroxysmus' Swamp Dragon";
+
             BardingResource = CraftResource.Iron;
             BardingExceptional = true;
             BardingHP = BardingMaxHP;

--- a/Scripts/Quests/Escortables.cs
+++ b/Scripts/Quests/Escortables.cs
@@ -841,10 +841,6 @@ namespace Server.Engines.Quests
 
             AddItem(new ThighBoots());
 
-            if (Female)
-                AddItem(new FancyDress(lowHue));
-            else
-                AddItem(new FancyShirt(lowHue));
             AddItem(new LongPants(lowHue));
 
             if (!Female)

--- a/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
+++ b/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
@@ -366,8 +366,9 @@ namespace Server.Engines.CityLoyalty
 		public virtual void AwardLove(Mobile from, double love, bool message = true)
 		{
             CityLoyaltyEntry entry = GetPlayerEntry<CityLoyaltyEntry>(from, true);
-			
-			if(entry.Hate > 10)
+
+            // TODO: Re-Enable this for The Awakening Event
+			/*if(entry.Hate > 10)
 			{
 				double convert = entry.Hate / 75;
                 entry.Neutrality += (int)convert;
@@ -384,7 +385,7 @@ namespace Server.Engines.CityLoyalty
                     e.Love -= (int)convert;
                     e.Neutrality += (int)convert;
 				}
-			}
+			}*/
 
             if (message && entry.ShowGainMessage)
             {
@@ -825,7 +826,8 @@ namespace Server.Engines.CityLoyalty
 
                 if (DateTime.UtcNow > _NextAtrophy)
                 {
-                    sys.PlayerTable.ForEach(t =>
+                    // TODO: Re-Enable this for The Awakening Event
+                    /*sys.PlayerTable.ForEach(t =>
                     {
                         CityLoyaltyEntry entry = t as CityLoyaltyEntry;
 
@@ -839,7 +841,7 @@ namespace Server.Engines.CityLoyalty
                             if (owner.LastOnline + LoveAtrophyDuration < DateTime.UtcNow)
                                 entry.Love -= entry.Love / 75;
                         }
-                    });
+                    });*/
 
                     _NextAtrophy = DateTime.UtcNow + TimeSpan.FromDays(1);
                 }

--- a/Scripts/Services/HuntmasterChallenge/ComplexHuntTrophy.cs
+++ b/Scripts/Services/HuntmasterChallenge/ComplexHuntTrophy.cs
@@ -118,11 +118,43 @@ namespace Server.Items
 
         public class HuntTrophyComponent : AddonComponent
         {
-            public override int LabelNumber { get { return 1084024 + ItemID; } }
+            public override int LabelNumber
+            {
+                get
+                {
+                    if (Info != null)
+                    {
+                        return Info.TrophyName.Number;
+                    }
+                    else
+                    {
+                        return base.LabelNumber;
+                    }
+                }
+            }
+
+            public HuntingTrophyInfo Info
+            {
+                get
+                {
+                    var addon = Addon as HuntTrophyAddon;
+
+                    if (addon != null)
+                    {
+                        return addon.Info;
+                    }
+
+                    return null;
+                }
+            }
 
             public HuntTrophyComponent(int id)
                 : base(id)
             {
+                if (Info != null && !String.IsNullOrEmpty(Info.TrophyName.String))
+                {
+                    Name = Info.TrophyName.String;
+                }
             }
 
             public override void GetProperties(ObjectPropertyList list)
@@ -243,6 +275,9 @@ namespace Server.Items
         public TextDefinition Species { get { return Info.Species; } }
 
         [CommandProperty(AccessLevel.GameMaster)]
+        public TextDefinition TrophyName { get { return Info.TrophyName; } }
+
+        [CommandProperty(AccessLevel.GameMaster)]
         public MeasuredBy MeasuredBy { get { return Info.MeasuredBy; } }
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -298,11 +333,11 @@ namespace Server.Items
             list.Add(1155718, Species.ToString());
 
             if (MeasuredBy == MeasuredBy.Length)
-                list.Add(1155711, MeasuredBy.ToString()); // Length: ~1_VAL~
+                list.Add(1155711, m_Measurement.ToString()); // Length: ~1_VAL~
             else if (MeasuredBy == MeasuredBy.Wingspan)
-                list.Add(1155710, MeasuredBy.ToString());	// Wingspan: ~1_VAL~
+                list.Add(1155710, m_Measurement.ToString());	// Wingspan: ~1_VAL~
             else
-                list.Add(1072225, MeasuredBy.ToString()); // Weight: ~1_WEIGHT~ stones
+                list.Add(1072225, m_Measurement.ToString()); // Weight: ~1_WEIGHT~ stones
         }
 
         public HuntTrophyAddonDeed(Serial serial)

--- a/Scripts/Services/HuntmasterChallenge/HuntingTrophyInfo.cs
+++ b/Scripts/Services/HuntmasterChallenge/HuntingTrophyInfo.cs
@@ -49,48 +49,44 @@ namespace Server.Engines.HuntsmasterChallenge
 
         public static void Configure()
         {
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.GrizzlyBear, typeof(GrizzlyBear),    0x9A26, new TextDefinition(1015242), 400, 800,  MeasuredBy.Weight, false));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.GrayWolf,    typeof(GreyWolf),       0x9A28, new TextDefinition(1029681), 70,  190,  MeasuredBy.Weight, false));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Cougar,      typeof(Cougar),         0x9A2A, new TextDefinition(1029603), 50,  140,  MeasuredBy.Weight, false));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Turkey,      typeof(Turkey),         0x9A2C, new TextDefinition(1155714), 10,  55,   MeasuredBy.Weight, false));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Bull,        typeof(Bull),           0x9A2E, new TextDefinition(1072495), 500, 1000, MeasuredBy.Weight, false, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Boar,        typeof(Boar),           0x9A30, new TextDefinition(1155715), 100, 400,  MeasuredBy.Weight, false, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Walrus,      typeof(Walrus),         0x9A32, new TextDefinition(1155716), 600, 1500, MeasuredBy.Weight, false, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Alligator,   typeof(Alligator),      0x9A34, new TextDefinition(1155717), 5,   15,   MeasuredBy.Length, false, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Eagle,       typeof(Eagle),          0x9A36, new TextDefinition(1072461), 5,   15,   MeasuredBy.Wingspan, false, true));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.GrizzlyBear, typeof(GrizzlyBear),    0x9A26, 1015242, 1123486, 400, 790,  MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.GrayWolf,    typeof(GreyWolf),       0x9A28, 1029681, 1123488, 50,  99,  MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Cougar,      typeof(Cougar),         0x9A2A, 1029603, 1123490, 100,  220,  MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Turkey,      typeof(Turkey),         0x9A2C, 1155714, 1123492, 10,  24,   MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Bull,        typeof(Bull),           0x9A2E, 1072495, 1123494, 1100, 2200, MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Boar,        typeof(Boar),           0x9A30, 1155715, 1123496, 100, 400,  MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Walrus,      typeof(Walrus),         0x9A32, 1155716, 1123498, 1200, 3700, MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Alligator,   typeof(Alligator),      0x9A34, 1155717, 1123500, 15,   30,   MeasuredBy.Length, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Eagle,       typeof(Eagle),          0x9A36, 1072461, 1123502, 10,   20,   MeasuredBy.Wingspan, false));
         
             // Pub 91 Additions
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.MyrmidexLarvae,  typeof(MyrmidexLarvae), 0x9C00, 0x9C04, new TextDefinition(1156276), 200, 400, MeasuredBy.Weight, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Najasaurus,      typeof(Najasaurus),     0x9C02, 0x9C06, new TextDefinition(1156283), 400, 800, MeasuredBy.Weight, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Anchisaur,       typeof(Anchisaur),      0x9C08, new TextDefinition(1156284), 400, 800, MeasuredBy.Weight, false, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Allosaurus,      typeof(Allosaurus),     0x9C0A, new TextDefinition(1156280), 400, 800, MeasuredBy.Weight, false, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Dimetrosaur,     typeof(Dimetrosaur),    0x9C0C, new TextDefinition(1156279), 400, 800, MeasuredBy.Weight, false, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Saurosaurus,     typeof(Saurosaurus),    0x9C0E, new TextDefinition(1156289), 400, 800, MeasuredBy.Weight, false, true));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.MyrmidexLarvae,  typeof(MyrmidexLarvae), 0x9C00, 0x9C04, 1156276, 1123960, 20, 40, MeasuredBy.Weight, true));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Najasaurus,      typeof(Najasaurus),     0x9C02, 0x9C06, 1156283, 1123962, 200, 400, MeasuredBy.Weight, true));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Anchisaur,       typeof(Anchisaur),      0x9C08, 1156284, 1123968, 200, 400, MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Allosaurus,      typeof(Allosaurus),     0x9C0A, 1156280, 1123970, 5000, 12000, MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Dimetrosaur,     typeof(Dimetrosaur),    0x9C0C, 1156279, 1123972, 200, 400, MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Saurosaurus,     typeof(Saurosaurus),    0x9C0E, 1156289, 1123974, 1500, 2000, MeasuredBy.Weight, false));
 
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.MyrmidexDrone,   typeof(MyrmidexDrone),  0x9DA6, new TextDefinition(1156134), 300, 600, MeasuredBy.Weight, false, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Tiger,           typeof(WildTiger),      0x9DA4, new TextDefinition(1156286), 400, 800, MeasuredBy.Weight, false, true));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.MyrmidexDrone,   typeof(MyrmidexDrone),  0x9DA6, 1156134, 1124382, 100, 200, MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Tiger,           typeof(WildTiger),      0x9DA4, 1156286, 1124380, 350, 700, MeasuredBy.Weight, false));
 
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Triceratops,     typeof(Triceratops),    0x9F2C, 0x9F2B, new TextDefinition(1124731), 400, 800, MeasuredBy.Weight, false, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.Lion,            typeof(Lion),           0x9F2E, 0x9F2D, new TextDefinition(1124736), 400, 800, MeasuredBy.Weight, false, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.WhiteTiger,      typeof(WildWhiteTiger), 0x9F30, 0x9F2F, new TextDefinition(1156286), 400, 800, MeasuredBy.Weight, false, true));
-            m_Infos.Add(new HuntingTrophyInfo(HuntType.BlackTiger,      typeof(WildBlackTiger), 0x9F32, 0x9F31, new TextDefinition(1156286), 400, 800, MeasuredBy.Weight, false, true));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Triceratops,     typeof(Triceratops),    0x9F2C, 0x9F2B, 1124731, 1124771, 10000, 15000, MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.Lion,            typeof(Lion),           0x9F2E, 0x9F2D, 1124736, 1124773, 350, 700, MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.WhiteTiger,      typeof(WildWhiteTiger), 0x9F30, 0x9F2F, 1156286, 1124775, 350, 700, MeasuredBy.Weight, false));
+            m_Infos.Add(new HuntingTrophyInfo(HuntType.BlackTiger,      typeof(WildBlackTiger), 0x9F32, 0x9F31, 1156286, 1124777, 350, 700, MeasuredBy.Weight, false));
             
-            //Publish 102 added: Please check code 
-			m_Infos.Add(new HuntingTrophyInfo(HuntType.Raptor,          typeof(Raptor),         0xA20E, 0xA20D, new TextDefinition(1095923),  400, 800, MeasuredBy.Weight, false));
-			m_Infos.Add(new HuntingTrophyInfo(HuntType.SeaSerpent,      typeof(SeaSerpent),     0xA20C, 0xA20C, new TextDefinition(1018242),   200, 600, MeasuredBy.Weight, false));
-			m_Infos.Add(new HuntingTrophyInfo(HuntType.Scorpion,        typeof(Scorpion),       0xA210, 0xA20F, new TextDefinition(1028420),   100, 500, MeasuredBy.Weight, false));
+            //Publish 102
+			m_Infos.Add(new HuntingTrophyInfo(HuntType.Raptor,          typeof(Raptor),         0xA20E, 0xA20D, 1095923, 1125508, 400, 800, MeasuredBy.Weight, false));
+			m_Infos.Add(new HuntingTrophyInfo(HuntType.SeaSerpent,      typeof(SeaSerpent),     0xA20C, 0xA20C, 1018242, 1125508, 200, 600, MeasuredBy.Weight, false));
+			m_Infos.Add(new HuntingTrophyInfo(HuntType.Scorpion,        typeof(Scorpion),       0xA210, 0xA20F, 1029657, 1125508, 250, 500, MeasuredBy.Weight, false));
         }
 
         private HuntType m_HuntType;
         private Type m_CreatureType;
         private MeasuredBy m_MeasuredBy;
-        private int m_SouthID;
-        private int m_EastID;
-        private TextDefinition m_Species;
-        private int m_MinMeasurement;
-        private int m_MaxMeasurement;
+        private int m_SouthID, m_EastID, m_MinMeasurement, m_MaxMeasurement;
+        private TextDefinition m_Species, m_TrophyName;
         private bool m_Complex;
-        private bool m_RequiresWall;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public HuntType HuntType { get { return m_HuntType; } }
@@ -111,6 +107,9 @@ namespace Server.Engines.HuntsmasterChallenge
         public TextDefinition Species { get { return m_Species; } }
 
         [CommandProperty(AccessLevel.GameMaster)]
+        public TextDefinition TrophyName { get { return m_TrophyName; } }
+
+        [CommandProperty(AccessLevel.GameMaster)]
         public int MinMeasurement { get { return m_MinMeasurement; } }
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -119,15 +118,12 @@ namespace Server.Engines.HuntsmasterChallenge
         [CommandProperty(AccessLevel.GameMaster)]
         public bool Complex { get { return m_Complex; } }
 
-        [CommandProperty(AccessLevel.GameMaster)]
-        public bool RequiresWall { get { return m_RequiresWall; } }
-
-        public HuntingTrophyInfo(HuntType type, Type creatureType, int southID, TextDefinition species, int minMeasurement, int maxMeasurement, MeasuredBy measuredBy, bool complex, bool requiresWall = false)
-            : this(type, creatureType, southID, southID + 1, species, minMeasurement, maxMeasurement, measuredBy, complex, requiresWall)
+        public HuntingTrophyInfo(HuntType type, Type creatureType, int southID, TextDefinition species, TextDefinition trophyName, int minMeasurement, int maxMeasurement, MeasuredBy measuredBy, bool complex)
+            : this(type, creatureType, southID, southID + 1, species, trophyName, minMeasurement, maxMeasurement, measuredBy, complex)
         {
         }
 
-        public HuntingTrophyInfo(HuntType type, Type creatureType, int southID, int eastID, TextDefinition species, int minMeasurement, int maxMeasurement, MeasuredBy measuredBy, bool complex, bool requiresWall = false)
+        public HuntingTrophyInfo(HuntType type, Type creatureType, int southID, int eastID, TextDefinition species, TextDefinition trophyName, int minMeasurement, int maxMeasurement, MeasuredBy measuredBy, bool complex)
         {
             m_HuntType = type;
             m_CreatureType = creatureType;
@@ -135,10 +131,10 @@ namespace Server.Engines.HuntsmasterChallenge
             m_SouthID = southID;
             m_EastID = eastID;
             m_Species = species;
+            m_TrophyName = trophyName;
             m_MinMeasurement = minMeasurement;
             m_MaxMeasurement = maxMeasurement;
             m_Complex = complex;
-            m_RequiresWall = requiresWall;
         }
 
         public static HuntingTrophyInfo GetInfo(HuntType type)

--- a/Scripts/Services/Pet Training/Gumps.cs
+++ b/Scripts/Services/Pet Training/Gumps.cs
@@ -35,7 +35,7 @@ namespace Server.Mobiles
             AddImage(40, 62, 0x82B);
             AddImage(40, 258, 0x82B);
 
-            if (Creature.Controlled && Creature.ControlMaster == User && PetTrainingHelper.CanControl(User, Creature, trainProfile))
+            if (Creature.Controlled && Creature.ControlMaster == User)
             {
                 AddImage(28, 272, 0x826);
 
@@ -1675,6 +1675,10 @@ namespace Server.Mobiles
                             {
                                 ResendGumps(profile.HasBegunTraining);
                             }));
+                    }
+                    else
+                    {
+                        User.SendLocalizedMessage(1157550); // You lack the taming skill required to train this creature.
                     }
                     break;
                 case 9:

--- a/Scripts/Services/Seasonal Events/TreasuresOfDoom/Region.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfDoom/Region.cs
@@ -15,6 +15,8 @@ namespace Server.Regions
         public MonestaryRegion()
             : base("Doom Monestary", Map.Malas, Region.DefaultPriority, new Rectangle2D(64, 204, 99, 37))
         {
+            GoLocation = new Point3D(79, 223, -1);
+
             Register();
         }
 

--- a/Scripts/Spells/Spellweaving/WordOfDeath.cs
+++ b/Scripts/Spells/Spellweaving/WordOfDeath.cs
@@ -57,10 +57,11 @@ namespace Server.Spells.Spellweaving
                 Effects.SendMovingParticles(new Entity(Serial.Zero, loc, m.Map), new Entity(Serial.Zero, m.Location, m.Map), 0xF5F, 1, 0, true, false, 0x21, 0x3F, 0x251D, 0, 0, EffectLayer.Head, 0);
 
                 double percentage = 0.05 * this.FocusLevel;
+                bool pvmThreshold = !m.Player && (((double)m.Hits / (double)m.HitsMax) < percentage);
 
                 int damage;
 
-                if (!m.Player && (((double)m.Hits / (double)m.HitsMax) < percentage))
+                if (pvmThreshold)
                 {
                     damage = 300;
                 }
@@ -76,10 +77,7 @@ namespace Server.Spells.Spellweaving
                 damage *= damageBonus + 100;
                 damage /= 100;
 
-                int[] types = new int[4];
-                types[Utility.Random(types.Length)] = 100;
-
-                SpellHelper.Damage(this, m, damage, 0, types[0], types[1], types[2], types[3]);	//Chaos damage.  Random elemental damage
+                SpellHelper.Damage(this, m, damage, 0, 0, 0, 0, 0, !pvmThreshold ? 100 : 0, pvmThreshold ? 100 : 0);
             }
 
             this.FinishSequence();

--- a/Scripts/VendorInfo/VendorInventory.cs
+++ b/Scripts/VendorInfo/VendorInventory.cs
@@ -184,7 +184,7 @@ namespace Server.Mobiles
                     {
                         if (AccountGold.Enabled && m_Inventory.Owner != null)
                         {
-                            Banker.Deposit(m_Inventory.Owner, m_Inventory.Gold, true);
+                            Banker.Deposit(house.Owner, m_Inventory.Gold, true);
                         }
                         else
                         {

--- a/Server/EventSink.cs
+++ b/Server/EventSink.cs
@@ -191,6 +191,8 @@ namespace Server
 
     public delegate void ContainerDroppedToEventHandler(ContainerDroppedToEventArgs e);
 
+    public delegate void TeleportMovementEventHandler(TeleportMovementEventArgs e);
+
     public class OnItemObtainedEventArgs : EventArgs
 	{
 		private readonly Mobile m_Mobile;
@@ -1657,6 +1659,20 @@ namespace Server
         }
     }
 
+    public class TeleportMovementEventArgs : EventArgs
+    {
+        public Mobile Mobile { get; set; }
+        public Point3D OldLocation { get; set; }
+        public Point3D NewLocation { get; set; }
+
+        public TeleportMovementEventArgs(Mobile m, Point3D oldLoc, Point3D newLoc)
+        {
+            Mobile = m;
+            OldLocation = oldLoc;
+            NewLocation = newLoc;
+        }
+    }
+
     public static class EventSink
 	{
 		public static event OnItemObtainedEventHandler OnItemObtained;
@@ -1751,6 +1767,7 @@ namespace Server
         public static event PlayerMurderedEventHandler PlayerMurdered;
         public static event AccountGoldChangeEventHandler AccountGoldChange;
         public static event ContainerDroppedToEventHandler ContainerDroppedTo;
+        public static event TeleportMovementEventHandler TeleportMovement;
 
         public static void InvokeOnItemObtained(OnItemObtainedEventArgs e)
 		{
@@ -2464,6 +2481,14 @@ namespace Server
             }
         }
 
+        public static void InvokeTeleportMovement(TeleportMovementEventArgs e)
+        {
+            if (TeleportMovement != null)
+            {
+                TeleportMovement(e);
+            }
+        }
+
         public static void Reset()
 		{
 			OnItemObtained = null;
@@ -2545,6 +2570,7 @@ namespace Server
             PlayerMurdered = null;
             AccountGoldChange = null;
             ContainerDroppedTo = null;
+            TeleportMovement = null;
         }
 	}
 }

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -10132,7 +10132,10 @@ namespace Server
 					}
 
 					ClearFastwalkStack();
-				}
+
+                    EventSink.InvokeTeleportMovement(new TeleportMovementEventArgs(this, oldLocation, newLocation));
+
+                }
 
 				Map map = m_Map;
 


### PR DESCRIPTION
- Added missing banners to banner deed
- Fixed Huntmaster trophy names
- Huntmaster trophies (ones that are only 1 piece) no longer come in deed form, per EA. Any and all deeds will be converted to the Trophy
- Added durability to Virute Shield
- Paroxysmus Swampy now has proper name
- Removed conflict from Merchange Escortable
- Gaining city loyalty no longer gains hate/neutrality in other Cities
- Pet training option now appears, even if the player will not be able to control the creature. It will simply fail and give a message when they commit to train, per EA
- Added direct damage to Word of Death while inside the damage threshold