### PR TITLE
Update to Honesty item turn-in for NPCs

### DIFF
--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -1139,6 +1139,11 @@ namespace Server.Mobiles
 
 		public override bool OnDragDrop(Mobile from, Item dropped)
 		{
+            if (dropped.GetSocket<HonestyItemSocket>() != null)
+            {
+                return base.OnDragDrop(from, dropped);
+            }
+
             if (ConvertsMageArmor && dropped is BaseArmor && CheckConvertArmor(from, (BaseArmor)dropped))
             {
                 return false;

--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -1139,10 +1139,28 @@ namespace Server.Mobiles
 
 		public override bool OnDragDrop(Mobile from, Item dropped)
 		{
-            if (dropped.GetSocket<HonestyItemSocket>() != null)
+            #region Honesty Item Check
+            var honestySocket = dropped.GetSocket<HonestyItemSocket>();
+
+            if (honestySocket != null)
             {
-                return base.OnDragDrop(from, dropped);
+                bool gainedPath = false;
+
+                if (honestySocket.HonestyOwner == this)
+                {
+                    VirtueHelper.Award(from, VirtueName.Honesty, 120, ref gainedPath);
+                    from.SendMessage(gainedPath ? "You have gained a path in Honesty!" : "You have gained in Honesty.");
+                    SayTo(from, 1074582); //Ah!  You found my property.  Thank you for your honesty in returning it to me.
+                    dropped.Delete();
+                    return true;
+                }
+                else
+                {
+                    this.SayTo(from, 501550, 0x3B2); // I am not interested in this.
+                    return false;
+                }              
             }
+            #endregion
 
             if (ConvertsMageArmor && dropped is BaseArmor && CheckConvertArmor(from, (BaseArmor)dropped))
             {

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -3078,19 +3078,24 @@ namespace Server.Mobiles
 
             var honestySocket = dropped.GetSocket<HonestyItemSocket>();
 
-            if (honestySocket != null && honestySocket.HonestyOwner == this)
+            if (honestySocket != null)
             {
-                VirtueHelper.Award(from, VirtueName.Honesty, 120, ref gainedPath);
+                if (honestySocket.HonestyOwner == this)
+                {
+                    VirtueHelper.Award(from, VirtueName.Honesty, 120, ref gainedPath);
+                    from.SendMessage(gainedPath ? "You have gained a path in Honesty!" : "You have gained in Honesty.");
+                    SayTo(from, 1074582); //Ah!  You found my property.  Thank you for your honesty in returning it to me.
+                    dropped.Delete();
+                    return true;
+                }
+                else
+                {
+                    this.SayTo(from, 501550, 0x3B2); // I am not interested in this.
+                    return false;
+                }
             }
-            else
-            {
-                return false;
-            }
-
-            from.SendMessage(gainedPath ? "You have gained a path in Honesty!" : "You have gained in Honesty.");
-            SayTo(from, 1074582); //Ah!  You found my property.  Thank you for your honesty in returning it to me.
-            dropped.Delete();
-            return true;
+            
+            return false;          
         }
 
         protected virtual BaseAI ForcedAI => null; 

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -3070,29 +3070,9 @@ namespace Server.Mobiles
             {
                 return true;
             }
-
             if (!from.InRange(Location, 2))
-                return base.OnDragDrop(from, dropped);
-
-            bool gainedPath = false;
-
-            var honestySocket = dropped.GetSocket<HonestyItemSocket>();
-
-            if (honestySocket != null)
             {
-                if (honestySocket.HonestyOwner == this)
-                {
-                    VirtueHelper.Award(from, VirtueName.Honesty, 120, ref gainedPath);
-                    from.SendMessage(gainedPath ? "You have gained a path in Honesty!" : "You have gained in Honesty.");
-                    SayTo(from, 1074582); //Ah!  You found my property.  Thank you for your honesty in returning it to me.
-                    dropped.Delete();
-                    return true;
-                }
-                else
-                {
-                    this.SayTo(from, 501550, 0x3B2); // I am not interested in this.
-                    return false;
-                }
+                return base.OnDragDrop(from, dropped);
             }
             
             return false;          

--- a/Scripts/Services/ViceVsVirtue/Mobiles/SilverTrader.cs
+++ b/Scripts/Services/ViceVsVirtue/Mobiles/SilverTrader.cs
@@ -140,6 +140,11 @@ namespace Server.Engines.VvV
 
         public override bool OnDragDrop(Mobile from, Item dropped)
         {
+            if (dropped.GetSocket<HonestyItemSocket>() != null)
+            {
+                return base.OnDragDrop(from, dropped);
+            }
+
             if (ViceVsVirtueSystem.IsVvV(from))
             {
                 if (!(dropped is IOwnerRestricted) || ((IOwnerRestricted)dropped).Owner == from)


### PR DESCRIPTION
Regarding Issue #4686

I moved the logic for the Honesty check into BaseVendor since only vendors can be assigned as an owner of an item, so it had no reason to be in BaseCreature.

I tested with Armorer, blacksmith's, and Silver Trader.  They now accept the Honesty item correctly.  Tested handing items to many mobile types , both honesty items, gold, and random objects, just to be sure BaseCreature logic is still good.