### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Addons/Harpsichord.cs
+++ b/Scripts/Items/Addons/Harpsichord.cs
@@ -183,7 +183,7 @@ namespace Server.Items
 
             BaseHouse house = BaseHouse.FindHouseAt(from);
 
-            if (house != null && (house.IsOwner(from) || (house.LockDowns.ContainsKey(this) && house.LockDowns[this] == from)))
+            if (house != null && (house.IsFriend(from) || (house.LockDowns.ContainsKey(this) && house.LockDowns[this] == from)))
             {
                 from.CloseGump(typeof(HarpsichordSongGump));
                 from.SendGump(new HarpsichordSongGump(List));

--- a/Scripts/Mobiles/NPCs/MysteriousWisp.cs
+++ b/Scripts/Mobiles/NPCs/MysteriousWisp.cs
@@ -291,7 +291,7 @@ namespace Server.Mobiles
                     }
                 }
 
-                m_ItemTable[item] = (int)((weight + Server.SkillHandlers.Imbuing.GetTotalWeight(item)) * 31.5);
+                m_ItemTable[item] = (int)((weight + Server.SkillHandlers.Imbuing.GetTotalWeight(item, -1, false, true)) * 31.5);
                 item.Movable = false;
                 this.Backpack.DropItem(item);
             }

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -2652,7 +2652,7 @@ namespace Server.Mobiles
 
         public int GetInsuranceCost(Item item)
         {
-            var imbueWeight = Imbuing.GetTotalWeight(item);
+            var imbueWeight = Imbuing.GetTotalWeight(item, -1, false, false);
             int cost = 600; // this handles old items, set items, etc
 
             if (item.GetType().IsAssignableFrom(typeof(Factions.FactionItem)))

--- a/Scripts/Services/Craft/Core/CraftGump.cs
+++ b/Scripts/Services/Craft/Core/CraftGump.cs
@@ -738,7 +738,6 @@ namespace Server.Engines.Craft
 
                                     break;
                                 }
-                            #region Stygian Abyss
                             case 9: // Alter Item (Gargoyle)
                                 {
                                     if (system.CanAlter)
@@ -775,7 +774,6 @@ namespace Server.Engines.Craft
                                     AutoCraftTimer.EndTimer(m_From);
                                     break;
                                 }
-                            #endregion
                         }
                         break;
                     }

--- a/Scripts/Services/LootGeneration/Imbuing/Core/ImbuingContext.cs
+++ b/Scripts/Services/LootGeneration/Imbuing/Core/ImbuingContext.cs
@@ -10,7 +10,6 @@ namespace Server
         public int Imbue_Mod { get; set; }
         public int Imbue_ModInt { get; set; }
         public int Imbue_ModVal { get; set; }
-        public int Imbue_SFBonus { get; set; }
         public int ImbMenu_Cat { get; set; }
         public int ImbMenu_ModInc { get; set; }
         public int Imbue_IWmax { get; set; }

--- a/Scripts/Services/LootGeneration/Imbuing/Gumps/ImbueGump.cs
+++ b/Scripts/Services/LootGeneration/Imbuing/Gumps/ImbueGump.cs
@@ -38,8 +38,9 @@ namespace Server.Gumps
 
         public override void AddGumpLayout()
         {
-            // SoulForge Check
-            if (!Imbuing.CheckSoulForge(User, 2))
+            double bonus = 0.0;
+
+            if (!Imbuing.CheckSoulForge(User, 2, out bonus))
                 return;
 
             ImbuingContext context = Imbuing.GetContext(User);
@@ -50,7 +51,7 @@ namespace Server.Gumps
             m_Info = ItemPropertyInfo.Table[m_ID];
 
             int minInt = ItemPropertyInfo.GetMinIntensity(m_Item, m_ID);
-            int maxInt = ItemPropertyInfo.GetMaxIntensity(m_Item, m_ID);
+            int maxInt = ItemPropertyInfo.GetMaxIntensity(m_Item, m_ID, true);
             int weight = m_Info.Weight;
 
             if (m_Value < minInt)
@@ -72,7 +73,7 @@ namespace Server.Gumps
             context.ImbMenu_ModInc = ItemPropertyInfo.GetScale(m_Item, m_ID);
 
             // Current Mod Weight
-            m_TotalItemWeight = Imbuing.GetTotalWeight(m_Item, m_ID);
+            m_TotalItemWeight = Imbuing.GetTotalWeight(m_Item, m_ID, false, true);
             m_TotalProps = Imbuing.GetTotalMods(m_Item, m_ID);
 
             if (maxInt <= 1)
@@ -160,10 +161,9 @@ namespace Server.Gumps
 
             // ===== CALCULATE DIFFICULTY =====
             var truePropWeight = (int)(((double)propWeight / (double)weight) * 100);
-            var trueTotalWeight = Imbuing.GetTotalWeight(m_Item, -1, false);
+            var trueTotalWeight = Imbuing.GetTotalWeight(m_Item, -1, false, true);
 
-            double dif;
-            double suc = Imbuing.GetSuccessChance(User, m_Item, trueTotalWeight, truePropWeight, out dif);
+            double suc = Imbuing.GetSuccessChance(User, m_Item, trueTotalWeight, truePropWeight, bonus);
 
             AddHtmlLocalized(300, 300, 150, 20, 1044057, 0xFFFFFF, false, false); // Success Chance:
             AddLabel(420, 300, GetSuccessChanceHue(suc), String.Format("{0}%", suc.ToString("0.0")));
@@ -305,21 +305,21 @@ namespace Server.Gumps
                     }
                 case 10054: // Increase Mod Value [>]
                     {
-                        m_Value = Math.Min(ItemPropertyInfo.GetMaxIntensity(m_Item, m_Info.ID), m_Value + 1);
+                        m_Value = Math.Min(ItemPropertyInfo.GetMaxIntensity(m_Item, m_Info.ID, true), m_Value + 1);
                         Refresh();
 
                         break;
                     }
                 case 10055: // Increase Mod Value [>>]
                     {
-                        m_Value = Math.Min(ItemPropertyInfo.GetMaxIntensity(m_Item, m_Info.ID), m_Value + 10);
+                        m_Value = Math.Min(ItemPropertyInfo.GetMaxIntensity(m_Item, m_Info.ID, true), m_Value + 10);
                         Refresh();
                         
                         break;
                     }
                 case 10056: // Maximum Mod Value [>>>]
                     {
-                        m_Value = ItemPropertyInfo.GetMaxIntensity(m_Item, m_Info.ID);
+                        m_Value = ItemPropertyInfo.GetMaxIntensity(m_Item, m_Info.ID, true);
                         Refresh();
                         
                         break;

--- a/Scripts/Services/LootGeneration/ItemPropertyInfo.cs
+++ b/Scripts/Services/LootGeneration/ItemPropertyInfo.cs
@@ -655,25 +655,26 @@ namespace Server.Items
             return 0;
         }
 
