### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Books/RunicAtlas.cs
+++ b/Scripts/Items/Books/RunicAtlas.cs
@@ -82,7 +82,7 @@ namespace Server.Items
 
                     g = new RunicAtlasGump((PlayerMobile)from, this);
                     g.Page = newPage;
-                    from.SendGump(g);
+                    BaseGump.SendGump(g);
                 }
             }
 

--- a/Scripts/Mobiles/AI/BaseAI.cs
+++ b/Scripts/Mobiles/AI/BaseAI.cs
@@ -236,7 +236,7 @@ namespace Server.Mobiles
 					list.Add(new InternalEntry(from, 6108, 14, m_Mobile, this, OrderType.Follow)); // Command: Follow
 					list.Add(new InternalEntry(from, 6107, 14, m_Mobile, this, OrderType.Guard)); // Command: Guard
 
-					if (m_Mobile.CanDrop)
+					if (m_Mobile.IsBonded)
 					{
 						list.Add(new InternalEntry(from, 6109, 14, m_Mobile, this, OrderType.Drop)); // Command: Drop
 					}
@@ -1232,7 +1232,7 @@ namespace Server.Mobiles
 			switch (m_Mobile.ControlOrder)
 			{
 				case OrderType.None:
-					//m_Mobile.ControlMaster.RevealingAction();
+					
 					m_Mobile.Home = m_Mobile.Location;
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
@@ -1240,14 +1240,14 @@ namespace Server.Mobiles
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Come:
-					//m_Mobile.ControlMaster.RevealingAction();
+					
 					m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Drop:
-					//m_Mobile.ControlMaster.RevealingAction();
+					
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = true;
@@ -1255,10 +1255,10 @@ namespace Server.Mobiles
 					break;
 				case OrderType.Friend:
 				case OrderType.Unfriend:
-					//m_Mobile.ControlMaster.RevealingAction();
+					
 					break;
 				case OrderType.Guard:
-					//m_Mobile.ControlMaster.RevealingAction();
+					
 					m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = true;
@@ -1268,7 +1268,7 @@ namespace Server.Mobiles
 					m_Mobile.ControlMaster.SendLocalizedMessage(1049671, petname); //~1_PETNAME~ is now guarding you.
 					break;
 				case OrderType.Attack:
-					//m_Mobile.ControlMaster.RevealingAction();
+					
 					m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 
@@ -1276,28 +1276,28 @@ namespace Server.Mobiles
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Patrol:
-					//m_Mobile.ControlMaster.RevealingAction();
+					
 					m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Release:
-					//m_Mobile.ControlMaster.RevealingAction();
+					
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Stay:
-					//m_Mobile.ControlMaster.RevealingAction();
+					
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Stop:
-					//m_Mobile.ControlMaster.RevealingAction();
+					
 					m_Mobile.Home = m_Mobile.Location;
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
@@ -1305,15 +1305,17 @@ namespace Server.Mobiles
 					m_Mobile.Combatant = null;
 					break;
 				case OrderType.Follow:
-					//m_Mobile.ControlMaster.RevealingAction();
-					m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
+					
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 
 					m_Mobile.Warmode = false;
 					m_Mobile.Combatant = null;
-					break;
+                    m_Mobile.AdjustSpeeds();
+
+                    m_Mobile.CurrentSpeed = m_Mobile.ActiveSpeed;
+                    break;
 				case OrderType.Transfer:
-					//m_Mobile.ControlMaster.RevealingAction();
+					
 					m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 					m_Mobile.PlaySound(m_Mobile.GetIdleSound());
 
@@ -1387,7 +1389,7 @@ namespace Server.Mobiles
 
 		public virtual bool DoOrderDrop()
 		{
-			if (m_Mobile.IsDeadPet || !m_Mobile.CanDrop)
+			if (m_Mobile.IsDeadPet || !m_Mobile.IsBonded)
 			{
 				return true;
 			}
@@ -2207,52 +2209,72 @@ namespace Server.Mobiles
 			return true;
 		}
 
-		public virtual void WalkRandom(int iChanceToNotMove, int iChanceToDir, int iSteps)
-		{
-			if (m_Mobile.Deleted || m_Mobile.DisallowAllMoves)
-			{
-				return;
-			}
+        public virtual void WalkRandom(int iChanceToNotMove, int iChanceToDir, int iSteps)
+        {
+            if (m_Mobile.Deleted || m_Mobile.DisallowAllMoves)
+            {
+                return;
+            }
 
-			for (var i = 0; i < iSteps; i++)
-			{
-				if (Utility.Random(8 * iChanceToNotMove) <= 8)
-				{
-					var iRndMove = Utility.Random(0, 8 + (9 * iChanceToDir));
+            if (m_Mobile.CanFly && Utility.Random(8 * iChanceToNotMove) <= 8)
+            {
+                var p = Point3D.Zero;
 
-					switch (iRndMove)
-					{
-						case 0:
-							DoMove(Direction.Up);
-							break;
-						case 1:
-							DoMove(Direction.North);
-							break;
-						case 2:
-							DoMove(Direction.Left);
-							break;
-						case 3:
-							DoMove(Direction.West);
-							break;
-						case 5:
-							DoMove(Direction.Down);
-							break;
-						case 6:
-							DoMove(Direction.South);
-							break;
-						case 7:
-							DoMove(Direction.Right);
-							break;
-						case 8:
-							DoMove(Direction.East);
-							break;
-						default:
-							DoMove(m_Mobile.Direction);
-							break;
-					}
-				}
-			}
-		}
+                for (int i = 0; i < 10; i++)
+                {
+                    p.X = m_Mobile.X + Utility.RandomList(-3, -2, 2, 3);
+                    p.Y = m_Mobile.Y + Utility.RandomList(-3, -2, 2, 3);
+                    p.Z = m_Mobile.Map.GetAverageZ(p.X, p.Y);
+
+                    if (m_Mobile.Home != Point3D.Zero && m_Mobile.RangeHome > 0 && !Utility.InRange(p, m_Mobile.Home, m_Mobile.RangeHome))
+                    {
+                        continue;
+                    }
+
+                    WalkMobileRange(p, 1, m_Mobile.CanFly, 0, 1);
+                    return;
+                }
+            }
+
+            for (var i = 0; i < iSteps; i++)
+            {
+                if (Utility.Random(8 * iChanceToNotMove) <= 8)
+                {
+                    var iRndMove = Utility.Random(0, 8 + (9 * iChanceToDir));
+
+                    switch (iRndMove)
+                    {
+                        case 0:
+                            DoMove(Direction.Up);
+                            break;
+                        case 1:
+                            DoMove(Direction.North);
+                            break;
+                        case 2:
+                            DoMove(Direction.Left);
+                            break;
+                        case 3:
+                            DoMove(Direction.West);
+                            break;
+                        case 5:
+                            DoMove(Direction.Down);
+                            break;
+                        case 6:
+                            DoMove(Direction.South);
+                            break;
+                        case 7:
+                            DoMove(Direction.Right);
+                            break;
+                        case 8:
+                            DoMove(Direction.East);
+                            break;
+                        default:
+                            DoMove(m_Mobile.Direction);
+                            break;
+                    }
+                }
+            }
+        }
 
 		public virtual double TransformMoveDelay(double delay)
 		{
@@ -2493,7 +2515,7 @@ namespace Server.Mobiles
 
 			if (m_Mobile.Home == Point3D.Zero)
 			{
-				if (m_Mobile.Spawner is SpawnEntry)
+                if (m_Mobile.Spawner is SpawnEntry)
 				{
 					Region region = ((SpawnEntry)m_Mobile.Spawner).Region;
 

--- a/Scripts/Mobiles/NPCs/BaseHire.cs
+++ b/Scripts/Mobiles/NPCs/BaseHire.cs
@@ -13,7 +13,6 @@ namespace Server.Mobiles
         private int m_HoldGold = 8;
         private Timer m_PayTimer;
 
-        public override bool OwnerCanRename { get { return false; } }
         public override bool IsBondable { get { return false; } }
         public override bool CanAutoStable { get { return false; } }
         public override bool CanDetectHidden { get { return false; } }

--- a/Scripts/Mobiles/NPCs/Shipwright.cs
+++ b/Scripts/Mobiles/NPCs/Shipwright.cs
@@ -6,6 +6,7 @@ namespace Server.Mobiles
     public class Shipwright : BaseVendor 
     { 
         private readonly List<SBInfo> m_SBInfos = new List<SBInfo>();
+
         [Constructable]
         public Shipwright()
             : base("the shipwright")

--- a/Scripts/Mobiles/Named/FireDaemonRenowned.cs
+++ b/Scripts/Mobiles/Named/FireDaemonRenowned.cs
@@ -67,7 +67,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return new Type[] { typeof(LegacyOfDespair) };
+                return new Type[] { };
             }
         }
 

--- a/Scripts/Mobiles/Named/FireElementalRenowned.cs
+++ b/Scripts/Mobiles/Named/FireElementalRenowned.cs
@@ -66,7 +66,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return new Type[] { typeof(TokenOfHolyFavor), typeof(SwordOfShatteredHopes) };
+                return new Type[] { typeof(TokenOfHolyFavor), typeof(SwordOfShatteredHopes), typeof(LegacyOfDespair) };
             }
         }
         public override double DispelDifficulty

--- a/Scripts/Mobiles/Named/SkeletalDragonRenowned.cs
+++ b/Scripts/Mobiles/Named/SkeletalDragonRenowned.cs
@@ -64,7 +64,7 @@ namespace Server.Mobiles
         {
             get
             {
-                return new Type[] { typeof(AxeOfAbandon), typeof(DemonBridleRing), typeof(VoidInfusedKilt) };
+                return new Type[] { typeof(AxeOfAbandon), typeof(DemonBridleRing), typeof(VoidInfusedKilt), typeof(BladeOfBattle) };
             }
         }
         public override bool ReacquireOnMovement

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -1001,6 +1001,11 @@ namespace Server.Mobiles
                 }
 
                 base.Combatant = value;
