### PR TITLE
Talisman Fixes

### DIFF
--- a/Scripts/Items/Equipment/Talismans/BaseTalisman.cs
+++ b/Scripts/Items/Equipment/Talismans/BaseTalisman.cs
@@ -771,15 +771,7 @@ namespace Server.Items
             #endregion
 
             if(Attributes.Brittle > 0)
-                list.Add(1116209); // Brittle
-
-            if (Blessed)
-            {
-                if (BlessedFor != null)
-                    list.Add(1072304, !String.IsNullOrEmpty(BlessedFor.Name) ? BlessedFor.Name : "Unnamed Warrior"); // Owned by ~1_name~
-                else
-                    list.Add(1072304, "Nobody"); // Owned by ~1_name~
-            }
+                list.Add(1116209); // Brittle           
 
             if (Parent is Mobile && m_MaxChargeTime > 0)
             {
@@ -812,83 +804,30 @@ namespace Server.Items
             m_AosSkillBonuses.GetProperties(list);
 
             int prop;
+			
+			if (m_Slayer != TalismanSlayerName.None)
+            {
+                if (m_Slayer == TalismanSlayerName.Goblin)
+                    list.Add(1095010);
+                else if (m_Slayer == TalismanSlayerName.Undead)
+                    list.Add(1060479);
+                else if (m_Slayer <= TalismanSlayerName.Wolf)
+                    list.Add(1072503 + (int)m_Slayer);
+                else
+                {
+                    switch (m_Slayer)
+                    {
+                        case TalismanSlayerName.Repond: list.Add(1079750); break;
+                        case TalismanSlayerName.Elemental: list.Add(1079749); break;
+                        case TalismanSlayerName.Demon: list.Add(1079748); break;
+                        case TalismanSlayerName.Arachnid: list.Add(1079747); break;
+                        case TalismanSlayerName.Reptile: list.Add(1079751); break;
+                        case TalismanSlayerName.Fey: list.Add(1154652); break;
+                    }
+                }
+            }  
 
-            if ((prop = m_AosAttributes.WeaponDamage) != 0)
-                list.Add(1060401, prop.ToString()); // damage increase ~1_val~%
-
-            if ((prop = m_AosAttributes.DefendChance) != 0)
-                list.Add(1060408, prop.ToString()); // defense chance increase ~1_val~%
-
-            if ((prop = m_AosAttributes.BonusDex) != 0)
-                list.Add(1060409, prop.ToString()); // dexterity bonus ~1_val~
-
-            if ((prop = m_AosAttributes.EnhancePotions) != 0)
-                list.Add(1060411, prop.ToString()); // enhance potions ~1_val~%
-
-            if ((prop = m_AosAttributes.CastRecovery) != 0)
-                list.Add(1060412, prop.ToString()); // faster cast recovery ~1_val~
-
-            if ((prop = m_AosAttributes.CastSpeed) != 0)
-                list.Add(1060413, prop.ToString()); // faster casting ~1_val~
-
-            if ((prop = m_AosAttributes.AttackChance) != 0)
-                list.Add(1060415, prop.ToString()); // hit chance increase ~1_val~%
-
-            if ((prop = m_AosAttributes.BonusHits) != 0)
-                list.Add(1060431, prop.ToString()); // hit point increase ~1_val~
-
-            if ((prop = m_AosAttributes.BonusInt) != 0)
-                list.Add(1060432, prop.ToString()); // intelligence bonus ~1_val~
-
-            if ((prop = m_AosAttributes.LowerManaCost) != 0)
-                list.Add(1060433, prop.ToString()); // lower mana cost ~1_val~%
-
-            if ((prop = m_AosAttributes.LowerRegCost) != 0)
-                list.Add(1060434, prop.ToString()); // lower reagent cost ~1_val~%
-
-            if ((prop = m_AosAttributes.Luck) != 0)
-                list.Add(1060436, prop.ToString()); // luck ~1_val~
-
-            if ((prop = m_AosAttributes.BonusMana) != 0)
-                list.Add(1060439, prop.ToString()); // mana increase ~1_val~
-
-            if ((prop = m_AosAttributes.RegenMana) != 0)
-                list.Add(1060440, prop.ToString()); // mana regeneration ~1_val~
-
-            if ((prop = m_AosAttributes.NightSight) != 0)
-                list.Add(1060441); // night sight
-
-            if ((prop = m_AosAttributes.ReflectPhysical) != 0)
-                list.Add(1060442, prop.ToString()); // reflect physical damage ~1_val~%
-
-            if ((prop = m_AosAttributes.RegenStam) != 0)
-                list.Add(1060443, prop.ToString()); // stamina regeneration ~1_val~
-
-            if ((prop = m_AosAttributes.RegenHits) != 0)
-                list.Add(1060444, prop.ToString()); // hit point regeneration ~1_val~
-
-            if ((prop = m_AosAttributes.SpellChanneling) != 0)
-                list.Add(1060482); // spell channeling
-
-            if ((prop = m_AosAttributes.SpellDamage) != 0)
-                list.Add(1060483, prop.ToString()); // spell damage increase ~1_val~%
-
-            if ((prop = m_AosAttributes.BonusStam) != 0)
-                list.Add(1060484, prop.ToString()); // stamina increase ~1_val~
-
-            if ((prop = m_AosAttributes.BonusStr) != 0)
-                list.Add(1060485, prop.ToString()); // strength bonus ~1_val~
-
-            if ((prop = m_AosAttributes.WeaponSpeed) != 0)
-                list.Add(1060486, prop.ToString()); // swing speed increase ~1_val~%
-
-            if (Core.ML && (prop = m_AosAttributes.IncreasedKarmaLoss) != 0)
-                list.Add(1075210, prop.ToString()); // Increased Karma Loss ~1val~%
-
-            if (m_MaxCharges > 0)
-                list.Add(1060741, m_Charges.ToString()); // charges: ~1_val~
-
-            #region SA
+			#region SA
             if ((prop = m_SAAbsorptionAttributes.CastingFocus) != 0)
                 list.Add(1113696, prop.ToString()); // Casting Focus ~1_val~%
 
@@ -925,33 +864,85 @@ namespace Server.Items
             if ((prop = m_SAAbsorptionAttributes.ResonanceKinetic) != 0)
                 list.Add(1113695, prop.ToString()); // Kinetic Resonance ~1_val~%
             #endregion
+            
+            if ((prop = m_AosAttributes.BonusDex) != 0)
+                list.Add(1060409, prop.ToString()); // dexterity bonus ~1_val~
+
+            if ((prop = m_AosAttributes.EnhancePotions) != 0)
+                list.Add(1060411, prop.ToString()); // enhance potions ~1_val~%
+
+            if ((prop = m_AosAttributes.CastRecovery) != 0)
+                list.Add(1060412, prop.ToString()); // faster cast recovery ~1_val~
+
+            if ((prop = m_AosAttributes.CastSpeed) != 0)
+                list.Add(1060413, prop.ToString()); // faster casting ~1_val~
+            
+            if ((prop = m_AosAttributes.BonusHits) != 0)
+                list.Add(1060431, prop.ToString()); // hit point increase ~1_val~
+
+            if ((prop = m_AosAttributes.BonusInt) != 0)
+                list.Add(1060432, prop.ToString()); // intelligence bonus ~1_val~                                
+
+            if ((prop = m_AosAttributes.BonusMana) != 0)
+                list.Add(1060439, prop.ToString()); // mana increase ~1_val~           
+
+            if ((prop = m_AosAttributes.NightSight) != 0)
+                list.Add(1060441); // night sight
+
+            if ((prop = m_AosAttributes.ReflectPhysical) != 0)
+                list.Add(1060442, prop.ToString()); // reflect physical damage ~1_val~%
+			
+			if ((prop = m_AosAttributes.BonusStr) != 0)
+                list.Add(1060485, prop.ToString()); // strength bonus ~1_val~
+			
+			if ((prop = m_AosAttributes.RegenHits) != 0)
+                list.Add(1060444, prop.ToString()); // hit point regeneration ~1_val~
+
+            if ((prop = m_AosAttributes.RegenStam) != 0)
+                list.Add(1060443, prop.ToString()); // stamina regeneration ~1_val~
+			
+			if ((prop = m_AosAttributes.RegenMana) != 0)
+                list.Add(1060440, prop.ToString()); // mana regeneration ~1_val~
+
+            if ((prop = m_AosAttributes.Luck) != 0)
+                list.Add(1060436, prop.ToString()); // luck ~1_val~
+			
+			if ((prop = m_AosAttributes.AttackChance) != 0)
+                list.Add(1060415, prop.ToString()); // hit chance increase ~1_val~%
+			
+			if ((prop = m_AosAttributes.LowerManaCost) != 0)
+                list.Add(1060433, prop.ToString()); // lower mana cost ~1_val~%
+			
+			if ((prop = m_AosAttributes.SpellDamage) != 0)
+                list.Add(1060483, prop.ToString()); // spell damage increase ~1_val~%
+			
+			if ((prop = m_AosAttributes.LowerRegCost) != 0)
+                list.Add(1060434, prop.ToString()); // lower reagent cost ~1_val~%
+         
+			if ((prop = m_AosAttributes.DefendChance) != 0)
+                list.Add(1060408, prop.ToString()); // defense chance increase ~1_val~%        
+
+            if ((prop = m_AosAttributes.BonusStam) != 0)
+                list.Add(1060484, prop.ToString()); // stamina increase ~1_val~          
+
+            if ((prop = m_AosAttributes.WeaponSpeed) != 0)
+                list.Add(1060486, prop.ToString()); // swing speed increase ~1_val~%
+			
+			if ((prop = m_AosAttributes.WeaponDamage) != 0)
+                list.Add(1060401, prop.ToString()); // damage increase ~1_val~%
+
+            if ((prop = m_AosAttributes.IncreasedKarmaLoss) != 0)
+                list.Add(1075210, prop.ToString()); // Increased Karma Loss ~1val~%                
 
             base.AddResistanceProperties(list);
 
-            if (this is ManaPhasingOrb)
-                list.Add(1116158); //Mana Phase
-
-            if (m_Slayer != TalismanSlayerName.None)
+            if (Blessed)
             {
-                if (m_Slayer == TalismanSlayerName.Goblin)
-                    list.Add(1095010);
-                else if (m_Slayer == TalismanSlayerName.Undead)
-                    list.Add(1060479);
-                else if (m_Slayer <= TalismanSlayerName.Wolf)
-                    list.Add(1072503 + (int)m_Slayer);
+                if (BlessedFor != null)
+                    list.Add(1072304, !String.IsNullOrEmpty(BlessedFor.Name) ? BlessedFor.Name : "Unnamed Warrior"); // Owned by ~1_name~
                 else
-                {
-                    switch (m_Slayer)
-                    {
-                        case TalismanSlayerName.Repond: list.Add(1079750); break;
-                        case TalismanSlayerName.Elemental: list.Add(1079749); break;
-                        case TalismanSlayerName.Demon: list.Add(1079748); break;
-                        case TalismanSlayerName.Arachnid: list.Add(1079747); break;
-                        case TalismanSlayerName.Reptile: list.Add(1079751); break;
-                        case TalismanSlayerName.Fey: list.Add(1154652); break;
-                    }
-                }
-            }
+                    list.Add(1072304, "Nobody"); // Owned by ~1_name~
+            }          
 
             if (m_MaxHitPoints > 0)
                 list.Add(1060639, "{0}\t{1}", m_HitPoints, m_MaxHitPoints); // durability ~1_val~ / ~2_val~

