### PR TITLE
ServUO_Pub57 - Fixed Server Crash when teleporting people out in PeerlessAltar.cs

### DIFF
--- a/Scripts/Services/Peerless/PeerlessAltar.cs
+++ b/Scripts/Services/Peerless/PeerlessAltar.cs
@@ -456,15 +456,21 @@ namespace Server.Items
             // teleport party to exit if not already there
             if (Fighters != null)
             {
-                Fighters.ForEach(x => Exit(x));
-                Fighters.Clear();
+                var fighters = new List<Mobile>(Fighters);
+
+                fighters.ForEach(x => Exit(x));
+
+                ColUtility.Free(fighters);
             }
 
             // delete master keys
             if (MasterKeys != null)
             {
-                MasterKeys.ForEach(x => x.Delete());
-                MasterKeys.Clear();
+                var keys = new List<Item>(MasterKeys);
+
+                keys.ForEach(x => x.Delete());
+
+                ColUtility.Free(keys);
             }
 
             // delete any remaining helpers
@@ -474,6 +480,9 @@ namespace Server.Items
             Peerless = null;
 
             Deadline = DateTime.MinValue;
+
+            ColUtility.Free(Fighters);
+            ColUtility.Free(MasterKeys);
         }
 
         public virtual void Exit(Mobile fighter)


### PR DESCRIPTION
The issue has been described [in this post](https://www.servuo.com/threads/server-crash-when-server-is-moving-players-out-of-bedlam-when-boss-is-death.12620/#post-75581)

Tasanar has provided with this solution and they are merging to master, I'm just sending a PR to keep ServUO_Pub57 in good conditions. 

