### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Services/City Loyalty System/Trading/DonationCrate.cs
+++ b/Scripts/Services/City Loyalty System/Trading/DonationCrate.cs
@@ -128,7 +128,7 @@ namespace Server.Engines.CityLoyalty
                 {
                     system.AddToTreasury(null, cargo.GetAwardAmount() * 1000);
                 }
-                else;
+                else
                 {
                     system.AddToTreasury(null, 100);
                 }

--- a/Scripts/Services/Craft/DefAlchemy.cs
+++ b/Scripts/Services/Craft/DefAlchemy.cs
@@ -287,7 +287,6 @@ namespace Server.Engines.Craft
 
                 index = AddCraft(typeof(FuseCord), 1116351, 1116305, 55.0, 105.0, typeof(DarkYarn), 1023615, 1, 1044253);
                 AddRes(index, typeof(BlackPowder), 1095826, 1, 1044253);
-                AddRes(index, typeof(DarkYarn), 1023613, 1, 1044253);
                 AddRes(index, typeof(Potash), 1116319, 1, 1044253);
                 SetNeedWater(index, true);
             }

--- a/Scripts/Services/Expansions/High Seas/Items/Cannons and Ammo/Cannon.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Cannons and Ammo/Cannon.cs
@@ -1410,6 +1410,8 @@ namespace Server.Items
                         {
                             m_Galleon.GalleonHold.DropItem(deed);
                         }
+
+                        newCannon.Delete();
                     }
                 }
             }

--- a/Scripts/Services/Expansions/High Seas/Items/Cannons and Ammo/ShipCannon.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Cannons and Ammo/ShipCannon.cs
@@ -885,8 +885,9 @@ namespace Server.Items
 			
 			if(pack == null)
 				return;
-			
-			double ingotsNeeded = 36 * (100 - Durability);
+
+            //double ingotsNeeded = 36 * (100 - Durability);
+            double ingotsNeeded = 36 * (int)DamageState;
 
             ingotsNeeded -= ((double)from.Skills[SkillName.Blacksmith].Value / 200.0) * ingotsNeeded;
 

--- a/Scripts/Services/Expansions/High Seas/Multis/BaseGalleon.cs
+++ b/Scripts/Services/Expansions/High Seas/Multis/BaseGalleon.cs
@@ -159,7 +159,7 @@ namespace Server.Multis
         public virtual int CaptiveOffset { get { return 0; } }
         public virtual double CannonDamageMod { get { return 1.0; } }
         public virtual int MaxHits { get { return 100; } }
-        public virtual double ScuttleLevel { get { return 33.0; } }
+        public virtual double ScuttleLevel { get { return 25.0; } }
         public virtual int RuneOffset { get { return 0; } }
         public virtual int ZSurface { get { return 0; } }
 
@@ -645,14 +645,17 @@ namespace Server.Multis
                         }
                     }
 
-                    TryAddCannon(captain, item.Location, cannon, null);
+                    if (!TryAddCannon(captain, item.Location, cannon, null))
+                    {
+                        cannon.Delete();
+                    }
                 }
             }
         }
 
-        public bool TryAddCannon(Mobile from, Point3D pnt, ShipCannonDeed deed)
+        public bool TryAddCannon(Mobile from, Point3D pnt, ShipCannonDeed deed, bool force = false)
         {
-            if (!IsNearLandOrDocks(this))
+            if (!IsNearLandOrDocks(this) && !force)
             {
                 if (from != null)
                 {

--- a/Scripts/Services/Expansions/High Seas/Spawners/BountyQuestSpawner.cs
+++ b/Scripts/Services/Expansions/High Seas/Spawners/BountyQuestSpawner.cs
@@ -499,26 +499,6 @@ namespace Server.Engines.Quests
                     hold.DropItem(steaks);
                 }
 
-                /*if (0.10 > Utility.RandomDouble())
-                {
-                    Item item = null;
-                    switch (Utility.Random(6))
-                    {
-                        case 0: item = new LightScatterShot(); break;
-                        case 1: item = new HeavyScatterShot(); break;
-                        case 2: item = new LightFragShot(); break;
-                        case 3: item = new HeavyFragShot(); break;
-                        case 4: item = new LightHotShot(); break;
-                        case 5: item = new HeavyHotShot(); break;
-                    }
-
-                    if (item != null)
-                    {
-                        item.Amount = Utility.RandomMinMax(2, 10);
-                        hold.DropItem(item);
-                    }
-                }*/
-
                 hold.DropItem(new Gold(Utility.RandomMinMax(5000, 25000)));
 
                 if (0.50 > Utility.RandomDouble())
@@ -663,10 +643,32 @@ namespace Server.Engines.Quests
                 //Rares
                 if (0.8 > Utility.RandomDouble())
                 {
+                    Item deed;
+
                     if (Utility.RandomBool())
-                        hold.DropItem(new HeavyShipCannonDeed());
+                    {
+                        if (Core.EJ)
+                        {
+                            deed = new CarronadeDeed();
+                        }
+                        else
+                        {
+                            deed = new HeavyShipCannonDeed();
+                        }
+                    }
                     else
-                        hold.DropItem(new LightShipCannonDeed());
+                    {
+                        if (Core.EJ)
+                        {
+                            deed = new CulverinDeed();
+                        }
+                        else
+                        {
+                            deed = new LightShipCannonDeed();
+                        }
+                    }
+
+                    hold.DropItem(deed);
                 }
 
                 if (0.025 > Utility.RandomDouble())
@@ -678,6 +680,23 @@ namespace Server.Engines.Quests
                 }
 
                 RefinementComponent.Roll(hold, 3, 0.25);
+
+                if (Server.Engines.Points.PointsSystem.RisingTide.Enabled)
+                {
+                    if (0.25 > Utility.RandomDouble())
+                    {
+                        hold.DropItem(new MaritimeCargo());
+
+                        if (0.1 > Utility.RandomDouble())
+                        {
+                            hold.DropItem(new MaritimeCargo());
+                        }
+                    }
+                    else if (0.25 > Utility.RandomDouble())
+                    {
+                        hold.DropItem(new MaritimeCargo());
+                    }
+                }
             }
         }
 

