### PR TITLE
Crash Fixes

### DIFF
--- a/Scripts/Items/Functional/EtherealRetouchingTool.cs
+++ b/Scripts/Items/Functional/EtherealRetouchingTool.cs
@@ -107,13 +107,7 @@ namespace Server.Items
             base.Deserialize(reader);
             int version = reader.ReadEncodedInt();
 
-            if (version == 0)
-                IsRewardItem = true;
-            else
-                IsRewardItem = reader.ReadBool();
-
-            if (LootType != LootType.Blessed)
-                LootType = LootType.Blessed;
+            IsRewardItem = reader.ReadBool();
         }
     }
 }

--- a/Scripts/Mobiles/Normal/AncientLich.cs
+++ b/Scripts/Mobiles/Normal/AncientLich.cs
@@ -48,12 +48,18 @@ namespace Server.Mobiles
         {
         }
 
+		public override bool CanFlee => false;
+		
         public override TribeType Tribe => TribeType.Undead;
-
+		
         public override bool Unprovokable => true;
+		
         public override bool BleedImmune => true;
+		
         public override Poison PoisonImmune => Poison.Lethal;
+		
         public override int TreasureMapLevel => 5;
+		
         public override int GetIdleSound()
         {
             return 0x19D;

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -3009,20 +3009,27 @@ namespace Server.Mobiles
 
         public override bool OnDragDrop(Mobile from, Item dropped)
         {
+            bool canDrop = false;
+
             if (CheckFeed(from, dropped))
             {
-                return true;
+                canDrop = true;
             }
-            if (CheckGold(from, dropped))
+            if (!canDrop && CheckGold(from, dropped))
+            {
+                canDrop = true;
+            }
+            if (!canDrop && !from.InRange(Location, 2) && base.OnDragDrop(from, dropped))
             {
                 return true;
-            }
-            if (!from.InRange(Location, 2))
-            {
-                return base.OnDragDrop(from, dropped);
             }
 
-            return false;
+            if (!canDrop)
+            {
+                PrivateOverheadMessage(MessageType.Regular, 0x3B2, 1043257, from.NetState); // The animal shies away.
+            }
+
+            return canDrop;
         }
 
         protected virtual BaseAI ForcedAI => null;

--- a/Scripts/Mobiles/Normal/SkeletalDrake.cs
+++ b/Scripts/Mobiles/Normal/SkeletalDrake.cs
@@ -44,13 +44,22 @@ namespace Server.Mobiles
         {
         }
 
+		public override bool CanFlee => false;
+		
         public override bool AutoDispel => true;
+		
         public override bool BleedImmune => true;
+		
         public override bool ReacquireOnMovement => true;
+		
         public override int Hides => 20;
-        public override int Meat => 19; // where's it hiding these? :)
+		
+        public override int Meat => 19; 
+		
         public override HideType HideType => HideType.Barbed;
+		
         public override Poison PoisonImmune => Poison.Lethal;
+		
         public override TribeType Tribe => TribeType.Undead;
 
         public override void GenerateLoot()

--- a/Scripts/Mobiles/Normal/SkeletalKnight.cs
+++ b/Scripts/Mobiles/Normal/SkeletalKnight.cs
@@ -43,8 +43,10 @@ namespace Server.Mobiles
         {
         }
 
+		public override bool CanFlee => false;
+		
         public override bool BleedImmune => true;
-
+		
         public override TribeType Tribe => TribeType.Undead;
 
         public override void GenerateLoot()

--- a/Scripts/Mobiles/Normal/SkeletalLich.cs
+++ b/Scripts/Mobiles/Normal/SkeletalLich.cs
@@ -46,18 +46,21 @@ namespace Server.Mobiles
             SetWeaponAbility(WeaponAbility.Dismount);
         }
 
