### PR TITLE
Fixes on MooringLine to avoid a server crash because a null pointer

### DIFF
--- a/Scripts/Services/Expansions/High Seas/Multis/MooringLine.cs
+++ b/Scripts/Services/Expansions/High Seas/Multis/MooringLine.cs
@@ -12,7 +12,7 @@ namespace Server.Items
         [CommandProperty(AccessLevel.GameMaster)]
         public BaseBoat Boat { get; private set; }
 
-        public override int LabelNumber { get { return Boat.IsRowBoat ? 1020935 : 1149697; } } // rope || mooring line
+        public override int LabelNumber => Boat == null || Boat.IsRowBoat ? 1020935 : 1149697; // rope || mooring line
 
         public MooringLine(BaseBoat boat)
             : base(5368)
@@ -73,7 +73,7 @@ namespace Server.Items
         {
             base.GetContextMenuEntries(from, list);
 
-            if (Boat.IsRowBoat && from.Alive && !Boat.Contains(from))
+            if (Boat != null && Boat.IsRowBoat && from.Alive && !Boat.Contains(from))
             {
                 list.Add(new DryDockEntry(Boat, from));
             }


### PR DESCRIPTION
This issue was commented [on this post](https://www.servuo.com/threads/server-crash-when-getting-close-to-a-map-location.12605/#post-75457)

The server was crashing because some old galleons that were deleted with one of the latest updates. This fix to MooringLine was provided by PyrO, I'm just sending this PR to keep Pub57 up to date.