+
+                if (Controlled)
+                {
+                    AdjustSpeeds();
+                }
             }
         }
 
@@ -4538,14 +4543,11 @@ namespace Server.Mobiles
         public virtual void AddCustomContextEntries(Mobile from, List<ContextMenuEntry> list)
         { }
 
-        public virtual bool CanDrop { get { return IsBonded; } }
-        public virtual bool OwnerCanRename { get { return true; } }
-
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)
         {
             base.GetContextMenuEntries(from, list);
 
-            if (m_bControlled && m_ControlMaster == from && !m_bSummoned && OwnerCanRename)
+            if (CanBeRenamedBy(from) && m_bControlled && m_ControlMaster == from && !m_bSummoned)
             {
                 list.Add(new RenameEntry(from, this));
             }

--- a/Scripts/Mobiles/Normal/Spellbinder.cs
+++ b/Scripts/Mobiles/Normal/Spellbinder.cs
@@ -10,7 +10,7 @@ namespace Server.Mobiles
             : base(AIType.AI_Spellbinder, FightMode.Aggressor, 10, 1, 0.2, 0.4)
         {
             Name = "a spectral spellbinder";
-            Body = 153;
+            Body = Utility.RandomList(26, 50, 56);
             BaseSoundID = 0x482;
 
             SetStr(46, 70);

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -53,7 +53,7 @@ namespace Server.Mobiles
 
 	#region Enums
 	[Flags]
-	public enum PlayerFlag : ulong // First 16 bits are reserved for default-distro use, start custom flags at 0x00010000
+	public enum PlayerFlag
 	{
 		None = 0x00000000,
 		Glassblowing = 0x00000001,
@@ -85,7 +85,6 @@ namespace Server.Mobiles
         ToggleCutTopiaries = 0x10000000,
         HasValiantStatReward = 0x20000000,
         RefuseTrades = 0x40000000,
-        DisabledPvpWarning = 0x80000000,
     }
 
     [Flags]
@@ -95,6 +94,7 @@ namespace Server.Mobiles
         ToggleStoneOnly             = 0x00000002,
         CanBuyCarpets               = 0x00000004,
         VoidPool                    = 0x00000008,
+        DisabledPvpWarning          = 0x00000010,
     }
 
 	public enum NpcGuild
@@ -252,13 +252,6 @@ namespace Server.Mobiles
 		private List<Mobile> m_RecentlyReported;
 
         public bool UseSummoningRite { get; set; }
-
-        #region Guantlet Points
-        /*private double m_GauntletPoints;
-
-		[CommandProperty(AccessLevel.Administrator)]
-		public double GauntletPoints { get { return m_GauntletPoints; } set { m_GauntletPoints = value; } }*/
-		#endregion
 
         #region Points System
         private PointsSystemProps _PointsSystemProps;
@@ -501,8 +494,8 @@ namespace Server.Mobiles
         [CommandProperty(AccessLevel.GameMaster)]
         public bool DisabledPvpWarning
         {
-            get { return GetFlag(PlayerFlag.DisabledPvpWarning); }
-            set { SetFlag(PlayerFlag.DisabledPvpWarning, value); }
+            get { return GetFlag(ExtendedPlayerFlag.DisabledPvpWarning); }
+            set { SetFlag(ExtendedPlayerFlag.DisabledPvpWarning, value); }
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -5943,9 +5936,12 @@ namespace Server.Mobiles
 
 			TransformContext context = TransformationSpellHelper.GetContext(this);
 
-			if (!Core.SA && context != null && context.Type == typeof(ReaperFormSpell))
+			if (context != null)
 			{
-				return WalkFoot;
+                if ((!Core.SA && context.Type == typeof(ReaperFormSpell)) || (!Core.HS && context.Type == typeof(Server.Spells.Mysticism.StoneFormSpell)))
+                {
+                    return WalkFoot;
+                }
 			}
 
 			bool running = ((dir & Direction.Running) != 0);

--- a/Scripts/Services/Expansions/High Seas/Persistence.cs
+++ b/Scripts/Services/Expansions/High Seas/Persistence.cs
@@ -1,4 +1,4 @@
-﻿using Server;
+using Server;
 using System;
 using Server.Engines.Quests;
 using Server.Mobiles;
@@ -14,7 +14,7 @@ namespace Server.Items
         public static string FilePath = Path.Combine("Saves", "Highseas.bin");
         public static bool DefaultRestrictBoats = true;
 
-        public static void Initialize()
+        /*public static void Configure()
         {
             if (Core.HS)
             {
@@ -31,7 +31,7 @@ namespace Server.Items
 
                 CommandSystem.Register("RestrictBoats", AccessLevel.GameMaster, new CommandEventHandler(SeaMarketRegion.SetRestriction_OnCommand));
             }
-        }
+        }*/
 
         public static void Configure()
         {
@@ -43,6 +43,19 @@ namespace Server.Items
                 SeaMarketRegion.RestrictBoats = DefaultRestrictBoats;
 
                 m_Instance = new HighSeasPersistance();
+
+                Region reg = new TokunoDocksRegion();
+                reg.Register();
+
+                SeaMarketRegion reg1 = new SeaMarketRegion(Map.Felucca);
+                SeaMarketRegion reg2 = new SeaMarketRegion(Map.Trammel);
+
+                reg1.Register();
+                reg2.Register();
+
+                SeaMarketRegion.SetRegions(reg1, reg2);
+
+                CommandSystem.Register("RestrictBoats", AccessLevel.GameMaster, new CommandEventHandler(SeaMarketRegion.SetRestriction_OnCommand));
             }
         }
 

--- a/Scripts/Services/MondainsLegacyQuests/BaseEscort.cs
+++ b/Scripts/Services/MondainsLegacyQuests/BaseEscort.cs
@@ -35,7 +35,6 @@ namespace Server.Engines.Quests
         {
         }
 
-        public override bool OwnerCanRename { get { return false; } }
         public override bool InitialInnocent { get { return true; } }
         public override bool IsInvulnerable { get { return false; } }
         public override bool Commandable { get { return false; } }

--- a/Scripts/Spells/Spellweaving/ReaperForm.cs
+++ b/Scripts/Spells/Spellweaving/ReaperForm.cs
@@ -90,14 +90,17 @@ namespace Server.Spells.Spellweaving
         }
         public static void Initialize()
         {
-            EventSink.Login += new LoginEventHandler(OnLogin);
+            if (!Core.SA)
+            {
+                EventSink.Login += new LoginEventHandler(OnLogin);
+            }
         }
 
         public static void OnLogin(LoginEventArgs e)
         {
             TransformContext context = TransformationSpellHelper.GetContext(e.Mobile);
 
-            if (context != null && context.Type == typeof(ReaperFormSpell) && !Core.SA)
+            if (context != null && context.Type == typeof(ReaperFormSpell))
                 e.Mobile.SendSpeedControl(SpeedControlType.WalkSpeed);
         }
 
@@ -115,7 +118,11 @@ namespace Server.Spells.Spellweaving
 
         public override void RemoveEffect(Mobile m)
         {
-            m.SendSpeedControl(SpeedControlType.Disable);
+            if (!Core.SA)
+            {
+                m.SendSpeedControl(SpeedControlType.Disable);
+            }
+
             BuffInfo.RemoveBuff(m, BuffIcon.ReaperForm);
         }
     }


### PR DESCRIPTION
- Fixed issue where dropping a rune in a runic atlas was not displaying the gump
- Explosion potions now do damage to user if they are in their Pack
- Flying creatures are more EA like when they are wandering
- Controlled creatures now slow down to attack, per EA
- Players can no longer rename hireable NPC's
- Shipwrights no longer lose their HS boat inventory at server startup
- Fixed various artifact drops on SA Mini Bosses
- Adjusted spellbinder body values per EA
- Added speed control for stone form for pre-HS servers.