### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Addons/BaseAddon.cs
+++ b/Scripts/Items/Addons/BaseAddon.cs
@@ -171,7 +171,7 @@ namespace Server.Items
             {
                 Point3D p3D = new Point3D(p.X + c.Offset.X, p.Y + c.Offset.Y, p.Z + c.Offset.Z);
 
-                if (!map.CanFit(p3D.X, p3D.Y, p3D.Z, c.ItemData.Height, false, true, (c.Z == 0)))
+                if (!map.CanFit(p3D.X, p3D.Y, p3D.Z, c.ItemData.Height, false, true, (c.Z == 0), true))
                     return AddonFitResult.Blocked;
                 if (!CheckHouse(from, p3D, map, c.ItemData.Height, ref house))
                     return AddonFitResult.NotInHouse;

--- a/Scripts/Items/Functional/SeedBox/SeedBox.cs
+++ b/Scripts/Items/Functional/SeedBox/SeedBox.cs
@@ -44,6 +44,7 @@ namespace Server.Engines.Plants
         [CommandProperty(AccessLevel.GameMaster)]
         public int UniqueCount => Entries == null ? 0 : Entries.Where(e => e != null && e.Seed != null && e.Seed.Amount > 0).Count();
 
+        public override int DefaultMaxWeight { get { return 0; } }
         public override double DefaultWeight => 10.0;
 
         [Constructable]

--- a/Scripts/Misc/LootPack.cs
+++ b/Scripts/Misc/LootPack.cs
@@ -143,7 +143,26 @@ namespace Server
 
                 if (item != null)
                 {
-                    if (item.Stackable)
+                    if (from is BaseCreature && item.LootType == LootType.Blessed)
+                    {
+                        Timer.DelayCall(TimeSpan.FromMilliseconds(25), () =>
+                        {
+                            var corpse = ((BaseCreature)from).Corpse;
+
+                            if (corpse != null)
+                            {
+                                if (!corpse.TryDropItem((BaseCreature)from, item, false))
+                                {
+                                    corpse.DropItem(item);
+                                }
+                            }
+                            else
+                            {
+                                item.Delete();
+                            }
+                        });
+                    }
+                    else if (item.Stackable)
                     {
                         cont.DropItemStacked(item);
                     }
@@ -666,6 +685,11 @@ namespace Server
         public static LootPack LootItem<T>(int min, int max, bool resource) where T : Item
         {
             return new LootPack(new[] { new LootPackEntry(false, resource, new LootPackItem[] { new LootPackItem(typeof(T), 1) }, 100.0, Utility.RandomMinMax(min, max)) });
+        }
+
+        public static LootPack LootItem<T>(int min, int max, bool spawnTime, bool onSteal) where T : Item
+        {
+            return new LootPack(new[] { new LootPackEntry(spawnTime, onSteal, new LootPackItem[] { new LootPackItem(typeof(T), 1) }, 100.0, Utility.RandomMinMax(min, max)) });
         }
 
         public static LootPack LootItem<T>(int amount, bool resource) where T : Item

--- a/Scripts/Mobiles/Bosses/BaseChampion.cs
+++ b/Scripts/Mobiles/Bosses/BaseChampion.cs
@@ -32,67 +32,6 @@ namespace Server.Mobiles
 
         public virtual bool CanGivePowerscrolls => true;
 
-        public static void GivePowerScrollTo(Mobile m, Item item, BaseChampion champ)
-        {
-            if (m == null)	//sanity
-                return;
-
-            if (m.Alive)
-                m.AddToBackpack(item);
-            else
-            {
-                if (m.Corpse != null && !m.Corpse.Deleted)
-                    m.Corpse.DropItem(item);
-                else
-                    m.AddToBackpack(item);
-            }
-
-            if (item is PowerScroll && m is PlayerMobile)
-            {
-                PlayerMobile pm = (PlayerMobile)m;
-
-                for (int j = 0; j < pm.JusticeProtectors.Count; ++j)
-                {
-                    Mobile prot = pm.JusticeProtectors[j];
-
-                    if (prot.Map != m.Map || prot.Murderer || prot.Criminal || !JusticeVirtue.CheckMapRegion(m, prot) || !prot.InRange(champ, 100))
-                        continue;
-
-                    int chance = 0;
-
-                    switch (VirtueHelper.GetLevel(prot, VirtueName.Justice))
-                    {
-                        case VirtueLevel.Seeker:
-                            chance = 60;
-                            break;
-                        case VirtueLevel.Follower:
-                            chance = 80;
-                            break;
-                        case VirtueLevel.Knight:
-                            chance = 100;
-                            break;
-                    }
-
-                    if (chance > Utility.Random(100))
-                    {
-                        PowerScroll powerScroll = CreateRandomPowerScroll();
-
-                        prot.SendLocalizedMessage(1049368); // You have been rewarded for your dedication to Justice!
-
-                        if (prot.Alive)
-                            prot.AddToBackpack(powerScroll);
-                        else
-                        {
-                            if (prot.Corpse != null && !prot.Corpse.Deleted)
-                                prot.Corpse.DropItem(powerScroll);
-                            else
-                                prot.AddToBackpack(powerScroll);
-                        }
-                    }
-                }
-            }
-        }
-
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
@@ -195,7 +134,7 @@ namespace Server.Mobiles
                 PowerScroll ps = CreateRandomPowerScroll();
                 m.SendLocalizedMessage(1049524); // You have received a scroll of power!
 
-                GivePowerScrollTo(m, ps, this);
+                GivePowerScrollTo(m, ps);
             }
 
             // Randomize - Primers
@@ -214,10 +153,86 @@ namespace Server.Mobiles
                 SkillMasteryPrimer p = CreateRandomPrimer();
                 m.SendLocalizedMessage(1156209); // You have received a mastery primer!
 
-                GivePowerScrollTo(m, p, this);
+                GivePowerScrollTo(m, p);
             }
 
             ColUtility.Free(toGive);