--- a/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
@@ -1938,7 +1938,7 @@ namespace Server.SkillHandlers
 
         public static int GetIntensityForAttribute(Item item, object attr, int checkID, int value)
         {
-            return GetIntensityForAttribute(item, ItemPropertyInfo.GetID(attr), checkID, value, true);
+            return GetIntensityForAttribute(item, attr, checkID, value, true);
         }
 
         public static int GetIntensityForAttribute(Item item, object attr, int checkID, int value, bool imbuingWeight)

--- a/Scripts/Services/Seasonal Events/RisingTide/PlunderBeaconAddon.cs
+++ b/Scripts/Services/Seasonal Events/RisingTide/PlunderBeaconAddon.cs
@@ -88,6 +88,11 @@ namespace Server.Items
                     cannon = new MannedBlundercannon(mob, d); break;
             }
 
+            if (mob == null)
+            {
+                cannon.CanFireUnmanned = true;
+            }
+
             cannon.MoveToWorld(new Point3D(X + xOffset, Y + yOffset, Z + zOffset), Map);
             Cannons.Add(cannon);
 
@@ -181,6 +186,23 @@ namespace Server.Items
             }
         }
 
+        public override void OnSectorActivate()
+        {
+            if (Timer == null)
+            {
+                Timer = Timer.DelayCall(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), OnTick);
+            }
+        }
+
+        public override void OnSectorDeactivate()
+        {
+            if (Timer != null && SpawnCount() >= MaxSpawn)
+            {
+                Timer.Stop();
+                Timer = null;
+            }
+        }
+
         public void OnTick()
         {
             var map = Map;
@@ -191,7 +213,7 @@ namespace Server.Items
             }
             else if (CannonsOperational && NextShoot < DateTime.UtcNow)
             {
-                foreach (var cannon in Cannons)
+                foreach (var cannon in Cannons.Where(c => c.CanFireUnmanned || (c.Operator != null && !c.Operator.Deleted && c.Operator.Alive)))
                 {
                     cannon.Scan(true);
                 }
@@ -201,7 +223,7 @@ namespace Server.Items
 
             if (NextSpawn < DateTime.UtcNow)
             {
-                if (Spawn.Where(s => s.Alive).Count() < MaxSpawn)
+                if (SpawnCount() < MaxSpawn)
                 {
                     Point3D p = Location;
                     var range = 15;
@@ -237,6 +259,11 @@ namespace Server.Items
                     creature.Delete();
                 }
             }
+        }
+
+        private int SpawnCount()
+        {
+            return Spawn.Where(s => s.Alive).Count();
         }
 
         private Type[] _SpawnTypes =