--- a/Scripts/Items/Equipment/Talismans/BaseTalisman.cs
+++ b/Scripts/Items/Equipment/Talismans/BaseTalisman.cs
@@ -785,6 +785,9 @@ namespace Server.Items
             {
                 list.Add(1061078, ArtifactRarity.ToString()); // artifact rarity ~1_val~
             }
+			
+			if (this is ManaPhasingOrb)
+                list.Add(1116158); //Mana Phase
 
             if (m_Killer != null && !m_Killer.IsEmpty && m_Killer.Amount > 0)
                 list.Add(1072388, "{0}\t{1}", m_Killer.Name != null ? m_Killer.Name.ToString() : "Unknown", m_Killer.Amount); // ~1_NAME~ Killer: +~2_val~%

--- a/Scripts/Items/Equipment/Talismans/BloodwoodSpirit.cs
+++ b/Scripts/Items/Equipment/Talismans/BloodwoodSpirit.cs
@@ -5,6 +5,8 @@ namespace Server.Items
     public class BloodwoodSpirit : BaseTalisman
     {
 		public override bool IsArtifact { get { return true; } }
+		public override int LabelNumber { get { return 1075034; } }// Bloodwood Spirit
+        public override bool ForceShowName { get { return true; } }
 		
         [Constructable]
         public BloodwoodSpirit()
@@ -23,36 +25,17 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override int LabelNumber
-        {
-            get
-            {
-                return 1075034;
-            }
-        }// Bloodwood Spirit
-        public override bool ForceShowName
-        {
-            get
-            {
-                return true;
-            }
-        }
+        
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write((int)1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0 && (this.Protection == null || this.Protection.IsEmpty))
-                this.Protection = GetRandomProtection(false);
         }
     }
 }

