### PR TITLE
Fixes Multiple Issues with Whips:

### DIFF
--- a/Scripts/Items/StoreBought/VirtueShield.cs
+++ b/Scripts/Items/StoreBought/VirtueShield.cs
@@ -3,8 +3,9 @@ using Server.Gumps;
 
 namespace Server.Items
 {
-    public class VirtueShield : BaseShield
+    public class VirtueShield : BaseShield, Server.Engines.Craft.IRepairable
     {
+		public Server.Engines.Craft.CraftSystem RepairSystem { get { return Server.Engines.Craft.DefBlacksmithy.CraftSystem; } }	
         public override int BasePhysicalResistance { get { return 8; } }
         public override int BaseFireResistance { get { return 8; } }
         public override int BaseColdResistance { get { return 8; } }

--- a/Scripts/Items/Tools/DyeTub.cs
+++ b/Scripts/Items/Tools/DyeTub.cs
@@ -217,7 +217,8 @@ namespace Server.Items
                     else if (m_Tub.AllowLeather)
                     {
                         if ((item is BaseArmor && (((BaseArmor)item).MaterialType == ArmorMaterialType.Leather || ((BaseArmor)item).MaterialType == ArmorMaterialType.Studded)) ||
-                            (item is BaseClothing && (((BaseClothing)item).DefaultResource == CraftResource.RegularLeather || item is WoodlandBelt)))
+                            (item is BaseClothing && (((BaseClothing)item).DefaultResource == CraftResource.RegularLeather || item is WoodlandBelt || item is BarbedWhip 
+							|| item is BladedWhip || item is SpikedWhip)))
                         {
                             if (!from.InRange(m_Tub.GetWorldLocation(), 1) || !from.InRange(item.GetWorldLocation(), 1))
                             {

--- a/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
@@ -227,7 +227,8 @@ namespace Server.SkillHandlers
             typeof(ClockworkLeggings), typeof(GargishClockworkLeggings), typeof(OrcishKinMask), typeof(SavageMask), typeof(VirtuososArmbands), 
             typeof(VirtuososCap), typeof(VirtuososCollar), typeof(VirtuososEarpieces), typeof(VirtuososKidGloves), typeof(VirtuososKilt), 
             typeof(VirtuososNecklace), typeof(VirtuososTunic), typeof(BestialArms), typeof(BestialEarrings), typeof(BestialGloves), typeof(BestialGorget),
-            typeof(BestialHelm), typeof(BestialKilt), typeof(BestialLegs), typeof(BestialNecklace)
+            typeof(BestialHelm), typeof(BestialKilt), typeof(BestialLegs), typeof(BestialNecklace), typeof(BarbedWhip), typeof(BladedWhip),
+			typeof(SpikedWhip)
         };
 
         private static Type[] _NonCraftables =

--- a/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
@@ -1135,9 +1135,12 @@ namespace Server.Items
             m_AllowableTable[typeof(ButcherKnife)] = DefBlacksmithy.CraftSystem;
             m_AllowableTable[typeof(GargishNecklace)] = DefBlacksmithy.CraftSystem;
             m_AllowableTable[typeof(GargishEarrings)] = DefBlacksmithy.CraftSystem;
-
             m_AllowableTable[typeof(GargishAmulet)] = DefBlacksmithy.CraftSystem;
-            m_AllowableTable[typeof(GargishStoneAmulet)] = DefMasonry.CraftSystem;
+            m_AllowableTable[typeof(GargishStoneAmulet)] = DefMasonry.CraftSystem;		
+			m_AllowableTable[typeof(BarbedWhip)] = DefTinkering.CraftSystem;
+			m_AllowableTable[typeof(SpikedWhip)] = DefTinkering.CraftSystem;
+			m_AllowableTable[typeof(BladedWhip)] = DefTinkering.CraftSystem;
+			
         }
 
         public static void Configure()

--- a/Scripts/Services/Seasonal Events/KrampusEncounter/Items/BarbedWhip.cs
+++ b/Scripts/Services/Seasonal Events/KrampusEncounter/Items/BarbedWhip.cs
@@ -3,13 +3,14 @@ using Server.Engines.Craft;
 
 namespace Server.Items
 {
-    public class BarbedWhip : BaseBashing
+    public class BarbedWhip : BaseBashing, Server.Engines.Craft.IRepairable
     {
-        public override int LabelNumber { get { return 1125641; } } // Barbed Whip
+		public Server.Engines.Craft.CraftSystem RepairSystem { get { return Server.Engines.Craft.DefTinkering.CraftSystem; } }
+        public override int LabelNumber { get { return 1125641; } } // Barbed Whip		
 
         [Constructable]
         public BarbedWhip()
-            : base(0xA28B)
+            : base(0xA289)
         {
             Weight = 5.0;
         }
@@ -18,77 +19,19 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override WeaponAbility PrimaryAbility
-        {
-            get
-            {
-                return WeaponAbility.ConcussionBlow;
-            }
-        }
-        public override WeaponAbility SecondaryAbility
-        {
-            get
-            {
-                return WeaponAbility.WhirlwindAttack;
-            }
-        }
-        public override int AosStrengthReq
-        {
-            get
-            {
-                return 20;
-            }
-        }
-        public override int AosMinDamage
-        {
-            get
-            {
-                return 13;
-            }
-        }
-        public override int AosMaxDamage
-        {
-            get
-            {
-                return 17;
-            }
-        }
-        public override float MlSpeed
-        {
-            get
-            {
-                return 3.25f;
-            }
-        }
-        public override int DefHitSound
-        {
-            get
-            {
-                return 0x23B;
-            }
-        }
-        public override int DefMissSound
-        {
-            get
-            {
-                return 0x23A;
-            }
-        }
-        public override int InitMinHits
-        {
-            get
-            {
-                return 30;
-            }
-        }
-        public override int InitMaxHits
-        {
-            get
-            {
-                return 60;
-            }
-        }
+		
+		public override bool CanBeWornByGargoyles { get { return true; } }
+        public override WeaponAbility PrimaryAbility { get { return WeaponAbility.ConcussionBlow; } }
+        public override WeaponAbility SecondaryAbility { get { return WeaponAbility.WhirlwindAttack; } }
+        public override int AosStrengthReq { get { return 20; } }
+        public override int AosMinDamage { get { return 13; } }
+        public override int AosMaxDamage { get { return 17; } }
+        public override float MlSpeed { get { return 3.25f; } }
+        public override int DefHitSound { get { return 0x23B; } }
+        public override int DefMissSound { get { return 0x23A; } }
+        public override int InitMinHits { get { return 30; } }
+        public override int InitMaxHits { get { return 60; } }
+		
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Services/Seasonal Events/KrampusEncounter/Items/BladedWhip.cs
+++ b/Scripts/Services/Seasonal Events/KrampusEncounter/Items/BladedWhip.cs
@@ -3,8 +3,9 @@ using Server.Engines.Craft;
 
 namespace Server.Items
 {
-    public class BladedWhip : BaseSword
+    public class BladedWhip : BaseSword, Server.Engines.Craft.IRepairable
     {
+		public Server.Engines.Craft.CraftSystem RepairSystem { get { return Server.Engines.Craft.DefTinkering.CraftSystem; } }
         public override int LabelNumber { get { return 1125643; } } // Bladed Whip
 
         [Constructable]
@@ -18,77 +19,19 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override WeaponAbility PrimaryAbility
-        {
-            get
-            {
-                return WeaponAbility.BleedAttack;
-            }
-        }
-        public override WeaponAbility SecondaryAbility
-        {
-            get
-            {
-                return WeaponAbility.WhirlwindAttack;
-            }
-        }
-        public override int AosStrengthReq
-        {
-            get
-            {
-                return 20;
-            }
-        }
-        public override int AosMinDamage
-        {
-            get
-            {
-                return 13;
-            }
-        }
-        public override int AosMaxDamage
-        {
-            get
-            {
-                return 17;
-            }
-        }
-        public override float MlSpeed
-        {
-            get
-            {
-                return 3.25f;
-            }
-        }
-        public override int DefHitSound
-        {
-            get
-            {
-                return 0x23B;
-            }
-        }
-        public override int DefMissSound
-        {
-            get
-            {
-                return 0x23A;
-            }
-        }
-        public override int InitMinHits
-        {
-            get
-            {
-                return 30;
-            }
-        }
-        public override int InitMaxHits
-        {
-            get
-            {
-                return 60;
-            }
-        }
+		
+		public override bool CanBeWornByGargoyles { get { return true; } }
+        public override WeaponAbility PrimaryAbility { get { return WeaponAbility.BleedAttack; } }
+        public override WeaponAbility SecondaryAbility { get { return WeaponAbility.WhirlwindAttack; } }
+        public override int AosStrengthReq { get { return 20; } }
+        public override int AosMinDamage { get { return 13; } }
+        public override int AosMaxDamage { get { return 17; } }
+        public override float MlSpeed { get { return 3.25f; } }
+        public override int DefHitSound { get { return 0x23B; } }
+        public override int DefMissSound { get { return 0x23A; } }
+        public override int InitMinHits { get { return 30; } }
+        public override int InitMaxHits { get { return 60; } }
+		
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Services/Seasonal Events/KrampusEncounter/Items/SpikedWhip.cs
+++ b/Scripts/Services/Seasonal Events/KrampusEncounter/Items/SpikedWhip.cs
@@ -3,13 +3,14 @@ using Server.Engines.Craft;
 
 namespace Server.Items
 {
-    public class SpikedWhip : BaseSword
+    public class SpikedWhip : BaseSword, Server.Engines.Craft.IRepairable
     {
-        public override int LabelNumber { get { return 1125643; } } // Bladed Whip
+		public Server.Engines.Craft.CraftSystem RepairSystem { get { return Server.Engines.Craft.DefTinkering.CraftSystem; } }
+        public override int LabelNumber { get { return 1125634; } } // Spiked Whip
 
         [Constructable]
         public SpikedWhip()
-            : base(0xA28B)
+            : base(0xA292)
         {
             Weight = 5.0;
         }
@@ -19,97 +20,20 @@ namespace Server.Items
         {
         }
 
-        public override WeaponAbility PrimaryAbility
-        {
-            get
-            {
-                return WeaponAbility.ArmorPierce;
-            }
-        }
-        public override WeaponAbility SecondaryAbility
-        {
-            get
-            {
-                return WeaponAbility.WhirlwindAttack;
-            }
-        }
-        public override int AosStrengthReq
-        {
-            get
-            {
-                return 20;
-            }
-        }
-        public override int AosMinDamage
-        {
-            get
-            {
-                return 13;
-            }
-        }
-        public override int AosMaxDamage
-        {
-            get
-            {
-                return 17;
-            }
-        }
-        public override float MlSpeed
-        {
-            get
-            {
-                return 3.25f;
-            }
-        }
-        public override int DefHitSound
-        {
-            get
-            {
-                return 0x23B;
-            }
-        }
-        public override int DefMissSound
-        {
-            get
-            {
-                return 0x23A;
-            }
-        }
-        public override int InitMinHits
-        {
-            get
-            {
-                return 30;
-            }
-        }
-        public override int InitMaxHits
-        {
-            get
-            {
-                return 60;
-            }
-        }
-        public override SkillName DefSkill
-        {
-            get
-            {
-                return SkillName.Fencing;
-            }
-        }
-        public override WeaponType DefType
-        {
-            get
-            {
-                return WeaponType.Piercing;
-            }
-        }
-        public override WeaponAnimation DefAnimation
-        {
-            get
-            {
-                return WeaponAnimation.Pierce1H;
-            }
-        }
+		public override bool CanBeWornByGargoyles { get { return true; } }
+        public override WeaponAbility PrimaryAbility { get { return WeaponAbility.ArmorPierce; } }
+        public override WeaponAbility SecondaryAbility { get { return WeaponAbility.WhirlwindAttack; } }
+        public override int AosStrengthReq { get { return 20; } }
+        public override int AosMinDamage { get { return 13; } }
+        public override int AosMaxDamage { get { return 17; } }
+        public override float MlSpeed { get { return 3.25f; } }
+        public override int DefHitSound { get { return 0x23B; } }
+        public override int DefMissSound { get { return 0x23A; } }
+        public override int InitMinHits { get { return 30; } }
+        public override int InitMaxHits { get { return 60; } }
+        public override SkillName DefSkill { get { return SkillName.Fencing; } }
+        public override WeaponType DefType { get { return WeaponType.Piercing; } }
+        public override WeaponAnimation DefAnimation { get { return WeaponAnimation.Pierce1H; } }
 
         public override void Serialize(GenericWriter writer)
         {


### PR DESCRIPTION
1. Virtue Shield can now be repaired.
2. Whips can now be imbued/reforged, use the correct specials, have the correct itemids and names, and can be correctly used by gargoyles.

https://trueuo.com/index.php?threads/whips-here-are-not-accurate-weapon-specials-are-wrong-fencing-is-misnamed.1729/