### PR TITLE
Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 /libdrng.so
 NoCommit
 CUSTOM
+TheBox
 *.pdb
 *.exe
 *.exe.mdb

--- a/Scripts/Gumps/ConfirmHouseResize.cs
+++ b/Scripts/Gumps/ConfirmHouseResize.cs
@@ -106,10 +106,17 @@ namespace Server.Gumps
                                 else
                                 {
                                     Banker.Deposit(m_Mobile, m_House.Price, true);
+
+                                    m_House.RemoveKeys(m_Mobile);
+                                    new TempNoHousingRegion(m_House, m_Mobile);
+                                    m_House.Delete();
+                                    return;
                                 }
                             }
                             else
+                            {
                                 toGive = m_House.GetDeed();
+                            }
                         }
                         else
                         {

--- a/Scripts/Items/Equipment/Armor/OrcHelm.cs
+++ b/Scripts/Items/Equipment/Armor/OrcHelm.cs
@@ -99,7 +99,7 @@ namespace Server.Items
         {
             get
             {
-                return ArmorMaterialType.Leather;
+                return ArmorMaterialType.Bone;
             }
         }
         public override CraftResource DefaultResource

--- a/Scripts/Misc/SkillCheck.cs
+++ b/Scripts/Misc/SkillCheck.cs
@@ -351,7 +351,7 @@ namespace Server.Misc
 				#endregion
 
 				#region Skill Masteries
-				else if (from is BaseCreature && (((BaseCreature)from).Controlled || ((BaseCreature)from).Summoned))
+				else if (from is BaseCreature && !(from is Server.Engines.Despise.DespiseCreature) && (((BaseCreature)from).Controlled || ((BaseCreature)from).Summoned))
 				{
 					var master = ((BaseCreature)from).GetMaster();
 

--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -2519,7 +2519,7 @@ namespace Server.Mobiles
 
         protected virtual bool CanConvertArmor(Mobile from, BaseArmor armor)
         {
-            if (armor == null || armor is BaseShield || armor.ArtifactRarity != 0 || armor.IsArtifact)
+            if (armor == null || armor is BaseShield/*|| armor.ArtifactRarity != 0 || armor.IsArtifact*/)
             {
                 from.SendLocalizedMessage(1113044); // You can't convert that.
                 return false;

--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -1237,14 +1237,14 @@ namespace Server.Mobiles
                     else
                         BulkOrderSystem.ComputePoints((LargeBOD)dropped, out points, out banked);
 
-                    context.AddPending(BODType, points);
-
                     switch (context.PointsMode)
                     {
                         case PointsMode.Enabled:
+                            context.AddPending(BODType, points);
                             from.SendGump(new ConfirmBankPointsGump((PlayerMobile)from, this, this.BODType, points, banked));
                             break;
                         case PointsMode.Disabled:
+                            context.AddPending(BODType, points);
                             from.SendGump(new RewardsGump(this, (PlayerMobile)from, this.BODType, points));
                             break;
                         case PointsMode.Automatic:

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -4249,7 +4249,7 @@ namespace Server.Mobiles
             }
         }
 
-        public Poison GetHitPoison()
+        public virtual Poison GetHitPoison()
         {
             if (!PetTrainingHelper.Enabled || !Controlled)
                 return HitPoison;

--- a/Scripts/Mobiles/Normal/DespiseCreature.cs
+++ b/Scripts/Mobiles/Normal/DespiseCreature.cs
@@ -77,6 +77,9 @@ namespace Server.Engines.Despise
                 if (m_Progress >= m_Power)
                 {
                     Power++;
+
+                    IncreaseResists();
+
                     m_Progress = 0;
                 }
 
@@ -131,6 +134,11 @@ namespace Server.Engines.Despise
         public override bool IsBondable { get { return false; } }
         public override bool GivesFameAndKarmaAward { get { return false; } }
         public override bool CanAutoStable { get { return false; } }
+
+        public override Poison GetHitPoison()
+        {
+            return null;
+        }
 
         public override TimeSpan ReacquireDelay
         { 
@@ -359,6 +367,15 @@ namespace Server.Engines.Despise
 
             FixedEffect(0x373A, 10, 30);
             PlaySound(0x209);
+        }
+
+        private void IncreaseResists()
+        {
+            SetResistance(ResistanceType.Physical, Math.Min(80, PhysicalResistanceSeed + Utility.RandomMinMax(5, 15)));
+            SetResistance(ResistanceType.Fire, Math.Min(80, FireResistSeed + Utility.RandomMinMax(5, 15)));
+            SetResistance(ResistanceType.Cold, Math.Min(80, ColdResistSeed + Utility.RandomMinMax(5, 15)));
+            SetResistance(ResistanceType.Poison, Math.Min(80, PoisonResistSeed + Utility.RandomMinMax(5, 15)));
+            SetResistance(ResistanceType.Energy, Math.Min(80, EnergyResistSeed + Utility.RandomMinMax(5, 15)));
         }
 
         public static int GetPowerLabel(int power)

--- a/Scripts/Mobiles/Normal/DespiseEvilCreatures.cs
+++ b/Scripts/Mobiles/Normal/DespiseEvilCreatures.cs
@@ -26,6 +26,7 @@ namespace Server.Engines.Despise
             Karma = GetKarmaEvil;
 
             Power = powerLevel;
+            SetMagicalAbility(MagicalAbility.Discordance);
         }
 
         protected override BaseAI ForcedAI { get { return new DespiseMeleeAI(this); } }

--- a/Scripts/Mobiles/Normal/DespiseGoodCreatures.cs
+++ b/Scripts/Mobiles/Normal/DespiseGoodCreatures.cs
@@ -25,6 +25,7 @@ namespace Server.Engines.Despise
             Karma = GetKarmaGood;
 
             Power = powerLevel;
+            SetMagicalAbility(MagicalAbility.Discordance);
         }
 
         protected override BaseAI ForcedAI { get { return new DespiseMeleeAI(this); } }
@@ -32,7 +33,6 @@ namespace Server.Engines.Despise
         public override int DexStart { get { return Utility.RandomMinMax(100, 110); } }
         public override int IntStart { get { return Utility.RandomMinMax(100, 110); } }
 
-        public override bool CanDiscord { get { return true; } }
         public override TimeSpan DiscordInterval { get { return TimeSpan.FromSeconds(45); } }
 
         public override Mobile GetBardTarget(bool creaturesOnly = false)

--- a/Scripts/Mobiles/Normal/Executioner.cs
+++ b/Scripts/Mobiles/Normal/Executioner.cs
@@ -9,54 +9,54 @@ namespace Server.Mobiles
         public Executioner()
             : base(AIType.AI_Melee, FightMode.Closest, 10, 1, 0.2, 0.4)
         { 
-            this.SpeechHue = Utility.RandomDyedHue(); 
-            this.Title = "the executioner"; 
-            this.Hue = Utility.RandomSkinHue(); 
+            SpeechHue = Utility.RandomDyedHue(); 
+            Title = "the executioner"; 
+            Hue = Utility.RandomSkinHue(); 
 
-            if (this.Female = Utility.RandomBool()) 
+            if (Female = Utility.RandomBool()) 
             { 
-                this.Body = 0x191; 
-                this.Name = NameList.RandomName("female"); 
-                this.AddItem(new Skirt(Utility.RandomRedHue())); 
+                Body = 0x191; 
+                Name = NameList.RandomName("female"); 
+                AddItem(new Skirt(Utility.RandomRedHue())); 
             }
             else 
             { 
-                this.Body = 0x190; 
-                this.Name = NameList.RandomName("male"); 
-                this.AddItem(new ShortPants(Utility.RandomRedHue())); 
+                Body = 0x190; 
+                Name = NameList.RandomName("male"); 
+                AddItem(new ShortPants(Utility.RandomRedHue())); 
             }
 
-            this.SetStr(386, 400);
-            this.SetDex(151, 165);
-            this.SetInt(161, 175);
+            SetStr(386, 400);
+            SetDex(151, 165);
+            SetInt(161, 175);
 
-            this.SetDamage(8, 10);
+            SetDamage(8, 10);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 35, 45);
-            this.SetResistance(ResistanceType.Fire, 25, 30);
-            this.SetResistance(ResistanceType.Cold, 25, 30);
-            this.SetResistance(ResistanceType.Poison, 10, 20);
-            this.SetResistance(ResistanceType.Energy, 10, 20);
+            SetResistance(ResistanceType.Physical, 35, 45);
+            SetResistance(ResistanceType.Fire, 25, 30);
+            SetResistance(ResistanceType.Cold, 25, 30);
+            SetResistance(ResistanceType.Poison, 10, 20);
+            SetResistance(ResistanceType.Energy, 10, 20);
 
-            this.SetSkill(SkillName.Anatomy, 125.0);
-            this.SetSkill(SkillName.Fencing, 46.0, 77.5);
-            this.SetSkill(SkillName.Macing, 35.0, 57.5);
-            this.SetSkill(SkillName.Poisoning, 60.0, 82.5);
-            this.SetSkill(SkillName.MagicResist, 83.5, 92.5);
-            this.SetSkill(SkillName.Swords, 125.0);
-            this.SetSkill(SkillName.Tactics, 125.0);
-            this.SetSkill(SkillName.Lumberjacking, 125.0);
+            SetSkill(SkillName.Anatomy, 125.0);
+            SetSkill(SkillName.Fencing, 46.0, 77.5);
+            SetSkill(SkillName.Macing, 35.0, 57.5);
+            SetSkill(SkillName.Poisoning, 60.0, 82.5);
+            SetSkill(SkillName.MagicResist, 83.5, 92.5);
+            SetSkill(SkillName.Swords, 125.0);
+            SetSkill(SkillName.Tactics, 125.0);
+            SetSkill(SkillName.Lumberjacking, 125.0);
 
-            this.Fame = 5000;
-            this.Karma = -5000;
+            Fame = 5000;
+            Karma = -5000;
 
-            this.VirtualArmor = 40;
+            VirtualArmor = 40;
 
-            this.AddItem(new ThighBoots(Utility.RandomRedHue())); 
-            this.AddItem(new Surcoat(Utility.RandomRedHue()));    
-            this.AddItem(new ExecutionersAxe());
+            AddItem(new ThighBoots(Utility.RandomRedHue())); 
+            AddItem(new Surcoat(Utility.RandomRedHue()));    
+            AddItem(new ExecutionersAxe());
 
             Utility.AssignRandomHair(this);
         }
@@ -73,10 +73,24 @@ namespace Server.Mobiles
                 return true;
             }
         }
