### PR TITLE
Fixes

### DIFF
--- a/Scripts/Abilities/SAPropEffects.cs
+++ b/Scripts/Abilities/SAPropEffects.cs
@@ -424,7 +424,7 @@ namespace Server.Items
 
             Server.Effects.PlaySound(defender.Location, defender.Map, 0x1DF);
 
-            BuffInfo.AddBuff(defender, new BuffInfo(BuffIcon.SplinteringEffect, 1154670, 1152144, TimeSpan.FromSeconds(10), defender));
+            BuffInfo.AddBuff(defender, new BuffInfo(BuffIcon.SplinteringEffect, 1154670, 1152144, TimeSpan.FromSeconds(4), defender));
         }
 
         public override void OnTick()
@@ -455,7 +455,7 @@ namespace Server.Items
 
         public static bool CheckHit(Mobile attacker, Mobile defender, WeaponAbility ability, Item weapon)
         {
-            if (defender == null || ability == WeaponAbility.Disarm || ability == WeaponAbility.InfectiousStrike || SkillMasterySpell.HasSpell(attacker, typeof(SkillMasterySpell)))
+            if (defender == null || ability == WeaponAbility.Disarm || ability == WeaponAbility.InfectiousStrike || SkillMasterySpell.HasSpell(attacker, typeof(SkillMasterySpell)) || VictimIsUnderEffects<SplinteringWeaponContext>(defender))
                 return false;
 
             SplinteringWeaponContext context = GetContext<SplinteringWeaponContext>(attacker, defender);

--- a/Scripts/Items/Addons/BaseAddon.cs
+++ b/Scripts/Items/Addons/BaseAddon.cs
@@ -1,5 +1,7 @@
 #region References
 using Server.Multis;
+
+using System;
 using System.Collections.Generic;
 #endregion
 
@@ -171,7 +173,7 @@ namespace Server.Items
             {
                 Point3D p3D = new Point3D(p.X + c.Offset.X, p.Y + c.Offset.Y, p.Z + c.Offset.Z);
 
-                if (!map.CanFit(p3D.X, p3D.Y, p3D.Z, c.ItemData.Height, false, true, (c.Z == 0), true))
+                if (!map.CanFit(p3D.X, p3D.Y, p3D.Z, Math.Max(1, c.ItemData.Height), false, true, (c.Z == 0), true))
                     return AddonFitResult.Blocked;
                 if (!CheckHouse(from, p3D, map, c.ItemData.Height, ref house))
                     return AddonFitResult.NotInHouse;

--- a/Scripts/Items/Addons/TheKingsCollection/BarrelSponge.cs
+++ b/Scripts/Items/Addons/TheKingsCollection/BarrelSponge.cs
@@ -82,21 +82,16 @@ namespace Server.Items
 
         public override BaseAddonDeed Deed => new BarrelSpongeDeed();
 
+        public override void GetProperties(ObjectPropertyList list, AddonComponent c)
+        {
+            list.Add(1154178, ResourceCount.ToString()); // Potions: ~1_COUNT~
+        }
+
         private class BarrelSpongeComponent : LocalizedAddonComponent
         {
             public BarrelSpongeComponent(int id)
                 : base(id, 1098376) // Barrel Sponge
             {
-            }
-
-            public override void GetProperties(ObjectPropertyList list)
-            {
-                base.GetProperties(list);
-
-                if (Addon is BarrelSpongeAddon)
-                {
-                    list.Add(1154178, ((BarrelSpongeAddon)Addon).ResourceCount.ToString()); // Potions: ~1_COUNT~
-                }
             }
 
             public BarrelSpongeComponent(Serial serial)

--- a/Scripts/Items/Addons/TheKingsCollection/FirePainting.cs
+++ b/Scripts/Items/Addons/TheKingsCollection/FirePainting.cs
@@ -67,39 +67,9 @@ namespace Server.Items
 
         public override BaseAddonDeed Deed => new FirePaintingDeed();
 
-        private class FirePaintingComponent : LocalizedAddonComponent
+        public override void GetProperties(ObjectPropertyList list, AddonComponent c)
         {
-            public FirePaintingComponent(int id)
-                : base(id, 1098378) // painting
-            {
-            }
-
-            public override void GetProperties(ObjectPropertyList list)
-            {
-                base.GetProperties(list);
-
-                if (Addon is FirePaintingAddon)
-                {
-                    list.Add(1154179, ((FirePaintingAddon)Addon).ResourceCount.ToString()); // Scrolls of Transcendence: ~1_COUNT~
-                }
-            }
-
-            public FirePaintingComponent(Serial serial)
-                : base(serial)
-            {
-            }
-
-            public override void Serialize(GenericWriter writer)
-            {
-                base.Serialize(writer);
-                writer.Write(0); // Version
-            }
-
-            public override void Deserialize(GenericReader reader)
-            {
-                base.Deserialize(reader);
-                int version = reader.ReadInt();
-            }
+            list.Add(1154179, ResourceCount.ToString()); // Scrolls of Transcendence: ~1_COUNT~
         }
 
         private void TryGiveResourceCount()

--- a/Scripts/Items/Addons/TheKingsCollection/ShipPainting.cs
+++ b/Scripts/Items/Addons/TheKingsCollection/ShipPainting.cs
@@ -67,39 +67,9 @@ namespace Server.Items
 
         public override BaseAddonDeed Deed => new ShipPaintingDeed();
 
-        private class ShipPaintingComponent : LocalizedAddonComponent
+        public override void GetProperties(ObjectPropertyList list, AddonComponent c)
         {
-            public ShipPaintingComponent(int id)
-                : base(id, 1098378) // painting
-            {
-            }
-
-            public override void GetProperties(ObjectPropertyList list)
-            {
-                base.GetProperties(list);
-
-                if (Addon is ShipPaintingAddon)
-                {
-                    list.Add(1154175, ((ShipPaintingAddon)Addon).ResourceCount.ToString()); // Powder Charges: ~1_COUNT~
-                }
-            }
-
-            public ShipPaintingComponent(Serial serial)
-                : base(serial)
-            {
-            }
-
-            public override void Serialize(GenericWriter writer)
-            {
-                base.Serialize(writer);
-                writer.Write(0); // Version
-            }
-
-            public override void Deserialize(GenericReader reader)
-            {
-                base.Deserialize(reader);
-                int version = reader.ReadInt();
-            }
+            list.Add(1154175, ResourceCount.ToString()); // Powder Charges: ~1_COUNT~
         }
 
         private void TryGiveResourceCount()

--- a/Scripts/Items/Artifacts/Equipment/Clothing/RobeOfTheEquinox.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/RobeOfTheEquinox.cs
@@ -10,7 +10,6 @@ namespace Server.Items
         [CommandProperty(AccessLevel.GameMaster)]
         public bool ElfOnly { get { return _ElfOnly; } set { _ElfOnly = value; InvalidateProperties(); } }
 
-
         [Constructable]
         public RobeOfTheEquinox()
             : base(0x1F04, 0xD6)

--- a/Scripts/Items/Consumables/Bola.cs
+++ b/Scripts/Items/Consumables/Bola.cs
@@ -151,9 +151,10 @@ namespace Server.Items
         {
             double toChance = Math.Min(45 + BaseArmor.GetRefinedDefenseChance(to),
                                        AosAttributes.GetValue(to, AosAttribute.DefendChance)) + 1;
+
             double fromChance = AosAttributes.GetValue(from, AosAttribute.AttackChance) + 1;
 
-            double hitChance = toChance / (fromChance * 2);
+            double hitChance = fromChance / (toChance * 2);
 
             if (Utility.RandomDouble() < hitChance)
             {

--- a/Scripts/Items/Consumables/Potions/ExplodingTarPotion.cs
+++ b/Scripts/Items/Consumables/Potions/ExplodingTarPotion.cs
@@ -1,7 +1,7 @@
-using Server.Misc;
 using Server.Network;
 using Server.Spells;
 using Server.Targeting;
+using Server.Mobiles;
 
 using System;
 using System.Collections.Generic;
@@ -12,7 +12,7 @@ namespace Server.Items
     [TypeAlias("Server.Items.ExplodingTarPotion")]
     public class ExplodingTarPotion : BasePotion
     {
-        public virtual int Radius { get { return 20; } }
+        public virtual int Radius { get { return 4; } }
 
         public override int LabelNumber => 1095147; // Exploding Tar Potion
         public override bool RequireFreeHand => false;
@@ -87,38 +87,23 @@ namespace Server.Items
 
             Consume();
 
-            // Effects
             Effects.PlaySound(loc, map, 0x207);
-            Geometry.Circle2D(loc, map, Radius, TarEffect, 270, 90);
 
-            Timer.DelayCall(TimeSpan.FromSeconds(1), new TimerStateCallback(CircleEffect2), new object[] { loc, map });
+            var skill = (int)from.Skills[SkillName.Alchemy].Value + AosAttributes.GetValue(from, AosAttribute.EnhancePotions);
 
-            foreach (Mobile m in SpellHelper.AcquireIndirectTargets(from, loc, map, Radius).OfType<Mobile>())
+            foreach (PlayerMobile m in SpellHelper.AcquireIndirectTargets(from, loc, map, Radius).OfType<PlayerMobile>())
             {
-                AddEffects(m);
+                if (Utility.Random(skill) > m.Skills[SkillName.MagicResist].Value / 2)
+                {
+                    AddEffects(m);
+                }
             }
         }
 
-        #region Effects
-        public virtual void TarEffect(Point3D p, Map map)
-        {
-            if (map.CanFit(p, 12, true, false))
-                Effects.SendLocationEffect(p, map, 0x376A, 4, 9);
-        }
-
-        public void CircleEffect2(object state)
-        {
-            object[] states = (object[])state;
-
-            Geometry.Circle2D((Point3D)states[0], (Map)states[1], Radius, TarEffect, 90, 270);
-        }
-        #endregion
-
-        #region Delay
         private static Dictionary<Mobile, Timer> _SlowEffects;
         private static Dictionary<Mobile, Timer> _Delay;
 
-        public static void AddEffects(Mobile m)
+        public static void AddEffects(PlayerMobile m)
         {
             if (_SlowEffects == null)
             {
@@ -129,7 +114,19 @@ namespace Server.Items
                 _SlowEffects[m].Stop();
             }
 
-            _SlowEffects[m] = Timer.DelayCall(TimeSpan.FromMinutes(1), mob => RemoveEffects(mob), m);
+            _SlowEffects[m] = Timer.DelayCall(TimeSpan.FromMinutes(2), mob => RemoveEffects(mob), m);
+
+            m.FixedParticles(0x36B0, 1, 14, 9915, 1109, 0, EffectLayer.Head);
+
+            Timer.DelayCall(TimeSpan.FromMilliseconds(150), () =>
+            {
+                m.FixedParticles(0x3779, 10, 20, 5002, EffectLayer.Head);
+            });
+
+            if (!m.Paralyzed)
+            {
+                m.AddBuff(new BuffInfo(BuffIcon.Paralyze, 1095150, 1095151, TimeSpan.FromMinutes(2), m));
+            }
 
             m.SendLocalizedMessage(1095151);
             m.SendSpeedControl(SpeedControlType.WalkSpeed);
@@ -167,7 +164,7 @@ namespace Server.Items
                 }
             }
 
-            _Delay[m] = Timer.DelayCall(TimeSpan.FromSeconds(60), EndDelay_Callback, m);
+            _Delay[m] = Timer.DelayCall(TimeSpan.FromSeconds(120), EndDelay_Callback, m);
         }
 
         public static int GetDelay(Mobile m)
@@ -208,7 +205,6 @@ namespace Server.Items
                 }
             }
         }