--- a/Scripts/Items/Equipment/Talismans/CollectionsBritLibraryTalismans.cs
+++ b/Scripts/Items/Equipment/Talismans/CollectionsBritLibraryTalismans.cs
@@ -6,6 +6,8 @@ namespace Server.Items
     public class TreatiseonAlchemyTalisman : BaseTalisman
     {
 		public override bool IsArtifact { get { return true; } }
+		public override int LabelNumber { get { return 1073353; } }// Library Talisman - Treatise on Alchemy
+        public override bool ForceShowName { get { return true; } }
 		
         [Constructable]
         public TreatiseonAlchemyTalisman()
@@ -13,8 +15,7 @@ namespace Server.Items
         { 
             Skill = TalismanSkill.Alchemy;
             SuccessBonus = GetRandomSuccessful();
-            Blessed = GetRandomBlessed();	
-			
+            Blessed = GetRandomBlessed();		
             Attributes.EnhancePotions = 15;			
             SkillBonuses.SetValues(0, SkillName.Magery, 5.0);
         }
@@ -23,32 +24,16 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override int LabelNumber
-        {
-            get
-            {
-                return 1073353;
-            }
-        }// Library Talisman - Treatise on Alchemy
-        public override bool ForceShowName
-        {
-            get
-            {
-                return true;
-            }
-        }
+        
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write((int)0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
         }
     }
