### PR TITLE
Hue Pickers

### DIFF
--- a/Scripts/Gumps/PlayerVendorGumps.cs
+++ b/Scripts/Gumps/PlayerVendorGumps.cs
@@ -806,6 +806,11 @@ namespace Server.Gumps
                 m_Mob = from;
             }
 
+            public override void Clip(ref int hue)
+            {
+                hue = (m_Vendor?.Race ?? Race.DefaultRace).ClipHairHue(hue);
+            }
+
             public override void OnResponse(int hue)
             {
                 if (m_Vendor.Deleted)
@@ -1190,6 +1195,11 @@ namespace Server.Gumps
                 m_Vendor = vendor;
                 m_FacialHair = facialHair;
                 m_From = from;
+            }
+
+            public override void Clip(ref int hue)
+            {
+                hue = (m_Vendor?.Race ?? Race.DefaultRace).ClipHairHue(hue);
             }
 
             public override void OnResponse(int hue)

--- a/Scripts/Gumps/Props/SetGump.cs
+++ b/Scripts/Gumps/Props/SetGump.cs
@@ -2,6 +2,7 @@
 using Server.Commands;
 using Server.HuePickers;
 using Server.Network;
+using System;
 using System.Collections;
 using System.Reflection;
 #endregion
@@ -261,6 +262,11 @@ namespace Server.Gumps
                 m_Stack = stack;
                 m_Page = page;
                 m_List = list;
+            }
+
+            public override void Clip(ref int hue)
+            {
+                hue = Math.Max(0, Math.Min(3000, hue));
             }
 
             public override void OnResponse(int hue)

--- a/Scripts/Services/XmlSpawner/XmlPropsGumps/XmlSetGump.cs
+++ b/Scripts/Services/XmlSpawner/XmlPropsGumps/XmlSetGump.cs
@@ -1,6 +1,7 @@
 using Server.Commands;
 using Server.HuePickers;
 using Server.Network;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -191,6 +192,11 @@ namespace Server.Gumps
                 m_Stack = stack;
                 m_Page = page;
                 m_List = list;
+            }
+
+            public override void Clip(ref int hue)
+            {
+                hue = Math.Max(0, Math.Min(3000, hue));
             }
 
             public override void OnResponse(int hue)

--- a/Server/HuePicker.cs
+++ b/Server/HuePicker.cs
@@ -1,4 +1,5 @@
 #region References
+using System;
 using Server.Network;
 #endregion
 
@@ -24,6 +25,11 @@ namespace Server.HuePickers
             while (m_Serial == 0);
 
             m_ItemID = itemID;
+        }
+
+        public virtual void Clip(ref int hue)
+        {
+            hue = Math.Max(0, Math.Min(1000, hue));
         }
 
         public virtual void OnResponse(int hue)

--- a/Server/Network/PacketHandlers.cs
+++ b/Server/Network/PacketHandlers.cs
@@ -622,6 +622,11 @@ namespace Server.Network
                 {
                     state.RemoveHuePicker(huePicker);
 
+                    hue = Math.Max(0, hue);
+
+                    if (state.Mobile == null || state.Mobile.AccessLevel < AccessLevel.GameMaster)
+                        huePicker.Clip(ref hue);
+                    
                     huePicker.OnResponse(hue);
 
                     break;
@@ -2508,6 +2513,13 @@ namespace Server.Network
                 race = Race.DefaultRace;
             }
 
+            hue = race.ClipSkinHue(hue);
+            hairHue = race.ClipHairHue(hairHue);
+            hairHuef = race.ClipHairHue(hairHuef);
+
+            shirtHue = Math.Max(0, Math.Min(1000, shirtHue));
+            pantsHue = Math.Max(0, Math.Min(1000, pantsHue));
+
             CityInfo[] info = state.CityInfo;
             IAccount a = state.Account;
 
@@ -2648,6 +2660,13 @@ namespace Server.Network
             {
                 race = Race.DefaultRace;
             }
+
+            hue = race.ClipSkinHue(hue);
+            hairHue = race.ClipHairHue(hairHue);
+            hairHuef = race.ClipHairHue(hairHuef);
+
+            shirtHue = Math.Max(0, Math.Min(1000, shirtHue));
+            pantsHue = Math.Max(0, Math.Min(1000, pantsHue));
 
             CityInfo[] info = state.CityInfo;
             IAccount a = state.Account;


### PR DESCRIPTION
Closed an exploit that allows hue picker input response to be spoofed to obtain any hue out of the normal selection ranges.
Every hue picker now clamps hues to the 0-1000 range by default, 0-3000 for staff implementations, and for skin/hair hues, it uses the existing race api.
This exploit and fix also affects character creation hue selections, which are handled separately to standard hue pickers.