### PR TITLE
Fixes BOD exploit.

### DIFF
--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -160,10 +160,12 @@ namespace Server.Mobiles
 
                             if (bulkOrder is LargeBOD)
                             {
+								m_From.CloseGump(typeof (LargeBODAcceptGump));
                                 m_From.SendGump(new LargeBODAcceptGump(m_From, (LargeBOD)bulkOrder));
                             }
                             else if (bulkOrder is SmallBOD)
                             {
+								m_From.CloseGump(typeof (LargeBODAcceptGump));
                                 m_From.SendGump(new SmallBODAcceptGump(m_From, (SmallBOD)bulkOrder));
                             }
                         }
@@ -196,10 +198,12 @@ namespace Server.Mobiles
 
                                 if (bulkOrder is LargeBOD)
                                 {
+									m_From.CloseGump(typeof (LargeBODAcceptGump));
                                     m_From.SendGump(new LargeBODAcceptGump(m_From, (LargeBOD)bulkOrder));
                                 }
                                 else if (bulkOrder is SmallBOD)
                                 {
+									m_From.CloseGump(typeof (LargeBODAcceptGump));
                                     m_From.SendGump(new SmallBODAcceptGump(m_From, (SmallBOD)bulkOrder));
                                 }
                             }

--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -165,7 +165,7 @@ namespace Server.Mobiles
                             }
                             else if (bulkOrder is SmallBOD)
                             {
-								m_From.CloseGump(typeof (LargeBODAcceptGump));
+								m_From.CloseGump(typeof (SmallBODAcceptGump));
                                 m_From.SendGump(new SmallBODAcceptGump(m_From, (SmallBOD)bulkOrder));
                             }
                         }
@@ -203,7 +203,7 @@ namespace Server.Mobiles
                                 }
                                 else if (bulkOrder is SmallBOD)
                                 {
-									m_From.CloseGump(typeof (LargeBODAcceptGump));
+									m_From.CloseGump(typeof (SmallBODAcceptGump));
                                     m_From.SendGump(new SmallBODAcceptGump(m_From, (SmallBOD)bulkOrder));
                                 }
                             }


### PR DESCRIPTION
Currently players who are eligible to receive a BOD can click on the NPC once, get the context menu Bulk Order Info and simply exit out of the menu or hit cancel over and over to cycle through Bulk Orders, to get the ones you want.

I wanted to know how UO blocks it so I tested. Sure enough if you simply close out of the menu or even hit cancel 3 times it still counts it as a grab. My fix simply makes sure there are no instances of BODAcceptGump and if there are, closes them, forcing a count.