@@ -56,17 +41,17 @@ namespace Server.Items
     public class PrimerOnArmsTalisman : BaseTalisman
     {
 		public override bool IsArtifact { get { return true; } }
+		public override int LabelNumber { get { return 1073354; } }// Library Talisman - A Primer on Arms
+        public override bool ForceShowName { get { return true; } }
 		
         [Constructable]
         public PrimerOnArmsTalisman()
             : base(0x2F59)
         { 
-            Blessed = GetRandomBlessed();	
-			
+            Blessed = GetRandomBlessed();			
             Attributes.BonusStr = 1;			
             Attributes.RegenHits = 2;
-            Attributes.WeaponDamage = 20;
-						
+            Attributes.WeaponDamage = 20;						
             Removal = TalismanRemoval.Damage;
             MaxChargeTime = 1200;
         }
@@ -75,32 +60,16 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override int LabelNumber
-        {
-            get
-            {
-                return 1073354;
-            }
-        }// Library Talisman - A Primer on Arms
-        public override bool ForceShowName
-        {
-            get
-            {
-                return true;
-            }
-        }
+      
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write((int)0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
         }
     }
@@ -108,17 +77,17 @@ namespace Server.Items
     public class MyBookTalisman : BaseTalisman
     {
 		public override bool IsArtifact { get { return true; } }
+		public override int LabelNumber { get { return 1073355; } }// Library Talisman - My Book
+        public override bool ForceShowName { get { return true; } }
 		
         [Constructable]
         public MyBookTalisman()
             : base(0x2F5A)
         { 
-            Blessed = GetRandomBlessed();	
-			
+            Blessed = GetRandomBlessed();			
             Skill = TalismanSkill.Inscription;
             SuccessBonus = GetRandomSuccessful();			
-            ExceptionalBonus = GetRandomExceptional();	
-			
+            ExceptionalBonus = GetRandomExceptional();			
             Attributes.BonusInt = 5;			
             Attributes.BonusMana = 2;
         }
@@ -127,32 +96,16 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override int LabelNumber
-        {
-            get
-            {
-                return 1073355;
-            }
-        }// Library Talisman - My Book
-        public override bool ForceShowName
-        {
-            get
-            {
-                return true;
-            }
-        }
+        
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write((int)0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
         }
     }
