### PR TITLE
Bug fixes

### DIFF
--- a/Scripts/Items/Decorative/GlassItems.cs
+++ b/Scripts/Items/Decorative/GlassItems.cs
@@ -11,8 +11,8 @@ namespace Server.Items
         public SmallFlask()
             : base(0x182E)
         {
-            this.Weight = 1.0;
-            this.Movable = true;
+            Weight = 1.0;
+            Movable = true;
         }
 
         public SmallFlask(Serial serial)
@@ -42,8 +42,8 @@ namespace Server.Items
         public MediumFlask()
             : base(0x182A)
         {
-            this.Weight = 1.0;
-            this.Movable = true;
+            Weight = 1.0;
+            Movable = true;
         }
 
         public MediumFlask(Serial serial)
@@ -73,8 +73,8 @@ namespace Server.Items
         public LargeFlask()
             : base(0x183B)
         {
-            this.Weight = 1.0;
-            this.Movable = true;
+            Weight = 1.0;
+            Movable = true;
         }
 
         public LargeFlask(Serial serial)
@@ -104,8 +104,8 @@ namespace Server.Items
         public CurvedFlask()
             : base(0x1832)
         {
-            this.Weight = 1.0;
-            this.Movable = true;
+            Weight = 1.0;
+            Movable = true;
         }
 
         public CurvedFlask(Serial serial)
@@ -135,8 +135,8 @@ namespace Server.Items
         public LongFlask()
             : base(0x1838)
         {
-            this.Weight = 1.0;
-            this.Movable = true;
+            Weight = 1.0;
+            Movable = true;
         }
 
         public LongFlask(Serial serial)
@@ -160,14 +160,28 @@ namespace Server.Items
     }
 
     [Flipable(0x1810, 0x1811)]
-    public class SpinningHourglass : Item
+    public class SpinningHourglass : Item, IFlipable
     {
+        public override int LabelNumber { get { return 1044592; } } // gargoyle hourglass
+
         [Constructable]
         public SpinningHourglass()
             : base(0x1810)
         {
-            this.Weight = 1.0;
-            this.Movable = true;
+            Weight = 1.0;
+            Movable = true;
+        }
+
+        public void OnFlip(Mobile from)
+        {
+            if (ItemID == 0x1810)
+            {
+                ItemID = 0x1811;
+            }
+            else
+            {
+                ItemID = 0x1810;
+            }
         }
 
         public SpinningHourglass(Serial serial)
@@ -196,8 +210,8 @@ namespace Server.Items
         public GreenBottle()
             : base(0x0EFB)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public GreenBottle(Serial serial)
@@ -226,8 +240,8 @@ namespace Server.Items
         public RedBottle()
             : base(0x0EFC)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public RedBottle(Serial serial)
@@ -256,8 +270,8 @@ namespace Server.Items
         public SmallBrownBottle()
             : base(0x0EFD)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public SmallBrownBottle(Serial serial)
@@ -286,8 +300,8 @@ namespace Server.Items
         public SmallGreenBottle()
             : base(0x0F01)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public SmallGreenBottle(Serial serial)
@@ -316,8 +330,8 @@ namespace Server.Items
         public SmallVioletBottle()
             : base(0x0F02)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public SmallVioletBottle(Serial serial)
@@ -346,8 +360,8 @@ namespace Server.Items
         public TinyYellowBottle()
             : base(0x0F03)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public TinyYellowBottle(Serial serial)
@@ -377,8 +391,8 @@ namespace Server.Items
         public SmallBlueFlask()
             : base(0x182A)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public SmallBlueFlask(Serial serial)
@@ -407,8 +421,8 @@ namespace Server.Items
         public SmallYellowFlask()
             : base(0x182B)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public SmallYellowFlask(Serial serial)
@@ -437,8 +451,8 @@ namespace Server.Items
         public SmallRedFlask()
             : base(0x182C)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public SmallRedFlask(Serial serial)
@@ -467,8 +481,8 @@ namespace Server.Items
         public SmallEmptyFlask()
             : base(0x182D)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public SmallEmptyFlask(Serial serial)
@@ -497,8 +511,8 @@ namespace Server.Items
         public YellowBeaker()
             : base(0x182E)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public YellowBeaker(Serial serial)
@@ -527,8 +541,8 @@ namespace Server.Items
         public RedBeaker()
             : base(0x182F)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public RedBeaker(Serial serial)
@@ -557,8 +571,8 @@ namespace Server.Items
         public BlueBeaker()
             : base(0x1830)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public BlueBeaker(Serial serial)
@@ -587,8 +601,8 @@ namespace Server.Items
         public GreenBeaker()
             : base(0x1831)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public GreenBeaker(Serial serial)
@@ -617,8 +631,8 @@ namespace Server.Items
         public EmptyCurvedFlaskW()
             : base(0x1832)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public EmptyCurvedFlaskW(Serial serial)
@@ -647,8 +661,8 @@ namespace Server.Items
         public RedCurvedFlask()
             : base(0x1833)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public RedCurvedFlask(Serial serial)
@@ -677,8 +691,8 @@ namespace Server.Items
         public LtBlueCurvedFlask()
             : base(0x1834)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public LtBlueCurvedFlask(Serial serial)
@@ -707,8 +721,8 @@ namespace Server.Items
         public EmptyCurvedFlaskE()
             : base(0x1835)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public EmptyCurvedFlaskE(Serial serial)
@@ -737,8 +751,8 @@ namespace Server.Items
         public BlueCurvedFlask()
             : base(0x1836)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public BlueCurvedFlask(Serial serial)
@@ -767,8 +781,8 @@ namespace Server.Items
         public GreenCurvedFlask()
             : base(0x1837)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public GreenCurvedFlask(Serial serial)
@@ -797,8 +811,8 @@ namespace Server.Items
         public RedRibbedFlask()
             : base(0x1838)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public RedRibbedFlask(Serial serial)
@@ -827,8 +841,8 @@ namespace Server.Items
         public VioletRibbedFlask()
             : base(0x1839)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public VioletRibbedFlask(Serial serial)
@@ -857,8 +871,8 @@ namespace Server.Items
         public EmptyRibbedFlask()
             : base(0x183A)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public EmptyRibbedFlask(Serial serial)
@@ -887,8 +901,8 @@ namespace Server.Items
         public LargeYellowFlask()
             : base(0x183B)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public LargeYellowFlask(Serial serial)
@@ -917,8 +931,8 @@ namespace Server.Items
         public LargeVioletFlask()
             : base(0x183C)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public LargeVioletFlask(Serial serial)
@@ -947,8 +961,8 @@ namespace Server.Items
         public LargeEmptyFlask()
             : base(0x183D)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public LargeEmptyFlask(Serial serial)
@@ -977,8 +991,8 @@ namespace Server.Items
         public AniRedRibbedFlask()
             : base(0x183E)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public AniRedRibbedFlask(Serial serial)
@@ -1007,8 +1021,8 @@ namespace Server.Items
         public AniLargeVioletFlask()
             : base(0x1841)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public AniLargeVioletFlask(Serial serial)
@@ -1037,8 +1051,8 @@ namespace Server.Items
         public AniSmallBlueFlask()
             : base(0x1844)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public AniSmallBlueFlask(Serial serial)
@@ -1067,8 +1081,8 @@ namespace Server.Items
         public SmallBlueBottle()
             : base(0x1847)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public SmallBlueBottle(Serial serial)
@@ -1097,8 +1111,8 @@ namespace Server.Items
         public SmallGreenBottle2()
             : base(0x1848)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public SmallGreenBottle2(Serial serial)
@@ -1128,8 +1142,8 @@ namespace Server.Items
         public EmptyVialsWRack()
             : base(0x185B)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public EmptyVialsWRack(Serial serial)
@@ -1159,8 +1173,8 @@ namespace Server.Items
         public FullVialsWRack()
             : base(0x185D)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public FullVialsWRack(Serial serial)
@@ -1189,8 +1203,8 @@ namespace Server.Items
         public EmptyVial()
             : base(0x0E24)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public EmptyVial(Serial serial)
@@ -1219,8 +1233,8 @@ namespace Server.Items
         public HourglassAni()
             : base(0x1811)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public HourglassAni(Serial serial)
@@ -1249,8 +1263,8 @@ namespace Server.Items
         public Hourglass()
             : base(0x1810)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public Hourglass(Serial serial)
@@ -1279,8 +1293,8 @@ namespace Server.Items
         public TinyRedBottle()
             : base(0x0F04)
         { 
-            this.Weight = 1.0;
-            this.Movable = true; 
+            Weight = 1.0;
+            Movable = true; 
         }
 
         public TinyRedBottle(Serial serial)

--- a/Scripts/Items/Equipment/Armor/GargishPlateArms.cs
+++ b/Scripts/Items/Equipment/Armor/GargishPlateArms.cs
@@ -41,29 +41,6 @@ namespace Server.Items
         public override Race RequiredRace { get { return Race.Gargoyle; } }
         public override bool CanBeWornByGargoyles { get { return true; } }
 
-        public override int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, ITool tool, CraftItem craftItem, int resHue)
-        {
-            Quality = (ItemQuality)quality;
-
-            if (makersMark)
-                Crafter = from;
-
-            Type resourceType = typeRes;
-
-            if (resourceType == null)
-                resourceType = craftItem.Resources.GetAt(0).ItemType;
-
-            Resource = CraftResources.GetFromType(resourceType);
-
-            PlayerConstructed = true;
-
-            CraftContext context = craftSystem.GetContext(from);
-
-            Hue = CraftResources.GetHue(Resource);
-
-            return quality;
-        }
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Mobiles/Bosses/Travesty.cs
+++ b/Scripts/Mobiles/Bosses/Travesty.cs
@@ -340,8 +340,7 @@ namespace Server.Mobiles
 
         public override bool OnBeforeDeath()
         {
-            if (m_Timer != null)
-                m_Timer.Stop();
+            RestoreBody();
 
             return base.OnBeforeDeath();
         }

