### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Consumables/Beverage.cs
+++ b/Scripts/Items/Consumables/Beverage.cs
@@ -1028,6 +1028,14 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
+            if (ShowQuantity)
+            {
+                list.Add(GetQuantityDescription());
+            }
+        }
+
+        public override void AddCraftedProperties(ObjectPropertyList list)
+        {
             if (_Crafter != null)
             {
                 list.Add(1050043, _Crafter.TitleName); // crafted by ~1_NAME~
@@ -1036,11 +1044,6 @@ namespace Server.Items
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional
-            }
-
-            if (ShowQuantity)
-            {
-                list.Add(GetQuantityDescription());
             }
         }
 

--- a/Scripts/Items/Consumables/Chocolatiering.cs
+++ b/Scripts/Items/Consumables/Chocolatiering.cs
@@ -22,10 +22,8 @@ namespace Server.Items
 			Hue = 1130;
 		}
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional
@@ -124,10 +122,8 @@ namespace Server.Items
             Hue = 1111;
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional
@@ -183,10 +179,8 @@ namespace Server.Items
         {
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional

--- a/Scripts/Items/Consumables/CookableFood.cs
+++ b/Scripts/Items/Consumables/CookableFood.cs
@@ -41,10 +41,8 @@ namespace Server.Items
         TextDefinition ICommodity.Description { get { return LabelNumber; } }
         bool ICommodity.IsDeedable { get { return true; } }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional

--- a/Scripts/Items/Consumables/Cooking.cs
+++ b/Scripts/Items/Consumables/Cooking.cs
@@ -58,10 +58,8 @@ namespace Server.Items
             return quality;
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional
@@ -187,10 +185,8 @@ namespace Server.Items
             Hue = 150;
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional
@@ -492,10 +488,8 @@ namespace Server.Items
             return quality;
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional

--- a/Scripts/Items/Consumables/EngravingTools.cs
+++ b/Scripts/Items/Consumables/EngravingTools.cs
@@ -598,7 +598,7 @@ namespace Server.Items
             {
                 return new Type[]
                 {
-                    typeof(ParagonChest), typeof(MetalChest), typeof(MetalGoldenChest)
+                    typeof(ParagonChest), typeof(MetalChest), typeof(MetalGoldenChest), typeof(MetalBox)
                 };
             }
         }

