### PR TITLE
FIXED: bug in case you start a shard from scratch with no regions.

### DIFF
--- a/Scripts/Services/Doom/GuardianRoom.cs
+++ b/Scripts/Services/Doom/GuardianRoom.cs
@@ -16,7 +16,8 @@ namespace Server.Engines.Doom
 		
 		public static void Initialize()
 		{
-            Instance.CheckDoors();
+            if (Instance != null)
+                Instance.CheckDoors();
 		}
 
         private Timer m_Timer;


### PR DESCRIPTION
If you remove the regions definitions in the XML file, you would have an error without this simple fix.