@@ -160,16 +113,16 @@ namespace Server.Items
     public class TalkingtoWispsTalisman : BaseTalisman
     {
 		public override bool IsArtifact { get { return true; } }
+		public override int LabelNumber { get { return 1073356; } }// Library Talisman - Talking to Wisps
+        public override bool ForceShowName { get { return true; } }
 		
         [Constructable]
         public TalkingtoWispsTalisman()
             : base(0x2F5B)
         { 
-            Blessed = GetRandomBlessed();	
-			
+            Blessed = GetRandomBlessed();			
             SkillBonuses.SetValues(0, SkillName.SpiritSpeak, 3.0);
-            SkillBonuses.SetValues(1, SkillName.EvalInt, 5.0);
-			
+            SkillBonuses.SetValues(1, SkillName.EvalInt, 5.0);			
             Removal = TalismanRemoval.Ward;
             MaxChargeTime = 1200;
         }
@@ -178,32 +131,16 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override int LabelNumber
-        {
-            get
-            {
-                return 1073356;
-            }
-        }// Library Talisman - Talking to Wisps
-        public override bool ForceShowName
-        {
-            get
-            {
-                return true;
-            }
-        }
+        
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write((int)0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
         }
     }
@@ -211,6 +148,8 @@ namespace Server.Items
     public class GrammarOfOrchishTalisman : BaseTalisman
     {
 		public override bool IsArtifact { get { return true; } }
+		public override int LabelNumber { get { return 1073358; } }// Library Talisman - a Grammar of Orchish (Summoner)
+        public override bool ForceShowName { get { return true; } }
 		
         [Constructable]
         public GrammarOfOrchishTalisman()
@@ -218,11 +157,9 @@ namespace Server.Items
         { 
             Blessed = GetRandomBlessed();	
             Protection = GetRandomProtection();
-            Summoner = new TalismanAttribute(typeof(SummonedOrcBrute), 0, 1072414);
-			
+            Summoner = new TalismanAttribute(typeof(SummonedOrcBrute), 0, 1072414);		
             SkillBonuses.SetValues(0, SkillName.MagicResist, 5.0);
-            SkillBonuses.SetValues(1, SkillName.Anatomy, 7.0);
-			
+            SkillBonuses.SetValues(1, SkillName.Anatomy, 7.0);			
             MaxChargeTime = 1800;
         }
 
@@ -230,32 +167,16 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override int LabelNumber
-        {
-            get
-            {
-                return 1073358;
-            }
-        }// Library Talisman - a Grammar of Orchish (Summoner)
-        public override bool ForceShowName
-        {
-            get
-            {
-                return true;
-            }
-        }
+        
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write((int)0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
         }
     }
@@ -263,55 +184,35 @@ namespace Server.Items
     public class BirdsofBritanniaTalisman : BaseTalisman
     {
 		public override bool IsArtifact { get { return true; } }
+		public override int LabelNumber { get { return 1074892; } }// Library Talisman - Birds of Britannia Random Summoner
+        public override bool ForceShowName { get { return true; } }
+        public override Type GetSummoner() {  return GetRandomSummonType(); }
 		
         [Constructable]
         public BirdsofBritanniaTalisman()
             : base(0x2F5A)
         { 
             Blessed = GetRandomBlessed();	
-            Slayer = TalismanSlayerName.Bird;
-			
+            Slayer = TalismanSlayerName.Bird;			
             SkillBonuses.SetValues(0, SkillName.AnimalTaming, 5.0);
-            SkillBonuses.SetValues(1, SkillName.AnimalLore, 5.0);
-			
+            SkillBonuses.SetValues(1, SkillName.AnimalLore, 5.0);		
             MaxChargeTime = 1800;
         }
 
         public BirdsofBritanniaTalisman(Serial serial)
             : base(serial)
         {
-        }
-
-        public override int LabelNumber
-        {
-            get
-            {
-                return 1074892;
-            }
-        }// Library Talisman - Birds of Britannia Random Summoner
-        public override bool ForceShowName
-        {
-            get
-            {
-                return true;
-            }
-        }
-        public override Type GetSummoner()
-        { 
-            return GetRandomSummonType();
-        }
+        }        
 
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write((int)0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
         }
     }
