### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Equipment/Weapons/BaseWeapon.cs
@@ -1117,6 +1117,11 @@ namespace Server.Items
 
             bonus += AosAttributes.GetValue(attacker, AosAttribute.AttackChance);
 
+            if (attacker is BaseCreature bc && !bc.Controlled && defender is BaseCreature bc2 && bc2.Controlled)
+            {
+                bonus = Math.Max(bonus, 45);
+            }
+
             //SA Gargoyle cap is 50, else 45
             bonus = Math.Min(attacker.Race == Race.Gargoyle ? 50 : 45, bonus);
 
@@ -1271,9 +1276,8 @@ namespace Server.Items
                     attacker.Send(new Swing(0, attacker, damageable));
                 }
 
-                if (attacker is BaseCreature)
+                if (attacker is BaseCreature bc)
                 {
-                    BaseCreature bc = (BaseCreature)attacker;
                     WeaponAbility ab = bc.TryGetWeaponAbility();
 
                     if (ab != null)

--- a/Scripts/Misc/AOS.cs
+++ b/Scripts/Misc/AOS.cs
@@ -307,9 +307,16 @@ namespace Server
                     }
                 }
 
-                if (fromCreature != null && fromCreature.Controlled && m.Player)
+                if (fromCreature != null)
                 {
-                    totalDamage /= 2;
+                    if (fromCreature.Controlled && m.Player)
+                    {
+                        totalDamage /= 2;
+                    }
+                    else if (type == DamageType.Melee && toCreature != null && toCreature.Controlled)
+                    {
+                        totalDamage += (int)((double)totalDamage * 0.10);
+                    }
                 }
             }
 

--- a/Scripts/Mobiles/Bosses/SlasherOfVeils.cs
+++ b/Scripts/Mobiles/Bosses/SlasherOfVeils.cs
@@ -77,6 +77,26 @@ namespace Server.Mobiles
 
         public override bool Unprovokable => false;
         public override bool BardImmune => false;