--- a/Scripts/Services/Seasonal Events/RisingTide/PlunderBeaconAddon.cs
+++ b/Scripts/Services/Seasonal Events/RisingTide/PlunderBeaconAddon.cs
@@ -213,7 +213,7 @@ namespace Server.Items
             }
             else if (CannonsOperational && NextShoot < DateTime.UtcNow)
             {
-                foreach (var cannon in Cannons.Where(c => c.CanFireUnmanned || (c.Operator != null && !c.Operator.Deleted && c.Operator.Alive)))
+                foreach (var cannon in Cannons.Where(c => c != null && !c.Deleted && (c.CanFireUnmanned || (c.Operator != null && !c.Operator.Deleted && c.Operator.Alive))))
                 {
                     cannon.Scan(true);
                 }

--- a/Scripts/Services/Seasonal Events/RisingTide/RisingTideData.cs
+++ b/Scripts/Services/Seasonal Events/RisingTide/RisingTideData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Server;
 using Server.Items;
@@ -37,13 +38,40 @@ namespace Server.Engines.Points
                 var bc = victim as BaseCreature;
                 var beacon = GetPlunderBeaconAt(bc);
 
-                if (beacon != null && CargoChance > Utility.RandomDouble())
+                if (beacon != null)
                 {
-                    damager.AddToBackpack(new MaritimeCargo());
-                    damager.SendLocalizedMessage(1158907); // You recover maritime trade cargo!
+                    if (CargoChance > Utility.RandomDouble())
+                    {
+                        damager.AddToBackpack(new MaritimeCargo());
+                        damager.SendLocalizedMessage(1158907); // You recover maritime trade cargo!
+                    }
+                }
+                else if (CargoDropsTypes.Any(type => type == bc.GetType()))
+                {
+                    double chance = 0.1;
+
+                    if (bc is BaseShipCaptain)
+                    {
+                        chance = 0.33;
+                    }
+
+                    if (chance > Utility.RandomDouble())
+                    {
+                        var corpse = victim.Corpse;
+
+                        if (corpse != null)
+                        {
+                            corpse.DropItem(new MaritimeCargo());
+                        }
+                    }
                 }
             }
         }
+
+        private Type[] CargoDropsTypes =
+        {
+            typeof(PirateCaptain), typeof(MerchantCaptain), typeof(PirateCrew), typeof(MerchantCrew)
+        };
 
         public static PlunderBeaconAddon GetPlunderBeaconAt(IEntity e)
         {

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/GoingGumshoeQuest.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/GoingGumshoeQuest.cs
@@ -269,7 +269,11 @@ namespace Server.Engines.Khaldun
             AddReward(new BaseReward(1158615)); // A unique opportunity with the Detective Branch
 
             AddObjective(new InternalObjective());
-            BookCase = GetBookcase();
+
+            if (!World.Loading)
+            {
+                BookCase = GetBookcase();
+            }
         }
 
         private LibraryBookcase GetBookcase()
@@ -304,21 +308,29 @@ namespace Server.Engines.Khaldun
             {
                 var quest = QuestHelper.GetQuest<GoingGumshoeQuest3>((PlayerMobile)from);
 
-                if (quest != null && !quest.FoundCipherBook && item == quest.BookCase)
+                if (quest != null && !quest.FoundCipherBook)
                 {
-                    quest.FoundCipherBook = true;
-
-                    from.PrivateOverheadMessage(Server.Network.MessageType.Regular, 0x47E, 1158713, from.NetState);
-                    // *You find the cipher text hidden among the books! Return to the Cryptologist to tell him where it is!*
-
-                    var region = Region.Find(from.Location, from.Map);
-
-                    if (region is QuestRegion)
+                    if (quest.BookCase == null)
                     {
-                        ((QuestRegion)region).ClearFromMessageTable(from);
+                        quest.BookCase = quest.GetBookcase();
                     }
 
-                    return true;
+                    if (item == quest.BookCase)
+                    {
+                        quest.FoundCipherBook = true;
+
+                        from.PrivateOverheadMessage(Server.Network.MessageType.Regular, 0x47E, 1158713, from.NetState);
+                        // *You find the cipher text hidden among the books! Return to the Cryptologist to tell him where it is!*
+
+                        var region = Region.Find(from.Location, from.Map);
+
+                        if (region is QuestRegion)
+                        {
+                            ((QuestRegion)region).ClearFromMessageTable(from);
+                        }
+
+                        return true;
+                    }
                 }
             }
 
@@ -353,6 +365,11 @@ namespace Server.Engines.Khaldun
             BookCase = reader.ReadItem();
             FoundCipherBook = reader.ReadBool();
             BegunDecrypting = reader.ReadBool();
+
+            if (BookCase == null)
+            {
+                Timer.DelayCall(() => GetBookcase());
+            }
         }
 
         private class InternalObjective : BaseObjective


### PR DESCRIPTION
*Existing Blunderbeacons will need to be deleted/destroyed prior to changes taking effect*

- Fixed issue where bods weren't caching correctly
- Removed additional yarn from crafting fuse cord
- Reduced ingot cost to repairing Cannons
- Added chance of maritime Cargo to pirate/merchant crews as well as their galleon holds
- Plunderbeacon cannons no longer fire if their operator is killed (North/South facing only). The east/west facing will continue to fire (as they have no visible operators) as long as any of the crew are alive
- Plunderbeacons now "deactivate" when no players are around, similiar to how AI on creatures deactivate
- Fixed erroneous going gumshoe quest message at server start