### PR TITLE
Item Drop

### DIFF
--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -5227,7 +5227,7 @@ namespace Server
                 int top = item.Z + id.CalcHeight;
                 if (top > p.Z) myTop = top;
 
-                if (top > maxZ || top < z)
+                if (top > maxZ || (top >= landTop && top < z))
                 {
                     continue;
                 }


### PR DESCRIPTION
Fixed an issue that prevented items from being properly dropped to the world on tiles below the average land elevation.
This issue only arises when dropping items within a 20z difference directly under a house, such as a Cellar at a house located in Malas at -110z.