+        }
+
+        public virtual void GivePowerScrollTo(Mobile m, Item item)
+        {
+            if (m == null)	//sanity
+                return;
+
+            if (m.Alive)
+                m.AddToBackpack(item);
+            else
+            {
+                if (m.Corpse != null && !m.Corpse.Deleted)
+                    m.Corpse.DropItem(item);
+                else
+                    m.AddToBackpack(item);
+            }
+
+            if (item is PowerScroll && m is PlayerMobile)
+            {
+                PlayerMobile pm = (PlayerMobile)m;
+
+                for (int j = 0; j < pm.JusticeProtectors.Count; ++j)
+                {
+                    Mobile prot = pm.JusticeProtectors[j];
+
+                    if (prot.Map != m.Map || prot.Murderer || prot.Criminal || !JusticeVirtue.CheckMapRegion(m, prot) || !prot.InRange(this, 100))
+                        continue;
+
+                    int chance = 0;
+
+                    switch (VirtueHelper.GetLevel(prot, VirtueName.Justice))
+                    {
+                        case VirtueLevel.Seeker:
+                            chance = 60;
+                            break;
+                        case VirtueLevel.Follower:
+                            chance = 80;
+                            break;
+                        case VirtueLevel.Knight:
+                            chance = 100;
+                            break;
+                    }
+
+                    if (chance > Utility.Random(100))
+                    {
+                        PowerScroll powerScroll = CreateRandomPowerScroll();
+
+                        prot.SendLocalizedMessage(1049368); // You have been rewarded for your dedication to Justice!
+
+                        if (prot.Alive)
+                            prot.AddToBackpack(powerScroll);
+                        else
+                        {
+                            if (prot.Corpse != null && !prot.Corpse.Deleted)
+                                prot.Corpse.DropItem(powerScroll);
+                            else
+                                prot.AddToBackpack(powerScroll);
+                        }
+                    }
+                }
+            }
+        }
+
+        public virtual PowerScroll CreateRandomPowerScroll()
+        {
+            int level;
+            double random = Utility.RandomDouble();
+
+            if (0.05 >= random)
+                level = 20;
+            else if (0.4 >= random)
+                level = 15;
+            else
+                level = 10;
+
+            return PowerScroll.CreateRandomNoCraft(level, level);
         }
 
         public virtual void OnChampPopped(ChampionSpawn spawn)
@@ -243,7 +258,6 @@ namespace Server.Mobiles
         {
             if (Map == Map.Felucca)
             {
-                //TODO: Confirm SE change or AoS one too?
                 List<DamageStore> rights = GetLootingRights();
                 List<Mobile> toGive = new List<Mobile>();
 
@@ -267,21 +281,6 @@ namespace Server.Mobiles
             }
 
             base.OnDeath(c);
-        }
-
-        private static PowerScroll CreateRandomPowerScroll()
-        {
-            int level;
-            double random = Utility.RandomDouble();
-
-            if (0.05 >= random)
-                level = 20;
-            else if (0.4 >= random)
-                level = 15;
-            else
-                level = 10;
-
-            return PowerScroll.CreateRandomNoCraft(level, level);
         }
 
         private static SkillMasteryPrimer CreateRandomPrimer()

--- a/Scripts/Mobiles/Bosses/Navery/Navrey.cs
+++ b/Scripts/Mobiles/Bosses/Navery/Navrey.cs
@@ -77,7 +77,7 @@ namespace Server.Mobiles
         {
             int random = Utility.Random(typelist.Length);
             Item item = Loot.Construct(typelist[random]);
-            DistributeArtifact(DemonKnight.FindRandomPlayer(bc), item);
+            DistributeArtifact(bc.RandomPlayerWithLootingRights(), item);
         }
 
         public static void DistributeArtifact(Mobile to, Item artifact)

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -5603,6 +5603,33 @@ namespace Server.Mobiles
             return LootingRights != null && LootingRights.Count > 0 && LootingRights[0].m_Mobile == m;
         }
 
+        public Mobile RandomPlayerWithLootingRights()
+        {
+            var rights = GetLootingRights();
+
+            if (rights == null)
+            {
+                return null;
+            }
+
+            for (int i = rights.Count - 1; i >= 0; --i)
+            {
+                var ds = rights[i];
+
+                if (!ds.m_HasRight)
+                {
+                    rights.RemoveAt(i);
+                }
+            }
+
+            if (rights.Count > 0)
+            {
+                return rights[Utility.Random(rights.Count)].m_Mobile;
+            }
+
+            return null;
+        }
+
         public List<DamageStore> GetLootingRights()
         {
             if (LootingRights != null)

--- a/Scripts/Mobiles/Normal/DemonKnight.cs
+++ b/Scripts/Mobiles/Normal/DemonKnight.cs
@@ -101,24 +101,6 @@ namespace Server.Mobiles
             base.OnDeath(c);
         }
 
