### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Artifacts/Equipment/Armor/CandlewoodTorch.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/CandlewoodTorch.cs
@@ -40,6 +40,25 @@ namespace Server.Items
                     ItemID = 0xF6B;
                 }
             }
+
+            var parent = Parent as Mobile;
+
+            if (parent == from && Burning)
+            {
+                Mobiles.MeerMage.StopEffect((Mobile)parent, true);
+                SwarmContext.CheckRemove((Mobile)parent);
+            }
+        }
+
+        public override void OnAdded(object parent)
+        {
+            base.OnAdded(parent);
+
+            if (parent is Mobile && Burning)
+            {
+                Mobiles.MeerMage.StopEffect((Mobile)parent, true);
+                SwarmContext.CheckRemove((Mobile)parent);
+            }
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Items/Consumables/BaseExplosionPotion.cs
+++ b/Scripts/Items/Consumables/BaseExplosionPotion.cs
@@ -159,7 +159,7 @@ namespace Server.Items
 			int min = Scale(from, MinDamage);
 			int max = Scale(from, MaxDamage);
 
-            var list = SpellHelper.AcquireIndirectTargets(from, loc, map, ExplosionRange).OfType<Mobile>().ToList();
+            var list = SpellHelper.AcquireIndirectTargets(from, loc, map, ExplosionRange, false).OfType<Mobile>().ToList();
 
             foreach (var m in list)
             {

--- a/Scripts/Items/Equipment/Light/Torch.cs
+++ b/Scripts/Items/Equipment/Light/Torch.cs
@@ -61,9 +61,6 @@ namespace Server.Items
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
-
-            if (Weight == 2.0)
-                Weight = 1.0;
         }
     }
 }

--- a/Scripts/Items/Resource/MiscMLResources.cs
+++ b/Scripts/Items/Resource/MiscMLResources.cs
@@ -14,8 +14,8 @@ namespace Server.Items
         public Blight(int amount)
             : base(0x3183)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public Blight(Serial serial)
@@ -53,8 +53,8 @@ namespace Server.Items
         public LuminescentFungi(int amount)
             : base(0x3191)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public LuminescentFungi(Serial serial)
@@ -92,8 +92,8 @@ namespace Server.Items
         public CapturedEssence(int amount)
             : base(0x318E)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public CapturedEssence(Serial serial)
@@ -137,8 +137,8 @@ namespace Server.Items
         public EyeOfTheTravesty(int amount)
             : base(0x318D)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public EyeOfTheTravesty(Serial serial)
@@ -182,8 +182,8 @@ namespace Server.Items
         public Corruption(int amount)
             : base(0x3184)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public Corruption(Serial serial)
@@ -227,8 +227,8 @@ namespace Server.Items
         public DreadHornMane(int amount)
             : base(0x318A)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public DreadHornMane(Serial serial)
@@ -272,8 +272,8 @@ namespace Server.Items
         public ParasiticPlant(int amount)
             : base(0x3190)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public ParasiticPlant(Serial serial)
@@ -317,8 +317,8 @@ namespace Server.Items
         public Muculent(int amount)
             : base(0x3188)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public Muculent(Serial serial)
@@ -362,8 +362,8 @@ namespace Server.Items
         public DiseasedBark(int amount)
             : base(0x318B)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public DiseasedBark(Serial serial)
@@ -407,8 +407,8 @@ namespace Server.Items
         public BarkFragment(int amount)
             : base(0x318F)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public BarkFragment(Serial serial)
@@ -452,8 +452,8 @@ namespace Server.Items
         public GrizzledBones(int amount)
             : base(0x318C)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public GrizzledBones(Serial serial)
@@ -477,8 +477,8 @@ namespace Server.Items
 
             int version = reader.ReadInt();
 
-            if (version <= 0 && this.ItemID == 0x318F)
-                this.ItemID = 0x318C;
+            if (version <= 0 && ItemID == 0x318F)
+                ItemID = 0x318C;
         }
     }
 
@@ -500,8 +500,8 @@ namespace Server.Items
         public LardOfParoxysmus(int amount)
             : base(0x3189)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public LardOfParoxysmus(Serial serial)
@@ -545,8 +545,8 @@ namespace Server.Items
         public PerfectEmerald(int amount)
             : base(0x3194)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public PerfectEmerald(Serial serial)