+
+        public override int Damage(int amount, Mobile from, bool informMount, bool checkDisrupt)
+        {
+            int dam = base.Damage(amount, from, informMount, checkDisrupt);
+
+            if (dam > 0)
+            {
+                AOS.Damage(from, this, dam, 0, 0, 0, 0, 0, 0, 100);
+                from.PlaySound(0x1F1);
+            }
+
+            return dam;
+        }
+
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.FilthyRich);
-            this.AddLoot(LootPack.Meager);
+            AddLoot(LootPack.FilthyRich);
+            AddLoot(LootPack.Meager);
         }
 
         public override void Serialize(GenericWriter writer) 

--- a/Scripts/Multis/HouseFoundation.cs
+++ b/Scripts/Multis/HouseFoundation.cs
@@ -757,6 +757,7 @@ namespace Server.Multis
             PacketHandlers.RegisterEncoded(0x0C, true, new OnEncodedPacketReceive(Designer_Close));
             PacketHandlers.RegisterEncoded(0x0D, true, new OnEncodedPacketReceive(Designer_Stairs));
             PacketHandlers.RegisterEncoded(0x0E, true, new OnEncodedPacketReceive(Designer_Sync));
+            PacketHandlers.RegisterEncoded(0x0F, true, new OnEncodedPacketReceive(Designer_Action)); // WTF does this do?
             PacketHandlers.RegisterEncoded(0x10, true, new OnEncodedPacketReceive(Designer_Clear));
             PacketHandlers.RegisterEncoded(0x12, true, new OnEncodedPacketReceive(Designer_Level));
 