+        public SkeletalLich(Serial serial) : base(serial)
+        {
+        }
+		
+		public override bool CanFlee => false;
+		
+        public override bool BleedImmune => true;
+		
+        public override Poison PoisonImmune => Poison.Lethal;
+		
+        public override int TreasureMapLevel => 1;
+
         public override void GenerateLoot()
         {
             AddLoot(LootPack.FilthyRich, 2);
-        }
-
-        public override bool BleedImmune => true;
-        public override Poison PoisonImmune => Poison.Lethal;
-
-        public override int TreasureMapLevel => 1;
-
-        public SkeletalLich(Serial serial) : base(serial)
-        {
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/SkeletalMage.cs
+++ b/Scripts/Mobiles/Normal/SkeletalMage.cs
@@ -46,8 +46,12 @@ namespace Server.Mobiles
         {
         }
 
+		public override bool CanFlee => false;
+		
         public override bool BleedImmune => true;
+		
         public override Poison PoisonImmune => Poison.Regular;
+		
         public override TribeType Tribe => TribeType.Undead;
 
         public override void GenerateLoot()

--- a/Scripts/Mobiles/Normal/Skeleton.cs
+++ b/Scripts/Mobiles/Normal/Skeleton.cs
@@ -42,6 +42,7 @@ namespace Server.Mobiles
         {
         }
 
+		public override bool CanFlee => false;
         public override bool BleedImmune => true;
         public override Poison PoisonImmune => Poison.Lesser;
         public override TribeType Tribe => TribeType.Undead;

--- a/Scripts/Mobiles/Normal/Wraith.cs
+++ b/Scripts/Mobiles/Normal/Wraith.cs
@@ -42,11 +42,14 @@ namespace Server.Mobiles
         {
         }
 
+		public override bool CanFlee => false;
+		
         public override bool BleedImmune => true;
 
         public override TribeType Tribe => TribeType.Undead;
 
         public override Poison PoisonImmune => Poison.Lethal;
+		
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Meager);

--- a/Scripts/Mobiles/Normal/Zombie.cs
+++ b/Scripts/Mobiles/Normal/Zombie.cs
@@ -38,8 +38,12 @@ namespace Server.Mobiles
         {
         }
 
+		public override bool CanFlee => false;
+		
         public override bool BleedImmune => true;
+		
         public override Poison PoisonImmune => Poison.Regular;
+		
         public override TribeType Tribe => TribeType.Undead;
 
         public override void GenerateLoot()

--- a/Scripts/Services/BulkOrders/Items/MasterChefsApron.cs
+++ b/Scripts/Services/BulkOrders/Items/MasterChefsApron.cs
@@ -15,7 +15,7 @@ namespace Server.Items
             Hue = 1990;
 
             while (_Bonus == 0)
-                _Bonus = BaseTalisman.GetRandomExceptional();
+                _Bonus = Utility.RandomMinMax(20, 30);
         }
 
         public override void GetProperties(ObjectPropertyList list)
@@ -33,7 +33,6 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
 
             writer.Write(_Bonus);
@@ -42,7 +41,6 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
 
             _Bonus = reader.ReadInt();

--- a/Scripts/Services/Craft/DefTailoring.cs
+++ b/Scripts/Services/Craft/DefTailoring.cs
@@ -75,7 +75,7 @@ namespace Server.Engines.Craft
 
         private static readonly Type[] m_TailorClothNonColorables = new Type[]
         {
-            typeof(DeerMask), typeof(BearMask), typeof(OrcMask), typeof(TribalMask), typeof(HornedTribalMask)
+            typeof(DeerMask), typeof(BearMask), typeof(OrcMask), typeof(TribalMask), typeof(HornedTribalMask), typeof(CuffsOfTheArchmage)
         };
 
         // singleton instance
@@ -688,7 +688,7 @@ namespace Server.Engines.Craft
             index = AddCraft(typeof(CuffsOfTheArchmage), 1049149, 1157348, 120.0, 120.1, typeof(Cloth), 1044455, 8, 1044287);
             AddRes(index, typeof(MidnightBracers), 1061093, 1, 1044253);
             AddRes(index, typeof(BloodOfTheDarkFather), 1157343, 5, 1044253);
