### PR TITLE
Paragon Chest Fix

### DIFF
--- a/Scripts/Items/Containers/ParagonChest.cs
+++ b/Scripts/Items/Containers/ParagonChest.cs
@@ -19,7 +19,7 @@ namespace Server.Items
         {
             m_Name = name;
             Hue = Utility.RandomList(m_Hues);
-            Fill(level);
+            Fill(level + 1);
         }
 
         public ParagonChest(Serial serial)


### PR DESCRIPTION
- Issue where gold amount was zero. Since TMap levels are now zero bases, this needs to be adjusted.