### PR TITLE
Fixes being able to collect BODs from 10

### DIFF
--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -145,7 +145,7 @@ namespace Server.Mobiles
 
 			public override void OnClick()
 			{
-                if (!m_From.InRange(m_Vendor.Location, 3))
+                if (!m_From.InRange(m_Vendor.Location, 10))
                     return;
 
 				EventSink.InvokeBODOffered(new BODOfferEventArgs(m_From, m_Vendor));


### PR DESCRIPTION
Fixes being able to collect BODs from 10 tiles out. The last update did not fully turn it on.