@@ -590,8 +590,8 @@ namespace Server.Items
         public DarkSapphire(int amount)
             : base(0x3192)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public DarkSapphire(Serial serial)
@@ -635,8 +635,8 @@ namespace Server.Items
         public Turquoise(int amount)
             : base(0x3193)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public Turquoise(Serial serial)
@@ -680,8 +680,8 @@ namespace Server.Items
         public EcruCitrine(int amount)
             : base(0x3195)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public EcruCitrine(Serial serial)
@@ -725,8 +725,8 @@ namespace Server.Items
         public WhitePearl(int amount)
             : base(0x3196)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public WhitePearl(Serial serial)
@@ -770,8 +770,8 @@ namespace Server.Items
         public FireRuby(int amount)
             : base(0x3197)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public FireRuby(Serial serial)
@@ -815,8 +815,8 @@ namespace Server.Items
         public BlueDiamond(int amount)
             : base(0x3198)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public BlueDiamond(Serial serial)
@@ -860,8 +860,8 @@ namespace Server.Items
         public BrilliantAmber(int amount)
             : base(0x3199)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public BrilliantAmber(Serial serial)
@@ -905,9 +905,9 @@ namespace Server.Items
         public Scourge(int amount)
             : base(0x3185)
         {
-            this.Stackable = true;
-            this.Amount = amount;
-            this.Hue = 150;
+            Stackable = true;
+            Amount = amount;
+            Hue = 150;
         }
 
         public Scourge(Serial serial)
@@ -933,30 +933,31 @@ namespace Server.Items
         }
     }
 
-    public class Putrefication : Item, ICommodity
+    [TypeAlias("Server.Items.Putrefication")]
+    public class Putrefaction : Item, ICommodity
     {
         [Constructable]
-        public Putrefication()
+        public Putrefaction()
             : this(1)
         {
         }
 
         [Constructable]
-        public Putrefication(int amountFrom, int amountTo)
+        public Putrefaction(int amountFrom, int amountTo)
             : this(Utility.RandomMinMax(amountFrom, amountTo))
         {
         }
 
         [Constructable]
-        public Putrefication(int amount)
+        public Putrefaction(int amount)
             : base(0x3186)
         {
-            this.Stackable = true;
-            this.Amount = amount;
-            this.Hue = 883;
+            Stackable = true;
+            Amount = amount;
+            Hue = 883;
         }
 
-        public Putrefication(Serial serial)
+        public Putrefaction(Serial serial)
             : base(serial)
         {
         }
@@ -997,9 +998,9 @@ namespace Server.Items
         public Taint(int amount)
             : base(0x3187)
         {
-            this.Stackable = true;
-            this.Amount = amount;
-            this.Hue = 731;
+            Stackable = true;
+            Amount = amount;
+            Hue = 731;
         }
 
         public Taint(Serial serial)
@@ -1075,8 +1076,8 @@ namespace Server.Items
         public SwitchItem(int amount)
             : base(0x2F5F)
         {
-            this.Stackable = true;
-            this.Amount = amount;
+            Stackable = true;
+            Amount = amount;
         }
 
         public SwitchItem(Serial serial)

--- a/Scripts/Mobiles/Named/Meraktus.cs
+++ b/Scripts/Mobiles/Named/Meraktus.cs
@@ -128,7 +128,7 @@ namespace Server.Mobiles
                         PackItem(new Taint());
                         break;
                     case 3:
-                        PackItem(new Putrefication());
+                        PackItem(new Putrefaction());
                         break;
                     case 4:
                         PackItem(new Corruption());

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -5802,6 +5802,10 @@ namespace Server.Mobiles
                     suffix = String.Format("[{0}]", Utility.FixHtml(guild.Abbreviation));
                 }
             }
+            else if (vvv)
+            {
+                suffix = "[VvV]";
+            }
 
             suffix = ApplyNameSuffix(suffix);
 

--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -2021,8 +2021,13 @@ namespace Server.Engines.Craft
 					tool.Delete();
 				}
 
