### PR TITLE
Add SetMutateAction helper function to the craft system.

### DIFF
--- a/Scripts/Services/Craft/Core/CraftItem.cs
+++ b/Scripts/Services/Craft/Core/CraftItem.cs
@@ -89,6 +89,8 @@ namespace Server.Engines.Craft
         public bool NeedWater { get; set; }
         public int ItemHue { get; set; }
 
+        public Action<Mobile, Item, ITool> MutateAction { get; set; }
+
         public void AddRecipe(int id, CraftSystem system)
         {
             if (Recipe != null)
@@ -1866,6 +1868,8 @@ namespace Server.Engines.Craft
                     m_PlantHue = PlantHue.None;
                     m_PlantPigmentHue = PlantPigmentHue.None;
 					#endregion
+
+                    MutateAction?.Invoke(from,item,tool);
 
                     if (CaddelliteCraft)
                     {

--- a/Scripts/Services/Craft/Core/CraftSystem.cs
+++ b/Scripts/Services/Craft/Core/CraftSystem.cs
@@ -460,6 +460,17 @@ namespace Server.Engines.Craft
             craftItem.DisplayID = id;
         }
 
+        /// <summary>
+        /// Add a callback Action to allow mutating the crafted item. Handy when you have a single Item Type but you want to create variations of it.
+        /// </summary>
+        /// <param name="index"></param>
+        /// <param name="action"></param>
+        public void SetMutateAction(int index, Action<Mobile, Item, ITool> action)
+        {
+            CraftItem craftItem = m_CraftItems.GetAt(index);
+            craftItem.MutateAction = action;
+        }
+
         public void SetForceSuccess(int index, int success)
         {
             CraftItem craftItem = m_CraftItems.GetAt(index);


### PR DESCRIPTION
Enables people to set a callback action to mutate an individual craft entry without needing to modify the base Type.

Example usage
``` 
index = AddCraft(typeof(EnchantedApple), 1073108, 1072952, 60.0, 85.0, typeof(Apple), "Red Enchanted Apple", 1, 1044253);
SetMutateAction(index,(player, item, tool) => { item.Hue = 55; });

index = AddCraft(typeof(EnchantedApple), 1073108, 1072952, 60.0, 85.0, typeof(Apple), "Green Enchanted Apple", 1, 1044253);
SetMutateAction(index,(player, item, tool) => { item.Hue = 99; });
```

Etc, access to the crafted item, the crafter and the tool used is provided in the callback.