--- a/Scripts/Items/Consumables/Food.cs
+++ b/Scripts/Items/Consumables/Food.cs
@@ -144,10 +144,8 @@ namespace Server.Items
             return Eat(from);
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional
@@ -1661,10 +1659,8 @@ namespace Server.Items
             }
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional
@@ -1698,6 +1694,8 @@ namespace Server.Items
 
     public class Hamburger : Food
     {
+        public override int LabelNumber { get { return 1125202; } } // hamburger
+
         [Constructable]
         public Hamburger()
             : this(1)
@@ -1734,6 +1732,8 @@ namespace Server.Items
     [Flipable(0xA0D8, 0xA0D9)]
     public class HotDog : Food
     {
+        public override int LabelNumber { get { return 1125201; } } // hot dog
+
         [Constructable]
         public HotDog()
             : this(1)
@@ -1770,6 +1770,8 @@ namespace Server.Items
     [Flipable(0xA0D6, 0xA0D7)]
     public class CookableSausage : Food
     {
+        public override int LabelNumber { get { return 1125198; } } // sausage
+
         [Constructable]
         public CookableSausage()
             : base(0xA0D6)

--- a/Scripts/Items/Containers/FurnitureContainer.cs
+++ b/Scripts/Items/Containers/FurnitureContainer.cs
@@ -69,10 +69,8 @@ namespace Server.Items
         {
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (m_Crafter != null)
             {
                 list.Add(1050043, m_Crafter.Name); // crafted by ~1_NAME~

--- a/Scripts/Items/Containers/LockableContainer.cs
+++ b/Scripts/Items/Containers/LockableContainer.cs
@@ -413,10 +413,8 @@ namespace Server.Items
             }
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (m_PlayerConstructed && m_Crafter != null)
             {
                 list.Add(1050043, m_Crafter.Name); // crafted by ~1_NAME~

--- a/Scripts/Items/Decorative/BaseLight.cs
+++ b/Scripts/Items/Decorative/BaseLight.cs
@@ -224,10 +224,8 @@ namespace Server.Items
             }
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_PlayerConstructed && _Crafter != null)
             {
                 list.Add(1050043, _Crafter.TitleName); // crafted by ~1_NAME~

--- a/Scripts/Items/Decorative/CraftableFurniture.cs
+++ b/Scripts/Items/Decorative/CraftableFurniture.cs
@@ -87,16 +87,15 @@ namespace Server.Items
             if (this.m_Quality == ItemQuality.Exceptional)
                 list.Add(1060636); // exceptional
         }
-		
-        public override void GetProperties(ObjectPropertyList list)
-        {
-            base.GetProperties(list);
 
+        public override void AddCraftedProperties(ObjectPropertyList list)
+        {
             CraftResourceInfo info = CraftResources.IsStandard(this.m_Resource) ? null : CraftResources.GetInfo(this.m_Resource);
 
             if (info != null && info.Number > 0)
                 list.Add(info.Number);
         }
+
 		public override void OnSingleClick(Mobile from)
 		{
 			base.OnSingleClick(from);

--- a/Scripts/Items/Decorative/Globe.cs
+++ b/Scripts/Items/Decorative/Globe.cs
@@ -27,10 +27,8 @@ namespace Server.Items
             Weight = 3.0;
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Crafter != null)
             {
                 list.Add(1050043, _Crafter.TitleName); // crafted by ~1_NAME~

--- a/Scripts/Items/Decorative/Utensils.cs
+++ b/Scripts/Items/Decorative/Utensils.cs
@@ -38,10 +38,8 @@ namespace Server.Items
         {
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Crafter != null)
             {
                 list.Add(1050043, _Crafter.TitleName); // crafted by ~1_NAME~

--- a/Scripts/Items/Equipment/Armor/BaseArmor.cs
+++ b/Scripts/Items/Equipment/Armor/BaseArmor.cs
@@ -2769,7 +2769,7 @@ namespace Server.Items
             return attrInfo.ArmorLuck;
         }
 
-        public override void AddWeightProperty(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
             if (OwnerName != null)
                 list.Add(1153213, OwnerName);
@@ -2785,9 +2785,10 @@ namespace Server.Items
 
             if (m_Altered)
                 list.Add(1111880); // Altered
+        }
 
-            AddLootTypeProperty(list);
-
+        public override void AddWeightProperty(ObjectPropertyList list)
+        {
             base.AddWeightProperty(list);
 
             if (IsVvVItem)

--- a/Scripts/Items/Equipment/Clothing/BaseClothing.cs
+++ b/Scripts/Items/Equipment/Clothing/BaseClothing.cs
@@ -1202,7 +1202,7 @@ namespace Server.Items
                 list.Add(Name);
         }
 
-        public override void AddWeightProperty(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
             if (OwnerName != null)
                 list.Add(1153213, OwnerName);
@@ -1218,9 +1218,10 @@ namespace Server.Items
 
             if (m_Altered)
                 list.Add(1111880); // Altered
+        }
 
-            AddLootTypeProperty(list);
-
+        public override void AddWeightProperty(ObjectPropertyList list)
+        {
             base.AddWeightProperty(list);
 
             if (IsVvVItem)

--- a/Scripts/Items/Equipment/Instruments/BaseInstrument.cs
+++ b/Scripts/Items/Equipment/Instruments/BaseInstrument.cs
@@ -459,18 +459,21 @@ namespace Server.Items
             UsesRemaining = Utility.RandomMinMax(InitMinUses, InitMaxUses);
         }
 
+        public override void AddCraftedProperties(ObjectPropertyList list)
+        {
+            if (m_Crafter != null)
+                list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
+
+            if (m_Quality == ItemQuality.Exceptional)
+                list.Add(1060636); // exceptional
+        }
+
         public override void GetProperties(ObjectPropertyList list)
         {
             int oldUses = m_UsesRemaining;
             CheckReplenishUses(false);
 
             base.GetProperties(list);
-
-            if (m_Crafter != null)
-				list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
-
-            if (m_Quality == ItemQuality.Exceptional)
-                list.Add(1060636); // exceptional
 
             list.Add(1060584, m_UsesRemaining.ToString()); // uses remaining: ~1_val~
 

--- a/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
+++ b/Scripts/Items/Equipment/Jewelry/BaseJewel.cs
@@ -795,7 +795,7 @@ namespace Server.Items
             return name;
         }
 
-        public override void AddWeightProperty(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
             if (OwnerName != null)
                 list.Add(1153213, OwnerName);
@@ -808,9 +808,10 @@ namespace Server.Items
 
             if (IsImbued)
                 list.Add(1080418); // (Imbued)
+        }
 
-            AddLootTypeProperty(list);
-
+        public override void AddWeightProperty(ObjectPropertyList list)
+        {
             base.AddWeightProperty(list);
 
             if (IsVvVItem)

--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -5415,7 +5415,7 @@ namespace Server.Items
 			return attrInfo.WeaponLuck;
 		}
 
-        public override void AddWeightProperty(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
             if (OwnerName != null)
             {
@@ -5442,8 +5442,11 @@ namespace Server.Items
                 list.Add(1111880); // Altered
             }
 
-            AddLootTypeProperty(list);
+            base.AddCraftedProperties(list);
+        }
 
+        public override void AddWeightProperty(ObjectPropertyList list)
+        {
             base.AddWeightProperty(list);
 
             if (IsVvVItem)

--- a/Scripts/Items/Resource/BarrelParts.cs
+++ b/Scripts/Items/Resource/BarrelParts.cs
@@ -24,10 +24,8 @@ namespace Server.Items
             Weight = 2;
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional
@@ -105,10 +103,8 @@ namespace Server.Items
             Weight = 1;
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional
@@ -185,10 +181,8 @@ namespace Server.Items
             Weight = 5;
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional
@@ -276,10 +270,8 @@ namespace Server.Items
             Weight = 1;
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional

--- a/Scripts/Items/Tools/BaseTool.cs
+++ b/Scripts/Items/Tools/BaseTool.cs
@@ -126,17 +126,20 @@ namespace Server.Items
         {
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (m_Crafter != null)
                 list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 
             if (m_Quality == ItemQuality.Exceptional)
                 list.Add(1060636); // exceptional
+        }
 
+        public override void AddWeightProperty(ObjectPropertyList list)
+        {
             list.Add(1060584, m_UsesRemaining.ToString()); // uses remaining: ~1_val~
+
+            base.AddWeightProperty(list);
         }
 
         public virtual void DisplayDurabilityTo(Mobile m)

--- a/Scripts/Items/Tools/FishingPole.cs
+++ b/Scripts/Items/Tools/FishingPole.cs
@@ -347,18 +347,21 @@ namespace Server.Items
             }
         }
 
+        public override void AddCraftedProperties(ObjectPropertyList list)
+        {
+            if (m_Crafter != null)
+                list.Add(1050043, m_Crafter.Name); // crafted by ~1_NAME~
+
+            if (m_Quality == ItemQuality.Exceptional)
+                list.Add(1060636); // exceptional
+        }
+
         public override void GetProperties(ObjectPropertyList list)
         {
             base.GetProperties(list);
 
             if (m_AosAttributes.Brittle != 0)
                 list.Add(1116209); // Brittle
-
-            if (m_Crafter != null)
-                list.Add(1050043, m_Crafter.Name); // crafted by ~1_NAME~
-
-            if (m_Quality == ItemQuality.Exceptional)
-                list.Add(1060636); // exceptional
 
             if (m_AosSkillBonuses != null)
                 m_AosSkillBonuses.GetProperties(list);

--- a/Scripts/Items/Tools/Key.cs
+++ b/Scripts/Items/Tools/Key.cs
@@ -288,10 +288,8 @@ namespace Server.Items
             from.Target = t;
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             string desc;
 
             if (m_KeyVal == 0)

--- a/Scripts/Items/Tools/KeyRing.cs
+++ b/Scripts/Items/Tools/KeyRing.cs
@@ -153,10 +153,8 @@ namespace Server.Items
             return false;
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Crafter != null)
             {
                 list.Add(1050043, _Crafter.TitleName); // crafted by ~1_NAME~

--- a/Scripts/Items/Tools/Scales.cs
+++ b/Scripts/Items/Tools/Scales.cs
@@ -33,10 +33,8 @@ namespace Server.Items
         {
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Crafter != null)
             {
                 list.Add(1050043, _Crafter.TitleName); // crafted by ~1_NAME~

--- a/Scripts/Items/Tools/Scissors.cs
+++ b/Scripts/Items/Tools/Scissors.cs
@@ -54,11 +54,9 @@ namespace Server.Items
                 m_ShowUsesRemaining = true;
 		}
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
-            if(m_Crafter != null)
+            if (m_Crafter != null)
                 list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 
             if (m_Quality == ItemQuality.Exceptional)

--- a/Scripts/Items/Tools/Spyglass.cs
+++ b/Scripts/Items/Tools/Spyglass.cs
@@ -74,10 +74,8 @@ namespace Server.Items
             }
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Crafter != null)
             {
                 list.Add(1050043, _Crafter.TitleName); // crafted by ~1_NAME~

--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -1755,7 +1755,7 @@ namespace Server.Mobiles
 
 						var aggrScore = m_Mobile.GetFightModeRanking(aggr, FightMode.Closest, false);
 
-						if ((newCombatant == null || aggrScore > newScore) && m_Mobile.InLOS(aggr))
+						if ((newCombatant == null || aggrScore > newScore || (aggrScore == newScore && !aggr.Player && newCombatant.Player)) && m_Mobile.InLOS(aggr))
 						{
 							newCombatant = aggr;
 							newScore = aggrScore;
@@ -3006,7 +3006,7 @@ namespace Server.Mobiles
 
 					theirVal = m_Mobile.GetFightModeRanking(m, acqType, bPlayerOnly);
 
-					if (theirVal > val)
+					if (theirVal > val || (theirVal == val && newFocusMob.Player && !m.Player))
 					{
 						newFocusMob = m;
 						val = theirVal;

--- a/Scripts/Mobiles/Bosses/DreadHorn.cs
+++ b/Scripts/Mobiles/Bosses/DreadHorn.cs
@@ -264,9 +264,9 @@ namespace Server.Mobiles
                     double percent = m.Skills.MagicResist.Value / 100;
                     int malas = (int)(-20 + (percent * 5.2));
 
-                    m.AddStatMod(new StatMod(StatType.Str, "DreadHornStr", m.Str < malas ? m.Str / 2 : malas, TimeSpan.FromSeconds(60)));
-                    m.AddStatMod(new StatMod(StatType.Dex, "DreadHornDex", m.Dex < malas ? m.Dex / 2 : malas, TimeSpan.FromSeconds(60)));
-                    m.AddStatMod(new StatMod(StatType.Int, "DreadHornInt", m.Int < malas ? m.Int / 2 : malas, TimeSpan.FromSeconds(60)));
+                    m.AddStatMod(new StatMod(StatType.Str, "DreadHornStr", m.Str < Math.Abs(malas) ? m.Str / 2 : malas, TimeSpan.FromSeconds(60)));
+                    m.AddStatMod(new StatMod(StatType.Dex, "DreadHornDex", m.Dex < Math.Abs(malas) ? m.Dex / 2 : malas, TimeSpan.FromSeconds(60)));
+                    m.AddStatMod(new StatMod(StatType.Int, "DreadHornInt", m.Int < Math.Abs(malas) ? m.Int / 2 : malas, TimeSpan.FromSeconds(60)));
                 }
 
                 m.SendLocalizedMessage(1075081); // *Dreadhorns eyes light up, his mouth almost a grin, as he slams one hoof to the ground!*

--- a/Scripts/Services/Expansions/High Seas/Items/Fish/FishPies.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Fish/FishPies.cs
@@ -179,14 +179,17 @@ namespace Server.Items
             }
         }
 
-        public override void GetProperties(ObjectPropertyList list)
+        public override void AddCraftedProperties(ObjectPropertyList list)
         {
-            base.GetProperties(list);
-
             if (_Quality == ItemQuality.Exceptional)
             {
                 list.Add(1060636); // Exceptional
             }
+        }
+
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            base.GetProperties(list);
 
             list.Add(BuffName, BuffAmount.ToString());
         }

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Mobiles.cs
@@ -32,13 +32,9 @@ namespace Server.Engines.Shadowguard
             SetResistance(ResistanceType.Energy, 10, 20);
 
             SetSkill(SkillName.Anatomy, 125.0);
-            SetSkill(SkillName.Fencing, 46.0, 77.5);
-            SetSkill(SkillName.Macing, 35.0, 57.5);
-            SetSkill(SkillName.Poisoning, 60.0, 82.5);
             SetSkill(SkillName.MagicResist, 83.5, 92.5);
-            SetSkill(SkillName.Swords, 125.0);
+            SetSkill(SkillName.Wrestling, 125.0);
             SetSkill(SkillName.Tactics, 125.0);
-            SetSkill(SkillName.Lumberjacking, 125.0);
 
             Fame = 1000;
             Karma = -1000;

--- a/Scripts/Services/LootGeneration/RunicReforging/Gumps.cs
+++ b/Scripts/Services/LootGeneration/RunicReforging/Gumps.cs
@@ -23,6 +23,7 @@ namespace Server.Gumps
 
         PowerfulAndStructural = Powerful | Structural,
         PowerfulAndFundamental = Powerful | Fundamental,
+        StructuralAndFundamental = Structural | Fundamental,
         PowerfulStructuralAndFundamental = PowerfulAndStructural | Fundamental
     }
 
@@ -287,29 +288,17 @@ namespace Server.Gumps
 
                             int min = 10;
                             int max = 80;
-                            int maxprops = 5;
-
-                            if (attrs != null)
-                            {
-                                min = attrs.RunicMinIntensity;
-                                max = attrs.RunicMaxIntensity;
-
-                                maxprops = Utility.RandomMinMax(attrs.RunicMinAttributes, attrs.RunicMaxAttributes);
-                            }
 
                             if (min < 10) min = 10;
                             if (max > 100) max = 100;
 
-                            int budget = GetBudget(ref maxprops);
+                            int budget = GetBudget();
                             
                             ReforgedPrefix prefix = ReforgedPrefix.None;
                             ReforgedSuffix suffix = ReforgedSuffix.None;
 
                             if ((m_Options & ReforgingOption.GrandArtifice) != 0)
                             {
-                                if (0.2 > Utility.RandomDouble())
-                                    maxprops++;
-
                                 // choosing name 1
                                 if ((m_Options & ReforgingOption.InspiredArtifice) != 0)
                                 {
@@ -376,7 +365,7 @@ namespace Server.Gumps
                                 suffix = (ReforgedSuffix)pre;
                             }
 
-                            RunicReforging.ApplyReforgedProperties(m_ToReforge, prefix, suffix, budget, min, max, maxprops, 0, m_Tool, m_Options);
+                            RunicReforging.ApplyReforgedProperties(m_ToReforge, prefix, suffix, budget, min, max, RunicReforging.GetPropertyCount(m_Tool), 0, m_Tool, m_Options);
 
                             OnAfterReforged(m_ToReforge);
                             from.SendLocalizedMessage(1152286); // You re-forge the item!
@@ -434,7 +423,7 @@ namespace Server.Gumps
             }
         }
 