-				// SkillCheck failed.
-				int num = craftSystem.PlayEndingEffect(from, true, true, toolBroken, endquality, false, this);
+                if (UseAllRes)
+                {
+                    MultipleSkillCheck(from, 1);
+                }
+
+                // SkillCheck failed.
+                int num = craftSystem.PlayEndingEffect(from, true, true, toolBroken, endquality, false, this);
 
 				if (tool != null && !tool.Deleted && tool.UsesRemaining > 0)
 				{

--- a/Scripts/Services/Craft/Core/CraftSystem.cs
+++ b/Scripts/Services/Craft/Core/CraftSystem.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+
 using Server.Items;
 
 namespace Server.Engines.Craft
@@ -263,9 +265,16 @@ namespace Server.Engines.Craft
             Systems.Add(system);
         }
 
+        private Type[] _GlobalNoConsume =
+        {
+            typeof(CapturedEssence), typeof(EyeOfTheTravesty), typeof(DiseasedBark),  typeof(LardOfParoxysmus), typeof(GrizzledBones), typeof(DreadHornMane),
+
+            typeof(Blight), typeof(Corruption), typeof(Muculent), typeof(Scourge), typeof(Putrefaction), typeof(Taint)
+        };
+
         public virtual bool ConsumeOnFailure(Mobile from, Type resourceType, CraftItem craftItem)
         {
-            return true;
+            return !_GlobalNoConsume.Any(t => t == resourceType);
         }
 
         public virtual bool ConsumeOnFailure(Mobile from, Type resourceType, CraftItem craftItem, ref MasterCraftsmanTalisman talisman)

--- a/Scripts/Services/Craft/DefBlacksmithy.cs
+++ b/Scripts/Services/Craft/DefBlacksmithy.cs
@@ -506,7 +506,7 @@ namespace Server.Engines.Craft
 
                     index = AddCraft(typeof(RuneCarvingKnife), 1011081, 1072915, 70.0, 120.0, typeof(IronIngot), 1044036, 9, 1044037);
                     AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
-                    AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+                    AddRes(index, typeof(Putrefaction), 1032678, 10, 1053098);
                     AddRes(index, typeof(Muculent), 1032680, 10, 1053098);
                     AddRecipe(index, (int)SmithRecipes.RuneCarvingKnife);
                     ForceNonExceptional(index);
@@ -528,7 +528,7 @@ namespace Server.Engines.Craft
                     index = AddCraft(typeof(LuminousRuneBlade), 1011081, 1072922, 70.0, 120.0, typeof(IronIngot), 1044036, 15, 1044037);
                     AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
                     AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
-                    AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+                    AddRes(index, typeof(Putrefaction), 1032678, 10, 1053098);
                     AddRecipe(index, (int)SmithRecipes.LuminousRuneBlade);
                     ForceNonExceptional(index);
 

--- a/Scripts/Services/Craft/DefBowFletching.cs
+++ b/Scripts/Services/Craft/DefBowFletching.cs
@@ -182,7 +182,7 @@ namespace Server.Engines.Craft
 
                 index = AddCraft(typeof(FaerieFire), 1044566, 1072908, 75.0, 125.0, typeof(Board), 1044041, 20, 1044351);
                 AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
-                AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+                AddRes(index, typeof(Putrefaction), 1032678, 10, 1053098);
                 AddRes(index, typeof(Taint), 1032679, 10, 1053098);
                 AddRecipe(index, (int)BowRecipes.FaerieFire);
                 ForceNonExceptional(index);
@@ -197,7 +197,7 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(MischiefMaker), 1044566, 1072910, 75.0, 125.0, typeof(Board), 1044041, 15, 1044351);
                 AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
                 AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
-                AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+                AddRes(index, typeof(Putrefaction), 1032678, 10, 1053098);
                 AddRecipe(index, (int)BowRecipes.MischiefMaker);
                 ForceNonExceptional(index);
 

--- a/Scripts/Services/Craft/DefCarpentry.cs
+++ b/Scripts/Services/Craft/DefCarpentry.cs
@@ -441,7 +441,7 @@ namespace Server.Engines.Craft
 
                 index = AddCraft(typeof(PhantomStaff), 1044566, 1072919, 90.0, 130.0, typeof(Board), 1044041, 16, 1044351);
                 AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
-                AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+                AddRes(index, typeof(Putrefaction), 1032678, 10, 1053098);
                 AddRes(index, typeof(Taint), 1032679, 10, 1053098);
                 AddRecipe(index, (int)CarpRecipes.PhantomStaff);
                 ForceNonExceptional(index);