-        public static Mobile FindRandomPlayer(BaseCreature creature)
-        {
-            List<DamageStore> rights = creature.GetLootingRights();
-
-            for (int i = rights.Count - 1; i >= 0; --i)
-            {
-                DamageStore ds = rights[i];
-
-                if (!ds.m_HasRight)
-                    rights.RemoveAt(i);
-            }
-
-            if (rights.Count > 0)
-                return rights[Utility.Random(rights.Count)].m_Mobile;
-
-            return null;
-        }
-
         public override bool TeleportsTo => true;
 
         public override void GenerateLoot()

--- a/Scripts/Mobiles/Normal/Ethereals.cs
+++ b/Scripts/Mobiles/Normal/Ethereals.cs
@@ -167,7 +167,6 @@ namespace Server.Mobiles
         }
 
         public int MountedID => Transparent ? TransparentMountedID : NonTransparentMountedID;
-
         public int MountedHue => Transparent ? TransparentMountedHue : NonTransparentMountedHue;
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -293,13 +292,11 @@ namespace Server.Mobiles
 
         public virtual bool Validate(Mobile from)
         {
-            #region SA
             if (from.Race == Race.Gargoyle)
             {
                 from.SendLocalizedMessage(1112281); // gargs can't mount
                 return false;
             }
-            #endregion
 
             if (Parent == null)
             {
@@ -369,11 +366,9 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(7); // version
 
             writer.Write(m_Transparent);
-
             writer.Write(m_TransparentMountedID);
             writer.Write(m_NonTransparentMountedID);
             writer.Write(m_TransparentMountedHue);
@@ -382,60 +377,24 @@ namespace Server.Mobiles
             writer.Write(m_StatueHue);
 
             writer.Write(m_IsRewardItem);
-
             writer.Write(m_Rider);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            LootType = LootType.Blessed;
-
             int version = reader.ReadInt();
 
-            switch (version)
-            {
-                case 7:
-                case 6:
-                case 5:
-                    m_Transparent = reader.ReadBool();
-                    m_TransparentMountedID = reader.ReadInt();
-                    m_NonTransparentMountedID = reader.ReadInt();
-                    m_TransparentMountedHue = reader.ReadInt();
-                    m_NonTransparentMountedHue = reader.ReadInt();
-                    m_StatueID = reader.ReadInt();
-                    m_StatueHue = reader.ReadInt();
+            m_Transparent = reader.ReadBool();
+            m_TransparentMountedID = reader.ReadInt();
+            m_NonTransparentMountedID = reader.ReadInt();
+            m_TransparentMountedHue = reader.ReadInt();
+            m_NonTransparentMountedHue = reader.ReadInt();
+            m_StatueID = reader.ReadInt();
+            m_StatueHue = reader.ReadInt();
 
-                    m_IsRewardItem = reader.ReadBool();
-                    m_Rider = reader.ReadMobile();
-                    break;
-                case 4:
-                    m_NonTransparentMountedID = reader.ReadInt(); // m_DefaultMountedID = reader.ReadInt();
-                    m_NonTransparentMountedHue = reader.ReadInt(); // m_OriginalHue = reader.ReadInt();
-                    m_TransparentMountedHue = reader.ReadInt(); // m_EtherealHue = reader.ReadInt();
-                    goto case 3;
-                case 3:
-                    reader.ReadBool();
-                    goto case 2;
-                case 2:
-                    m_IsRewardItem = reader.ReadBool();
-                    goto case 0;
-                case 1:
-                    reader.ReadInt();
-                    goto case 0;
-                case 0:
-                    {
-                        m_TransparentMountedID = reader.ReadInt(); // m_MountedID = reader.ReadInt();
-                        m_StatueID = reader.ReadInt(); // m_RegularID = reader.ReadInt();
-                        m_Rider = reader.ReadMobile();
-
-                        if (m_TransparentMountedID == 0x3EA2)
-                        {
-                            m_TransparentMountedID = 0x3EAA;
-                        }
-                    }
-                    break;
-            }
+            m_IsRewardItem = reader.ReadBool();
+            m_Rider = reader.ReadMobile();
 
             AddFollowers();
         }
@@ -497,7 +456,8 @@ namespace Server.Mobiles
         }
 
         public virtual void OnRiderDamaged(Mobile from, ref int amount, bool willKill)
-        { }
+        {
+        }
 
         private class EtherealSpell : Spell
         {
@@ -577,8 +537,6 @@ namespace Server.Mobiles
                 {
                     Caster.SendLocalizedMessage(1049455); // You have been disrupted while attempting to summon your ethereal mount!
                 }
-
-                //m_Mount.UnmountMe();
             }
 
             public override void OnCast()