-            AddRes(index, typeof(DarkSapphire), 1032690, 5, 1044253);
+            AddRes(index, typeof(DarkSapphire), 1032690, 4, 1044253);
             ForceNonExceptional(index);
             AddRecipe(index, (int)TailorRecipe.CuffsOfTheArchmage);
             #endregion

--- a/Scripts/Services/Dungeons/Shadowguard/Mobiles.cs
+++ b/Scripts/Services/Dungeons/Shadowguard/Mobiles.cs
@@ -238,7 +238,7 @@ namespace Server.Engines.Shadowguard
     }
 
     public class VileTreefellow : FeralTreefellow
-    {
+    {		
         [Constructable]
         public VileTreefellow()
         {
@@ -263,6 +263,12 @@ namespace Server.Engines.Shadowguard
             SetWeaponAbility(WeaponAbility.Dismount);
             SetWeaponAbility(WeaponAbility.ForceOfNature);
         }
+		
+		public VileTreefellow(Serial serial) : base(serial)
+        {
+        }
+		
+		public override bool CanFlee => false; // Per Publish 90 - Treefellows in the Shadowguard Orchard encounter will no longer flee
 
         public override void OnGaveMeleeAttack(Mobile defender)
         {
@@ -286,10 +292,6 @@ namespace Server.Engines.Shadowguard
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Rich, 3);
-        }
-
-        public VileTreefellow(Serial serial) : base(serial)
-        {
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Services/Peerless/PeerlessAltar.cs
+++ b/Scripts/Services/Peerless/PeerlessAltar.cs
@@ -453,15 +453,21 @@ namespace Server.Items
             // teleport party to exit if not already there
             if (Fighters != null)
             {
-                Fighters.ForEach(x => Exit(x));
-                Fighters.Clear();
+                var fighters = new List<Mobile>(Fighters);
+
+                fighters.ForEach(x => Exit(x));
+
+                ColUtility.Free(fighters);
             }
 
             // delete master keys
             if (MasterKeys != null)
             {
-                MasterKeys.ForEach(x => x.Delete());
-                MasterKeys.Clear();
+                var keys = new List<Item>(MasterKeys);
+
+                keys.ForEach(x => x.Delete());
+
+                ColUtility.Free(keys);
             }
 
             // delete any remaining helpers
@@ -469,8 +475,10 @@ namespace Server.Items
 
             // reset summoner, boss		
             Peerless = null;
-
             Deadline = DateTime.MinValue;
+
+            ColUtility.Free(Fighters);
+            ColUtility.Free(MasterKeys);
         }
 
         public virtual void Exit(Mobile fighter)

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/CultistsRitualTome.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/CultistsRitualTome.cs
@@ -13,11 +13,13 @@ namespace Server.Items
             LootType = LootType.Blessed;
 
             Slayer = SlayerGroup.RandomSuperSlayerTOL();
-            //Caddellite Infused
+
             Attributes.DefendChance = 5;
             Attributes.SpellDamage = 25;
             Attributes.CastRecovery = 2;
             Attributes.LowerManaCost = 4;
+
+            AttachSocket(new Caddellite());
         }
 
         public CultistsRitualTome(Serial serial)
@@ -28,13 +30,18 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(0); // version
+            writer.Write(1); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
+
+            if (version == 0)
+            {
+                AttachSocket(new Caddellite());
+            }
         }
     }
 }

