### PR TITLE
PR: Makefile and ServUO.sln Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 MCS=mcs
 EXENAME=ServUO
 CURPATH=`pwd`
+SCRPATH=${CURPATH}/Scripts
 SRVPATH=${CURPATH}/Server
-SDKPATH=${CURPATH}/Ultima
-REFS=System.Drawing.dll
+APPPATH=${CURPATH}/Application
+ICOPATH=${CURPATH}/Application
+REFS=System.Drawing.dll,System.Web.dll,System.Data.dll,System.IO.Compression.FileSystem.dll
 NOWARNS=0618,0219,0414,1635
 
 PHONY : default build clean run
@@ -11,10 +13,10 @@ PHONY : default build clean run
 default: run
 
 debug: 
-	${MCS} -target:library -out:${CURPATH}/Ultima.dll -r:${REFS} -nowarn:${NOWARNS} -d:DEBUG -d:MONO -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SDKPATH}/*.cs
-	${MCS} -win32icon:${SRVPATH}/servuo.ico -r:${CURPATH}/Ultima.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/${EXENAME}.exe -d:DEBUG -d:MONO -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SRVPATH}/*.cs
-	sed -i.bak -e 's/<!--//g; s/-->//g' ${EXENAME}.exe.config
-
+	${MCS} -target:library -out:${CURPATH}/Server.dll -r:${REFS} -nowarn:${NOWARNS} -d:DEBUG -d:MONO -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SRVPATH}/*.cs
+	${MCS} -target:library -out:${CURPATH}/Scripts.dll -r:${CURPATH}/Server.dll,${REFS} -nowarn:${NOWARNS} -d:MONO -d:DEBUG -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${SCRPATH}/*.cs
+	${MCS} -win32icon:${ICOPATH}/servuo.ico -r:${CURPATH}/Server.dll,${CURPATH}/Scripts.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/${EXENAME}.exe -d:DEBUG -d:MONO -d:ServUO -d:NEWTIMERS -nologo -debug -unsafe -recurse:${APPPATH}/*.cs
+	${CURPATH}/${EXENAME}.sh
 run: build
 	${CURPATH}/${EXENAME}.sh
 
@@ -28,14 +30,17 @@ clean:
 	rm -f Ultima.dll.mdb
 	rm -f *.bin
 
-Ultima.dll: Ultima/*.cs
-	${MCS} -target:library -out:${CURPATH}/Ultima.dll -r:${REFS} -nowarn:${NOWARNS} -d:MONO -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SDKPATH}/*.cs
 
-${EXENAME}.exe: Ultima.dll Server/*.cs
-	${MCS} -win32icon:${SRVPATH}/servuo.ico -r:${CURPATH}/Ultima.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/${EXENAME}.exe -d:MONO -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SRVPATH}/*.cs
+Server.dll: Server/*.cs
+	${MCS} -target:library -out:${CURPATH}/Server.dll -r:${REFS} -nowarn:${NOWARNS} -d:MONO -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SRVPATH}/*.cs
+
+Scripts.dll: Server.dll Scripts/
+	${MCS} -target:library -out:${CURPATH}/Scripts.dll -r:${CURPATH}/Server.dll,${REFS} -nowarn:${NOWARNS} -d:MONO -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:${SCRPATH}/*.cs
+
+${EXENAME}.exe: Server.dll Scripts.dll Application/*.cs 
+	${MCS} -win32icon:${ICOPATH}/servuo.ico -r:${CURPATH}/Server.dll,${CURPATH}/Scripts.dll,${REFS} -nowarn:${NOWARNS} -target:exe -out:${CURPATH}/${EXENAME}.exe -d:MONO -d:ServUO -d:NEWTIMERS -nologo -optimize -unsafe -recurse:./Application/*.cs
 
 ${EXENAME}.sh: ${EXENAME}.exe
 	echo "#!/bin/sh" > ${CURPATH}/${EXENAME}.sh
 	echo "mono ${CURPATH}/${EXENAME}.exe" >> ${CURPATH}/${EXENAME}.sh
 	chmod a+x ${CURPATH}/${EXENAME}.sh
-	sed -i.bak -e 's/<!--//g; s/-->//g' ${EXENAME}.exe.config

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Run `Compile.WIN - Release.bat` for production environments.
 `make`
 
 
-#### Ubuntu
+#### Ubuntu / Debian
 
-`apt-get install mono-complete`  
+`apt-get install zlib1g-dev`
+`apt-get install mono-complete`
 `make`
 
 

--- a/ServUO.sln
+++ b/ServUO.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServUO", "Application\ServUO.csproj", "{1A651504-B0F6-4D8C-B869-F84F645FE4CC}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scripts", "Scripts\Scripts.csproj", "{308EA7C6-2873-4E47-AF3F-ABBA3F8AB63E}"
 	ProjectSection(ProjectDependencies) = postProject
 		{AE4A9EAA-E0EB-4DC9-9604-BE4289F9F6C3} = {AE4A9EAA-E0EB-4DC9-9604-BE4289F9F6C3}
@@ -15,16 +17,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServUO", "Application\ServUO.csproj", "{1A651504-B0F6-4D8C-B869-F84F645FE4CC}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{308EA7C6-2873-4E47-AF3F-ABBA3F8AB63E}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{308EA7C6-2873-4E47-AF3F-ABBA3F8AB63E}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{308EA7C6-2873-4E47-AF3F-ABBA3F8AB63E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{308EA7C6-2873-4E47-AF3F-ABBA3F8AB63E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{308EA7C6-2873-4E47-AF3F-ABBA3F8AB63E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{308EA7C6-2873-4E47-AF3F-ABBA3F8AB63E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AE4A9EAA-E0EB-4DC9-9604-BE4289F9F6C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
The makefile was updated to run on linux,
the readme also includes the zlib, without that the server crashes too

and finally the changes to the ServUO.sln, with that you can grab the files, run vs, and instantly hit play instead of changing the start project everytime. Also set it use the Debug Profile when it is requested to run as such, for the Scripts project