@@ -595,291 +553,232 @@ namespace Server.Mobiles
 
     public class EtherealHorse : EtherealMount
     {
+        public override int LabelNumber => 1041298; // Ethereal Horse Statuette
+
         [Constructable]
         public EtherealHorse()
             : base(0x20DD, 0x3EAA, 0x3EA0)
-        { }
+        {
+        }
 
         public EtherealHorse(Serial serial)
             : base(serial)
-        { }
+        {
+        }
 
-        public override int LabelNumber => 1041298;  // Ethereal Horse Statuette
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                NonTransparentMountedID = 0x3EA0;
-                Transparent = true;
-            }
         }
     }
 
     public class EtherealLlama : EtherealMount
     {
+        public override int LabelNumber => 1041300; // Ethereal Llama Statuette
+
         [Constructable]
         public EtherealLlama()
             : base(0x20F6, 0x3EAB, 0x3EA6)
-        { }
+        {
+        }
 
         public EtherealLlama(Serial serial)
             : base(serial)
-        { }
+        {
+        }
 
-        public override int LabelNumber => 1041300;  // Ethereal Llama Statuette
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                NonTransparentMountedID = 0x3EA6;
-                Transparent = true;
-            }
         }
     }
 
     public class EtherealOstard : EtherealMount
     {
+        public override int LabelNumber => 1041299; // Ethereal Ostard Statuette
+
         [Constructable]
         public EtherealOstard()
             : base(0x2135, 0x3EAC, 0x3EA5)
-        { }
+        {
+        }
 
         public EtherealOstard(Serial serial)
             : base(serial)
-        { }
+        {
+        }
 
-        public override int LabelNumber => 1041299;  // Ethereal Ostard Statuette
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                NonTransparentMountedID = 0x3EA5;
-                Transparent = true;
-            }
         }
     }
 
     public class EtherealRidgeback : EtherealMount
     {
+        public override int LabelNumber => 1049747; // Ethereal Ridgeback Statuette
+
         [Constructable]
         public EtherealRidgeback()
             : base(0x2615, 0x3E9A, 0x3EBA, DefaultEtherealHue)
-        { }
+        {
+        }
 
         public EtherealRidgeback(Serial serial)
             : base(serial)
-        { }
+        {
+        }
 
-        public override int LabelNumber => 1049747;  // Ethereal Ridgeback Statuette
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(2); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                NonTransparentMountedID = 0x3EBA;
-                Transparent = true;
-            }
-
-            if (version == 1)
-            {
-                TransparentMountedHue = DefaultEtherealHue;
-            }
         }
     }
 
     public class EtherealUnicorn : EtherealMount
     {
+        public override int LabelNumber => 1049745; // Ethereal Unicorn Statuette
+
         [Constructable]
         public EtherealUnicorn()
             : base(0x25CE, 0x3E9B, 0x3EB4, DefaultEtherealHue)
-        { }
+        {
+        }
 
         public EtherealUnicorn(Serial serial)
             : base(serial)
-        { }
+        {
+        }
 
-        public override int LabelNumber => 1049745;  // Ethereal Unicorn Statuette
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(2); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                NonTransparentMountedID = 0x3EB4;
-                Transparent = true;
-            }
-
-            if (version == 1)
-            {
-                TransparentMountedHue = DefaultEtherealHue;
-            }
         }
     }
 
     public class EtherealBeetle : EtherealMount
     {
+        public override int LabelNumber => 1049748; // Ethereal Beetle Statuette
+
         [Constructable]
         public EtherealBeetle()
             : base(0x260F, 0x3E97, 0x3EBC, DefaultEtherealHue)
-        { }
+        {
+        }
 
         public EtherealBeetle(Serial serial)
             : base(serial)
-        { }
+        {
+        }
 
-        public override int LabelNumber => 1049748;  // Ethereal Beetle Statuette
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(2); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                NonTransparentMountedID = 0x3EBC;
-                Transparent = true;
-            }
-
-            if (version == 1)
-            {
-                TransparentMountedHue = DefaultEtherealHue;
-            }
         }
     }
 
     public class EtherealKirin : EtherealMount
     {
+        public override int LabelNumber => 1049746; // Ethereal Ki-Rin Statuette
+
         [Constructable]
         public EtherealKirin()
             : base(0x25A0, 0x3E9C, 0x3EAD, DefaultEtherealHue)
-        { }
+        {
+        }
 
         public EtherealKirin(Serial serial)
             : base(serial)
-        { }
+        {
+        }
 
-        public override int LabelNumber => 1049746;  // Ethereal Ki-Rin Statuette
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(2); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                NonTransparentMountedID = 0x3EAD;
-                Transparent = true;
-            }
-
-            if (version == 1)
-            {
-                TransparentMountedHue = DefaultEtherealHue;
-            }
         }
     }
 
     public class EtherealSwampDragon : EtherealMount
     {
+        public override int LabelNumber => 1049749; // Ethereal Swamp Dragon Statuette
+
         [Constructable]
         public EtherealSwampDragon()
             : base(0x2619, 0x3E98, 0x3EBD, DefaultEtherealHue, 0x851)
-        { }
+        {
+        }
 
         public EtherealSwampDragon(Serial serial)
             : base(serial)
-        { }
+        {
+        }
 
-        public override int LabelNumber => 1049749;  // Ethereal Swamp Dragon Statuette
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                NonTransparentMountedID = 0x3EBD;
-                NonTransparentMountedHue = 0x851;
-                Transparent = true;
-            }
         }
     }
 
     public class RideablePolarBear : EtherealMount
     {
+        public override int LabelNumber => 1076159; // Rideable Polar Bear
+
         [Constructable]
         public RideablePolarBear()
             : base(0x20E1, 0x3EC5, 0x3EC5, DefaultEtherealHue)
@@ -889,32 +788,26 @@ namespace Server.Mobiles
 
         public RideablePolarBear(Serial serial)
             : base(serial)
-        { }
-
-        public override int LabelNumber => 1076159;  // Rideable Polar Bear
+        {
+        }      
 
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(2); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadEncodedInt();
-
-            if (version == 1)
-            {
-                Transparent = false;
-            }
         }
     }
 
     public class EtherealCuSidhe : EtherealMount
     {
+        public override int LabelNumber => 1080386; // Ethereal Cu Sidhe Statuette
+
         [Constructable]
         public EtherealCuSidhe()
             : base(0x2D96, 0x3E91, 0x3E91, DefaultEtherealHue)
@@ -924,31 +817,26 @@ namespace Server.Mobiles
 
         public EtherealCuSidhe(Serial serial)
             : base(serial)
-        { }
-
-        public override int LabelNumber => 1080386;  // Ethereal Cu Sidhe Statuette
+        {
+        }
+        
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadEncodedInt();
-
-            if (version == 0)
-            {
-                Transparent = false;
-            }
         }
     }
 
     public class EtherealHiryu : EtherealMount
     {
+        public override int LabelNumber => 1113813; // Ethereal Hiryu Statuette
+
         [Constructable]
         public EtherealHiryu()
             : base(0x276A, 0x3E94, 0x3E94, DefaultEtherealHue)
@@ -958,31 +846,26 @@ namespace Server.Mobiles
 
         public EtherealHiryu(Serial serial)
             : base(serial)
-        { }
+        {
+        }
 
-        public override int LabelNumber => 1113813;  // Ethereal Hiryu Statuette
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadEncodedInt();
-
-            if (version == 0)
-            {
-                Transparent = false;
-            }
         }
     }
 
     public class EtherealReptalon : EtherealMount
     {
+        public override int LabelNumber => 1113812; // Ethereal Reptalon Statuette
+
         [Constructable]
         public EtherealReptalon()
             : base(0x2d95, 0x3e90, 0x3e90, DefaultEtherealHue)
@@ -992,31 +875,26 @@ namespace Server.Mobiles
 
         public EtherealReptalon(Serial serial)
             : base(serial)
-        { }
+        {
+        }
 
-        public override int LabelNumber => 1113812;  // Ethereal Reptalon Statuette
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.WriteEncodedInt(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadEncodedInt();
-
-            if (version == 0)
-            {
-                Transparent = false;
-            }
         }
     }
 
     public class ChargerOfTheFallen : EtherealMount
     {
+        public override int LabelNumber => 1074816; // Charger of the Fallen Statuette
+
         [Constructable]
         public ChargerOfTheFallen()
             : base(0x2D9C, 0x3E92, 0x3E92, DefaultEtherealHue)
@@ -1026,33 +904,25 @@ namespace Server.Mobiles
 
         public ChargerOfTheFallen(Serial serial)
             : base(serial)
-        { }
-
-        public override int LabelNumber => 1074816;  // Charger of the Fallen Statuette
+        {
+        }
 
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                Transparent = false;
-            }
         }
     }
 
     public class EtherealBoura : EtherealMount
     {
-        public override int LabelNumber => 1150006;  // Rideable Boura Statuette
+        public override int LabelNumber => 1150006; // Rideable Boura Statuette
 
         [Constructable]
         public EtherealBoura()
@@ -1069,26 +939,19 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(2); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 1)
-            {
-                Transparent = false;
-            }
         }
     }
 
     public class EtherealAncientHellHound : EtherealMount
     {
-        public override int LabelNumber => 1155723;  // Ancient Hell Hound Statuette
+        public override int LabelNumber => 1155723; // Ancient Hell Hound Statuette
 
         [Constructable]
         public EtherealAncientHellHound()
@@ -1105,25 +968,20 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(2); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 1)
-            {
-                Transparent = false;
-            }
         }
     }
 
     public class EtherealTiger : EtherealMount
     {
+        public override int LabelNumber => 1154589; // Ethereal Tiger Statuette
+
         [Constructable]
         public EtherealTiger()
             : this(false)
@@ -1139,33 +997,25 @@ namespace Server.Mobiles
 
         public EtherealTiger(Serial serial)
             : base(serial)
-        { }
-
-        public override int LabelNumber => 1154589;  // Ethereal Tiger Statuette
+        {
+        }
 
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                Transparent = false;
-            }
         }
     }
 
     public class EtherealTarantula : EtherealMount
     {
-        public override int LabelNumber => 1157081;  // Tarantula Statuette
+        public override int LabelNumber => 1157081; // Tarantula Statuette
 
         [Constructable]
         public EtherealTarantula()
@@ -1173,7 +1023,6 @@ namespace Server.Mobiles
         {
             Transparent = false;
         }
-
 
         public EtherealTarantula(Serial serial)
             : base(serial)
@@ -1183,26 +1032,19 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                Transparent = false;
-            }
         }
     }
 
     public class EtherealLasher : EtherealMount
     {
-        public override int LabelNumber => 1157214;  // Lasher
+        public override int LabelNumber => 1157214; // Lasher
 
         [Constructable]
         public EtherealLasher()
@@ -1219,26 +1061,19 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                Transparent = false;
-            }
         }
     }
 
     public class EtherealSerpentineDragon : EtherealMount
     {
-        public override int LabelNumber => 1157995;  // Ethereal Dragon Statuette
+        public override int LabelNumber => 1157995; // Ethereal Dragon Statuette
 
         [Constructable]
         public EtherealSerpentineDragon()
@@ -1255,20 +1090,13 @@ namespace Server.Mobiles
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                Transparent = false;
-            }
         }
     }
 