@@ -319,17 +220,17 @@ namespace Server.Items
     public class TheLifeOfTravelingMinstrelTalisman : BaseTalisman
     {
 		public override bool IsArtifact { get { return true; } }
+		public override int LabelNumber { get { return 1073360; } }// Library Talisman - The Life of a Traveling Minstrel
+        public override bool ForceShowName { get { return true; } }
 		
         [Constructable]
         public TheLifeOfTravelingMinstrelTalisman()
             : base(0x2F5B)
         { 
             Blessed = GetRandomBlessed();	
-            Protection = GetRandomProtection();
-			
+            Protection = GetRandomProtection();		
             SkillBonuses.SetValues(0, SkillName.Provocation, 5.0);
-            SkillBonuses.SetValues(1, SkillName.Musicianship, 5.0);
-			
+            SkillBonuses.SetValues(1, SkillName.Musicianship, 5.0);			
             Removal = TalismanRemoval.Curse;
             MaxChargeTime = 1200;		
         }
@@ -338,32 +239,16 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override int LabelNumber
-        {
-            get
-            {
-                return 1073360;
-            }
-        }// Library Talisman - The Life of a Traveling Minstrel
-        public override bool ForceShowName
-        {
-            get
-            {
-                return true;
-            }
-        }
+        
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write((int)0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
         }
     }

--- a/Scripts/Items/Equipment/Talismans/ManaPhasingOrb.cs
+++ b/Scripts/Items/Equipment/Talismans/ManaPhasingOrb.cs
@@ -7,7 +7,6 @@ namespace Server.Items
     public class ManaPhasingOrb : BaseTalisman, Server.Engines.Craft.IRepairable
     {
         public override int LabelNumber { get { return 1116230; } }
-
         public Server.Engines.Craft.CraftSystem RepairSystem { get { return Server.Engines.Craft.DefTinkering.CraftSystem; } }
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
@@ -19,7 +18,6 @@ namespace Server.Items
             Charges = 50;
             MaxCharges = Charges;
             Hue = 1165;
-
             Attributes.Brittle = 1;
             Attributes.LowerManaCost = 6;
 

--- a/Scripts/Items/Equipment/Talismans/RandomTalisman.cs
+++ b/Scripts/Items/Equipment/Talismans/RandomTalisman.cs
@@ -48,14 +48,12 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write((int)0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
         }
     }

--- a/Scripts/Items/Equipment/Talismans/Slither.cs
+++ b/Scripts/Items/Equipment/Talismans/Slither.cs
@@ -5,6 +5,8 @@ namespace Server.Items
     public class Slither : BaseTalisman
     {
 		public override bool IsArtifact { get { return true; } }
+		public override int LabelNumber { get{return 1114782;} }// Slither
+		
         [Constructable]
         public Slither()
             : base(0x2F5B)
@@ -19,9 +21,7 @@ namespace Server.Items
         public Slither(Serial serial)
             : base(serial)
         {
-        }
-		
-		public override int LabelNumber { get{return 1114782;} }// Slither
+        }				
 
         public override void Deserialize(GenericReader reader)
         {

--- a/Scripts/Items/Equipment/Talismans/TalismanofGoblinSlaying.cs
+++ b/Scripts/Items/Equipment/Talismans/TalismanofGoblinSlaying.cs
@@ -4,44 +4,31 @@ namespace Server.Items
 {
     public class TalismanofGoblinSlaying : BaseTalisman
     {
+		public override int LabelNumber { get { return 1095011; } }//Talisman of Goblin Slaying
+        public override bool ForceShowName { get { return true; } }
+		
         [Constructable]
         public TalismanofGoblinSlaying()
             : base(0x2F58)
         { 
-            this.Slayer = TalismanSlayerName.Goblin;
-            this.MaxChargeTime = 1200;
+            Slayer = TalismanSlayerName.Goblin;
+            MaxChargeTime = 1200;
         }
 
         public TalismanofGoblinSlaying(Serial serial)
             : base(serial)
         {
         }
-
-        public override int LabelNumber
-        {
-            get
-            {
-                return 1095011;
-            }
-        }//Talisman of Goblin Slaying
-        public override bool ForceShowName
-        {
-            get
-            {
-                return true;
-            }
-        }
+        
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadEncodedInt();
         }
     }

--- a/Scripts/Items/Equipment/Talismans/Talismans.cs
+++ b/Scripts/Items/Equipment/Talismans/Talismans.cs
@@ -17,9 +17,9 @@ namespace Server.Items
         public BaseFormTalisman()
             : base(0x2F59)
         {
-            this.LootType = LootType.Blessed;
-            this.Layer = Layer.Talisman;
-            this.Weight = 1.0;
+            LootType = LootType.Blessed;
+            Layer = Layer.Talisman;
+            Weight = 1.0;
         }
 
         public BaseFormTalisman(Serial serial)
@@ -27,13 +27,8 @@ namespace Server.Items
         {
         }
 
-        public virtual TalismanForm Form
-        {
-            get
-            {
-                return TalismanForm.Squirrel;
-            }
-        }
+        public virtual TalismanForm Form { get { return TalismanForm.Squirrel; } }
+		
         public static bool EntryEnabled(Mobile m, Type type)
         {
             if (type == typeof(Squirrel))
@@ -56,14 +51,12 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(0); //version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadEncodedInt();
         }
 
@@ -82,6 +75,8 @@ namespace Server.Items
 
     public class FerretFormTalisman : BaseFormTalisman
     {
+		public override TalismanForm Form { get { return TalismanForm.Ferret; } }
+		
         [Constructable]
         public FerretFormTalisman()
             : base()
@@ -93,30 +88,23 @@ namespace Server.Items
         {
         }
 
-        public override TalismanForm Form
-        {
-            get
-            {
-                return TalismanForm.Ferret;
-            }
-        }
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(0); //version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadEncodedInt();
         }
     }
 
     public class SquirrelFormTalisman : BaseFormTalisman
     {
+		public override TalismanForm Form { get { return TalismanForm.Squirrel; } }
+		
         [Constructable]
         public SquirrelFormTalisman()
             : base()
@@ -127,31 +115,24 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override TalismanForm Form
-        {
-            get
-            {
-                return TalismanForm.Squirrel;
-            }
-        }
+        
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(0); //version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadEncodedInt();
         }
     }
 
     public class CuSidheFormTalisman : BaseFormTalisman
     {
+		public override TalismanForm Form { get { return TalismanForm.CuSidhe; } }
+		
         [Constructable]
         public CuSidheFormTalisman()
             : base()
@@ -163,30 +144,23 @@ namespace Server.Items
         {
         }
 
-        public override TalismanForm Form
-        {
-            get
-            {
-                return TalismanForm.CuSidhe;
-            }
-        }
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(0); //version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadEncodedInt();
         }
     }
 
     public class ReptalonFormTalisman : BaseFormTalisman
     {
+		public override TalismanForm Form { get { return TalismanForm.Reptalon; } }
+		
         [Constructable]
         public ReptalonFormTalisman()
             : base()
@@ -198,24 +172,15 @@ namespace Server.Items
         {
         }
 
-        public override TalismanForm Form
-        {
-            get
-            {
-                return TalismanForm.Reptalon;
-            }
-        }
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(0); //version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadEncodedInt();
         }
     }