@@ -528,7 +528,7 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(IronwoodCrown), 1062760, 1072924, 85.0, 120.0, typeof(Board), 1044041, 10, 1044351);
                 AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
                 AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
-                AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+                AddRes(index, typeof(Putrefaction), 1032678, 10, 1053098);
                 AddRecipe(index, (int)CarpRecipes.IronwoodCrown);
                 ForceNonExceptional(index);
 
@@ -560,7 +560,7 @@ namespace Server.Engines.Craft
                 index = AddCraft(typeof(DarkwoodLegs), 1062760, 1073484, 85.0, 120.0, typeof(Board), 1044041, 15, 1044351);
                 AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
                 AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
-                AddRes(index, typeof(Putrefication), 1072137, 10, 1053098);
+                AddRes(index, typeof(Putrefaction), 1072137, 10, 1053098);
                 ForceNonExceptional(index);
 
                 index = AddCraft(typeof(DarkwoodPauldrons), 1062760, 1073485, 85.0, 120.0, typeof(Board), 1044041, 15, 1044351);
@@ -571,7 +571,7 @@ namespace Server.Engines.Craft
 
                 index = AddCraft(typeof(DarkwoodGloves), 1062760, 1073486, 85.0, 120.0, typeof(Board), 1044041, 15, 1044351);
                 AddRes(index, typeof(CapturedEssence), 1032686, 1, 1053098);
-                AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+                AddRes(index, typeof(Putrefaction), 1032678, 10, 1053098);
                 AddRes(index, typeof(Muculent), 1032680, 10, 1053098);
                 ForceNonExceptional(index);
             }

--- a/Scripts/Services/Craft/DefTailoring.cs
+++ b/Scripts/Services/Craft/DefTailoring.cs
@@ -484,7 +484,7 @@ namespace Server.Engines.Craft
             {
                 index = AddCraft(typeof(SpellWovenBritches), 1015293, 1072929, 92.5, 117.5, typeof(Leather), 1044462, 15, 1044463);
                 AddRes(index, typeof(EyeOfTheTravesty), 1032685, 1, 1044253);
-                AddRes(index, typeof(Putrefication), 1032678, 10, 1044253);
+                AddRes(index, typeof(Putrefaction), 1032678, 10, 1044253);
                 AddRes(index, typeof(Scourge), 1032677, 10, 1044253);
                 AddRecipe(index, (int)TailorRecipe.SpellWovenBritches);
                 ForceNonExceptional(index);

--- a/Scripts/Services/Peerless/BasePeerless.cs
+++ b/Scripts/Services/Peerless/BasePeerless.cs
@@ -273,7 +273,7 @@ namespace Server.Mobiles
                         PackItem(new Taint());
                         break;
                     case 3:
-                        PackItem(new Putrefication());
+                        PackItem(new Putrefaction());
                         break;
                     case 4:
                         PackItem(new Corruption());

--- a/Scripts/Spells/Base/SpellHelper.cs
+++ b/Scripts/Spells/Base/SpellHelper.cs
@@ -631,6 +631,11 @@ namespace Server.Spells
         }
 
         public static IEnumerable<IDamageable> AcquireIndirectTargets(Mobile caster, IPoint3D p, Map map, int range)
+        {
+            return AcquireIndirectTargets(caster, p, map, range, true);
+        }
+
+        public static IEnumerable<IDamageable> AcquireIndirectTargets(Mobile caster, IPoint3D p, Map map, int range, bool losCheck)
         {  
             if (map == null)
             {
@@ -646,7 +651,7 @@ namespace Server.Spells
                     continue;
                 }
 
-                if (!id.Alive || !caster.InLOS(id) || !caster.CanBeHarmful(id, false))
+                if (!id.Alive || (losCheck && !caster.InLOS(id)) || !caster.CanBeHarmful(id, false))
                 {
                     continue;
                 }


### PR DESCRIPTION
- Explosion Potions no longer use throwers LOS for Damage
- Fixed class name for "Putrefaction"
- Failed craft no longer consumes ML Peerless resources
- Vendor Searing now recursively checks child containers in vendors backpack
- Vendor Searching now shows price of parent container if the entire container is for sale
- Candlewood Torch now removed swarm
- Coffee Grinder now works properly