--- a/Scripts/Services/Dungeons/CovetousVoidSpawn/Creatures/Cora.cs
+++ b/Scripts/Services/Dungeons/CovetousVoidSpawn/Creatures/Cora.cs
@@ -298,7 +298,7 @@ namespace Server.Mobiles
 
             if (0.30 > Utility.RandomDouble())
             {
-                Mobile m = DemonKnight.FindRandomPlayer(this);
+                Mobile m = RandomPlayerWithLootingRights();
 
                 if (m != null)
                 {

--- a/Scripts/Services/Dungeons/CovetousVoidSpawn/Region.cs
+++ b/Scripts/Services/Dungeons/CovetousVoidSpawn/Region.cs
@@ -68,7 +68,7 @@ namespace Server.Engines.VoidPool
 
                     if (chance > Utility.RandomDouble())
                     {
-                        Mobile mob = DemonKnight.FindRandomPlayer((BaseCreature)m);
+                        Mobile mob = ((BaseCreature)m).RandomPlayerWithLootingRights();
 
                         if (mob != null)
                         {

--- a/Scripts/Services/Dungeons/TheExodusEncounter/Mobiles/ClockworkExodus.cs
+++ b/Scripts/Services/Dungeons/TheExodusEncounter/Mobiles/ClockworkExodus.cs
@@ -92,20 +92,24 @@ namespace Server.Mobiles
         {
             int random = Utility.Random(typelist.Length);
             Item item = Loot.Construct(typelist[random]);
-            DistributeArtifact(DemonKnight.FindRandomPlayer(bc), item);
+            DistributeArtifact(bc.RandomPlayerWithLootingRights(), item);
         }
 
         public static void DistributeArtifact(Mobile to, Item artifact)
         {
-            if (to == null || artifact == null)
-                return;
+            if (to != null)
+            {
+                Container pack = to.Backpack;
 
-            Container pack = to.Backpack;
+                if (pack == null || !pack.TryDropItem(to, artifact, false))
+                    to.BankBox.DropItem(artifact);
 
-            if (pack == null || !pack.TryDropItem(to, artifact, false))
-                to.BankBox.DropItem(artifact);
-
-            to.SendLocalizedMessage(502088); // A special gift has been placed in your backpack.
+                to.SendLocalizedMessage(502088); // A special gift has been placed in your backpack.
+            }
+            else if (artifact != null)
+            {
+                artifact.Delete();
+            }
         }
 
         public override bool OnBeforeDeath()

--- a/Scripts/Services/Expansions/High Seas/Spawners/BountyQuestSpawner.cs
+++ b/Scripts/Services/Expansions/High Seas/Spawners/BountyQuestSpawner.cs
@@ -664,18 +664,17 @@ namespace Server.Engines.Quests
 
                 if (Server.Engines.Points.PointsSystem.RisingTide.Enabled)
                 {
-                    if (0.25 > Utility.RandomDouble())
+                    hold.DropItem(new MaritimeCargo());
+                    hold.DropItem(new MaritimeCargo());
+
+                    if (galleon is OrcishGalleon)
                     {
                         hold.DropItem(new MaritimeCargo());
 
-                        if (0.1 > Utility.RandomDouble())
+                        if (Utility.RandomBool())
                         {
                             hold.DropItem(new MaritimeCargo());
                         }
-                    }
-                    else if (0.25 > Utility.RandomDouble())
-                    {
-                        hold.DropItem(new MaritimeCargo());
                     }
                 }
             }

--- a/Scripts/Services/ExploringTheDeep/Mobiles/TheMasterInstructor.cs
+++ b/Scripts/Services/ExploringTheDeep/Mobiles/TheMasterInstructor.cs
@@ -109,7 +109,7 @@ namespace Server.Mobiles
 
         public override bool OnBeforeDeath()
         {
-            Mobile killer = DemonKnight.FindRandomPlayer(this);
+            Mobile killer = RandomPlayerWithLootingRights();
 
             if (killer != null)
             {

--- a/Scripts/Services/Harvest/Fishing.cs
+++ b/Scripts/Services/Harvest/Fishing.cs
@@ -460,9 +460,15 @@ namespace Server.Engines.Harvest
                         else
                         {
                             if (Utility.RandomBool())
+                            {
                                 chest = new MetalGoldenChest();
+                                chest.Name = "metal chest";
+                            }
                             else
+                            {
                                 chest = new WoodenChest();
+                                chest.Name = "wooden chest";
+                            }
                         }
 
                         if (sos.IsAncient)

--- a/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
+++ b/Scripts/Services/LootGeneration/Imbuing/Core/Imbuing.cs
@@ -214,7 +214,8 @@ namespace Server.SkillHandlers
             typeof(VirtuososCap), typeof(VirtuososCollar), typeof(VirtuososEarpieces), typeof(VirtuososKidGloves), typeof(VirtuososKilt),
             typeof(VirtuososNecklace), typeof(VirtuososTunic), typeof(BestialArms), typeof(BestialEarrings), typeof(BestialGloves), typeof(BestialGorget),
             typeof(BestialHelm), typeof(BestialKilt), typeof(BestialLegs), typeof(BestialNecklace), typeof(BarbedWhip), typeof(BladedWhip),
-            typeof(SpikedWhip), typeof(SkullGnarledStaff), typeof(GargishSkullGnarledStaff), typeof(SkullLongsword), typeof(GargishSkullLongsword), typeof(JukaBow)
+            typeof(SpikedWhip), typeof(SkullGnarledStaff), typeof(GargishSkullGnarledStaff), typeof(SkullLongsword), typeof(GargishSkullLongsword), typeof(JukaBow),
+            typeof(SlayerLongbow)
         };
 
         private static readonly Type[] _NonCraftables =

--- a/Scripts/Services/New Magincia/Magincia Bazaar/Core/BrokerEntries.cs
+++ b/Scripts/Services/New Magincia/Magincia Bazaar/Core/BrokerEntries.cs
@@ -82,8 +82,7 @@ namespace Server.Engines.NewMagincia
         /// <returns></returns>
         public bool PlayerCanBuy(int amount)
         {
-            //return (m_SellAtLimit == 0 || m_Stock >= m_SellAtLimit) && m_Stock > 0 && m_SellPricePer > 0 && m_SellLimit < amount;
-            return (m_SellLimit == 0 || amount <= ActualSellLimit) && m_SellPricePer > 0;
+            return (m_SellLimit == 0 || amount <= ActualSellLimit) && m_Stock > 0 &&  m_SellPricePer > 0;
         }
 
         /// <summary>
@@ -93,8 +92,7 @@ namespace Server.Engines.NewMagincia
         /// <returns></returns>
         public bool PlayerCanSell(int amount)
         {
-            //(m_BuyAtLimit == 0 || m_Stock <= entry.BuyAtLimit) && m_Stock > 0 && m_BuyPricePer * amount <= m_Broker.BankBalance && m_BuyPricePer > 0 && m_BuyLimit < amount;
-            return (m_BuyLimit == 0 || amount <= ActualBuyLimit) && m_Stock > 0 && m_BuyPricePer > 0 && m_BuyPricePer <= m_Broker.BankBalance;
+            return (m_BuyLimit == 0 || amount <= ActualBuyLimit) && m_BuyPricePer > 0 && m_BuyPricePer <= m_Broker.BankBalance;
         }
 
         public CommodityBrokerEntry(GenericReader reader)

--- a/Scripts/Services/Seasonal Events/RisingTide/PlunderBeacon.cs
+++ b/Scripts/Services/Seasonal Events/RisingTide/PlunderBeacon.cs
@@ -52,13 +52,10 @@ namespace Server.Items
 
                 for (int i = 0; i < eligables.Count; i++)
                 {
-                    if (0.25 > Utility.RandomDouble())
-                    {
-                        Mobile winner = eligables[i];
+                    Mobile winner = eligables[i];
 
-                        winner.AddToBackpack(new MaritimeCargo(CargoQuality.Mythical));
-                        winner.SendLocalizedMessage(1158907); // You recover maritime trade cargo!
-                    }
+                    winner.AddToBackpack(new MaritimeCargo(CargoQuality.Mythical));
+                    winner.SendLocalizedMessage(1158907); // You recover maritime trade cargo!
                 }
             }
 

--- a/Scripts/Services/Seasonal Events/RisingTide/PlunderBeaconAddon.cs
+++ b/Scripts/Services/Seasonal Events/RisingTide/PlunderBeaconAddon.cs
@@ -514,5 +514,54 @@ namespace Server.Items
 		};
 
         #endregion
+
+        public static List<PlunderBeaconAddon> Beacons { get; set; }
+
+        public static void AddBeacon(PlunderBeaconAddon beacon)
+        {
+            if (Beacons == null)
+            {
+                Beacons = new List<PlunderBeaconAddon>();
+            }
+
+            Beacons.Add(beacon);
+        }
+
+        public static void RemoveBeacon(PlunderBeaconAddon beacon)
+        {
+            if (Beacons != null && Beacons.Contains(beacon))
+            {
+                Beacons.Remove(beacon);
+            }
+        }
+
+        public static void Initialize()
+        {
+            if (Server.Engines.Points.PointsSystem.RisingTide.Enabled)
+            {
+                EventSink.CreatureDeath += OnCreatureDeath;
+            }
+        }
+
+        public static void OnCreatureDeath(CreatureDeathEventArgs e)
+        {
+            var killed = e.Creature as BaseCreature;
+
+            if (killed != null && Beacons != null && Beacons.Any(b => b.Spawn != null && b.Spawn.ContainsKey(killed)))
+            {
+                double chance = killed is PirateCrew ? 0.15 : 0.025;
+
+                if (chance >= Utility.RandomDouble())
+                {
+                    var m = killed.RandomPlayerWithLootingRights();
+
+                    if (m != null)
+                    {
+                        m.AddToBackpack(new MaritimeCargo());
+                        m.SendLocalizedMessage(1158907); // You recover maritime trade cargo!
+                    }
+                }
+            }
+        }
     }
 }

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Creatures/KhalAnkur.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Creatures/KhalAnkur.cs
@@ -331,6 +331,20 @@ namespace Server.Mobiles
             AddLoot(LootPack.Meager);
         }
 