--- a/Scripts/Items/Equipment/Talismans/TotemOfVoid.cs
+++ b/Scripts/Items/Equipment/Talismans/TotemOfVoid.cs
@@ -6,6 +6,8 @@ namespace Server.Items
     public class TotemOfVoid : BaseTalisman
     {
 		public override bool IsArtifact { get { return true; } }
+		public override int LabelNumber { get { return 1075035; } }// Totem of the Void
+        public override bool ForceShowName { get { return true; } }
 		
         [Constructable]
         public TotemOfVoid()
@@ -23,21 +25,7 @@ namespace Server.Items
             : base(serial)
         {
         }
-
-        public override int LabelNumber
-        {
-            get
-            {
-                return 1075035;
-            }
-        }// Totem of the Void
-        public override bool ForceShowName
-        {
-            get
-            {
-                return true;
-            }
-        }
+        
         public override Type GetSummoner()
         {
             return Utility.RandomBool() ? typeof(SummonedSkeletalKnight) : typeof(SummonedSheep);
@@ -46,18 +34,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write((int)1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0 && (this.Protection == null || this.Protection.IsEmpty))
-                this.Protection = GetRandomProtection(false);
         }
     }
 }

--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -1261,14 +1261,7 @@ namespace Server
         public virtual void AddLootTypeProperty(ObjectPropertyList list)
         {
             if (DisplayLootType)
-            {
-                Mobile blessedFor = BlessedFor;
-
-                if (blessedFor != null && !blessedFor.Deleted)
-                {
-                    AddBlessedForProperty(list, blessedFor);
-                }
-
+            {               
                 if (m_LootType == LootType.Blessed)
                 {
                     list.Add(1038021); // blessed


### PR DESCRIPTION
1. Cleaned up talismans.
2. Most talisman properties should now be in the correct order when compared to OSI.
3. Removed blessedFor from a display override in the core (Item.cs) this was causing owned by items to display Owned By and Blessed For at the same time.

The only time Blessed For is called is if a personal bless deed was used and this is handled in BaseArmor, BaseWeapon, ect ect.

Required a core recompile. 