--- a/Scripts/Mobiles/NPCs/Sam.cs
+++ b/Scripts/Mobiles/NPCs/Sam.cs
@@ -9,10 +9,10 @@ namespace Server.Items
         public BritanniaWaters()
             : base("Sam", "the fisher")
         {
-            this.StartTier = 10000000;
-            this.DailyDecay = 100000;
+            StartTier = 10000000;
+            DailyDecay = 100000;
 			
-            this.DonationLabel = 1073440; // Britannia Waters Section Donation Representative.
+            DonationLabel = 1073440; // Britannia Waters Section Donation Representative.
         }
 
         public BritanniaWaters(Serial serial)
@@ -36,40 +36,40 @@ namespace Server.Items
         }
         public override void InitBody()
         {
-            this.InitStats(100, 100, 25);
+            InitStats(100, 100, 25);
 			
-            this.Female = false;	
-            this.CantWalk = true;
-            this.Race = Race.Human;		
+            Female = false;	
+            CantWalk = true;
+            Race = Race.Human;		
 			
-            this.Hue = 0x8402;
-            this.HairItemID = 0x2044;
-            this.HairHue = 0x46B;
-            this.FacialHairItemID = 0x203F;
-            this.FacialHairHue = 0x46B;
+            Hue = 0x8402;
+            HairItemID = 0x2044;
+            HairHue = 0x46B;
+            FacialHairItemID = 0x203F;
+            FacialHairHue = 0x46B;
         }
 
         public override void InitOutfit()
         { 
-            this.AddItem(new Backpack());						
-            this.AddItem(new FishingPole());				
-            this.AddItem(new Shoes(0x71F));				
-            this.AddItem(new Doublet(0x52E));				
-            this.AddItem(new LongPants(0x656));	
+            AddItem(new Backpack());						
+            AddItem(new FishingPole());				
+            AddItem(new Shoes(0x71F));				
+            AddItem(new Doublet(0x52E));				
+            AddItem(new LongPants(0x656));	
         }
 
         public override void Init()
         {
             base.Init();
 			
-            this.Donations.Add(new CollectionItem(typeof(Gold), 0xEEF, 1073116, 0x0, 0.06666));
-            this.Donations.Add(new CollectionItem(typeof(BankCheck), 0x14F0, 1075013, 0x34, 0.06666));	
+            Donations.Add(new CollectionItem(typeof(Gold), 0xEEF, 1073116, 0x0, 0.06666));
+            Donations.Add(new CollectionItem(typeof(BankCheck), 0x14F0, 1075013, 0x34, 0.06666));	
 			
-            this.Donations.Add(new CollectionItem(typeof(RawFishSteak), 0x97A, 1075087, 0x0, 0.25));	
-            this.Donations.Add(new CollectionItem(typeof(Fish), 0x9CC, 1074939, 0x0, 1));										
-            this.Donations.Add(new CollectionItem(typeof(FishingPole), 0xDC0, 1011406, 0x0, 2));				
-            this.Donations.Add(new CollectionItem(typeof(BrownBook), 0xFEF, 1074906, 0x0, 3));
-            this.Donations.Add(new CollectionItem(typeof(TanBook), 0xFF0, 1074906, 0x0, 3));
+            Donations.Add(new CollectionItem(typeof(RawFishSteak), 0x97A, 1075087, 0x0, 0.25));	
+            Donations.Add(new CollectionItem(typeof(Fish), 0x9CC, 1074939, 0x0, 1));										
+            Donations.Add(new CollectionItem(typeof(FishingPole), 0xDC0, 1011406, 0x0, 2));				
+            Donations.Add(new CollectionItem(typeof(BrownBook), 0xFEF, 1074906, 0x0, 3));
+            Donations.Add(new CollectionItem(typeof(TanBook), 0xFF0, 1074906, 0x0, 3));
 
             #region High Seas
             Donations.Add(new CollectionItem(typeof(Lobster), 17619, 1096491, 0x0, 10));
@@ -77,35 +77,36 @@ namespace Server.Items
             #endregion
 
             int[] hues = new int[] { 0x1E0, 0x190, 0x151 };			
-            this.Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendBodySash), 0x1541, 1073346, 0x190, 100000.0, hues));
-            this.Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendFeatheredHat), 0x171A, 1073347, 0x190, 100000.0, hues));
-            this.Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendSurcoat), 0x1FFD, 1073348, 0x190, 100000.0, hues));
-            this.Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendPants), 0x1539, 1073349, 0x190, 100000.0, hues));			
-            this.Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendCloak), 0x1515, 1073350, 0x190, 100000.0, hues));			
-            this.Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendDoublet), 0x1F7B, 1073351, 0x190, 100000.0, hues));			
-            this.Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendSkirt), 0x1537, 1073352, 0x190, 100000.0, hues));
-            this.Rewards.Add(new CollectionTitle(1073341, 1073859, 100000.0)); // Britain Public Library Contributor
+            Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendBodySash), 0x1541, 1073346, 0x190, 100000.0, hues));
+            Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendFeatheredHat), 0x171A, 1073347, 0x190, 100000.0, hues));
+            Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendSurcoat), 0x1FFD, 1073348, 0x190, 100000.0, hues));
+            Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendPants), 0x1539, 1073349, 0x190, 100000.0, hues));			
+            Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendCloak), 0x1515, 1073350, 0x190, 100000.0, hues));			
+            Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendDoublet), 0x1F7B, 1073351, 0x190, 100000.0, hues));			
+            Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendSkirt), 0x1537, 1073352, 0x190, 100000.0, hues));
+            Rewards.Add(new CollectionTitle(1073341, 1073859, 100000.0)); // Britain Public Library Contributor
 			
             hues = new int[] { 0x0, 0x1C2, 0x320, 0x190, 0x1E0 };
