### PR TITLE
Crash Fix

### DIFF
--- a/Scripts/Items/Internal/ItemSockets/EnchantedHotItem.cs
+++ b/Scripts/Items/Internal/ItemSockets/EnchantedHotItem.cs
@@ -25,15 +25,15 @@ namespace Server.Items
             {
                 EndTimer();
             }
-            else if (Owner.RootParent is Mobile)
+            else if (Owner.RootParent is Mobile m)
             {
-                if (((Mobile)Owner.RootParent).Region.IsPartOf("Wrong"))
+                if (m.Region != null && m.Region.IsPartOf("Wrong"))
                 {
-                    AOS.Damage((Mobile)Owner.RootParent, Utility.RandomMinMax(10, 13), 0, 100, 0, 0, 0);
+                    AOS.Damage(m, Utility.RandomMinMax(10, 13), 0, 100, 0, 0, 0);
 
                     if (0.2 > Utility.RandomDouble())
                     {
-                        ((Mobile)Owner.RootParent).SendLocalizedMessage(1152086); // Ouch! These stolen items are hot!
+                        m.SendLocalizedMessage(1152086); // Ouch! These stolen items are hot!
                     }
                 }
             }


### PR DESCRIPTION
Crash fix for enchanted hot item sockets...

RootParent needs to be cached, it can change when accessed due to it being a computed property.
The crash in reference to this update was caused by the parent of the target item being validated as a Mobile, but then evaluating as a Corpse at a later point.

Exception:
System.InvalidCastException: Unable to cast object of type 'Server.Items.Corpse' to type 'Server.Mobile'.