+        private int _120Scrolls = 4;
+
+        public override PowerScroll CreateRandomPowerScroll()
+        {
+            if (_120Scrolls > 0)
+            {
+                _120Scrolls--;
+
+                return PowerScroll.CreateRandomNoCraft(20, 20);
+            }
+
+            return base.CreateRandomPowerScroll();
+        }
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Services/TimeOfLegends.cs
+++ b/Scripts/Services/TimeOfLegends.cs
@@ -135,7 +135,7 @@ namespace Server
         public static Type[] ArmorDropTypes => _ArmorDropTypes;
         private static readonly Type[] _ArmorDropTypes =
         {
-            typeof(AloronsBustier), typeof(AloronsGorget), typeof(AloronsHelm), typeof(AloronsLegs), typeof(AloronsLongSkirt), typeof(AloronsSkirt), typeof(AloronsTunic),
+            typeof(AloronsBustier), typeof(AloronsGorget), typeof(AloronsHelm), typeof(AloronsLegs), typeof(AloronsLongSkirt), typeof(AloronsSkirt), typeof(AloronsTunic), typeof(AloronsShorts),
             typeof(DardensBustier), typeof(DardensHelm), typeof(DardensLegs), typeof(DardensSleeves), typeof(DardensTunic)
         };
 

--- a/Server/Map.cs
+++ b/Server/Map.cs
@@ -844,40 +844,45 @@ namespace Server
 
         public bool CanFit(Point3D p, int height, bool checkBlocksFit, bool checkMobiles)
         {
-            return CanFit(p.m_X, p.m_Y, p.m_Z, height, checkBlocksFit, checkMobiles, true);
+            return CanFit(p.m_X, p.m_Y, p.m_Z, height, checkBlocksFit, checkMobiles, true, false);
         }
 
         public bool CanFit(Point2D p, int z, int height, bool checkBlocksFit)
         {
-            return CanFit(p.m_X, p.m_Y, z, height, checkBlocksFit, true, true);
+            return CanFit(p.m_X, p.m_Y, z, height, checkBlocksFit, true, true, false);
         }
 
         public bool CanFit(Point3D p, int height)
         {
-            return CanFit(p.m_X, p.m_Y, p.m_Z, height, false, true, true);
+            return CanFit(p.m_X, p.m_Y, p.m_Z, height, false, true, true, false);
         }
 
         public bool CanFit(Point2D p, int z, int height)
         {
-            return CanFit(p.m_X, p.m_Y, z, height, false, true, true);
+            return CanFit(p.m_X, p.m_Y, z, height, false, true, true, false);
         }
 
         public bool CanFit(int x, int y, int z, int height)
         {
-            return CanFit(x, y, z, height, false, true, true);
+            return CanFit(x, y, z, height, false, true, true, false);
         }
 
         public bool CanFit(int x, int y, int z, int height, bool checksBlocksFit)
         {
-            return CanFit(x, y, z, height, checksBlocksFit, true, true);
+            return CanFit(x, y, z, height, checksBlocksFit, true, true, false);
         }
 
         public bool CanFit(int x, int y, int z, int height, bool checkBlocksFit, bool checkMobiles)
         {
-            return CanFit(x, y, z, height, checkBlocksFit, checkMobiles, true);
+            return CanFit(x, y, z, height, checkBlocksFit, checkMobiles, true, false);
         }
 
         public bool CanFit(int x, int y, int z, int height, bool checkBlocksFit, bool checkMobiles, bool requireSurface)