-        #endregion
 
         private class ThrowTarget : Target
         {
@@ -231,7 +227,6 @@ namespace Server.Items
                 if (p == null || from.Map == null)
                     return;
 
-                // Add delay
                 AddDelay(from);
 
                 SpellHelper.GetSurfaceTop(ref p);

--- a/Scripts/Items/Equipment/Spellbooks/Spellbook.cs
+++ b/Scripts/Items/Equipment/Spellbooks/Spellbook.cs
@@ -345,7 +345,7 @@ namespace Server.Items
                     {
                         SpecialMove.SetCurrentMove(from, move);
                     }
-                    else
+                    else if (e.Target != null)
                     {
                         Mobile to = World.FindMobile(e.Target.Serial);
                         Item toI = World.FindItem(e.Target.Serial);

--- a/Scripts/Items/StoreBought/MerchantsTrinket.cs
+++ b/Scripts/Items/StoreBought/MerchantsTrinket.cs
@@ -1,8 +1,9 @@
-﻿namespace Server.Items
+namespace Server.Items
 {
     public class MerchantsTrinket : GoldEarrings
     {
         private bool _Greater;
+        private int _UsesRemaining;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public int Bonus => Greater ? 10 : 5;
@@ -10,12 +11,16 @@
         [CommandProperty(AccessLevel.GameMaster)]
         public bool Greater { get { return _Greater; } set { _Greater = value; InvalidateProperties(); } }
 
-        public override int LabelNumber => _Greater ? 1156828 : 1156827;  // Merchant's Trinket - 5% / 10%
+        [CommandProperty(AccessLevel.GameMaster)]
+        public int UsesRemaining { get { return _UsesRemaining; } set { _UsesRemaining = value; InvalidateProperties(); } }
+
+        public override int LabelNumber => 1071399; // Merchant's Trinket
 
         [Constructable]
         public MerchantsTrinket()
             : this(false)
         {
+            LootType = LootType.Blessed;
         }
 
         [Constructable]
@@ -23,6 +28,8 @@
         {
             Greater = greater;
             LootType = LootType.Blessed;
+
+            UsesRemaining = 90;
         }
 
         public MerchantsTrinket(Serial serial)
@@ -30,10 +37,30 @@
         {
         }
 
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            base.GetProperties(list);
+
+            list.Add(1071398, Bonus.ToString()); // Discount Rate of Vendor Charge: ~1_val~%
+            list.Add(1159250); // Non-commission vendors only.
+        }
+
+        public override void AddWeightProperty(ObjectPropertyList list)
+        {
+            if (_UsesRemaining > 0)
+            {
+                list.Add(1060584, _UsesRemaining.ToString()); // uses remaining: ~1_val~
+            }
+
+            base.AddWeightProperty(list);
+        }
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-            writer.Write(0);
+            writer.Write(1);
+
+            writer.Write(_UsesRemaining);
             writer.Write(_Greater);
         }
 
@@ -41,7 +68,18 @@
         {
             base.Deserialize(reader);
             int version = reader.ReadInt();
-            _Greater = reader.ReadBool();
+
+            switch (version)
+            {
+                case 1:
+                    _UsesRemaining = reader.ReadInt();
+                    _Greater = reader.ReadBool();
+                    break;
+                case 0:
+                    _Greater = reader.ReadBool();
+                    _UsesRemaining = 90;
+                    break;
+            }
         }
     }
 }

