### PR TITLE
Fixes a new PlayerMobile.cs crash

### DIFF
--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -5780,7 +5780,7 @@ namespace Server.Mobiles
                     }
                 }
             }
-            else if (DisplayGuildAbbr)
+            else if (guild != null && DisplayGuildAbbr)
             {
                 if (vvv)
                 {

--- a/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
@@ -1981,8 +1981,6 @@ namespace Server.SkillHandlers
 
                 if (attrs != null && attrs.SpellChanneling > 0)
                     value++;
-
-                Console.WriteLine("Value: {0}", value);
             }
             
             if (value <= 0)

--- a/Scripts/Services/Seasonal Events/RisingTide/RisingTideData.cs
+++ b/Scripts/Services/Seasonal Events/RisingTide/RisingTideData.cs
@@ -40,7 +40,6 @@ namespace Server.Engines.Points
 
                 if (beacon != null)
                 {
-                    Console.WriteLine("Checking Cargo: {0}", bc);
                     if (CargoChance > Utility.RandomDouble())
                     {
                         damager.AddToBackpack(new MaritimeCargo());


### PR DESCRIPTION
System.NullReferenceException: Object reference not set to an instance of an object.
   at Server.Mobiles.PlayerMobile.AddNameProperties(ObjectPropertyList list)
   at Server.Mobile.GetProperties(ObjectPropertyList list)
   at Server.Mobiles.PlayerMobile.GetProperties(ObjectPropertyList list)
   at Server.Mobile.get_PropertyList()
   at Server.Mobile.get_OPLPacket()
   at Server.Mobile.SendEverything()
   at Server.Mobile.set_Map(Map value)
   at Server.Mobile.set_NetState(NetState value)
   at Server.Network.PacketHandlers.PlayCharacter(NetState state, PacketReader pvSrc)
   at Server.Network.MessagePump.HandleReceive(NetState ns)
   at Server.Network.MessagePump.Slice()
   at Server.Core.Main(String[] args)

This crash happened non stop after the recent changes. Adding back in that null check stopes the crashes.