--- a/Scripts/Services/Seasonal Events/TreasuresOfKotlCity/Items/Rewards.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKotlCity/Items/Rewards.cs
@@ -322,6 +322,7 @@ namespace Server.Items
     {
         public override int LabelNumber => 1155607;  // Boots of Escaping
 
+        [Constructable]
         public BootsOfEscaping()
         {
             Attributes.BonusDex = 4;

--- a/Scripts/Services/TreasureMaps/TreasureMapChest.cs
+++ b/Scripts/Services/TreasureMaps/TreasureMapChest.cs
@@ -572,7 +572,10 @@ namespace Server.Items
                 {
                     BaseCreature spawn = TreasureMap.Spawn(Level, GetWorldLocation(), Map, from, false);
 
-                    spawn.Hue = 2725;
+                    if (spawn != null)
+                    {
+                        spawn.Hue = 2725;
+                    }
                 }
             }
 

--- a/Scripts/VendorInfo/SBPlayerBarkeeper.cs
+++ b/Scripts/VendorInfo/SBPlayerBarkeeper.cs
@@ -25,8 +25,21 @@ namespace Server.Mobiles
                 Add(new BeverageBuyInfo(typeof(Pitcher), BeverageType.Liquor, 11, 20, 0x1F99, 0));
                 Add(new BeverageBuyInfo(typeof(Pitcher), BeverageType.Wine, 11, 20, 0x1F9B, 0));
                 Add(new BeverageBuyInfo(typeof(Pitcher), BeverageType.Water, 11, 20, 0x1F9D, 0));
-                // TODO: pizza
-                // TODO: bowl of *, tomato soup
+                
+				Add(new GenericBuyInfo(typeof(CheesePizza), 8, 10, 0x1040, 0)); // OSI just has Pizza
+				
+				Add(new GenericBuyInfo(typeof(WoodenBowlOfCarrots), 3, 20, 0x15F9, 0));
+                Add(new GenericBuyInfo(typeof(WoodenBowlOfCorn), 3, 20, 0x15FA, 0));
+                Add(new GenericBuyInfo(typeof(WoodenBowlOfLettuce), 3, 20, 0x15FB, 0));
+                Add(new GenericBuyInfo(typeof(WoodenBowlOfPeas), 3, 20, 0x15FC, 0));
+                Add(new GenericBuyInfo(typeof(EmptyPewterBowl), 2, 20, 0x15FD, 0));
+                Add(new GenericBuyInfo(typeof(PewterBowlOfCorn), 3, 20, 0x15FE, 0));
+                Add(new GenericBuyInfo(typeof(PewterBowlOfLettuce), 3, 20, 0x15FF, 0));
+                Add(new GenericBuyInfo(typeof(PewterBowlOfPeas), 3, 20, 0x1601, 0));
+                Add(new GenericBuyInfo(typeof(PewterBowlOfPotatos), 3, 20, 0x1601, 0));
+                Add(new GenericBuyInfo(typeof(WoodenBowlOfStew), 3, 20, 0x1604, 0));
+                Add(new GenericBuyInfo(typeof(WoodenBowlOfTomatoSoup), 3, 20, 0x1606, 0));
+				
                 Add(new GenericBuyInfo("1016450", typeof(Chessboard), 2, 20, 0xFA6, 0));
                 Add(new GenericBuyInfo("1016449", typeof(CheckerBoard), 2, 20, 0xFA6, 0));
                 Add(new GenericBuyInfo(typeof(Backgammon), 2, 20, 0xE1C, 0));

--- a/Scripts/VendorInfo/SBSEFood.cs
+++ b/Scripts/VendorInfo/SBSEFood.cs
@@ -19,7 +19,7 @@ namespace Server.Mobiles
                 Add(new GenericBuyInfo(typeof(Wasabi), 2, 20, 0x24E9, 0));
                 Add(new GenericBuyInfo(typeof(BentoBox), 6, 20, 0x2836, 0));
                 Add(new GenericBuyInfo(typeof(BentoBox), 6, 20, 0x2837, 0));
-                Add(new GenericBuyInfo(typeof(GreenTeaBasket), 1000, 20, 0x284B, 0));
+                Add(new GenericBuyInfo(typeof(GreenTeaBasket), 2, 1000, 0x284B, 0));
             }
         }
 


### PR DESCRIPTION
- Fixed a crash that could result if players remained in a peerless zone right up to the 15 minute kick out time.
- Fixed a crash that could result when digging up treasure chests.

Bug Fixes
- Player barkeeps now sell the correct food.
- Various undead no longer flee.