### PR TITLE
FIXED server crash when using old tiledata

### DIFF
--- a/Scripts/Multis/HouseTeleporterTile.cs
+++ b/Scripts/Multis/HouseTeleporterTile.cs
@@ -14,7 +14,8 @@ namespace Server.Multis
     {
         public static void Initialize()
         {
-            TileData.ItemTable[0x574A].Flags = TileFlag.None;
+            if(TileData.ItemTable.Length >= 0x574A)
+                TileData.ItemTable[0x574A].Flags = TileFlag.None;
         }
 
         public static int MaxCharges = 1000;


### PR DESCRIPTION
FIXED: the server was crashing when using old versions of tiledata for HouseTeleporterTile as it is hardcoded.
You may check all all the posts about this error by searching "HouseTeleporterTile" in servuo forum.
The fix is obvious.