### PR TITLE
Fixed Mono Server Reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Run `Compile.WIN - Release.bat` for production environments.
 
 #### Ubuntu / Debian
 
-`apt-get install zlib1g-dev`
-`apt-get install mono-complete`
+`apt-get install zlib1g-dev`  
+`apt-get install mono-complete`  
 `make`
 
 

--- a/Server/Main.cs
+++ b/Server/Main.cs
@@ -322,16 +322,46 @@ namespace Server
 			Kill(false);
 		}
 
+#if MONO
+		private static string[] SupportedTerminals => new string[]
+		{
+			"xfce4-terminal", "gnome-terminal", "xterm"
+		};
+
+		private static void RebootTerminal(int i = 0)
+		{
+			if(SupportedTerminals.Length > i)
+			{
+				try {
+					if(SupportedTerminals[i] != "xterm")
+						Process.Start(SupportedTerminals[i], $"--working-directory={BaseDirectory} -x ./ServUO.sh");
+					else
+						Process.Start(SupportedTerminals[i], $"-lcc {BaseDirectory} -e ./ServUO.sh");
+					Thread.Sleep(500); // a sleep here to not close the programm to quick, so that the new windows cant start.
+				}
+				catch(System.ComponentModel.Win32Exception)
+				{
+					RebootTerminal(i+1);
+				}
+			}
+		}
+#endif
+
 		public static void Kill(bool restart)
 		{
 			HandleClosed();
 
 			if (restart)
 			{
+#if MONO
+				RebootTerminal();
+				Environment.Exit(0);
+			}
+#else				
 				Process.Start(ExePath, Arguments);
 			}
-
 			Process.Kill();
+#endif
 		}
 
 		private static void HandleClosed()


### PR DESCRIPTION
- Finally server on Linux can restart the server without having to manually close the server first.  #4398
- Also fixed the line break issue in the linux area in the readme, caused by me