-        private int GetBudget(ref int maxprops)
+        private int GetBudget()
         {
             int budget;
 
@@ -532,6 +521,10 @@ namespace Server.Gumps
             private ReforgedSuffix m_Suffix;
             private bool m_IsPrefix;
 
+            private static int White = 0x6F7B;
+            private static int Green = 0x4BB2;
+            private static int Yellow = 0x6B55;
+
             public ItemNameGump(Item toreforge, BaseRunicTool tool, ReforgingOption options, ReforgedPrefix prefix, ReforgedSuffix suffix, bool isprefix)
                 : base(100, 100)
             {
@@ -558,12 +551,12 @@ namespace Server.Gumps
                     if ((isprefix && prefix == (ReforgedPrefix)i) || (!isprefix && suffix == (ReforgedSuffix)i))
                     {
                         buttonID = 4006;
-                        buttonHue = 0x7652;
+                        buttonHue = Green;
                     }
                     else
                     {
                         buttonID = 4005;
-                        buttonHue = 0x4BB2;
+                        buttonHue = White;
                     }
 
                     if (RunicReforging.HasSelection(i, toreforge, tool, m_Options, (int)m_Prefix, (int)m_Suffix))
@@ -572,7 +565,7 @@ namespace Server.Gumps
                     }
                     else
                     {
-                        buttonHue = 0x7652;
+                        buttonHue = Yellow;
                     }
 
                     AddHtmlLocalized(55, y, 250, 20, RunicReforging.GetName(i), buttonHue, false, false);
@@ -580,7 +573,7 @@ namespace Server.Gumps
                     y += 25;
                 }
 