-            this.Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendLantern), 0xA25, 1073339, 0x1C2, 200000.0, hues));
-            this.Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendReadingChair), 0x2DEB, 1073340, 0x1C2, 200000.0, hues));			
-            this.Rewards.Add(new CollectionTitle(1073342, 1073860, 200000.0)); // Distinguished Library Contributor
-            this.Rewards.Add(new CollectionHuedItem(typeof(SherryTheMouseQuotes), 0xFBD, 1073300, 0x1C2, 350000.0, hues));	
-            this.Rewards.Add(new CollectionHuedItem(typeof(WyrdBeastmasterQuotes), 0xFBD, 1073310, 0x1C2, 350000.0, hues));	
-            this.Rewards.Add(new CollectionHuedItem(typeof(MercenaryJustinQuotes), 0xFBD, 1073317, 0x1C2, 350000.0, hues));	
-            this.Rewards.Add(new CollectionHuedItem(typeof(HeigelOfMoonglowQuotes), 0xFBD, 1073327, 0x1C2, 350000.0, hues));	
-            this.Rewards.Add(new CollectionHuedItem(typeof(TraderHoraceQuotes), 0xFBD, 1073338, 0x1C2, 350000.0, hues));				
-            this.Rewards.Add(new CollectionTitle(1073343, 1073861, 350000.0)); // Honored Library Contributor			
-            this.Rewards.Add(new CollectionItem(typeof(TreatiseonAlchemyTalisman), 0x2F58, 1073353, 0x0, 550000.0));			
-            this.Rewards.Add(new CollectionItem(typeof(PrimerOnArmsTalisman), 0x2F59, 1073354, 0x0, 550000.0));		
-            this.Rewards.Add(new CollectionItem(typeof(MyBookTalisman), 0x2F5A, 1073355, 0x0, 550000.0));			
-            this.Rewards.Add(new CollectionItem(typeof(TalkingtoWispsTalisman), 0x2F5B, 1073356, 0x0, 550000.0));		
-            this.Rewards.Add(new CollectionItem(typeof(GrammarOfOrchishTalisman), 0x2F59, 1073358, 0x0, 550000.0));
-            this.Rewards.Add(new CollectionItem(typeof(BirdsofBritanniaTalisman), 0x2F5A, 1073359, 0x0, 550000.0));	
-            this.Rewards.Add(new CollectionItem(typeof(TheLifeOfTravelingMinstrelTalisman), 0x2F5A, 1073360, 0x0, 550000.0));						
-            this.Rewards.Add(new CollectionTitle(1073344, 1073862, 550000.0)); // Prominent Library Contributor
-            this.Rewards.Add(new CollectionTitle(1073345, 1073863, 800000.0)); // Eminent Library Contributor
-            this.Rewards.Add(new CollectionItem(typeof(MaritimeGlasses), 0x2FB8, 1073364, 0x581, 800000.0));				
+            Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendLantern), 0xA25, 1073339, 0x1C2, 200000.0, hues));
+            Rewards.Add(new CollectionHuedItem(typeof(LibraryFriendReadingChair), 0x2DEB, 1073340, 0x1C2, 200000.0, hues));			
+            Rewards.Add(new CollectionTitle(1073342, 1073860, 200000.0)); // Distinguished Library Contributor
+            Rewards.Add(new CollectionHuedItem(typeof(SherryTheMouseQuotes), 0xFBD, 1073300, 0x1C2, 350000.0, hues));	
+            Rewards.Add(new CollectionHuedItem(typeof(WyrdBeastmasterQuotes), 0xFBD, 1073310, 0x1C2, 350000.0, hues));	
+            Rewards.Add(new CollectionHuedItem(typeof(MercenaryJustinQuotes), 0xFBD, 1073317, 0x1C2, 350000.0, hues));	
+            Rewards.Add(new CollectionHuedItem(typeof(HeigelOfMoonglowQuotes), 0xFBD, 1073327, 0x1C2, 350000.0, hues));	
+            Rewards.Add(new CollectionHuedItem(typeof(TraderHoraceQuotes), 0xFBD, 1073338, 0x1C2, 350000.0, hues));				
+            Rewards.Add(new CollectionTitle(1073343, 1073861, 350000.0)); // Honored Library Contributor			
+            Rewards.Add(new CollectionItem(typeof(TreatiseonAlchemyTalisman), 0x2F58, 1073353, 0x0, 550000.0));			
+            Rewards.Add(new CollectionItem(typeof(PrimerOnArmsTalisman), 0x2F59, 1073354, 0x0, 550000.0));		
+            Rewards.Add(new CollectionItem(typeof(MyBookTalisman), 0x2F5A, 1073355, 0x0, 550000.0));			
+            Rewards.Add(new CollectionItem(typeof(TalkingtoWispsTalisman), 0x2F5B, 1073356, 0x0, 550000.0));		
+            Rewards.Add(new CollectionItem(typeof(GrammarOfOrchishTalisman), 0x2F59, 1073358, 0x0, 550000.0));
+            Rewards.Add(new CollectionItem(typeof(BirdsofBritanniaTalisman), 0x2F5A, 1073359, 0x0, 550000.0));	
+            Rewards.Add(new CollectionItem(typeof(TheLifeOfTravelingMinstrelTalisman), 0x2F5A, 1073360, 0x0, 550000.0));						
+            Rewards.Add(new CollectionTitle(1073344, 1073862, 550000.0)); // Prominent Library Contributor
+            Rewards.Add(new CollectionTitle(1073345, 1073863, 800000.0)); // Eminent Library Contributor
+            Rewards.Add(new CollectionItem(typeof(MaritimeGlasses), 0x2FB8, 1073364, 0x581, 800000.0));
+            Rewards.Add(new CollectionItem(typeof(Server.Multis.BritannianShipDeed), 0x14F4, 1150017, 0x0, 10000000));
         }
 
         public override bool CanDonate(PlayerMobile player)

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -2139,7 +2139,7 @@ namespace Server.Mobiles
                     }
                 }
 