--- a/Scripts/Misc/RaceDefinitions.cs
+++ b/Scripts/Misc/RaceDefinitions.cs
@@ -467,7 +467,7 @@ namespace Server.Misc
 
         public static bool ValidateEquipment(Mobile from, Item equipment, bool message)
         {
-            if (AllRaceTypes.Any(type => type == equipment.GetType()) || AllRaceIDs.Any(id => id == equipment.ItemID))
+            if ((AllRaceTypes.Any(type => type == equipment.GetType()) || AllRaceIDs.Any(id => id == equipment.ItemID)) && ValidateElfOrHuman(from, equipment))
             {
                 return true;
             }
@@ -514,6 +514,18 @@ namespace Server.Misc
                 }
 
                 return false;
+            }
+
+            return true;
+        }
+
+        public static bool ValidateElfOrHuman(Mobile from, Item equipment)
+        {
+            var elfOrHuman = equipment as ICanBeElfOrHuman;
+
+            if (elfOrHuman != null)
+            {
+                return from.Race == Race.Elf || !elfOrHuman.ElfOnly;
             }
 
             return true;

--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -136,7 +136,7 @@ namespace Server.Mobiles
 
             public override void OnClick()
             {
-                if (!m_From.InRange(m_Vendor.Location, 10))
+                if (!m_From.InRange(m_Vendor.Location, 20))
                     return;
 
                 EventSink.InvokeBODOffered(new BODOfferEventArgs(m_From, m_Vendor));

--- a/Scripts/Mobiles/NPCs/PlayerVendor.cs
+++ b/Scripts/Mobiles/NPCs/PlayerVendor.cs
@@ -328,6 +328,7 @@ namespace Server.Mobiles
                 return ChargePerRealWorldDay / 12;
             }
         }