-                AddHtmlLocalized(45, 412, 100, 20, 1060675, 0x6F7B, false, false);
+                AddHtmlLocalized(45, 412, 100, 20, 1060675, White, false, false);
                 AddButton(10, 412, 4017, 4019, 0, GumpButtonType.Reply, 0);
             }
 

--- a/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
@@ -345,102 +345,334 @@ namespace Server.Items
                 return false;
 
             // Cannot choose same suffix/prefix
-            if (index != 0 && (index == prefix || index == suffix))
-                return false;
+            //if (index != 0 && (index == prefix || index == suffix))
+            //    return false;HasOption(options, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulAndFundamental)
 
-            switch (tool.Resource)
+            var type = ItemPropertyInfo.GetItemType(toreforge);
+
+            if (type == ItemType.Melee)
             {
-                default:
-                case CraftResource.DullCopper:
-                    {
-                        if ((index == 10 || index == 11) && (options & ReforgingOption.Powerful) != 0 &&
-                                                            (options & ReforgingOption.Fundamental) != 0)
+                switch (tool.Resource)
+                {
+                    case CraftResource.DullCopper:
+                        if (index == 8 && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
                             return false;
-                    }
-                    break;
-                case CraftResource.ShadowIron:
-                case CraftResource.SpinedLeather:
-                case CraftResource.OakWood:
-                    {
-                        if ((index == 10 || index == 11) && ((options & ReforgingOption.Structural) != 0 ||
-                                                             (options & ReforgingOption.Fundamental) != 0))
+                        break;
+                    case CraftResource.ShadowIron:
+                        if (index == 8 && HasOption(options, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental))
                             return false;
+                        else if (index >= 8 && index <= 10 && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Copper:
+                        if (index == 8 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental))
+                            return false;
+                        if (index >= 8 && index <= 10 && HasOption(options, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Bronze:
+                        if (index == 8)
+                            return false;
+                        if (index == 9 && HasOption(options, ReforgingOption.Powerful))
+                            return false;
+                        if (index >= 8 && index <= 10 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Gold:
+                        if (index == 8)
+                            return false;
+                        if (index >= 8 && index <= 10 && HasOption(options, ReforgingOption.Powerful, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Agapite:
+                    case CraftResource.Verite:
+                        if (index >= 8 && index <= 10)
+                            return false;
+                        if (index == 12 && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Valorite:
+                        if (index >= 8 && index <= 10)
+                            return false;
+                        if (index == 12 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
 
-                        if (index == 5 && (options & ReforgingOption.Powerful) != 0 &&
-                                          (options & ReforgingOption.Fundamental) != 0)
+                    case CraftResource.OakWood:
+                        if (index == 8 && HasOption(options, ReforgingOption.StructuralAndFundamental))
                             return false;
+                        if (index >= 8 && index <= 10 && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.AshWood:
+                        if (index == 8)
+                            return false;
+                        if (index >= 8 && index <= 10 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.YewWood:
+                        if (index >= 8 && index <= 10)
+                            return false;
+                        if (index == 12 && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Heartwood:
+                        if (index >= 8 && index <= 10)
+                            return false;
+                        if (index == 12 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                }
+            }
+            else if (type == ItemType.Ranged)
+            {
+                switch (tool.Resource)
+                {
+                    case CraftResource.OakWood:
+                        if (index == 10 && HasOption(options, ReforgingOption.PowerfulAndStructural))
+                            return false;
+                        if ((index == 8 || index == 10) && HasOption(options, ReforgingOption.PowerfulAndFundamental))
+                            return false;
+                        if (index >= 8 && index <= 10 && (HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental) || HasOption(options, ReforgingOption.StructuralAndFundamental)))
+                            return false;
+                        break;
+                    case CraftResource.AshWood:
+                        if (index == 8 || index == 10)
+                            return false;
+                        if (index >= 8 && index <= 10 && HasOption(options, ReforgingOption.PowerfulAndStructural))
+                            return false;
+                        if (index >= 8 && index <= 11 && HasOption(options, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental)) 
+                            return false;
+                        break;
+                    case CraftResource.YewWood:
+                        if (index >= 8 && index <= 11)
+                            return false;
+                        break;
+                    case CraftResource.Heartwood:
+                        if (index >= 8 && index <= 11)
+                            return false;
+                        if (index == 12 && HasOption(options, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                }
+            }
+            else if (type == ItemType.Shield)
+            {
+                if (index == 10)
+                    return false;
 
-                        return true;
-                    }
-                case CraftResource.Copper:
-                case CraftResource.HornedLeather:
-                case CraftResource.AshWood:
-                    {
+                switch (tool.Resource)
+                {
+                    case CraftResource.DullCopper:
+                        if (index == 8 && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.ShadowIron:
+                        if (index == 8 && HasOption(options, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental))
+                            return false;
+                        if ((index == 8 || index == 9) && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Copper:
+                        if (index == 8 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental))
+                            return false;
+                        else if ((index == 8 || index == 9) && HasOption(options, ReforgingOption.StructuralAndFundamental))
+                            return false;
+                        else if ((index == 5 || index == 8 || index == 9) && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Bronze:
+                        if (index == 8)
+                            return false;
+                        else if (index == 9 && HasOption(options, ReforgingOption.PowerfulAndStructural))
+                            return false;
+                        else if ((index == 9 || index == 5) && HasOption(options, ReforgingOption.PowerfulAndFundamental))
+                            return false;
+                        else if ((index == 9 || index == 5 || index == 11) && HasOption(options, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Gold:
+                        if (index == 8)
+                            return false;
+                        else if (index == 9 && HasOption(options, ReforgingOption.Powerful))
+                            return false;
+                        else if ((index == 5 || index == 9) && HasOption(options, ReforgingOption.PowerfulAndStructural))
+                            return false;
+                        else if ((index == 9 || index == 5 || index == 11) && HasOption(options, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Agapite:
+                        if (index == 8 || index == 9)
+                            return false;
+                        else if ((index == 5 || index == 11) && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Verite:
+                    case CraftResource.Valorite:
+                        if (index == 8 || index == 9 || index == 11)
+                            return false;
+                        else if (index == 5 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+
+                    case CraftResource.OakWood:
+                        if (index == 8 && HasOption(options, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental))
+                            return false;
+                        if ((index == 8 || index == 9) && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.AshWood:
+                        if (index == 8)
+                            return false;
+                        else if (index == 9 && HasOption(options, ReforgingOption.PowerfulAndStructural))
+                            return false;
+                        else if ((index == 9 || index == 5) && HasOption(options, ReforgingOption.PowerfulAndFundamental))
+                            return false;
+                        else if ((index == 9 || index == 5 || index == 11) && HasOption(options, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.YewWood:
+                        if (index == 8 || index == 9)
+                            return false;
+                        else if ((index == 5 || index == 11) && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Heartwood:
+                        if (index == 8 || index == 9 || index == 11)
+                            return false;
+                        else if (index == 5 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                }
+            }
+            else if (type == ItemType.Armor)
+            {
+                switch (tool.Resource)
+                {
+                    case CraftResource.DullCopper:
+                        if ((index == 10 || index == 11) && HasOption(options, ReforgingOption.PowerfulAndFundamental))
+                            return false;
+                        else if ((index == 5 || index == 10 || index == 11) && HasOption(options, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.ShadowIron:
+                        if ((index == 10 || index == 11) && HasOption(options, ReforgingOption.PowerfulAndStructural))
+                            return false;
+                        else if ((index == 5 || index == 10 || index == 11) && HasOption(options, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental))
+                            return false;
+                        else if ((index == 5 || index == 9 || index == 10 || index == 11) && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Copper:
                         if (index == 10 || index == 11)
                             return false;
-
-                        if (index == 5 && ((options & ReforgingOption.Structural) != 0 ||
-                                           (options & ReforgingOption.Fundamental) != 0))
+                        else if (index == 5 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental))
                             return false;
-
-                        if (index == 9 && (options & ReforgingOption.Fundamental) != 0)
+                        else if ((index == 5 || index == 9) && HasOption(options, ReforgingOption.StructuralAndFundamental))
                             return false;
-
-                        if (index == 12 && tool.Resource == CraftResource.Copper && (options & ReforgingOption.Structural) != 0 &&
-                                                                                    (options & ReforgingOption.Fundamental) != 0)
+                        else if ((index == 5 || index == 9 || index == 5) && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
                             return false;
-
-                        if (index == 12 && (options & ReforgingOption.Structural) != 0 &&
-                                           (options & ReforgingOption.Fundamental) != 0)
-                            return false;
-                    }
-                    break;
-                case CraftResource.Bronze:
-                case CraftResource.Gold:
-                    {
+                        break;
+                    case CraftResource.Bronze:
                         if (index == 10 || index == 11)
                             return false;
-
-                        if ((index == 5 || index == 9) && (options & ReforgingOption.Powerful) != 0 &&
-                                                          (options & ReforgingOption.Structural) != 0)
+                        else if ((index == 5 || index == 9) && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental))
                             return false;
-
-                        if (index == 5 && (options & ReforgingOption.Structural) != 0)
+                        else if ((index == 5 || index == 9 || index == 12) && HasOption(options, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
                             return false;
-
-                        if (index == 12 && (options & ReforgingOption.Structural) != 0 &&
-                                            (options & ReforgingOption.Fundamental) != 0)
+                        break;
+                    case CraftResource.Gold:
+                        if (index == 10 || index == 11)
                             return false;
-                    }
-                    break;
-                case CraftResource.Agapite:
-                case CraftResource.YewWood:
-                    {
+                        else if (index == 9 && HasOption(options, ReforgingOption.Powerful))
+                            return false;
+                        else if ((index == 5 || index == 9 || index == 12) && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Agapite:
+                        if (index >= 9 && index <= 11)
+                            return false;
+                        else if (index == 12 && HasOption(options, ReforgingOption.Powerful))
+                            return false;
+                        else if ((index == 12 || index == 5) && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.Verite:
+                    case CraftResource.Valorite:
+                        if (index >= 9 && index <= 12)
+                            return false;
+                        else if (index == 5 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+
+                    case CraftResource.SpinedLeather:
+                        if ((index == 10 || index == 11) && HasOption(options, ReforgingOption.PowerfulAndStructural))
+                            return false;
+                        else if ((index == 10 || index == 11 || index == 5) && HasOption(options, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental))
+                            return false;
+                        else if ((index == 9 || index == 10 || index == 11 || index == 5) && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.HornedLeather:
+                        if (index == 10 || index == 11)
+                            return false;
+                        else if (index == 9 && HasOption(options, ReforgingOption.Powerful))
+                            return false;
+                        else if ((index == 5 || index == 9 || index == 12) && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.BarbedLeather:
+                        if (index >= 9 && index <= 12)
+                            return false;
+                        else if (index == 5 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+
+                    case CraftResource.OakWood:
+                        if ((index == 10 || index == 11) && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental))
+                            return false;
+                        else if (index == 9 && HasOption(options, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.AshWood:
+                        if (index == 10 || index == 11)
+                            return false;
+                        else if ((index == 5 || index == 9) && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental))
+                            return false;
+                        else if ((index == 5 || index == 9 || index == 12) && HasOption(options, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
+                            return false;
+                        break;
+                    case CraftResource.YewWood:
                         if (index == 9 || index == 10 || index == 11)
                             return false;
-
-                        if (index == 12 && (options & ReforgingOption.Powerful) != 0)
+                        else if (index == 12 && HasOption(options, ReforgingOption.Powerful))
                             return false;
-
-                        if ((index == 5 || index == 12) && (options & ReforgingOption.Structural) != 0)
+                        else if ((index == 5 || index == 12) && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
                             return false;
-                    }
-                    break;
-                case CraftResource.Heartwood:
-                case CraftResource.Verite:
-                case CraftResource.BarbedLeather:
-                case CraftResource.Valorite:
-                    {
-                        if (index == 9 || index == 10 || index == 11 || index == 12)
+                        break;
+                    case CraftResource.Heartwood:
+                        if (index >= 9 && index <= 12)
                             return false;
-
-                        if (index == 5 && (options & ReforgingOption.Structural) != 0)
+                        else if (index == 5 && HasOption(options, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndStructural, ReforgingOption.PowerfulAndFundamental, ReforgingOption.StructuralAndFundamental, ReforgingOption.PowerfulStructuralAndFundamental))
                             return false;
-                    }
-                    break;
+                        break;
+                }
             }
 
             return true;
+        }
+
+        public static bool HasOption(ReforgingOption options, params ReforgingOption[] optionArray)
+        {
+            foreach (var option in optionArray)
+            {
+                if ((options & option) == option)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static void CheckAttributes(Item item, List<NamedInfoCol> list, bool reforged)
@@ -514,6 +746,32 @@ namespace Server.Items
 
             if (suffixCount > suffixcolcount)
                 suffixCount = suffixcolcount;
+        }
+
+        public static int GetPropertyCount(BaseRunicTool tool)
+        {
+            switch (tool.Resource)
+            {
+                case CraftResource.DullCopper:
+                case CraftResource.ShadowIron: return Utility.RandomMinMax(1, 2);
+                case CraftResource.Copper: return Utility.RandomMinMax(2, 3);
+                case CraftResource.Bronze:
+                case CraftResource.Gold: return 3;
+                case CraftResource.Agapite:
+                case CraftResource.Verite: return Utility.RandomMinMax(3, 4);
+                case CraftResource.Valorite: return 5;
+
+                case CraftResource.SpinedLeather: return Utility.RandomMinMax(1, 2);
+                case CraftResource.HornedLeather: return 3;
+                case CraftResource.BarbedLeather: return 5;
+
+                case CraftResource.OakWood: return Utility.RandomMinMax(1, 2);
+                case CraftResource.AshWood: return 2;
+                case CraftResource.YewWood: return 3;
+                case CraftResource.Heartwood: return 5;
+            }
+
+            return 1;
         }
 
         private static bool ApplyPrefixSuffixAttribute(Item item, NamedInfoCol col, int resIndex, int preIndex, int percLow, int percHigh, ref int budget, int luckchance, bool reforged, bool powerful)
@@ -812,14 +1070,14 @@ namespace Server.Items
                 case CraftResource.Verite:
                 case CraftResource.Valorite:
                 case CraftResource.Copper: return 2;
-                case CraftResource.HornedLeather:
-                case CraftResource.BarbedLeather:
                 case CraftResource.SpinedLeather: return 3;
                 case CraftResource.OakWood: return 4;
                 case CraftResource.YewWood:
                 case CraftResource.Heartwood:
                 case CraftResource.Bloodwood:
                 case CraftResource.Frostwood:
+                case CraftResource.HornedLeather:
+                case CraftResource.BarbedLeather:
                 case CraftResource.AshWood: return 5;
             }
         }
@@ -1266,34 +1524,31 @@ namespace Server.Items
                 HardCap = hardcap;
             }
 
-            public int RandomRangedIntensity(Item item, int resIndex, int preIndex)
+            public int RandomRangedIntensity(Item item, int id, int resIndex, int preIndex)
             {
                 int[] range = item is BaseRanged && SecondaryInfo != null ? SecondaryInfo[resIndex] : Info[resIndex];
 
-                if (preIndex == 0)
+                var max = range[preIndex];
+                var min = Math.Max(ItemPropertyInfo.GetMinIntensity(item, id), (int)((double)range[0] * .75));
+                int value;
+
+                if (Utility.RandomBool())
                 {
-                    return range[0];
+                    value = Utility.RandomBool() ? min : max;
+                }
+                else
+                {
+                    value = Utility.RandomMinMax(min, max);
                 }
 
-                if (preIndex == 1)
+                var scale = ItemPropertyInfo.GetScale(item, id);
+
+                if (scale > 1 && value > scale)
                 {
-                    return Utility.RandomBool() ? range[0] : range[1];
+                    value = (value / scale) * scale;
                 }
 
-                // EA seems to favor the minimum and the maximum intensity equally, while fucking everything in the middle. Sounds like the government!
-                int[] weightedRange;
-
-                switch (preIndex)
-                {
-                    default: weightedRange = range; break;
-                    case 2: weightedRange = new int[] { range[0], range[0], range[1], range[2], range[2] }; break;
-                    case 3: weightedRange = new int[] { range[0], range[0], range[1], range[2], range[3], range[3] }; break;
-                    case 4: weightedRange = new int[] { range[0], range[0], range[1], range[2], range[3], range[4], range[4] }; break;
-                    case 5: weightedRange = new int[] { range[0], range[0], range[0], range[1], range[2], range[3], range[4], range[5], range[5], range[5] }; break;
-                    case 6: weightedRange = new int[] { range[0], range[0], range[0], range[1], range[2], range[3], range[4], range[5], range[6], range[6], range[6] }; break;
-                }
-
-                return weightedRange[Utility.Random(weightedRange.Length)];
+                return value;
             }
 
             public int Min(int resIndex, int preIndex, Item item)
@@ -2093,7 +2348,6 @@ namespace Server.Items
                 }
             }
 
-            Console.WriteLine("Should not reach this!");
             return 0;
         }
 
@@ -2422,7 +2676,7 @@ namespace Server.Items
 
         public static bool ApplyReforgedNameProperty(Item item, int id, NamedInfoCol info, int resIndex, int preIndex, int perclow, int perchigh, ref int budget, int luckchance, bool reforged, bool powerful)
         {
-            int value = info.RandomRangedIntensity(item, resIndex, preIndex);
+            int value = info.RandomRangedIntensity(item, id, resIndex, preIndex);
 
             Imbuing.SetProperty(item, id, value);
 
@@ -2745,6 +2999,29 @@ namespace Server.Items
             new int[] { 100, 120, 140, 150, 150, 150, 150 },
             new int[] { 150, 150, 150, 150, 150, 150, 150 },
         };
+
+        //30% LOW IN MIN
+        /* switch (resource)
+ {
+     default:
+     case CraftResource.DullCopper: return 0;
+     case CraftResource.ShadowIron: return 1;
+     case CraftResource.Bronze:
+     case CraftResource.Gold:
+     case CraftResource.Agapite:
+     case CraftResource.Verite:
+     case CraftResource.Valorite:
+     case CraftResource.Copper: return 2;
+     case CraftResource.SpinedLeather: return 3;
+     case CraftResource.OakWood: return 4;
+     case CraftResource.YewWood:
+     case CraftResource.Heartwood:
+     case CraftResource.Bloodwood:
+     case CraftResource.Frostwood:
+     case CraftResource.HornedLeather:
+     case CraftResource.BarbedLeather:
+     case CraftResource.AshWood: return 5;
+ }*/
 
         public static int[][] MageWeaponTable = new int[][]
         {

--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -1260,24 +1260,27 @@ namespace Server
         /// </summary>
         public virtual void AddLootTypeProperty(ObjectPropertyList list)
         {
-            Mobile blessedFor = BlessedFor;
+            if (DisplayLootType)
+            {
+                Mobile blessedFor = BlessedFor;
 
-            if (blessedFor != null && !blessedFor.Deleted)
-            {
-                AddBlessedForProperty(list, blessedFor);
-            }
+                if (blessedFor != null && !blessedFor.Deleted)
+                {
+                    AddBlessedForProperty(list, blessedFor);
+                }
 
-            if (m_LootType == LootType.Blessed)
-            {
-                list.Add(1038021); // blessed
-            }
-            else if (m_LootType == LootType.Cursed)
-            {
-                list.Add(1049643); // cursed
-            }
-            else if (Insured)
-            {
-                list.Add(1061682); // <b>insured</b>
+                if (m_LootType == LootType.Blessed)
+                {
+                    list.Add(1038021); // blessed
+                }
+                else if (m_LootType == LootType.Cursed)
+                {
+                    list.Add(1049643); // cursed
+                }
+                else if (Insured)
+                {
+                    list.Add(1061682); // <b>insured</b>
+                }
             }
         }
 
@@ -1344,26 +1347,6 @@ namespace Server
         }
 
         /// <summary>
-        ///     Overridable. Displays cliloc 1072788-1072789.
-        /// </summary>
-        public virtual void AddWeightProperty(ObjectPropertyList list)
-        {
-            if (Weight == 0)
-                return;
-
-            int weight = PileWeight + TotalWeight;
-
-            if (weight == 1)
-            {
-                list.Add(1072788, weight.ToString()); //Weight: ~1_WEIGHT~ stone
-            }
-            else
-            {
-                list.Add(1072789, weight.ToString()); //Weight: ~1_WEIGHT~ stones
-            }
-        }
-
-        /// <summary>
         ///     Overridable. Adds header properties. By default, this invokes <see cref="AddNameProperty" />,
         ///     <see
         ///         cref="AddBlessedForProperty" />
@@ -1385,21 +1368,43 @@ namespace Server
                 AddLockedDownProperty(list);
             }
 
-            if (DisplayLootType)
-            {
-                AddLootTypeProperty(list);
-            }
-
-            if (DisplayWeight)
-            {
-                AddWeightProperty(list);
-            }
+            AddCraftedProperties(list);
+            AddLootTypeProperty(list);
+            AddWeightProperty(list);
 
             AppendChildNameProperties(list);
 
             if (QuestItem)
             {
                 AddQuestItemProperty(list);
+            }
+        }
+
+        /// <summary>
+        /// Overrideable, used to add crafted by, excpetional, etc properties to items
+        /// </summary>
+        /// <param name="list"></param>
+        public virtual void AddCraftedProperties(ObjectPropertyList list)
+        {
+        }
+
+        /// <summary>
+        ///     Overridable. Displays cliloc 1072788-1072789.
+        /// </summary>
+        public virtual void AddWeightProperty(ObjectPropertyList list)
+        {
+            if (DisplayWeight && Weight > 0)
+            {
+                int weight = PileWeight + TotalWeight;
+
+                if (weight == 1)
+                {
+                    list.Add(1072788, weight.ToString()); //Weight: ~1_WEIGHT~ stone
+                }
+                else
+                {
+                    list.Add(1072789, weight.ToString()); //Weight: ~1_WEIGHT~ stones
+                }
             }
         }
 


### PR DESCRIPTION
- More property adjustments. We may have it right this time! Needs core recompile...
- Runic Reforging options/runic kit will now remove the proper named prefix/suffix per EA
- Bumped horned/barbed runic kits to the higher end intensity roll. These seem to jive with most tests on EA
- Reforging minimum intensity for named properties no longer go from the tables, they are 75% of max. This seems to hold up on all EA tests
- Crafting items that use all resources now only consume 1 on fail. successful craft will also send a spell gain check for each item crafted.
- Fightmode ranking will always choose a pet over a player in the even of a tie
- Fixed issue wehre dread horn was moving stats to 1 if they were too Low
- Reduced shadowguard pirate skills, hopefully they become easier bardable