### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Gumps/BaseRewardGump.cs
+++ b/Scripts/Gumps/BaseRewardGump.cs
@@ -176,7 +176,7 @@ namespace Server.Gumps
 
                     User.SendLocalizedMessage(1073621); // Your reward has been placed in your backpack.
                     RemovePoints(citem.Points);
-                    User.PlaySound(0x5A8);
+                    User.PlaySound(0x5A7);
                 }
             }
         }

--- a/Scripts/Items/Resource/BarrelParts.cs
+++ b/Scripts/Items/Resource/BarrelParts.cs
@@ -21,7 +21,7 @@ namespace Server.Items
         public BarrelLid()
             : base(0x1DB8)
         {
-            this.Weight = 2;
+            Weight = 2;
         }
 
         public override void GetProperties(ObjectPropertyList list)
@@ -84,7 +84,7 @@ namespace Server.Items
     }
 
     [FlipableAttribute(0x1EB1, 0x1EB2, 0x1EB3, 0x1EB4)]
-    public class BarrelStaves : Item, IResource
+    public class BarrelStaves : Item, IResource, IQuality
     {
         private CraftResource _Resource;
         private ItemQuality _Quality;
@@ -102,7 +102,7 @@ namespace Server.Items
         public BarrelStaves()
             : base(0x1EB1)
         {
-            this.Weight = 1;
+            Weight = 1;
         }
 
         public override void GetProperties(ObjectPropertyList list)
@@ -164,7 +164,7 @@ namespace Server.Items
         }
     }
 
-    public class BarrelHoops : Item, IResource
+    public class BarrelHoops : Item, IResource, IQuality
     {
         private CraftResource _Resource;
         private ItemQuality _Quality;
@@ -182,7 +182,7 @@ namespace Server.Items
         public BarrelHoops()
             : base(0x1DB7)
         {
-            this.Weight = 5;
+            Weight = 5;
         }
 
         public override void GetProperties(ObjectPropertyList list)
@@ -255,7 +255,7 @@ namespace Server.Items
         }
     }
 
-    public class BarrelTap : Item, IResource
+    public class BarrelTap : Item, IResource, IQuality
     {
         private CraftResource _Resource;
         private ItemQuality _Quality;
@@ -273,7 +273,7 @@ namespace Server.Items
         public BarrelTap()
             : base(0x1004)
         {
-            this.Weight = 1;
+            Weight = 1;
         }
 
         public override void GetProperties(ObjectPropertyList list)

--- a/Scripts/Mobiles/Normal/AbyssalAbomination.cs
+++ b/Scripts/Mobiles/Normal/AbyssalAbomination.cs
@@ -1,4 +1,3 @@
-/* Based on AbysmalHorror, still no infos on Abyssal Abomination... Including correct body ID */
 using System;
 using Server.Items;
 
@@ -12,7 +11,7 @@ namespace Server.Mobiles
             : base(AIType.AI_NecroMage, FightMode.Closest, 10, 1, 0.2, 0.4)
         {
             Name = "an Abyssal Abomination";
-            Body = 742;
+            Body = 312;
             Hue = 769;
             BaseSoundID = 0x451;
 

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -1831,14 +1831,13 @@ namespace Server.Mobiles
 
             double dMinTameSkill = m_CurrentTameSkill;
 
-            if (dMinTameSkill > -24.9 && AnimalTaming.CheckMastery(m, this))
+            if (dMinTameSkill > -24.9 && DarkWolfFamiliar.CheckMastery(m, this))
             {
                 dMinTameSkill = -24.9;
             }
 
-            int taming =
-                (int)((useBaseSkill ? m.Skills[SkillName.AnimalTaming].Base : m.Skills[SkillName.AnimalTaming].Value) * 10);
-            int lore = (int)((useBaseSkill ? m.Skills[SkillName.AnimalLore].Base : m.Skills[SkillName.AnimalLore].Value) * 10);
+            int taming = (int)((useBaseSkill ? m.Skills[SkillName.AnimalTaming].Base : m.Skills[SkillName.AnimalTaming].Value) * 10);
+            int lore =   (int)((useBaseSkill ? m.Skills[SkillName.AnimalLore].Base : m.Skills[SkillName.AnimalLore].Value) * 10);
             int bonus = 0, chance = 700;
 
             if (Core.ML)

--- a/Scripts/Mobiles/Normal/GreaterDragon.cs
+++ b/Scripts/Mobiles/Normal/GreaterDragon.cs
@@ -156,35 +156,13 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write((int)3);
+            writer.Write((int)0);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
-
-			switch(version)
-			{
-                case 3:
-				case 2:
-					break;
-				case 1:
-					SetDamage(24, 33);
-					SetStam(0);
-					break;
-				case 0:
-					Server.SkillHandlers.AnimalTaming.ScaleStats(this, 0.50);
-					Server.SkillHandlers.AnimalTaming.ScaleSkills(this, 0.80, 0.90); // 90% * 80% = 72% of original skills trainable to 90%
-					Skills[SkillName.Magery].Base = Skills[SkillName.Magery].Cap; // Greater dragons have a 90% cap reduction and 90% skill reduction on magery
-					SetStam(0);
-					break;
-			}
-
-            if (version == 2)
-            {
-                SetWeaponAbility(WeaponAbility.BleedAttack);
-            }
         }
     }
 }