+        {
+            return CanFit(x, y, z, height, checkBlocksFit, checkMobiles, requireSurface, false);
+        }
+
+        public bool CanFit(int x, int y, int z, int height, bool checkBlocksFit, bool checkMobiles, bool requireSurface, bool ignoreRoof)
         {
             if (this == Internal)
             {
@@ -906,15 +911,16 @@ namespace Server
 
             StaticTile[] staticTiles = Tiles.GetStaticTiles(x, y, true);
 
-            bool surface, impassable;
+            bool surface, impassable, roof;
 
             foreach (StaticTile t in staticTiles)
             {
                 ItemData id = TileData.ItemTable[t.ID & TileData.MaxItemValue];
                 surface = id.Surface;
                 impassable = id.Impassable;
+                roof = (id.Flags & TileFlag.Roof) != 0;
 
-                if ((surface || impassable) && (t.Z + id.CalcHeight) > z && (z + height) > t.Z)
+                if ((surface || impassable) && (!ignoreRoof || !roof) && (t.Z + id.CalcHeight) > z && (z + height) > t.Z)
                 {
                     return false;
                 }


### PR DESCRIPTION
- Addons now ignore roofs (since they ignore floors if their height is > 16), as per EA.
- Blessed items will now drop as loot
- Consolidated methods for getting a random player from looting rights list
- PlunderBeacons and its spawn now give cargo, per EA
- Pirate/Merchant ships now give the proper amount of cargo during rising tides events
- Players can now sell commodities to brokers with no stock
- Mirror Image formula fix.
- Slayer Longbows can now be imbued.