+
         public int ChargePerRealWorldDay
         {
             get
@@ -340,7 +341,7 @@ namespace Server.Mobiles
 
                 int perDay = (int)(60 + (total / 500) * 3);
 
-                MerchantsTrinket trinket = FindItemOnLayer(Layer.Earrings) as MerchantsTrinket;
+                var trinket = GetMerchantsTrinket();
 
                 if (trinket != null)
                 {
@@ -350,6 +351,19 @@ namespace Server.Mobiles
                 return perDay;
             }
         }
+
+        public MerchantsTrinket GetMerchantsTrinket()
+        {
+            var trinket = FindItemOnLayer(Layer.Earrings) as MerchantsTrinket;
+
+            if (trinket != null && trinket.UsesRemaining > 0)
+            {
+                return trinket;
+            }
+
+            return null;
+        }
+
         public static void TryToBuy(Item item, Mobile from)
         {
             PlayerVendor vendor = item.RootParent as PlayerVendor;
@@ -1619,11 +1633,8 @@ namespace Server.Mobiles
                 var vendor = list[i];
                 vendor.NextPayTime = DateTime.UtcNow + GetInterval();
 
-                int pay;
-                int totalGold;
-
-                pay = vendor.ChargePerRealWorldDay;
-                totalGold = vendor.HoldGold;
+                var pay = vendor.ChargePerRealWorldDay;
+                var totalGold = vendor.HoldGold;
 
                 if (pay > totalGold)
                 {
@@ -1632,6 +1643,13 @@ namespace Server.Mobiles
                 else
                 {
                     vendor.HoldGold -= pay;
+
+                    var trinket = vendor.GetMerchantsTrinket();
+
+                    if (trinket != null)
+                    {
+                        trinket.UsesRemaining--;
+                    }
                 }
             }
 

--- a/Scripts/Mobiles/Named/Coil.cs
+++ b/Scripts/Mobiles/Named/Coil.cs
@@ -21,7 +21,7 @@ namespace Server.Mobiles
             SetDex(202, 283);
             SetInt(88, 142);
 
-            SetHits(628, 1291);
+            SetHits(1079, 1166);
 
             SetDamage(19, 28);
 
@@ -51,6 +51,7 @@ namespace Server.Mobiles
         {
         }
 
+        public override bool DeathAdderCharmable => false;
         public override Poison HitPoison => Poison.Lethal;
         public override Poison PoisonImmune => Poison.Lethal;
         public override bool GivesMLMinorArtifact => true;
@@ -59,7 +60,7 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            AddLoot(LootPack.UltraRich, 3);
+            AddLoot(LootPack.FilthyRich, 3);
             AddLoot(LootPack.Gems, 2);
             AddLoot(LootPack.LootItem<Bone>(false, true));
             AddLoot(LootPack.ArcanistScrolls);

--- a/Scripts/Mobiles/Named/Gnaw.cs
+++ b/Scripts/Mobiles/Named/Gnaw.cs
@@ -50,6 +50,7 @@ namespace Server.Mobiles
 
         public override int Hides => 28;
         public override int Meat => 4;
+		
         public override void GenerateLoot()
         {
             AddLoot(LootPack.FilthyRich, 2);

--- a/Scripts/Mobiles/Named/Malefic.cs
+++ b/Scripts/Mobiles/Named/Malefic.cs
@@ -49,12 +49,13 @@ namespace Server.Mobiles
             : base(serial)
         {
         }
+		
         public override bool CanBeParagon => false;
         public override bool GivesMLMinorArtifact => true;
 
         public override void GenerateLoot()
         {
-            AddLoot(LootPack.UltraRich, 3);
+            AddLoot(LootPack.FilthyRich, 3);
             AddLoot(LootPack.ArcanistScrolls);
         }
 

--- a/Scripts/Mobiles/Named/Silk.cs
+++ b/Scripts/Mobiles/Named/Silk.cs
@@ -50,7 +50,7 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            AddLoot(LootPack.UltraRich, 2);
+            AddLoot(LootPack.FilthyRich, 2);
             AddLoot(LootPack.ArcanistScrolls);
         }
 

--- a/Scripts/Mobiles/Named/Virulent.cs
+++ b/Scripts/Mobiles/Named/Virulent.cs
@@ -57,7 +57,7 @@ namespace Server.Mobiles
 
         public override void GenerateLoot()
         {
-            AddLoot(LootPack.UltraRich, 4);
+            AddLoot(LootPack.FilthyRich, 3);
             AddLoot(LootPack.ArcanistScrolls, 0, 1);
             AddLoot(LootPack.LootItem<SpidersSilk>(8, true));
         }

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -2562,7 +2562,7 @@
     <Compile Include="Mobiles\Normal\ValoriteElemental.cs" />
     <Compile Include="Mobiles\Normal\VampireBat.cs" />
     <Compile Include="Mobiles\Normal\VeriteElemental.cs" />
-    <Compile Include="Mobiles\Normal\Virulent.cs" />
+    <Compile Include="Mobiles\Named\Virulent.cs" />
     <Compile Include="Mobiles\Normal\VorpalBunny.cs" />
     <Compile Include="Mobiles\Normal\WailingBanshee.cs" />
     <Compile Include="Mobiles\Normal\Walrus.cs" />

--- a/Scripts/Services/City Loyalty System/Trading/TradeCrate.cs
+++ b/Scripts/Services/City Loyalty System/Trading/TradeCrate.cs
@@ -28,7 +28,7 @@ namespace Server.Engines.CityLoyalty
 
                 foreach (TradeEntry.TradeDetails details in Entry.Details)
                 {
-                    if (GetAmount(details.ItemType) < details.Amount)
+                    if (details.Count(this) < details.Amount)
                         return false;
                 }
 
@@ -148,12 +148,14 @@ namespace Server.Engines.CityLoyalty
             {
                 if(details.Match(item.GetType()))
                 {
-                    int hasAmount = GetAmount(item.GetType());
+                    int hasAmount = details.Count(this);
 
                     if (hasAmount + item.Amount > details.Amount)
                     {
                         if (message)
+                        {
                             from.SendLocalizedMessage(1151726); // You are trying to add too many of this item to the trade order. Only add the required quantity
+                        }
 
                         break;
                     }
@@ -166,7 +168,9 @@ namespace Server.Engines.CityLoyalty
             }
 
             if (!canAdd && message)
+            {
                 from.SendLocalizedMessage(1151725); // This trade order does not require this item.
+            }
 
             return canAdd;
         }

--- a/Scripts/Services/Dungeons/Shadowguard/Items.cs
+++ b/Scripts/Services/Dungeons/Shadowguard/Items.cs
@@ -129,7 +129,6 @@ namespace Server.Engines.Shadowguard
         public OrchardEncounter Encounter { get; set; }
 
         private bool _Thrown;
-        private bool _EatenByPet;
 
         public ShadowguardApple(OrchardEncounter encounter, ShadowguardCypress tree)
         {
@@ -237,7 +236,7 @@ namespace Server.Engines.Shadowguard
         {
             base.OnDelete();
 
-            if (!_Thrown && !_EatenByPet && Encounter != null)
+            if (!_Thrown && Encounter != null)
             {
                 foreach (PlayerMobile pm in Encounter.Region.GetEnumeratedMobiles().OfType<PlayerMobile>())
                 {
@@ -267,18 +266,6 @@ namespace Server.Engines.Shadowguard
                     Encounter.AddSpawn(creature);
                 }
             }
-        }
-
-        public override bool DropToMobile(Mobile from, Mobile target, Point3D p)
-        {
-            var bc = target as BaseCreature;
-
-            if (bc != null && !bc.IsDeadPet && bc.Controlled && (bc.ControlMaster == from || bc.IsPetFriend(from)))
-            {
-                _EatenByPet = true;
-            }
-
-            return base.DropToMobile(from, target, p);
         }
 
         public override void Delete()

--- a/Scripts/Services/Dungeons/Shadowguard/ShadowguardEncounter.cs
+++ b/Scripts/Services/Dungeons/Shadowguard/ShadowguardEncounter.cs
@@ -232,7 +232,8 @@ namespace Server.Engines.Shadowguard
             Point3D p = StartLoc;
             ConvertOffset(ref p);
 
-            MovePlayer(m, p);
+            BaseCreature.TeleportPets(m, p, m.Map);
+            MovePlayer(m, p, false);
             m.CloseGump(typeof(ShadowguardGump));
 
             if (m is PlayerMobile)

--- a/Scripts/Services/ExploringTheDeep/Mobiles/Djinn.cs
+++ b/Scripts/Services/ExploringTheDeep/Mobiles/Djinn.cs
@@ -60,13 +60,6 @@ namespace Server.Mobiles
             m_Timer.Start();
         }
 
-        public override void GenerateLoot()
-        {
-            AddLoot(LootPack.FilthyRich);
-        }
-
-        public override int TreasureMapLevel => 4;
-
         public override void OnDeath(Container c)
         {
             List<DamageStore> rights = GetLootingRights();

--- a/Scripts/Services/ExploringTheDeep/Mobiles/IceWyrm.cs
+++ b/Scripts/Services/ExploringTheDeep/Mobiles/IceWyrm.cs
@@ -95,13 +95,15 @@ namespace Server.Mobiles
         }
 
         public override bool ReacquireOnMovement => true;
-        public override int TreasureMapLevel => 4;
-        public override int Meat => 20;
-        public override int Hides => 25;
-        public override HideType HideType => HideType.Barbed;
-        public override FoodType FavoriteFood => FoodType.Meat;
-        public override bool CanAngerOnTame => true;
-        public override bool CanRummageCorpses => true;
+
+        public override int Meat => 0;
+		public override int Scales => 0;
+        public override int Hides => 0;
+		
+		public override void GenerateLoot()
+        {
+			// Kept blank to zero out the loot created by it's base class
+        }
 
         public override void OnAfterDelete()
         {

--- a/Scripts/Services/ExploringTheDeep/Mobiles/MercutioTheUnsavory.cs
+++ b/Scripts/Services/ExploringTheDeep/Mobiles/MercutioTheUnsavory.cs
@@ -119,11 +119,6 @@ namespace Server.Mobiles
         {
         }
 
-        public override void GenerateLoot()
-        {
-            AddLoot(LootPack.Average);
-        }
-
         public class InternalSelfDeleteTimer : Timer
         {
             private readonly MercutioTheUnsavory Mare;

--- a/Scripts/Services/ExploringTheDeep/Mobiles/ObsidianWyvern.cs
+++ b/Scripts/Services/ExploringTheDeep/Mobiles/ObsidianWyvern.cs
@@ -139,12 +139,6 @@ namespace Server.Mobiles
 
         public override bool BardImmune => true;
 
-        public override void GenerateLoot()
-        {
-            AddLoot(LootPack.FilthyRich, 3);
-            AddLoot(LootPack.Gems, 5);
-        }
-
         public override int GetIdleSound() { return 0x2D3; }
         public override int GetHurtSound() { return 0x2D1; }
 

--- a/Scripts/Services/ExploringTheDeep/Mobiles/OrcEngineer.cs
+++ b/Scripts/Services/ExploringTheDeep/Mobiles/OrcEngineer.cs
@@ -124,6 +124,11 @@ namespace Server.Mobiles
             : base(serial)
         {
         }
+		
+		public override void GenerateLoot()
+        {
+			// Kept blank to zero out the loot created by it's base class
+        }
 
         public override void Serialize(GenericWriter writer)
         {

--- a/Scripts/Services/Help/HelpGump.cs
+++ b/Scripts/Services/Help/HelpGump.cs
@@ -206,6 +206,10 @@ namespace Server.Engines.Help
                         {
                             from.Location = house.BanLocation;
                         }
+                        else if (CityLoyalty.CityTradeSystem.HasTrade(from))
+                        {
+                            from.SendLocalizedMessage(1151733); // You cannot do that while carrying a Trade Order.
+                        }
                         else if (from.Region.IsPartOf<Regions.Jail>())
                         {
                             from.SendLocalizedMessage(1114345, "", 0x35); // You'll need a better jailbreak plan than that!
@@ -262,6 +266,10 @@ namespace Server.Engines.Help
                             if (from.Region.IsPartOf<Regions.Jail>())
                             {
                                 from.SendLocalizedMessage(1114345, "", 0x35); // You'll need a better jailbreak plan than that!
+                            }
+                            else if (CityLoyalty.CityTradeSystem.HasTrade(from))
+                            {
+                                from.SendLocalizedMessage(1151733); // You cannot do that while carrying a Trade Order.
                             }
                             else if (from.Region.IsPartOf("Haven Island"))
                             {

--- a/Scripts/Services/Help/StuckMenu.cs
+++ b/Scripts/Services/Help/StuckMenu.cs
@@ -1,3 +1,4 @@
+using Server.Engines.CityLoyalty;
 using Server.Gumps;
 using Server.Mobiles;
 using Server.Network;
@@ -191,6 +192,10 @@ namespace Server.Menus.Questions
                 if (m_Mobile == m_Sender)
                     m_Mobile.SendLocalizedMessage(1010588); // You choose not to go to any city.
             }
+            else if (CityTradeSystem.HasTrade(m_Mobile))
+            {
+                m_Mobile.SendLocalizedMessage(1151733); // You cannot do that while carrying a Trade Order.
+            }
             else
             {
                 int index = info.ButtonID - 1;
@@ -247,7 +252,7 @@ namespace Server.Menus.Questions
 
             protected override void OnTick()
             {
-                if (m_Mobile.NetState == null || DateTime.UtcNow > m_End)
+                if (m_Mobile.NetState == null || DateTime.UtcNow > m_End || CityTradeSystem.HasTrade(m_Mobile))
                 {
                     m_Mobile.Frozen = false;
                     m_Mobile.CloseGump(typeof(StuckMenu));

--- a/Scripts/Services/TreasureMaps/TreasureMapChest.cs
+++ b/Scripts/Services/TreasureMaps/TreasureMapChest.cs
@@ -418,14 +418,9 @@ namespace Server.Items
                     else if (0.15 > Utility.RandomDouble())
                         special = GetRandomSpecial(level, cont.Map);
                 }
-                else if (.10 > Utility.RandomDouble())
+                else if (0.10 > Utility.RandomDouble())
                 {
                     special = GetRandomSpecial(level, cont.Map);
-                }
-
-                if (Engines.Points.PointsSystem.JollyRogerData.Enabled && .30 > Utility.RandomDouble())
-                {
-                    cont.DropItem(new MysteriousFragment());
                 }
             }
 
@@ -443,6 +438,9 @@ namespace Server.Items
 
             if (newSpecial != null)
                 cont.DropItem(newSpecial);
+
+            if (Engines.Points.PointsSystem.JollyRogerData.Enabled && 0.15 > Utility.RandomDouble())
+                cont.DropItem(new MysteriousFragment());
 
             int rolls = 2;
 
@@ -591,37 +589,41 @@ namespace Server.Items
         {
             ExecuteTrap(from);
 
-            if (!AncientGuardians.Any(g => g.Alive))
+            if (!AncientGuardians.Any(g => g != null && g.Alive))
             {
                 BaseCreature spawn = TreasureMap.Spawn(Level, GetWorldLocation(), Map, from, false);
-                spawn.NoLootOnDeath = true;
 
-                spawn.Name = "Ancient Chest Guardian";
-                spawn.Title = "(Guardian)";
-                spawn.Tamable = false;
-
-                if (spawn.HitsMaxSeed >= 0)
-                    spawn.HitsMaxSeed = (int)(spawn.HitsMaxSeed * Paragon.HitsBuff);
-
-                spawn.RawStr = (int)(spawn.RawStr * Paragon.StrBuff);
-                spawn.RawInt = (int)(spawn.RawInt * Paragon.IntBuff);
-                spawn.RawDex = (int)(spawn.RawDex * Paragon.DexBuff);
-
-                spawn.Hits = spawn.HitsMax;
-                spawn.Mana = spawn.ManaMax;
-                spawn.Stam = spawn.StamMax;
-
-                spawn.Hue = 1960;
-
-                for (int i = 0; i < spawn.Skills.Length; i++)
+                if (spawn != null)
                 {
-                    Skill skill = spawn.Skills[i];
+                    spawn.NoLootOnDeath = true;
 
-                    if (skill.Base > 0.0)
-                        skill.Base *= Paragon.SkillsBuff;
+                    spawn.Name = "Ancient Chest Guardian";
+                    spawn.Title = "(Guardian)";
+                    spawn.Tamable = false;
+
+                    if (spawn.HitsMaxSeed >= 0)
+                        spawn.HitsMaxSeed = (int)(spawn.HitsMaxSeed * Paragon.HitsBuff);
+
+                    spawn.RawStr = (int)(spawn.RawStr * Paragon.StrBuff);
+                    spawn.RawInt = (int)(spawn.RawInt * Paragon.IntBuff);
+                    spawn.RawDex = (int)(spawn.RawDex * Paragon.DexBuff);
+
+                    spawn.Hits = spawn.HitsMax;
+                    spawn.Mana = spawn.ManaMax;
+                    spawn.Stam = spawn.StamMax;
+
+                    spawn.Hue = 1960;
+
+                    for (int i = 0; i < spawn.Skills.Length; i++)
+                    {
+                        Skill skill = spawn.Skills[i];
+
+                        if (skill.Base > 0.0)
+                            skill.Base *= Paragon.SkillsBuff;
+                    }
+
+                    AncientGuardians.Add(spawn);
                 }
-
-                AncientGuardians.Add(spawn);
             }
         }
 

--- a/Scripts/Services/TreasureMaps/TreasureMapInfo.cs
+++ b/Scripts/Services/TreasureMaps/TreasureMapInfo.cs
@@ -861,11 +861,11 @@ namespace Server.Items
             #region Decorations
             switch (level)
             {
-                case TreasureLevel.Stash: dropChance = 0.0; break;
-                case TreasureLevel.Supply: dropChance = 0.2; break;
-                case TreasureLevel.Cache: dropChance = 0.4; break;
-                case TreasureLevel.Hoard: dropChance = 0.5; break;
-                case TreasureLevel.Trove: dropChance = .75; break;
+                case TreasureLevel.Stash: dropChance = 0.00; break;
+                case TreasureLevel.Supply: dropChance = 0.10; break;
+                case TreasureLevel.Cache: dropChance = 0.20; break;
+                case TreasureLevel.Hoard: dropChance = 0.40; break;
+                case TreasureLevel.Trove: dropChance = 0.50; break;
             }
 
             if (Utility.RandomDouble() < dropChance)
@@ -898,11 +898,11 @@ namespace Server.Items
 
             switch (level)
             {
-                case TreasureLevel.Stash: dropChance = 0.0; break;
+                case TreasureLevel.Stash: dropChance = 0.00; break;
                 case TreasureLevel.Supply: dropChance = 0.10; break;
                 case TreasureLevel.Cache: dropChance = 0.20; break;
                 case TreasureLevel.Hoard: dropChance = 0.50; break;
-                case TreasureLevel.Trove: dropChance = .75; break;
+                case TreasureLevel.Trove: dropChance = 0.75; break;
             }
 
             if (Utility.RandomDouble() < dropChance)

--- a/Scripts/Services/Vendor Searching/VendorSearch.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearch.cs
@@ -1211,6 +1211,14 @@ namespace Server.Engines.VendorSearching
         public bool IsChild { get; set; }
         public bool IsAuction { get; set; }
 
+        public Map Map
+        {
+            get
+            {
+                return Vendor != null ? Vendor.Map : AuctionSafe != null ? AuctionSafe.Map : null;
+            }
+        }
+
         public SearchItem(PlayerVendor vendor, Item item, int price, bool isChild)
         {
             Vendor = vendor;

--- a/Scripts/Services/Vendor Searching/VendorSearchGump.cs
+++ b/Scripts/Services/Vendor Searching/VendorSearchGump.cs
@@ -414,12 +414,12 @@ namespace Server.Engines.VendorSearching
 
             for (int i = start; i < start + PerPage && i < Items.Count; i++)
             {
-                Item item = Items[i].Item;
-                int price = Items[i].Price;
+                var item = Items[i].Item;
+                var price = Items[i].Price;
+                var map = Items[i].Map;
 
                 Rectangle2D bounds = ItemBounds.Table[item.ItemID];
                 int y = 101 + (index * 75);
-                Map map = item.Map;
 
                 if (map == null && item.RootParentEntity is Mobile)
                     map = ((Mobile)item.RootParentEntity).Map;
@@ -476,7 +476,7 @@ namespace Server.Engines.VendorSearching
 
                         if (!_GivenTo[item.Item].Contains(User))
                         {
-                            VendorSearchMap map = new VendorSearchMap(item.Item, item.IsAuction);
+                            VendorSearchMap map = new VendorSearchMap(item);
 
                             if (User.Backpack == null || !User.Backpack.TryDropItem(User, map, false))
                                 map.Delete();


### PR DESCRIPTION
- Fixed a rare crash that could occur with Vendor Search.
- Mysterious fragments drop in t-maps correctly now when Jolly Rogers is enabled.
- Display issue fix for various Kings Collection Items.cs
- Bola has incorrect (reversed) logic, this has been corrected.
- Various changes to make Exploding Tar Potion work per EA.
- Merchants Trinket upgraded to match EA. (Has charges now)
- Various confirmed loot tone downs on various ML named monsters.
- Fixed an exploit with Exploring the Deep quest monsters.
- Fixed various exploits with using the help menu to circumvent the Trade Order restrictions.