--- a/Scripts/Mobiles/Summons/DarkWolf.cs
+++ b/Scripts/Mobiles/Summons/DarkWolf.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Linq;
+
+using Server.Spells.Necromancy;
 
 namespace Server.Mobiles
 {
@@ -8,33 +11,33 @@ namespace Server.Mobiles
         private DateTime m_NextRestore;
         public DarkWolfFamiliar()
         {
-            this.Name = "a dark wolf";
-            this.Body = 99;
-            this.Hue = 0x901;
-            this.BaseSoundID = 0xE5;
+            Name = "a dark wolf";
+            Body = 99;
+            Hue = 0x901;
+            BaseSoundID = 0xE5;
 
-            this.SetStr(100);
-            this.SetDex(90);
-            this.SetInt(90);
+            SetStr(100);
+            SetDex(90);
+            SetInt(90);
 
-            this.SetHits(60);
-            this.SetStam(90);
-            this.SetMana(0);
+            SetHits(60);
+            SetStam(90);
+            SetMana(0);
 
-            this.SetDamage(5, 10);
+            SetDamage(5, 10);
 
-            this.SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-            this.SetResistance(ResistanceType.Physical, 40, 50);
-            this.SetResistance(ResistanceType.Fire, 25, 40);
-            this.SetResistance(ResistanceType.Cold, 25, 40);
-            this.SetResistance(ResistanceType.Poison, 25, 40);
-            this.SetResistance(ResistanceType.Energy, 25, 40);
+            SetResistance(ResistanceType.Physical, 40, 50);
+            SetResistance(ResistanceType.Fire, 25, 40);
+            SetResistance(ResistanceType.Cold, 25, 40);
+            SetResistance(ResistanceType.Poison, 25, 40);
+            SetResistance(ResistanceType.Energy, 25, 40);
 
-            this.SetSkill(SkillName.Wrestling, 85.1, 90.0);
-            this.SetSkill(SkillName.Tactics, 50.0);
+            SetSkill(SkillName.Wrestling, 85.1, 90.0);
+            SetSkill(SkillName.Tactics, 50.0);
 
-            this.ControlSlots = 1;
+            ControlSlots = 1;
         }
 
         public DarkWolfFamiliar(Serial serial)
@@ -42,19 +45,36 @@ namespace Server.Mobiles
         {
         }
 
+        public static readonly Type[] ControlTypes =
+        {
+            typeof(DireWolf), typeof(GreyWolf), typeof(TimberWolf), typeof(WhiteWolf), typeof(BakeKitsune)
+        };
+
+        public static bool CheckMastery(Mobile tamer, BaseCreature creature)
+        {
+            var familiar = (BaseCreature)SummonFamiliarSpell.Table[tamer];
+
+            if (familiar != null && !familiar.Deleted && familiar is DarkWolfFamiliar && ControlTypes.Any(t => t == creature.GetType()))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         public override void OnThink()
         {
             base.OnThink();
 
-            if (DateTime.UtcNow < this.m_NextRestore)
+            if (DateTime.UtcNow < m_NextRestore)
                 return;
 
-            this.m_NextRestore = DateTime.UtcNow + TimeSpan.FromSeconds(2.0);
+            m_NextRestore = DateTime.UtcNow + TimeSpan.FromSeconds(2.0);
 
-            Mobile caster = this.ControlMaster;
+            Mobile caster = ControlMaster;
 
             if (caster == null)
-                caster = this.SummonMaster;
+                caster = SummonMaster;
 
             if (caster != null)
                 ++caster.Stam;

--- a/Scripts/Services/Expansions/High Seas/Quests/ProfessionalBountyQuest/Mobiles/BaseShipCaptain.cs
+++ b/Scripts/Services/Expansions/High Seas/Quests/ProfessionalBountyQuest/Mobiles/BaseShipCaptain.cs
@@ -1,4 +1,4 @@
-﻿using Server;
+using Server;
 using System;
 using Server.Items;
 using Server.Multis;
@@ -131,15 +131,20 @@ namespace Server.Mobiles
             else
                 gal = new GargishGalleon(Direction.North);
 
-            if (gal.CanFit(this.Location, this.Map, gal.ItemID))
+            var p = Location;
+            Map map = Map;
+
+            // Move this sucka out of the way!
+            Internalize();
+
+            if (gal.CanFit(p, map, gal.ItemID))
             {
                 gal.Owner = this;
-                gal.MoveToWorld(this.Location, this.Map);
+                gal.MoveToWorld(p, map);
                 m_Galleon = gal;
 
                 Server.Engines.Quests.BountyQuestSpawner.FillHold(m_Galleon);
-
-                this.MoveToWorld(new Point3D(gal.X, gal.Y - 1, gal.ZSurface), this.Map);
+                MoveToWorld(new Point3D(p.X, p.Y - 1, gal.Z + gal.ZSurface), map);
 
                 int crewCount = Utility.RandomMinMax(3, 5);
 
@@ -151,7 +156,7 @@ namespace Server.Mobiles
                         crew.Title = "the orc captain";
 
                     AddToCrew(crew);
-                    crew.MoveToWorld(new Point3D(gal.X + Utility.RandomList(-1, 1), gal.Y + Utility.RandomList(-1, 0, 1), gal.ZSurface), this.Map);
+                    crew.MoveToWorld(new Point3D(gal.X + Utility.RandomList(-1, 1), gal.Y + Utility.RandomList(-1, 0, 1), gal.ZSurface), map);
                 }
 
                 gal.AutoAddCannons(this);

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Encounters.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Encounters.cs
@@ -211,6 +211,7 @@ namespace Server.Engines.Shadowguard
         public List<BaseCreature> Spawn { get; set; }
 
         public Item Bones { get; set; }
+        public ShadowguardApple Apple { get; set; }
 
         public override Type AddonType { get { return typeof(OrchardAddon); } }
 
@@ -316,6 +317,11 @@ namespace Server.Engines.Shadowguard
 		{
             ClearSpawn();
 
+            if (Apple != null)
+            {
+                Apple.Delete();
+            }
+
             if (Trees != null)
             {
                 List<ShadowguardCypress> list = new List<ShadowguardCypress>(Trees.Where(t => t != null && !t.Deleted));
@@ -335,6 +341,34 @@ namespace Server.Engines.Shadowguard
                 Bones = null;
             }
 		}
+
+        public void OnApplePicked()
+        {
+            if (Trees == null)
+                return;
+
+            foreach (var tree in Trees.Where(t => t != null && !t.Deleted))
+            {
+                if (tree.Foilage != null)
+                {
+                    tree.Foilage.ItemID--;
+                }
+            }
+        }
+
+        public void OnAppleDeleted()
+        {
+            if (Trees == null)
+                return;
+
+            foreach (var tree in Trees.Where(t => t != null && !t.Deleted))
+            {
+                if (tree.Foilage != null)
+                {
+                    tree.Foilage.ItemID++;
+                }
+            }
+        }
 
         public override void Serialize(GenericWriter writer)
         {

--- a/Scripts/Services/Pet Training/PetTrainingHelper.cs
+++ b/Scripts/Services/Pet Training/PetTrainingHelper.cs
@@ -1720,13 +1720,13 @@ namespace Server.Mobiles
 
                                 if (bc is GreaterDragon)
                                 {
-                                    AnimalTaming.ScaleSkills(bc, 0.72, 0.90); // 72% of original skills trainable to 90%
+                                    AnimalTaming.ScaleSkills(bc, 0.72, 0.90, true); // 72% of original skills trainable to 90%
                                     bc.Skills[SkillName.Magery].Base = bc.Skills[SkillName.Magery].Cap;
                                     // Greater dragons have a 90% cap reduction and 90% skill reduction on magery
                                 }
                                 else
                                 {
-                                    AnimalTaming.ScaleSkills(bc, 0.90);
+                                    AnimalTaming.ScaleSkills(bc, 0.90, true);
                                 }
 
                                 Timer.DelayCall(TimeSpan.FromSeconds(.25), () =>

--- a/Scripts/Services/PointsSystems/PointsSystem.cs
+++ b/Scripts/Services/PointsSystems/PointsSystem.cs
@@ -111,10 +111,9 @@ namespace Server.Engines.Points
 
             if (entry != null)
             {
-                SetPoints((PlayerMobile)from, Math.Min(MaxPoints, entry.Points + points));
-
                 double old = entry.Points;
 
+                SetPoints((PlayerMobile)from, Math.Min(MaxPoints, entry.Points + points));
                 SendMessage((PlayerMobile)from, old, points, quest);
             }
         }

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/BandanaBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/BandanaBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/BascinetBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/BascinetBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/CircletBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/CircletBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/FeatheredHatBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/FeatheredHatBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/GargishEarringsBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/GargishEarringsBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/JesterHatBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/JesterHatBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/NorseHelmBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/NorseHelmBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/PlateHelmBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/PlateHelmBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/RoyalCircletBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/RoyalCircletBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/SkullcapBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/SkullcapBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/TricorneHatBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/TricorneHatBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/WizardsHatBearingTheCrestOfBlackthorn.cs
+++ b/Scripts/Services/Revamped Dungeons/BlackthornDungeon/Items/MaceAndShieldBase/WizardsHatBearingTheCrestOfBlackthorn.cs
@@ -48,9 +48,9 @@ namespace Server.Items
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 
-        public override void AppendChildNameProperties(ObjectPropertyList list)
+        public override void AddWeightProperty(ObjectPropertyList list)
         {
-            base.AppendChildNameProperties(list);
+            base.AddWeightProperty(list);
 
             int prop;
 

--- a/Scripts/Skills/AnimalTaming.cs
+++ b/Scripts/Skills/AnimalTaming.cs
@@ -7,7 +7,6 @@ using Server.Factions;
 using Server.Mobiles;
 using Server.Network;
 using Server.Spells;
-using Server.Spells.Necromancy;
 using Server.Spells.Spellweaving;
 using Server.Targeting;
 #endregion
@@ -53,22 +52,6 @@ namespace Server.SkillHandlers
             // We're not sure why this is getting hung up. Now, its 30 second timeout + 10 seconds (max) to tame
 			return TimeSpan.FromSeconds(40.0);
 		}
-		
-		public static bool CheckMastery(Mobile tamer, BaseCreature creature)
-		{
-			BaseCreature familiar = (BaseCreature)SummonFamiliarSpell.Table[tamer];
-
-			if (familiar != null && !familiar.Deleted && familiar is DarkWolfFamiliar)
-			{
-				if (creature is DireWolf || creature is GreyWolf || creature is TimberWolf || creature is WhiteWolf ||
-					creature is BakeKitsune)
-				{
-					return true;
-				}
-			}
-
-			return false;
-		}
 
 		public static bool MustBeSubdued(BaseCreature bc)
 		{
@@ -109,16 +92,20 @@ namespace Server.SkillHandlers
 			}
 		}
 
-		public static void ScaleSkills(BaseCreature bc, double scalar)
+		public static void ScaleSkills(BaseCreature bc, double scalar, bool firstTame)
 		{
-			ScaleSkills(bc, scalar, scalar);
+			ScaleSkills(bc, scalar, scalar, firstTame);
 		}
 
-		public static void ScaleSkills(BaseCreature bc, double scalar, double capScalar)
+		public static void ScaleSkills(BaseCreature bc, double scalar, double capScalar, bool firstTame)
 		{
 			for (int i = 0; i < bc.Skills.Length; ++i)
 			{
-                bc.Skills[i].Cap = Math.Max(100.0, bc.Skills[i].Base * capScalar);
+                if (!Core.TOL || firstTame)
+                {
+                    bc.Skills[i].Cap = Math.Max(100.0, bc.Skills[i].Base * capScalar);
+                }
+
 				bc.Skills[i].Base *= scalar;
 
 				if (bc.Skills[i].Base > bc.Skills[i].Cap)
@@ -194,7 +181,7 @@ namespace Server.SkillHandlers
 							creature.PrivateOverheadMessage(MessageType.Regular, 0x3B2, 1054025, from.NetState);
 								// You must subdue this creature before you can tame it!
 						}
-						else if (CheckMastery(from, creature) || from.Skills[SkillName.AnimalTaming].Value >= creature.CurrentTameSkill)
+						else if (DarkWolfFamiliar.CheckMastery(from, creature) || from.Skills[SkillName.AnimalTaming].Value >= creature.CurrentTameSkill)
 						{
 							FactionWarHorse warHorse = creature as FactionWarHorse;
 
@@ -323,7 +310,7 @@ namespace Server.SkillHandlers
 					}
 					else if (!m_Tamer.CanSee(m_Creature) || !m_Tamer.InLOS(m_Creature) || !CanPath())
 					{
-						m_BeingTamed.Remove(m_Creature);
+                        m_BeingTamed.Remove(m_Creature);
 						m_Tamer.NextSkillTime = Core.TickCount;
 						m_Tamer.SendLocalizedMessage(1049654);
 							// You do not have a clear path to the animal you are taming, and must cease your attempt.
@@ -413,37 +400,38 @@ namespace Server.SkillHandlers
 						}
 
 						double minSkill = m_Creature.CurrentTameSkill + (m_Creature.Owners.Count * 6.0);
+                        bool necroMastery = DarkWolfFamiliar.CheckMastery(m_Tamer, m_Creature);
 
-						if (minSkill > -24.9 && CheckMastery(m_Tamer, m_Creature))
+                        if (minSkill > -24.9 && necroMastery)
 						{
 							minSkill = -24.9; // 50% at 0.0?
 						}
 
 						minSkill += 24.9;
 
-						if (CheckMastery(m_Tamer, m_Creature) || alreadyOwned ||
+						if (necroMastery || alreadyOwned ||
 							m_Tamer.CheckTargetSkill(SkillName.AnimalTaming, m_Creature, minSkill - 25.0, minSkill + 25.0))
 						{
                             if (m_Creature.Owners.Count == 0) // First tame
                             {
                                 if (m_Creature is GreaterDragon)
                                 {
-                                    ScaleSkills(m_Creature, 0.72, 0.90); // 72% of original skills trainable to 90%
+                                    ScaleSkills(m_Creature, 0.72, 0.90, true); // 72% of original skills trainable to 90%
                                     m_Creature.Skills[SkillName.Magery].Base = m_Creature.Skills[SkillName.Magery].Cap;
                                     // Greater dragons have a 90% cap reduction and 90% skill reduction on magery
                                 }
                                 else if (m_Paralyzed)
                                 {
-                                    ScaleSkills(m_Creature, 0.86); // 86% of original skills if they were paralyzed during the taming
+                                    ScaleSkills(m_Creature, 0.86, true); // 86% of original skills if they were paralyzed during the taming
                                 }
                                 else
                                 {
-                                    ScaleSkills(m_Creature, 0.90); // 90% of original skills
+                                    ScaleSkills(m_Creature, 0.90, true); // 90% of original skills
                                 }
                             }
                             else
                             {
-                                ScaleSkills(m_Creature, 0.90); // 90% of original skills
+                                ScaleSkills(m_Creature, 0.90, false); // 90% of original skills
                             }
 
 							if (alreadyOwned)

--- a/Scripts/Skills/Discordance.cs
+++ b/Scripts/Skills/Discordance.cs
@@ -89,7 +89,7 @@ namespace Server.SkillHandlers
             {
                 // According to uoherald bard must remain alive, visible, and 
                 // within range of the target or the effect ends in 15 seconds.
-                if (!targ.Alive || targ.Deleted || !from.Alive || from.Hidden || targ.Hidden)
+                if (!targ.Alive || targ.Deleted || targ.IsDeadBondedPet || !from.Alive || from.Hidden || targ.Hidden || from.IsDeadBondedPet)
                 {
                     ends = true;
                 }

--- a/Scripts/Spells/Bushido/LightningStrike.cs
+++ b/Scripts/Spells/Bushido/LightningStrike.cs
@@ -57,7 +57,7 @@ namespace Server.Spells.Bushido
                 var ThePlayer = from as PlayerMobile;
                 if(ThePlayer != null)
                 {
-                    ThePlayer.ExecutesLightningStrike = this.BaseMana;
+                    ThePlayer.ExecutesLightningStrike = BaseMana;
                 }
             }
             return isValid;
@@ -73,26 +73,42 @@ namespace Server.Spells.Bushido
         public override bool OnBeforeSwing(Mobile attacker, Mobile defender)
         {
             /* no mana drain before actual hit */
-            bool enoughMana = this.CheckMana(attacker, false);
-            return this.Validate(attacker);
+            bool enoughMana = CheckMana(attacker, false);
+            return Validate(attacker);
         }
 
         public override bool OnBeforeDamage(Mobile attacker, Mobile defender)
         {
             ClearCurrentMove(attacker);
 
-            if (this.CheckMana(attacker, true))
+            if (CheckMana(attacker, true))
             {
                 attacker.SendLocalizedMessage(1063168); // You attack with lightning precision!
                 defender.SendLocalizedMessage(1063169); // Your opponent's quick strike causes extra damage!
                 defender.FixedParticles(0x3818, 1, 11, 0x13A8, 0, 0, EffectLayer.Waist);
                 defender.PlaySound(0x51D);
 
-                this.CheckGain(attacker);
-                this.SetContext(attacker);
+                CheckGain(attacker);
+                SetContext(attacker);
             }
 
             return base.OnBeforeDamage(attacker, defender);
+        }
+
+        public override void CheckGain(Mobile m)
+        {
+            // Lighning strike will gain to 120, albeit slow
+            if (Core.SA && m.Skills[MoveSkill].Value >= 87.5)
+            {
+                if (0.25 > Utility.RandomDouble())
+                {
+                    m.CheckSkill(MoveSkill, 0, m.Skills[MoveSkill].Cap);
+                }
+            }
+            else
+            {
+                base.CheckGain(m);
+            }
         }
 
         public override void OnUse(Mobile m)


### PR DESCRIPTION
- Fixed sound in reward Gumps
- Barrel parts can now be crafted exceptional
- Fixed incorrect body value for Abyssal Abomination
- Shadowguard Orchard Encounter Apples now behave correctly
- Subsequent tames on creatures no longer lower its skill caps
- Fixed improper property placement on some of the blackthorn Items
- Fixed incorrect shame crystal Message
- Discordance now expires on dead Pets
- Lightning Strike now gains (although slow) to 120