+
+        [CommandProperty(AccessLevel.Counselor)]
+        public override int PhysicalResistance => Weakened ? base.PhysicalResistance / 2 : base.PhysicalResistance;
+
+        [CommandProperty(AccessLevel.Counselor)]
+        public override int FireResistance => Weakened ? base.FireResistance / 2 : base.FireResistance;
+
+        [CommandProperty(AccessLevel.Counselor)]
+        public override int ColdResistance => Weakened ? base.ColdResistance / 2 : base.ColdResistance;
+
+        [CommandProperty(AccessLevel.Counselor)]
+        public override int PoisonResistance => Weakened ? base.PoisonResistance / 2 : base.PoisonResistance;
+
+        [CommandProperty(AccessLevel.Counselor)]
+        public override int EnergyResistance => Weakened ? base.EnergyResistance / 2 : base.EnergyResistance;
+
+        private static readonly Rectangle2D _WeakBounds = new Rectangle2D(740, 466, 20, 20);
+
+        public bool Weakened => Map == Map.TerMur && _WeakBounds.Contains(this);
+
         public override int GetIdleSound()
         {
             return 1589;

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -6598,9 +6598,10 @@ namespace Server.Mobiles
             Mobile target = GetBardTarget(Controlled);
 
             if (target == null || !target.InLOS(this) || !InRange(target.Location, BaseInstrument.GetBardRange(this, SkillName.Discordance)) || CheckInstrument() == null)
+            {
                 return false;
+            }
 
-            // TODO: get mana
             if (AbilityProfile != null && AbilityProfile.HasAbility(MagicalAbility.Discordance) && Mana < 25)
             {
                 return false;
@@ -6614,7 +6615,9 @@ namespace Server.Mobiles
                 Spell = null;
 
             if (!UseSkill(SkillName.Discordance))
+            {
                 return false;
+            }
 
             if (Target is Discordance.DiscordanceTarget)
             {
@@ -6688,10 +6691,7 @@ namespace Server.Mobiles
 
             if (inst == null)
             {
-                if (Backpack == null)
-                    return null;
-
-                inst = Backpack.FindItemByType(typeof(BaseInstrument)) as BaseInstrument;
+                inst = Backpack == null ? null : Backpack.FindItemByType(typeof(BaseInstrument)) as BaseInstrument;
 
                 if (inst == null)
                 {

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -1495,6 +1495,11 @@ namespace Server.Mobiles
                     #endregion
                 }
 
+                if (from.Mount is VvVMount && !ViceVsVirtueSystem.IsVvV(from))
+                {
+                    from.Mount.Rider = null;
+                }
+
                 if (moved)
                 {
                     from.SendLocalizedMessage(500647); // Some equipment has been moved to your backpack.

--- a/Scripts/Services/Dungeons/DespiseRevamped/AI.cs
+++ b/Scripts/Services/Dungeons/DespiseRevamped/AI.cs
@@ -24,7 +24,11 @@ namespace Server.Engines.Despise
             {
                 default:
                     {
-                        m_Creature.ControlOrder = OrderType.Follow;
+                        if (m_Creature.ControlOrder != OrderType.Follow)
+                        {
+                            m_Creature.ControlOrder = OrderType.Follow;
+                        }
+
                         DoOrderFollow();
                     }
                     break;
@@ -110,7 +114,11 @@ namespace Server.Engines.Despise
 
             if (m_Creature.Combatant == null)
             {
-                m_Creature.ControlOrder = OrderType.Follow;
+                if (m_Creature.ControlOrder != OrderType.Follow)
+                {
+                    m_Creature.ControlOrder = OrderType.Follow;
+                }
+
                 m_Creature.ControlTarget = m_Creature.ControlMaster;
                 Action = ActionType.Guard;
                 DoOrderFollow();
@@ -171,7 +179,7 @@ namespace Server.Engines.Despise
 
             foreach (Mobile m in eable)
             {
-                if (m is DespiseCreature || m is DespiseBoss)
+                if (m_Creature.CanSee(m) && m_Creature.InLOS(m) && (m is DespiseCreature || m is DespiseBoss))
                 {
                     DespiseCreature dc = m as DespiseCreature;
 
@@ -205,7 +213,7 @@ namespace Server.Engines.Despise
             {
                 p = m_Creature.Orb.GetAnchorActual();
 
-                if (m_Creature.InRange(p, range))
+                if (m_Creature.InRange(p, range + 1))
                 {
                     return false;
                 }
@@ -248,7 +256,11 @@ namespace Server.Engines.Despise
             {
                 default:
                     {
-                        m_Creature.ControlOrder = OrderType.Follow;
+                        if (m_Creature.ControlOrder != OrderType.Follow)
+                        {
+                            m_Creature.ControlOrder = OrderType.Follow;
+                        }
+
                         DoOrderFollow();
                     }
                     break;
@@ -334,7 +346,11 @@ namespace Server.Engines.Despise
 
             if (m_Creature.Combatant == null)
             {
-                m_Creature.ControlOrder = OrderType.Follow;
+                if (m_Creature.ControlOrder != OrderType.Follow)
+                {
+                    m_Creature.ControlOrder = OrderType.Follow;
+                }
+
                 m_Creature.ControlTarget = m_Creature.ControlMaster;
                 Action = ActionType.Guard;
                 DoOrderFollow();
@@ -395,7 +411,7 @@ namespace Server.Engines.Despise
 
             foreach (Mobile m in eable)
             {
-                if (m is DespiseCreature || m is DespiseBoss)
+                if (m_Creature.CanSee(m) && m_Creature.InLOS(m) && (m is DespiseCreature || m is DespiseBoss))
                 {
                     DespiseCreature dc = m as DespiseCreature;
 
@@ -429,7 +445,7 @@ namespace Server.Engines.Despise
             {
                 p = m_Creature.Orb.GetAnchorActual();
 
-                if (m_Creature.InRange(p, range))
+                if (m_Creature.InRange(p, range + 1))
                 {
                     return false;
                 }

--- a/Scripts/Services/ViceVsVirtue/Items/Rewards/VvVSteeds.cs
+++ b/Scripts/Services/ViceVsVirtue/Items/Rewards/VvVSteeds.cs
@@ -43,15 +43,15 @@ namespace Server.Engines.VvV
             list.Add(1154937); // vvv item
         }
 
-        public override void OnDoubleClick(Mobile m)
+        public override void OnDoubleClick(Mobile from)
         {
-            if (!ViceVsVirtueSystem.IsVvV(m))
+            if (!ViceVsVirtueSystem.IsVvV(from) && from.AccessLevel == AccessLevel.Player)
             {
-                m.SendLocalizedMessage(1155496); // This item can only be used by VvV participants!
+                from.SendLocalizedMessage(1155496); // This item can only be used by VvV participants!
                 return;
             }
 
-            base.OnDoubleClick(m);
+            base.OnDoubleClick(from);
         }
 
         public VvVSteedStatuette(Serial serial) : base(serial)
@@ -184,6 +184,18 @@ namespace Server.Engines.VvV
                 ControlMaster.PrivateOverheadMessage(Server.Network.MessageType.Regular, 1154, 1155550, ControlMaster.NetState); // *Your steed has depleted it's battle readiness!*
 
             Delete();
+        }
+
+        public override void OnDoubleClick(Mobile from)
+        {
+            if (!ViceVsVirtueSystem.IsVvV(from) && from.AccessLevel == AccessLevel.Player)
+            {
+                from.SendLocalizedMessage(1155561); // You are no longer in Vice vs Virtue!
+            }
+            else
+            {
+                base.OnDoubleClick(from);
+            }
         }
 
         public override void OnDeath(Container c)


### PR DESCRIPTION
Non-VvV players can no longer use vvv mounts
slasher of veils is now weak while inside the chamber of virtue. (shards should move his spawn up north more outside the chamber)
Removed annoying spamming sound for despise creatures

Controlled pets will now take slightly more damage from monsters and bosses.
This is the beginning of our attempts to better balance out pets vs how they are on production in regards to their ability to tank major end content bosses without the need of the tamer to heal or monitor the said pet.
All testing has been done on OSI and we are interested in feedback from OSI players.