+        public static int GetMaxIntensity(Item item, object attribute)
+        {
+            return GetMaxIntensity(item, GetID(attribute), false);
+        }
+
         /// <summary>
         /// Maximum intensity in regards to imbuing weight calculation. Some items may be over this 'cap'
         /// </summary>
-        /// <param name="item"></param>
-        /// <param name="attribute"></param>
+        /// <param name="item">item to check</param>
+        /// <param name="id">property id</param>
+        /// <param name="imbuing">true for imbuing, false for loot</param>
         /// <returns></returns>
-        public static int GetMaxIntensity(Item item, object attribute)
-        {
-            return GetMaxIntensity(item, GetID(attribute));
-        }
-
-        public static int GetMaxIntensity(Item item, int id)
+        public static int GetMaxIntensity(Item item, int id, bool imbuing)
         {
             if (Table.ContainsKey(id))
             {
                 var info = Table[id].GetItemTypeInfo(GetItemType(item));
 
-                // First, we try to get the max intensity from the PropInfo. If null, we go to the default MaxIntenity
-                if (info == null)
+                // First, we try to get the max intensity from the PropInfo. If null or we're getting an intensity for imbuing purpopses, we go to the default MaxIntenity
+                if (info == null || imbuing)
                 {
                     if (Core.SA && item is BaseWeapon && (id == 25 || id == 27))
                     {
@@ -785,7 +786,7 @@ namespace Server.Items
         }
 
         /// <summary>
-        /// Gets teh associated attribute, ie AosAttribute, etc
+        /// Gets the associated attribute, ie AosAttribute, etc
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>

--- a/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
@@ -2385,7 +2385,7 @@ namespace Server.Items
                 return 0;
 
             int max = Imbuing.GetMaxWeight(item);
-            ItemPower power = GetItemPower(item, Imbuing.GetTotalWeight(item), Imbuing.GetTotalMods(item), false);
+            ItemPower power = GetItemPower(item, Imbuing.GetTotalWeight(item, -1, false, false), Imbuing.GetTotalMods(item), false);
             double chance = Utility.RandomDouble();
 
             if (item is BaseJewel && power >= ItemPower.MajorArtifact)
@@ -2556,7 +2556,7 @@ namespace Server.Items
 
         public static ItemPower ApplyItemPower(Item item, bool reforged)
         {
-            ItemPower ip = GetItemPower(item, Imbuing.GetTotalWeight(item), Imbuing.GetTotalMods(item), reforged);
+            ItemPower ip = GetItemPower(item, Imbuing.GetTotalWeight(item, -1, false, false), Imbuing.GetTotalMods(item), reforged);
 
             if (item is ICombatEquipment)
             {
@@ -2659,7 +2659,7 @@ namespace Server.Items
         public static bool ApplyProperty(Item item, int id, int perclow, int perchigh, ref int budget, int luckchance, bool reforged, bool powerful)
         {
             int min = ItemPropertyInfo.GetMinIntensity(item, id);
-            int naturalMax = ItemPropertyInfo.GetMaxIntensity(item, id);
+            int naturalMax = ItemPropertyInfo.GetMaxIntensity(item, id, false);
             int max = naturalMax;
             int[] overcap = null;
 

--- a/Scripts/Skills/ItemIdentification.cs
+++ b/Scripts/Skills/ItemIdentification.cs
@@ -91,7 +91,7 @@ namespace Server.Items
                         }
                         else
                         {
-                            int weight = Imbuing.GetTotalWeight(item);
+                            int weight = Imbuing.GetTotalWeight(item, -1, false, true);
                             string imbIngred = null;
                             double skill = from.Skills[SkillName.Imbuing].Base;
                             bool badSkill = false;


### PR DESCRIPTION
Imbuing success now gives the proper bonus. The formula is still off from EA.

Item total imbuing weight is now EA accurate. Max weight is calculated using the default value, or the old Runic/Imbuing max.

Loot Max Weight is calculated by that item type's max weight of that property.

Harpsichord is now usable by house friends