-                if (with is HarvestersBlade)
+                if (special)
                 {
                     feathers = (int)Math.Ceiling((double)feathers * 1.1);
                     wool = (int)Math.Ceiling((double)wool * 1.1);
@@ -2207,17 +2207,30 @@ namespace Server.Mobiles
                 if (hides != 0)
                 {
                     Item leather = null;
+                    var cutHides = (with is SkinningKnife && from.FindItemOnLayer(Layer.OneHanded) == with) || special || with is ButchersWarCleaver;
 
                     switch (HideType)
                     {
                         default:
-                        case HideType.Regular: leather = new Leather(hides); break;
-                        case HideType.Spined: leather = new SpinedLeather(hides); break;
-                        case HideType.Horned: leather = new HornedLeather(hides); break;
-                        case HideType.Barbed: leather = new BarbedLeather(hides); break;
+                        case HideType.Regular:
+                            if (cutHides) leather = new Leather(hides);
+                            else leather = new Hides(hides);
+                            break;
+                        case HideType.Spined:
+                            if (cutHides) leather = new SpinedLeather(hides);
+                            else leather = new SpinedHides(hides);
+                            break;
+                        case HideType.Horned:
+                            if (cutHides) leather = new HornedLeather(hides);
+                            else leather = new HornedHides(hides);
+                            break;
+                        case HideType.Barbed:
+                            if (cutHides) leather = new BarbedLeather(hides);
+                            else leather = new BarbedHides(hides);
+                            break;
                     }
 
-                    if (!Core.AOS || (!special && !(with is ButchersWarCleaver)) || !from.AddToBackpack(leather))
+                    if (!Core.AOS || !cutHides || !from.AddToBackpack(leather))
                     {
                         corpse.AddCarvedItem(leather, from);
                         from.SendLocalizedMessage(500471); // You skin it, and the hides are now in the corpse.

--- a/Scripts/Regions/HouseRegion.cs
+++ b/Scripts/Regions/HouseRegion.cs
@@ -463,6 +463,14 @@ namespace Server.Regions
             return base.OnSingleClick(from, o);
         }
 
+        public override void OnDelete(Item item)
+        {
+            if (House.IsLockedDown(item) || House.IsSecure(item))
+            {
+                House.SetLockdown(null, item, false); 
+            }
+        }
+
         private static Rectangle3D[] GetArea(BaseHouse house)
         {
             int x = house.X;

--- a/Scripts/Services/LootGeneration/ItemPropertyInfo.cs
+++ b/Scripts/Services/LootGeneration/ItemPropertyInfo.cs
@@ -1178,7 +1178,7 @@ namespace Server.Items
         public static bool HasHitSpell(BaseWeapon wep)
         {
             return wep.WeaponAttributes.HitFireball > 0 || wep.WeaponAttributes.HitLightning > 0 || wep.WeaponAttributes.HitMagicArrow > 0
-                /*|| wep.WeaponAttributes.HitCurse > 0*/ || wep.WeaponAttributes.HitHarm > 0;
+                /*|| wep.WeaponAttributes.HitCurse > 0*/ || wep.WeaponAttributes.HitHarm > 0 || wep.WeaponAttributes.HitDispel > 0;
         }
 
         public static bool HasHitArea(BaseWeapon wep)

--- a/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
+++ b/Scripts/Services/LootGeneration/RunicReforging/RunicReforging.cs
@@ -787,8 +787,8 @@ namespace Server.Items
                 switch ((string)attribute)
                 {
                     case "RandomEater": attribute = GetRandomEater(); break;
-                    case "HitSpell": attribute = GetRandomEater(); break;
-                    case "HitArea": attribute = GetRandomEater(); break;
+                    case "HitSpell": attribute = GetRandomHitSpell(); break;
+                    case "HitArea": attribute = GetRandomHitArea(); break;
                     case "Slayer": attribute = BaseRunicTool.GetRandomSlayer(); break;
                     case "WeaponVelocity": break;
                     case "ElementalDamage": attribute = GetRandomElemental(); break;
@@ -1555,50 +1555,6 @@ namespace Server.Items
 
                 return value;
             }
-
-            /*public int Min(int resIndex, int preIndex, Item item)
-            {
-                if (HardCap == 1)
-                    return 1;
-
-                int max = Max(resIndex, preIndex, item);
-
-                if (resIndex != -1 && preIndex != -1)
-                {
-                    return item is BaseRanged && SecondaryInfo != null ? SecondaryInfo[resIndex][0] : Info[resIndex][0];
-                }
-
-                return (int)((double)max * .5);
-            }
-
-            public int Max(int resIndex, int preIndex, Item item)
-            {
-                int[][] info = item is BaseRanged && SecondaryInfo != null ? SecondaryInfo : Info;
-
-                if (resIndex != -1 && preIndex != -1)
-                {
-                    if (item is BaseWeapon && this.Attribute is AosWeaponAttribute && ((AosWeaponAttribute)this.Attribute == AosWeaponAttribute.HitLeechHits
-                                                            || (AosWeaponAttribute)this.Attribute == AosWeaponAttribute.HitLeechMana))
-                    {
-                        int weight = Info[resIndex][preIndex];
-                        return (int)(((BaseWeapon)item).MlSpeed * (weight * 100) / (100 + ((BaseWeapon)item).Attributes.WeaponSpeed));
-                    }
-
-                    if (info != null && resIndex >= 0 && resIndex < info.Length && preIndex >= 0 && preIndex < info[resIndex].Length)
-                    {
-                        return info[resIndex][preIndex];
-                    }
-
-                    return HardCap;
-                }
-
-                if (info == null)
-                {
-                    return HardCap;
-                }
-
-                return info[Info.Length - 1][Info[Info.Length - 1].Length - 1];
-            }*/
         }
 
         public static object GetRandomHitSpell()

--- a/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
+++ b/Scripts/Services/MondainsLegacyQuests/Helpers/QuestHelper.cs
@@ -530,14 +530,25 @@ namespace Server.Engines.Quests
             if (quest == null)
                 return false;
 
-            for (int i = 0; i < quest.Objectives.Count; i ++)
+            bool complete = false;
+
+            for (int i = 0; i < quest.Objectives.Count && !complete; i ++)
             {
                 if (quest.Objectives[i] is ObtainObjective)
                 {
                     ObtainObjective obtain = (ObtainObjective)quest.Objectives[i];
-					
-                    if (obtain.MaxProgress > CountQuestItems(quest.Owner, obtain.Obtain))
+
+                    if (CountQuestItems(quest.Owner, obtain.Obtain) >= obtain.MaxProgress)
+                    {
+                        if (!quest.AllObjectives)
+                        {
+                            complete = true;
+                        }
+                    }
+                    else
+                    {
                         return false;
+                    }
                 }
                 else if (quest.Objectives[i] is DeliverObjective)
                 {
@@ -885,11 +896,11 @@ namespace Server.Engines.Quests
 
         public override void OnClick()
         {
-            if (!this.Owner.From.Alive)
+            if (!Owner.From.Alive)
                 return;
 				
-            this.Owner.From.SendLocalizedMessage(1072352); // Target the item you wish to toggle Quest Item status on <ESC> to cancel			
-            this.Owner.From.BeginTarget(-1, false, TargetFlags.None, new TargetCallback(ToggleQuestItem_Callback));
+            Owner.From.SendLocalizedMessage(1072352); // Target the item you wish to toggle Quest Item status on <ESC> to cancel			
+            Owner.From.BeginTarget(-1, false, TargetFlags.None, new TargetCallback(ToggleQuestItem_Callback));
         }
 
         private void ToggleQuestItem_Callback(Mobile from, object obj)

--- a/Scripts/Services/Pet Training/AreaEffects.cs
+++ b/Scripts/Services/Pet Training/AreaEffects.cs
@@ -525,7 +525,7 @@ namespace Server.Mobiles
             public Type[] Uses { get; private set; }
 
             public AuraDefinition()
-                : this(TimeSpan.FromSeconds(5), 4, 5, 0, 0, 0, 0, 0, 0, 0, new Type[] { })
+                : this(TimeSpan.FromSeconds(5), 4, 5, 0, 0, 0, 0, 0, 0, 100, new Type[] { })
             {
             }
 
@@ -564,7 +564,7 @@ namespace Server.Mobiles
 
                 cora = new AuraDefinition(typeof(CoraTheSorceress));
                 cora.Range = 3;
-                cora.Damage = 0;
+                cora.Damage = 10;
                 cora.Fire = 0;
                 Definitions.Add(cora);
 

--- a/Scripts/Services/Revamped Dungeons/WrongDungeon/Items/StinkingCauldron.cs
+++ b/Scripts/Services/Revamped Dungeons/WrongDungeon/Items/StinkingCauldron.cs
@@ -20,7 +20,7 @@ namespace Server.Items
 
         private void GooeyMaggotsSpawn()
         {
-            if (Map != Map.Internal)
+            if (Map != null && Map != Map.Internal)
             {
                 int amount = Utility.RandomMinMax(1, 2);
 

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Generate.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Generate.cs
@@ -20,7 +20,11 @@ namespace Server.Engines.Khaldun
             {
                 EventSink.WorldSave += OnWorldSave;
 
-                KhaldunCampRegion.InstanceTram = new KhaldunCampRegion(Map.Trammel);
+                if (!Siege.SiegeShard)
+                {
+                    KhaldunCampRegion.InstanceTram = new KhaldunCampRegion(Map.Trammel);
+                }
+
                 KhaldunCampRegion.InstanceFel = new KhaldunCampRegion(Map.Felucca);
             }
         }
@@ -84,7 +88,7 @@ namespace Server.Engines.Khaldun
 
         public static void Generate()
         {
-            if (KhaldunResearcher.InstanceTram == null)
+            if (KhaldunResearcher.InstanceTram == null && !Siege.SiegeShard)
             {
                 KhaldunResearcher.InstanceTram = new KhaldunResearcher();
                 KhaldunResearcher.InstanceTram.MoveToWorld(new Point3D(6009, 3771, 21), Map.Trammel);
@@ -96,7 +100,7 @@ namespace Server.Engines.Khaldun
                 KhaldunResearcher.InstanceFel.MoveToWorld(new Point3D(6009, 3771, 21), Map.Felucca);
             }
 
-            if (LeadInvestigator.InstanceTram == null)
+            if (LeadInvestigator.InstanceTram == null && !Siege.SiegeShard)
             {
                 LeadInvestigator.InstanceTram = new LeadInvestigator();
                 LeadInvestigator.InstanceTram.MoveToWorld(new Point3D(6010, 3776, 19), Map.Trammel);
@@ -108,7 +112,7 @@ namespace Server.Engines.Khaldun
                 LeadInvestigator.InstanceFel.MoveToWorld(new Point3D(6010, 3776, 19), Map.Felucca);
             }
 
-            if (CaddelliteVendor.InstanceTram == null)
+            if (CaddelliteVendor.InstanceTram == null && !Siege.SiegeShard)
             {
                 CaddelliteVendor.InstanceTram = new CaddelliteVendor();
                 CaddelliteVendor.InstanceTram.MoveToWorld(new Point3D(6018, 3749, 21), Map.Trammel);
@@ -120,10 +124,13 @@ namespace Server.Engines.Khaldun
                 CaddelliteVendor.InstanceFel.MoveToWorld(new Point3D(6018, 3749, 21), Map.Felucca);
             }
 
-            var champ = new ChampionSpawn();
-            champ.Type = ChampionSpawnType.Khaldun;
-            champ.MoveToWorld(new Point3D(5469, 1461, 20), Map.Trammel);
-            ChampionSystem.AllSpawns.Add(champ);
+            if (!Siege.SiegeShard)
+            {
+                var champ = new ChampionSpawn();
+                champ.Type = ChampionSpawnType.Khaldun;
+                champ.MoveToWorld(new Point3D(5469, 1461, 20), Map.Trammel);
+                ChampionSystem.AllSpawns.Add(champ);
+            }
 
             champ = new ChampionSpawn();
             champ.Type = ChampionSpawnType.Khaldun;
@@ -141,140 +148,142 @@ namespace Server.Engines.Khaldun
 
         public static void GenerateQuestContent()
         {
+            var map = Siege.SiegeShard ? Map.Felucca : Map.Trammel;
+
             var addon = new KhaldunDecorationAddon();
-            addon.MoveToWorld(new Point3D(6232, 2887, -1), Map.Trammel);
+            addon.MoveToWorld(new Point3D(6232, 2887, -1), map);
 
             // Britain
-            var door = new TrapDoor("boreas", new Point3D(6242, 2892, 17), Map.Trammel);
+            var door = new TrapDoor("boreas", new Point3D(6242, 2892, 17), map);
             var book = new MysteriousBook(door);
             var dust = new DustPile(door);
-            var teleporter = new Teleporter(new Point3D(1369, 1465, 10), Map.Trammel);
+            var teleporter = new Teleporter(new Point3D(1369, 1465, 10), map);
 
-            door.MoveToWorld(new Point3D(1369, 1465, 10), Map.Trammel);
-            book.MoveToWorld(new Point3D(6240, 2885, 8), Map.Trammel);
-            dust.MoveToWorld(new Point3D(6256, 2889, 13), Map.Trammel);
-            teleporter.MoveToWorld(new Point3D(6242, 2892, 17), Map.Trammel);
+            door.MoveToWorld(new Point3D(1369, 1465, 10), map);
+            book.MoveToWorld(new Point3D(6240, 2885, 8), map);
+            dust.MoveToWorld(new Point3D(6256, 2889, 13), map);
+            teleporter.MoveToWorld(new Point3D(6242, 2892, 17), map);
 
-            new GumshoeBottles().MoveToWorld(new Point3D(6154, 2901, 6), Map.Trammel);
-            new GumshoeBottles().MoveToWorld(new Point3D(6154, 2902, 6), Map.Trammel);
+            new GumshoeBottles().MoveToWorld(new Point3D(6154, 2901, 6), map);
+            new GumshoeBottles().MoveToWorld(new Point3D(6154, 2902, 6), map);
 
-            new GumshoeDeed().MoveToWorld(new Point3D(6161, 2901, 6), Map.Trammel);
+            new GumshoeDeed().MoveToWorld(new Point3D(6161, 2901, 6), map);
 
-            new GumshoeRope().MoveToWorld(new Point3D(6163, 2896, 0), Map.Trammel);
-            new GumshoeRope().MoveToWorld(new Point3D(6163, 2896, 1), Map.Trammel);
+            new GumshoeRope().MoveToWorld(new Point3D(6163, 2896, 0), map);
+            new GumshoeRope().MoveToWorld(new Point3D(6163, 2896, 1), map);
 
-            new GumshoeMap().MoveToWorld(new Point3D(6166, 2895, 6), Map.Trammel);
-            new GumshoeMap().MoveToWorld(new Point3D(6166, 2895, 7), Map.Trammel);
+            new GumshoeMap().MoveToWorld(new Point3D(6166, 2895, 6), map);
+            new GumshoeMap().MoveToWorld(new Point3D(6166, 2895, 7), map);
 
-            new GumshoeTools().MoveToWorld(new Point3D(6160, 2901, 6), Map.Trammel);
+            new GumshoeTools().MoveToWorld(new Point3D(6160, 2901, 6), map);
 
             // Moonglow
-            door = new TrapDoor("carthax", new Point3D(6198, 2893, 17), Map.Trammel);
+            door = new TrapDoor("carthax", new Point3D(6198, 2893, 17), map);
             book = new MysteriousBook(door);
             dust = new DustPile(door);
-            teleporter = new Teleporter(new Point3D(4550, 1306, 8), Map.Trammel);
+            teleporter = new Teleporter(new Point3D(4550, 1306, 8), map);
 
-            door.MoveToWorld(new Point3D(4550, 1306, 8), Map.Trammel);
-            book.MoveToWorld(new Point3D(6207, 2884, 7), Map.Trammel);
-            dust.MoveToWorld(new Point3D(6208, 2885, 12), Map.Trammel);
-            teleporter.MoveToWorld(new Point3D(6198, 2893, 17), Map.Trammel);
+            door.MoveToWorld(new Point3D(4550, 1306, 8), map);
+            book.MoveToWorld(new Point3D(6207, 2884, 7), map);
+            dust.MoveToWorld(new Point3D(6208, 2885, 12), map);
+            teleporter.MoveToWorld(new Point3D(6198, 2893, 17), map);
 
-            new GumshoeBottles().MoveToWorld(new Point3D(6198, 2888, 6), Map.Trammel);
+            new GumshoeBottles().MoveToWorld(new Point3D(6198, 2888, 6), map);
 
-            new GumshoeRope().MoveToWorld(new Point3D(6200, 2887, 0), Map.Trammel);
-            new GumshoeRope().MoveToWorld(new Point3D(6200, 2887, 1), Map.Trammel);
+            new GumshoeRope().MoveToWorld(new Point3D(6200, 2887, 0), map);
+            new GumshoeRope().MoveToWorld(new Point3D(6200, 2887, 1), map);
 
-            new GumshoeMap().MoveToWorld(new Point3D(6198, 2887, 6), Map.Trammel);
-            new GumshoeMap().MoveToWorld(new Point3D(6198, 2887, 7), Map.Trammel);
+            new GumshoeMap().MoveToWorld(new Point3D(6198, 2887, 6), map);
+            new GumshoeMap().MoveToWorld(new Point3D(6198, 2887, 7), map);
 
-            new GumshoeTools().MoveToWorld(new Point3D(6198, 2889, 6), Map.Trammel);
+            new GumshoeTools().MoveToWorld(new Point3D(6198, 2889, 6), map);
 
             // Vesper
-            door = new TrapDoor("moriens", new Point3D(6154, 2898, 17), Map.Trammel);
+            door = new TrapDoor("moriens", new Point3D(6154, 2898, 17), map);
             book = new MysteriousBook(door);
             dust = new DustPile(door);
-            teleporter = new Teleporter(new Point3D(2762, 848, 0), Map.Trammel);
+            teleporter = new Teleporter(new Point3D(2762, 848, 0), map);
 
-            door.MoveToWorld(new Point3D(2762, 848, 0), Map.Trammel);
-            book.MoveToWorld(new Point3D(6167, 2896, 6), Map.Trammel);
-            dust.MoveToWorld(new Point3D(6163, 2885, 0), Map.Trammel);
-            teleporter.MoveToWorld(new Point3D(6154, 2898, 17), Map.Trammel);
+            door.MoveToWorld(new Point3D(2762, 848, 0), map);
+            book.MoveToWorld(new Point3D(6167, 2896, 6), map);
+            dust.MoveToWorld(new Point3D(6163, 2885, 0), map);
+            teleporter.MoveToWorld(new Point3D(6154, 2898, 17), map);
 
-            new GumshoeBottles().MoveToWorld(new Point3D(6240, 2884, 6), Map.Trammel);
-            new GumshoeBottles().MoveToWorld(new Point3D(6239, 2885, 6), Map.Trammel);
+            new GumshoeBottles().MoveToWorld(new Point3D(6240, 2884, 6), map);
+            new GumshoeBottles().MoveToWorld(new Point3D(6239, 2885, 6), map);
 
-            new GumshoeRope().MoveToWorld(new Point3D(6241, 2884, 0), Map.Trammel);
-            new GumshoeRope().MoveToWorld(new Point3D(6241, 2884, 1), Map.Trammel);
+            new GumshoeRope().MoveToWorld(new Point3D(6241, 2884, 0), map);
+            new GumshoeRope().MoveToWorld(new Point3D(6241, 2884, 1), map);
 
-            new GumshoeMap().MoveToWorld(new Point3D(6240, 2885, 6), Map.Trammel);
-            new GumshoeMap().MoveToWorld(new Point3D(6240, 2885, 7), Map.Trammel);
+            new GumshoeMap().MoveToWorld(new Point3D(6240, 2885, 6), map);
+            new GumshoeMap().MoveToWorld(new Point3D(6240, 2885, 7), map);
 
-            new GumshoeTools().MoveToWorld(new Point3D(6239, 2886, 6), Map.Trammel);
+            new GumshoeTools().MoveToWorld(new Point3D(6239, 2886, 6), map);
 
             // Yew
-            door = new TrapDoor("tenebrae", new Point3D(6294, 2891, 17), Map.Trammel);
+            door = new TrapDoor("tenebrae", new Point3D(6294, 2891, 17), map);
             book = new MysteriousBook(door);
             dust = new DustPile(door);
-            teleporter = new Teleporter(new Point3D(712, 1104, 0), Map.Trammel);
+            teleporter = new Teleporter(new Point3D(712, 1104, 0), map);
 
-            door.MoveToWorld(new Point3D(712, 1104, 0), Map.Trammel);
-            book.MoveToWorld(new Point3D(6294, 2887, 6), Map.Trammel);
-            dust.MoveToWorld(new Point3D(6291, 2875, 9), Map.Trammel);
-            teleporter.MoveToWorld(new Point3D(6294, 2891, 17), Map.Trammel);
+            door.MoveToWorld(new Point3D(712, 1104, 0), map);
+            book.MoveToWorld(new Point3D(6294, 2887, 6), map);
+            dust.MoveToWorld(new Point3D(6291, 2875, 9), map);
+            teleporter.MoveToWorld(new Point3D(6294, 2891, 17), map);
 
-            new GumshoeBottles().MoveToWorld(new Point3D(6303, 2887, 6), Map.Trammel);
-            new GumshoeBottles().MoveToWorld(new Point3D(6304, 2887, 6), Map.Trammel);
+            new GumshoeBottles().MoveToWorld(new Point3D(6303, 2887, 6), map);
+            new GumshoeBottles().MoveToWorld(new Point3D(6304, 2887, 6), map);
 
-            new GumshoeRope().MoveToWorld(new Point3D(6299, 2887, 0), Map.Trammel);
-            new GumshoeRope().MoveToWorld(new Point3D(6299, 2887, 1), Map.Trammel);
+            new GumshoeRope().MoveToWorld(new Point3D(6299, 2887, 0), map);
+            new GumshoeRope().MoveToWorld(new Point3D(6299, 2887, 1), map);
 
-            new GumshoeMap().MoveToWorld(new Point3D(6294, 2888, 6), Map.Trammel);
-            new GumshoeMap().MoveToWorld(new Point3D(6294, 2888, 7), Map.Trammel);
+            new GumshoeMap().MoveToWorld(new Point3D(6294, 2888, 6), map);
+            new GumshoeMap().MoveToWorld(new Point3D(6294, 2888, 7), map);
 
-            new GumshoeTools().MoveToWorld(new Point3D(6294, 2889, 6), Map.Trammel);
+            new GumshoeTools().MoveToWorld(new Point3D(6294, 2889, 6), map);
 
             // Gravestones
             var grave = new DamagedHeadstone(1158607); // brit
-            grave.MoveToWorld(new Point3D(1378, 1445, 10), Map.Trammel);
+            grave.MoveToWorld(new Point3D(1378, 1445, 10), map);
 
             grave = new DamagedHeadstone(1158608); // vesper
             grave.ItemID = 4477;
-            grave.MoveToWorld(new Point3D(2747, 882, 0), Map.Trammel);
+            grave.MoveToWorld(new Point3D(2747, 882, 0), map);
 
             grave = new DamagedHeadstone(1158609); // moonglow
-            grave.MoveToWorld(new Point3D(4545, 1316, 8), Map.Trammel);
+            grave.MoveToWorld(new Point3D(4545, 1316, 8), map);
 
             grave = new DamagedHeadstone(1158610); // yew
-            grave.MoveToWorld(new Point3D(723, 1104, 0), Map.Trammel);
+            grave.MoveToWorld(new Point3D(723, 1104, 0), map);
 
             // footprints
             var footprints = new BloodyFootPrints(0x1E06);
-            footprints.MoveToWorld(new Point3D(1383, 1452, 10), Map.Trammel);
+            footprints.MoveToWorld(new Point3D(1383, 1452, 10), map);
 
             footprints = new BloodyFootPrints(0x1E06);
-            footprints.MoveToWorld(new Point3D(1383, 1456, 10), Map.Trammel);
+            footprints.MoveToWorld(new Point3D(1383, 1456, 10), map);
 
             footprints = new BloodyFootPrints(0x1E06);
-            footprints.MoveToWorld(new Point3D(1383, 1461, 10), Map.Trammel);
+            footprints.MoveToWorld(new Point3D(1383, 1461, 10), map);
 
             footprints = new BloodyFootPrints(0x1E06);
-            footprints.MoveToWorld(new Point3D(1383, 1464, 10), Map.Trammel);
+            footprints.MoveToWorld(new Point3D(1383, 1464, 10), map);
 
             footprints = new BloodyFootPrints(0x1E03);
-            footprints.MoveToWorld(new Point3D(1378, 1464, 10), Map.Trammel);
+            footprints.MoveToWorld(new Point3D(1378, 1464, 10), map);
 
             var st = new Static(0x2006);
             st.Stackable = true;
             st.Amount = 0x191;
             st.Hue = 0x47E;
-            st.MoveToWorld(new Point3D(5808, 3270, -15), Map.Trammel);
+            st.MoveToWorld(new Point3D(5808, 3270, -15), map);
             st.Name = "A Corpse of Liane";
 
             st = new Static(0x2006);
             st.Stackable = true;
             st.Amount = 86;
             st.Hue = 0x47E;
-            st.MoveToWorld(new Point3D(5807, 3268, -15), Map.Trammel);
+            st.MoveToWorld(new Point3D(5807, 3268, -15), map);
             st.Name = "A Corpse of an Ophidian Beserker";
         }
     }

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Generate.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Generate.cs
@@ -124,9 +124,11 @@ namespace Server.Engines.Khaldun
                 CaddelliteVendor.InstanceFel.MoveToWorld(new Point3D(6018, 3749, 21), Map.Felucca);
             }
 
+            ChampionSpawn champ = null;
+
             if (!Siege.SiegeShard)
             {
-                var champ = new ChampionSpawn();
+                champ = new ChampionSpawn();
                 champ.Type = ChampionSpawnType.Khaldun;
                 champ.MoveToWorld(new Point3D(5469, 1461, 20), Map.Trammel);
                 ChampionSystem.AllSpawns.Add(champ);

--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -4372,6 +4372,13 @@ namespace Server
                 Spawner.Remove(this);
                 Spawner = null;
             }
+
+            var region = Region.Find(GetWorldLocation(), Map);
+
+            if (region != null)
+            {
+                region.OnDelete(this);
+            }
         }
 
         public virtual void OnParentDeleted(object parent)

--- a/Server/Region.cs
+++ b/Server/Region.cs
@@ -1061,6 +1061,10 @@ namespace Server
 			return true;
 		}
 
+        public virtual void OnDelete(Item item)
+        {
+        }
+
         public virtual void GetContextMenuEntries(Mobile from, List<Server.ContextMenus.ContextMenuEntry> list, Item item)
         {
         }


### PR DESCRIPTION
- Gave Spinning Hourglass proper label, and inherits IFlipable for use with house deco tool
- Removed redundant OnCraft from Garg Plate Arms
- Travesty now restores body prior to death
- Added Britannian Ship to Fisherman collection Mobiles
- hides should now be cut properly using special tools
- Deleting items in a house region will now properly reflect houses lockdowns/secures *Requires Core Recompile*
- Hit Dispel now properly counts as a hit spell property on weapons, removing remote chance this and another hit spell would appear
- AllObjectives property set to false in Mondains Quests (Custom) will now work properly with obtain quest objectives
- Fixed crash from stinking cauldron
- Added seige shard support for Treasures of Khaldun generation