@@ -792,6 +793,11 @@ namespace Server.Multis
                 // Resend full house state
                 design.SendDetailedInfoTo(state);
             }
+        }
+
+        public static void Designer_Action(NetState state, IEntity e, EncodedReader pvSrc)
+        {
+            // TODO: What does this do?
         }
 
         public static void Designer_Clear(NetState state, IEntity e, EncodedReader pvSrc)

--- a/Scripts/Services/City Loyalty System/CityLoyaltyEntry.cs
+++ b/Scripts/Services/City Loyalty System/CityLoyaltyEntry.cs
@@ -90,7 +90,12 @@ namespace Server.Engines.CityLoyalty
             City = city;
             ShowGainMessage = true;
 		}
-		
+
+        public override string ToString()
+        {
+            return String.Format("{0} {1}", City.ToString(), IsCitizen ? "[Citizen]" : String.Empty);
+        }
+
 		public void DeclareCitizenship()
 		{
 			IsCitizen = true;

--- a/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
+++ b/Scripts/Services/City Loyalty System/CityLoyaltySystem.cs
@@ -367,15 +367,15 @@ namespace Server.Engines.CityLoyalty
 		{
             CityLoyaltyEntry entry = GetPlayerEntry<CityLoyaltyEntry>(from, true);
 
-            // TODO: Re-Enable this for The Awakening Event
-			/*if(entry.Hate > 10)
+			if(entry.Hate > 10)
 			{
 				double convert = entry.Hate / 75;
                 entry.Neutrality += (int)convert;
                 entry.Hate -= (int)convert;
 			}
-			
-			foreach(CityLoyaltySystem sys in Cities.Where(s => s.City != this.City))
+
+            // TODO: Re-Enable this for The Awakening Event
+            /*foreach (CityLoyaltySystem sys in Cities.Where(s => s.City != this.City))
 			{
                 CityLoyaltyEntry e = sys.GetPlayerEntry<CityLoyaltyEntry>(from, true);
 

--- a/Scripts/Services/City Loyalty System/Trading/TradeSystem.cs
+++ b/Scripts/Services/City Loyalty System/Trading/TradeSystem.cs
@@ -714,6 +714,11 @@ namespace Server.Engines.CityLoyalty
 			public CityTradeEntry(PlayerMobile pm) : base(pm)
 			{
 			}
+
+            public override string ToString()
+            {
+                return "...";
+            }
 			
 			public override void Serialize(GenericWriter writer)
 			{

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
@@ -58,10 +58,23 @@ namespace Server.Engines.Shadowguard
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich, 3);
+            AddLoot(LootPack.Rich, 3);
         }
 
         public override bool AlwaysMurderer { get { return true; } }
+
+        public override int Damage(int amount, Mobile from, bool informMount, bool checkDisrupt)
+        {
+            int dam = base.Damage(amount, from, informMount, checkDisrupt);
+
+            if (dam > 0)
+            {
+                AOS.Damage(from, this, Math.Max(1, (int)((double)dam * .37)), 0, 0, 0, 0, 0, 0, 100);
+                from.PlaySound(0x1F1);
+            }
+
+            return dam;
+        }
 
         public ShadowguardPirate(Serial serial) : base(serial)
         {
@@ -102,7 +115,7 @@ namespace Server.Engines.Shadowguard
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.FilthyRich, 3);
+            AddLoot(LootPack.FilthyRich, 3);
         }
 
         public ShantyThePirate(Serial serial) : base(serial)
@@ -138,12 +151,12 @@ namespace Server.Engines.Shadowguard
 
         public override bool OnBeforeDeath()
         {
-            FountainEncounter encounter = ShadowguardController.GetEncounter(this.Location, this.Map) as FountainEncounter;
+            FountainEncounter encounter = ShadowguardController.GetEncounter(Location, Map) as FountainEncounter;
 
             if (encounter != null)
             {
                 var canal = new ShadowguardCanal();
-                canal.MoveToWorld(this.Location, this.Map);
+                canal.MoveToWorld(Location, Map);
                 encounter.AddShadowguardCanal(canal);
             }
 
@@ -269,7 +282,7 @@ namespace Server.Engines.Shadowguard
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich, 3);
+            AddLoot(LootPack.Rich, 3);
         }
 
         public VileTreefellow(Serial serial) : base(serial)
@@ -379,7 +392,7 @@ namespace Server.Engines.Shadowguard
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich, 3);
+            AddLoot(LootPack.Rich, 3);
         }
 
         public EnsorcelledArmor(Serial serial) : base(serial)
@@ -435,7 +448,7 @@ namespace Server.Engines.Shadowguard
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.Rich, 3);
+            AddLoot(LootPack.Rich, 3);
         }
 
         public VileDrake(Serial serial) : base(serial)
@@ -482,30 +495,30 @@ namespace Server.Engines.Shadowguard
         {
             base.OnThink();
 
-            BelfryEncounter encounter = ShadowguardController.GetEncounter(this.Location, this.Map) as BelfryEncounter;
+            BelfryEncounter encounter = ShadowguardController.GetEncounter(Location, Map) as BelfryEncounter;
 
-            if (encounter != null && this.Z == -20)
+            if (encounter != null && Z == -20)
             {
                 Point3D p = encounter.SpawnPoints[0];
                 encounter.ConvertOffset(ref p);
 
-                this.MoveToWorld(p, this.Map);
+                MoveToWorld(p, Map);
             }
         }
 
         protected override bool OnMove(Direction d)
         {
-            if (ShadowguardController.GetEncounter(this.Location, this.Map) != null)
+            if (ShadowguardController.GetEncounter(Location, Map) != null)
             {
-                int x = this.X;
-                int y = this.Y;
+                int x = X;
+                int y = Y;
 
                 Movement.Movement.Offset(d, ref x, ref y);
 
-                Point3D p = new Point3D(x, y, this.Map.GetAverageZ(x, y));
+                Point3D p = new Point3D(x, y, Map.GetAverageZ(x, y));
                 int z = p.Z;
 
-                IPooledEnumerable eable = this.Map.GetItemsInRange(p, 0);
+                IPooledEnumerable eable = Map.GetItemsInRange(p, 0);
 
                 foreach (Item item in eable)
                 {
@@ -515,7 +528,7 @@ namespace Server.Engines.Shadowguard
                     }
                 }
 
-                StaticTile[] staticTiles = this.Map.Tiles.GetStaticTiles(x, y, true);
+                StaticTile[] staticTiles = Map.Tiles.GetStaticTiles(x, y, true);
 
                 foreach (StaticTile tile in staticTiles)
                 {
@@ -527,7 +540,7 @@ namespace Server.Engines.Shadowguard
 
                 eable.Free();
 
-                if (z < this.Z)
+                if (z < Z)
                     return false;
             }
 
@@ -536,7 +549,7 @@ namespace Server.Engines.Shadowguard
 
         public override int Damage(int amount, Mobile from, bool informmount, bool checkfizzle)
         {
-            if (from == null || (ShadowguardController.GetEncounter(this.Location, this.Map) != null && this.Z == from.Z))
+            if (from == null || (ShadowguardController.GetEncounter(Location, Map) != null && Z == from.Z))
             {
                 return base.Damage(amount, from, informmount, checkfizzle);
             }
@@ -546,7 +559,7 @@ namespace Server.Engines.Shadowguard
 
         public override void GenerateLoot()
         {
-            this.AddLoot(LootPack.FilthyRich, 3);
+            AddLoot(LootPack.FilthyRich, 3);
             AddLoot(LootPack.Gems, 8);
         }
 
@@ -554,7 +567,7 @@ namespace Server.Engines.Shadowguard
         {
             base.OnGaveMeleeAttack(defender);
 
-            if (this.Map != null && 0.25 > Utility.RandomDouble())
+            if (Map != null && 0.5 > Utility.RandomDouble())
             {
                 int pushRange = Utility.RandomMinMax(2, 4);
 
@@ -567,9 +580,9 @@ namespace Server.Engines.Shadowguard
                     Movement.Movement.Offset(d, ref x, ref y);
                 }
 
-                int z = this.Map.GetAverageZ(x, y);
+                int z = Map.GetAverageZ(x, y);
 
-                IPooledEnumerable eable = this.Map.GetItemsInRange(new Point3D(x, y, z), 0);
+                IPooledEnumerable eable = Map.GetItemsInRange(new Point3D(x, y, z), 0);
 
                 foreach (Item item in eable)
                 {
@@ -581,7 +594,7 @@ namespace Server.Engines.Shadowguard
 
                 eable.Free();
 
-                StaticTile[] staticTiles = this.Map.Tiles.GetStaticTiles(x, y, true);
+                StaticTile[] staticTiles = Map.Tiles.GetStaticTiles(x, y, true);
 
                 foreach (StaticTile tile in staticTiles)
                 {
@@ -591,7 +604,7 @@ namespace Server.Engines.Shadowguard
                         z = tile.Z + itemData.CalcHeight;
                 }
 
-                defender.MoveToWorld(new Point3D(x, y, Z), this.Map);
+                defender.MoveToWorld(new Point3D(x, y, Z), Map);
             }
         }
 
@@ -663,24 +676,24 @@ namespace Server.Engines.Shadowguard
 
         protected override bool OnMove(Direction d)
         {
-            RoofEncounter encounter = ShadowguardController.GetEncounter(this.Location, this.Map) as RoofEncounter;
+            RoofEncounter encounter = ShadowguardController.GetEncounter(Location, Map) as RoofEncounter;
 
             if (encounter != null)
             {
                 Point3D spawn = encounter.SpawnPoints[0];
 
-                int x = this.X;
-                int y = this.Y;
+                int x = X;
+                int y = Y;
 
                 Movement.Movement.Offset(d, ref x, ref y);
 
-                Point3D p = new Point3D(x, y, this.Map.GetAverageZ(x, y));
+                Point3D p = new Point3D(x, y, Map.GetAverageZ(x, y));
                 int z = p.Z;
 
                 if (p.Y < spawn.Y - 5 || p.Y > spawn.Y + 4 || p.X > spawn.X + 4 || p.X < spawn.X - 5)
                     return false;
 
-                IPooledEnumerable eable = this.Map.GetItemsInRange(p, 0);
+                IPooledEnumerable eable = Map.GetItemsInRange(p, 0);
                 Item i = null;
 
                 foreach (Item item in eable)
@@ -692,7 +705,7 @@ namespace Server.Engines.Shadowguard
                     }
                 }
 
-                StaticTile[] staticTiles = this.Map.Tiles.GetStaticTiles(x, y, true);
+                StaticTile[] staticTiles = Map.Tiles.GetStaticTiles(x, y, true);
 
                 foreach (StaticTile tile in staticTiles)
                 {
@@ -704,7 +717,7 @@ namespace Server.Engines.Shadowguard
 
                 eable.Free();
 
-                if (z < this.Z)
+                if (z < Z)
                     return false;
             }
 
@@ -715,24 +728,24 @@ namespace Server.Engines.Shadowguard
         {
             base.OnThink();
 
-            RoofEncounter encounter = ShadowguardController.GetEncounter(this.Location, this.Map) as RoofEncounter;
+            RoofEncounter encounter = ShadowguardController.GetEncounter(Location, Map) as RoofEncounter;
 
             if (encounter != null)
             {
                 Point3D spawn = encounter.SpawnPoints[0];
-                Point3D p = this.Location;
+                Point3D p = Location;
                 encounter.ConvertOffset(ref spawn);
 
-                if (this.Z < 30 || p.Y < spawn.Y - 5 || p.Y > spawn.Y + 4 || p.X > spawn.X + 4 || p.X < spawn.X - 5)
+                if (Z < 30 || p.Y < spawn.Y - 5 || p.Y > spawn.Y + 4 || p.X > spawn.X + 4 || p.X < spawn.X - 5)
                 {
-                    this.MoveToWorld(spawn, Map.TerMur);
+                    MoveToWorld(spawn, Map.TerMur);
                 }
             }
         }
 
         public override int Damage(int amount, Mobile from, bool informMount, bool checkfizzle)
         {
-            RoofEncounter encounter = ShadowguardController.GetEncounter(this.Location, this.Map) as RoofEncounter;
+            RoofEncounter encounter = ShadowguardController.GetEncounter(Location, Map) as RoofEncounter;
 
             if (encounter != null && from != null)
             {

--- a/Scripts/Services/HuntmasterChallenge/ComplexHuntTrophy.cs
+++ b/Scripts/Services/HuntmasterChallenge/ComplexHuntTrophy.cs
@@ -177,6 +177,8 @@ namespace Server.Items
                         list.Add(1155711, addon.Measurement.ToString()); // Length: ~1_VAL~
                     else if (addon.MeasuredBy == MeasuredBy.Wingspan)
                         list.Add(1155710, addon.Measurement.ToString());	// Wingspan: ~1_VAL~
+                    else
+                        list.Add(1072225, addon.Measurement.ToString()); // Weight: ~1_WEIGHT~ stones
                 }
             }
 

--- a/Scripts/Services/Pathing/FastMovement.cs
+++ b/Scripts/Services/Pathing/FastMovement.cs
@@ -132,9 +132,10 @@ namespace Server.Movement
 			foreach (var tile in tiles)
 			{
 				itemData = TileData.ItemTable[tile.ID & TileData.MaxItemValue];
+                flags = itemData.Flags;
 
-				#region SA
-				if (m != null && m.Flying && Insensitive.Equals(itemData.Name, "hover over"))
+                #region SA
+                if (m != null && m.Flying && (Insensitive.Equals(itemData.Name, "hover over") || (flags & TileFlag.HoverOver) != 0))
 				{
 					newZ = tile.Z;
 					return true;
@@ -166,8 +167,6 @@ namespace Server.Movement
 					}
 				}
 				#endregion
-
-				flags = itemData.Flags;
 
 				if ((flags & ImpassableSurface) != TileFlag.Surface && (!canSwim || (flags & TileFlag.Wet) == 0))
 				{
@@ -243,7 +242,7 @@ namespace Server.Movement
 				flags = itemData.Flags;
 
 				#region SA
-				if (m != null && m.Flying && Insensitive.Equals(itemData.Name, "hover over"))
+				if (m != null && m.Flying && (Insensitive.Equals(itemData.Name, "hover over") || (flags & TileFlag.HoverOver) != 0))
 				{
 					newZ = item.Z;
 					return true;

--- a/Scripts/Services/Pathing/Movement.cs
+++ b/Scripts/Services/Pathing/Movement.cs
@@ -178,8 +178,10 @@ namespace Server.Movement
             {
                 StaticTile tile = tiles[i];
                 ItemData itemData = TileData.ItemTable[tile.ID & TileData.MaxItemValue];
-				#region SA
-                if (m != null && m.Flying && (itemData.Name == "hover over"))
+                TileFlag flags = itemData.Flags;
+
+                #region SA
+                if (m != null && m.Flying && (itemData.Name == "hover over" || (flags & TileFlag.HoverOver) != 0))
                 {
                     newZ = tile.Z;
                     return true;
@@ -205,8 +207,6 @@ namespace Server.Movement
                     }
                 }
 				#endregion
-
-                TileFlag flags = itemData.Flags;
 
                 if ((flags & ImpassableSurface) == TileFlag.Surface || (canSwim && (flags & TileFlag.Wet) != 0)) // Surface && !Impassable
                 {
@@ -263,7 +263,7 @@ namespace Server.Movement
                 TileFlag flags = itemData.Flags;
 
 				#region SA
-                if (m != null && m.Flying && (itemData.Name == "hover over"))
+                if (m != null && m.Flying && (itemData.Name == "hover over" || (flags & TileFlag.HoverOver) != 0))
                 {
                     newZ = item.Z;
                     return true;

--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -767,7 +767,7 @@ namespace Server.Mobiles
                 new TrainingDefinition(typeof(Ridgeback), Class.Clawed, MagicalAbility.StandardClawedOrTailed, SpecialAbilityClawed, WepAbility1, AreaEffectNone, 1, 3),
                 new TrainingDefinition(typeof(RuddyBoura), Class.Tailed, MagicalAbility.StandardClawedOrTailed, SpecialAbilityTailed, WepAbility1, AreaEffectNone, 2, 3),
                 new TrainingDefinition(typeof(RuneBeetle), Class.Insectoid, MagicalAbility.RuneBeetle, SpecialAbilityNone, WepAbilityNone, AreaEffectNone, 3, 5),
-                new TrainingDefinition(typeof(SabertoothedTiger), Class.ClawedAndTailed, MagicalAbility.SabreToothedTiger, SpecialAbilitySabreTri, WepAbilityNone, AreaEffectNone, 2, 5),
+                new TrainingDefinition(typeof(SabertoothedTiger), Class.ClawedAndTailed, MagicalAbility.SabreToothedTiger, SpecialAbilitySabreTri, WepAbility1, AreaEffectNone, 2, 5),
                 //new TrainingDefinition(typeof(SakkhranBirdOfPrey), Class.MagicalAndTailed, MagicalAbility.None, SpecialAbilityNone, WepAbilityNone, AreaEffectNone, 1, 1),
                 new TrainingDefinition(typeof(Saurosaurus), Class.Tailed, MagicalAbility.Poisoning, SpecialAbilityNone, WepAbilityNone, AreaEffectNone, 3, 5),
                 new TrainingDefinition(typeof(SavageRidgeback), Class.Clawed, MagicalAbility.None, SpecialAbilityNone, WepAbilityNone, AreaEffectNone, 1, 3),

--- a/Scripts/Services/PointsSystems/PlayerMobileProps.cs
+++ b/Scripts/Services/PointsSystems/PlayerMobileProps.cs
@@ -6,6 +6,7 @@ using Server.Engines.Quests;
 using Server.Engines.Points;
 using Server.Accounting;
 using Server.Engines.BulkOrders;
+using Server.Engines.CityLoyalty;
 
 namespace Server.Mobiles
 {
@@ -151,6 +152,23 @@ namespace Server.Mobiles
             set
             {
                 PointsSystem.TreasuresOfDoom.SetPoints(Player, value);
+            }
+        }
+
+        private CityLoyaltyProps _CityLoyaltyProps;
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityLoyaltyProps CityLoyalty
+        {
+            get
+            {
+                if (_CityLoyaltyProps == null)
+                    _CityLoyaltyProps = new CityLoyaltyProps(Player);
+
+                return _CityLoyaltyProps;
+            }
+            set
+            {
             }
         }
     }
@@ -300,6 +318,129 @@ namespace Server.Mobiles
         {
             Type = type;
             Entry = entry;
+        }
+    }
+
+    [PropertyObject]
+    public class CityLoyaltyProps
+    {
+        public PlayerMobile Player { get; private set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityLoyaltyEntry Moonglow
+        {
+            get
+            {
+                return CityLoyaltySystem.Moonglow.GetPlayerEntry<CityLoyaltyEntry>(Player);
+            }
+            set { }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityLoyaltyEntry Britain
+        {
+            get
+            {
+                return CityLoyaltySystem.Britain.GetPlayerEntry<CityLoyaltyEntry>(Player);
+            }
+            set { }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityLoyaltyEntry Jhelom
+        {
+            get
+            {
+                return CityLoyaltySystem.Jhelom.GetPlayerEntry<CityLoyaltyEntry>(Player);
+            }
+            set { }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityLoyaltyEntry Yew
+        {
+            get
+            {
+                return CityLoyaltySystem.Yew.GetPlayerEntry<CityLoyaltyEntry>(Player);
+            }
+            set { }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityLoyaltyEntry Minoc
+        {
+            get
+            {
+                return CityLoyaltySystem.Minoc.GetPlayerEntry<CityLoyaltyEntry>(Player);
+            }
+            set { }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityLoyaltyEntry Trinsic
+        {
+            get
+            {
+                return CityLoyaltySystem.Trinsic.GetPlayerEntry<CityLoyaltyEntry>(Player);
+            }
+            set { }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityLoyaltyEntry SkaraBrae
+        {
+            get
+            {
+                return CityLoyaltySystem.SkaraBrae.GetPlayerEntry<CityLoyaltyEntry>(Player);
+            }
+            set { }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityLoyaltyEntry NewMagincia
+        {
+            get
+            {
+                return CityLoyaltySystem.NewMagincia.GetPlayerEntry<CityLoyaltyEntry>(Player);
+            }
+            set { }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityLoyaltyEntry Vesper
+        {
+            get
+            {
+                return CityLoyaltySystem.Vesper.GetPlayerEntry<CityLoyaltyEntry>(Player);
+            }
+            set { }
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public CityTradeSystem.CityTradeEntry TradeEntry
+        {
+            get
+            {
+                return CityLoyaltySystem.CityTrading.GetPlayerEntry<CityTradeSystem.CityTradeEntry>(Player);
+            }
+            set { }
+        }
+
+        public CityLoyaltyProps(PlayerMobile pm)
+        {
+            Player = pm;
+        }
+
+        public override string ToString()
+        {
+            var sys = CityLoyaltySystem.GetCitizenship(Player, false);
+
+            if (sys != null)
+            {
+                return String.Format("Citizenship: {0}", sys.City.ToString());
+            }
+
+            return base.ToString();
         }
     }
 }

--- a/Scripts/Services/PointsSystems/PointsSystem.cs
+++ b/Scripts/Services/PointsSystems/PointsSystem.cs
@@ -394,8 +394,11 @@ namespace Server.Engines.Points
 
     public class PointsEntry
 	{
-		public PlayerMobile Player { get; set; }
-		public double Points { get; set; }
+        [CommandProperty(AccessLevel.GameMaster)]
+		public PlayerMobile Player { get; private set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public double Points { get; set; }
 
         public PointsEntry(PlayerMobile pm)
         {

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -358,8 +358,11 @@ namespace Server.Spells
             string name = String.Format("[Magic] {0} Buff", type);
 
             StatMod mod = target.GetStatMod(name);
-			if (mod != null)
-				offset = Math.Max(mod.Offset, offset);
+
+            if (mod != null)
+            {
+                offset = Math.Max(mod.Offset, offset);
+            }
 
             target.AddStatMod(new StatMod(type, name, offset, duration));
 			Timer.DelayCall(duration, RemoveStatOffsetCallback, target);
@@ -469,11 +472,11 @@ namespace Server.Spells
                 switch( type )
                 {
                     case StatType.Str:
-                        return (int)(target.RawStr * percent);
+                        return (int)Math.Ceiling(target.RawStr * percent);
                     case StatType.Dex:
-                        return (int)(target.RawDex * percent);
+                        return (int)Math.Ceiling(target.RawDex * percent);
                     case StatType.Int:
-                        return (int)(target.RawInt * percent);
+                        return (int)Math.Ceiling(target.RawInt * percent);
                 }
             }
 

--- a/Scripts/Spells/Skill Masteries/CombatTraining.cs
+++ b/Scripts/Spells/Skill Masteries/CombatTraining.cs
@@ -360,6 +360,11 @@ namespace Server.Spells.SkillMasteries
 
             protected override void OnTarget(Mobile from, object targeted)
             {
+                if (targeted is Server.Engines.Despise.DespiseCreature)
+                {
+                    return;
+                }
+
                 if (targeted is BaseCreature && ((BaseCreature)targeted).GetMaster() == from && from.Spell == Spell)
                 {
                     Spell.Caster.FixedEffect(0x3779, 10, 20, 1270, 0);

--- a/Scripts/Spells/Skill Masteries/Whispering.cs
+++ b/Scripts/Spells/Skill Masteries/Whispering.cs
@@ -43,7 +43,7 @@ namespace Server.Spells.SkillMasteries
 				return false;
 			}
 
-            if (Caster is PlayerMobile && ((PlayerMobile)Caster).AllFollowers == null || ((PlayerMobile)Caster).AllFollowers.Count == 0)
+            if (Caster is PlayerMobile && ((PlayerMobile)Caster).AllFollowers == null || ((PlayerMobile)Caster).AllFollowers.Where(m => !(m is Server.Engines.Despise.DespiseCreature)).Count() == 0)
             {
                 Caster.SendLocalizedMessage(1156112); // This ability requires you to have pets.
                 return false;
@@ -65,7 +65,7 @@ namespace Server.Spells.SkillMasteries
 			{
                 if (Caster is PlayerMobile)
                 {
-                    foreach (Mobile m in ((PlayerMobile)Caster).AllFollowers.Where(m => m.Map == Caster.Map && Caster.InRange(m.Location, PartyRange)))
+                    foreach (Mobile m in ((PlayerMobile)Caster).AllFollowers.Where(m => m.Map == Caster.Map && Caster.InRange(m.Location, PartyRange) && !(m is Server.Engines.Despise.DespiseCreature)))
                     {
                         Effects.SendLocationParticles(EffectItem.Create(m.Location, m.Map, EffectItem.DefaultDuration), 0, 0, 0, 0, 0, 5060, 0);
                         Effects.PlaySound(m.Location, m.Map, 0x243);

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -1547,9 +1547,19 @@ namespace Server
 			{
 				return true;
 			}
-			else if (target is Item && ((Item)target).RootParent == this)
+			else if (target is Item)
 			{
-				return true;
+                var item = (Item)target;
+
+                if (item.RootParent == this)
+                {
+                    return true;
+                }
+
+                if (item.Parent is Container)
+                {
+                    return InLOS(item.Parent);
+                }
 			}
 
 			return m_Map.LineOfSight(this, target);
@@ -4542,11 +4552,11 @@ namespace Server
 					else if (from.AccessLevel < AccessLevel.GameMaster && !from.InRange(item.GetWorldLocation(), 2))
 					{
 						reject = LRReason.OutOfRange;
-					}
+                    }
 					else if (!from.CanSee(item) || !from.InLOS(item))
 					{
 						reject = LRReason.OutOfSight;
-					}
+                    }
 					else if (!item.VerifyMove(from))
 					{
 						reject = LRReason.CannotLift;

--- a/Server/TileData.cs
+++ b/Server/TileData.cs
@@ -154,7 +154,7 @@ namespace Server
 		Wearable = 0x00400000,
 		LightSource = 0x00800000,
 		Animation = 0x01000000,
-		NoDiagonal = 0x02000000,
+        HoverOver = 0x02000000,
 		Unknown3 = 0x04000000,
 		Armor = 0x08000000,
 		Roof = 0x10000000,


### PR DESCRIPTION
- Orc Helm now gives 3% inherent LMC
- Animal Taming Masteries can no longer be used on Despise Creatures
- Mage Armor Conversion now enabled for artifacts
- Despise Creatures now raise resists as they level up
- Despise creatures should now properly discord (those that discord)
- Enabled Damage reflection for executioners (%100) and Shadowguard pirates (37%)
- Added 0x0F Encoded packet, even though there is no use for this yet. THis will keep the packet file from being filled up
- Added City Loyalty and Trade properties to PlayerMobile Command Properties
- Shadowguard apple trees now only produce 1 apple, per EA
- Increased bump chances of Shadowguard Greater Dragon
- Added Weight propery to Hunt trophies (not item weight, but weight when hunted)
- Added proper weapon abilities to saber toohted tiger
- Stat offset for buffs/curses now use math.ceiling
- Replaced TileFlag NoDiagonal with HoverOver (proper EA Use)
- Fixed issue where LOS was returning false from stacked containers in houses with roof