### PR TITLE
Add basic configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@
 *.csproj.user
 *.DotSettings.user
 *.ini
+*.nupkg
 
 # Include Data Files
 !/Data/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: csharp
-solution: ServUO.sln
-mono: latest
-
-addons:
-  sonarcloud:
-    organization: "serv-uo"

--- a/Config/PlayerCaps.cfg
+++ b/Config/PlayerCaps.cfg
@@ -10,10 +10,10 @@ SkillCap=1000
 
 # Sets the default total skill cap. Since skills have a decimal value
 # they also need to have a decimal value added to their skillcap
-TotalSkillCap=5,800
+TotalSkillCap=60000
 
 # The total stat cap
-TotalStatCap=225
+TotalStatCap=975
 
 # The individual str cap
 StrCap=325

--- a/Config/PlayerCaps.cfg
+++ b/Config/PlayerCaps.cfg
@@ -10,28 +10,28 @@ SkillCap=1000
 
 # Sets the default total skill cap. Since skills have a decimal value
 # they also need to have a decimal value added to their skillcap
-TotalSkillCap=7000
+TotalSkillCap=5,800
 
 # The total stat cap
 TotalStatCap=225
 
 # The individual str cap
-StrCap=125
+StrCap=325
 
 # The individual dex cap
-DexCap=125
+DexCap=325
 
 # The individual int cap
-IntCap=125
+IntCap=325
 
 # The individual enhanced str cap for players
-StrMaxCap=150
+StrMaxCap=350
 
 # The individual enhanced dex cap for players
-DexMaxCap=150
+DexMaxCap=350
 
 # The individual enhanced int cap for players
-IntMaxCap=150
+IntMaxCap=350
 
 #------------
 # Exisitng chars too
@@ -49,7 +49,7 @@ EnablePlayerStatTimeDelay=false
 # Format: dd:hh:mm:ss 
 PlayerStatTimeDelay=00:00:15:00
 
-# If true, limit a pet's ability to gain stats within a certain time  window.
+# If true, limit a pet's ability to gain stats within a certain time window.
 # I think this was disabled by OSI Publish 45 as well, but no certain.
 EnablePetStatTimeDelay=false
 
@@ -64,8 +64,8 @@ EnableAntiMacro=False
 
 # The percentage chance for a player to gain in a stat. Default is 5% from OSI
 # publish 45 notes.
-PlayerChanceToGainStats=5.0
+PlayerChanceToGainStats=20.0
 
 # The percentage chance for a pet to gain in a stat. Default is 5% infered from
 # OSI publish 45 notes.
-PetChanceToGainStats=5.0
+PetChanceToGainStats=20.0

--- a/Config/PlayerCaps.cfg
+++ b/Config/PlayerCaps.cfg
@@ -10,10 +10,10 @@ SkillCap=1000
 
 # Sets the default total skill cap. Since skills have a decimal value
 # they also need to have a decimal value added to their skillcap
-TotalSkillCap=60000
+TotalSkillCap=99999
 
 # The total stat cap
-TotalStatCap=975
+TotalStatCap=9999
 
 # The individual str cap
 StrCap=325

--- a/Config/Server.cfg
+++ b/Config/Server.cfg
@@ -1,6 +1,6 @@
 
 # The displayed name of the shard
-Name=My Shard
+Name=Flawless Haven
 
 # The default setting for Address, a value of 'null', will use your local IP address.
 # If all of your local IP addresses are private network addresses and AutoDetect is 'true'

--- a/Config/Server.cfg
+++ b/Config/Server.cfg
@@ -1,6 +1,6 @@
 
 # The displayed name of the shard
-Name=My Shard
+Name=The Flawless Haven
 
 # The default setting for Address, a value of 'null', will use your local IP address.
 # If all of your local IP addresses are private network addresses and AutoDetect is 'true'

--- a/Config/Server.cfg
+++ b/Config/Server.cfg
@@ -1,6 +1,6 @@
 
 # The displayed name of the shard
-Name=The Flawless Haven
+Name=My Shard
 
 # The default setting for Address, a value of 'null', will use your local IP address.
 # If all of your local IP addresses are private network addresses and AutoDetect is 'true'

--- a/Config/Staff.cfg
+++ b/Config/Staff.cfg
@@ -1,9 +1,9 @@
 #General configuration for gmbody-command
 Staffbody=False
 UseColoring=True
-GiveBoots=True
-CutHair=False
-CutFacialHair=False
+GiveBoots=False
+CutHair=True
+CutFacialHair=True
 
 #Coloring configuration
 Owner=1001

--- a/Config/Store.cfg
+++ b/Config/Store.cfg
@@ -1,7 +1,7 @@
 # Configuration for Ultima Store
 
 # Enable or disable the Ultima Store
-Enabled=True
+Enabled=False
 
 # Website address for more information.
 Website=https://uo.com/ultima-store/

--- a/README.md
+++ b/README.md
@@ -1,46 +1,19 @@
-# [ServUO]
+# Flawless Haven Shard
+This is an Ultima Online shard meant to provide a fun experience to its players. Crafted to be used by one or a small party of players to enjoy what this game has to offer while at the same time introducing a few custom experiences to promote the role-playing experience.
 
-[![Build Status](https://travis-ci.com/ServUO/ServUO.svg?branch=master)](https://travis-ci.com/ServUO/ServUO)
-[![GitHub issues](https://img.shields.io/github/issues/servuo/servuo.svg)](https://github.com/ServUO/ServUO/issues)
-[![GitHub release](https://img.shields.io/github/release/servuo/servuo.svg)](https://github.com/ServUO/ServUO/releases)
-[![GitHub repo size](https://img.shields.io/github/repo-size/servuo/servuo.svg)](https://github.com/ServUO/ServUO/)
-[![Discord](https://img.shields.io/discord/110970849628000256.svg)](https://discord.gg/0cQjvnFUN26nRt7y)
-[![GitHub contributors](https://img.shields.io/github/contributors/servuo/servuo.svg)](https://github.com/ServUO/ServUO/graphs/contributors)
-[![GitHub](https://img.shields.io/github/license/servuo/servuo.svg?color=a)](https://github.com/ServUO/ServUO/blob/master/LICENSE)
+## Characteristics
+ - Powered by ServUO which means that all expansions content is available up to Times of Lengends/Endless Journey.
+ - The Ultima Store is disabled.
+ - No Skill Cap.
+ - Each stat can be raised up to 325.
+ - The chance to gain a new stat point is 20%.
 
+More features will be added to promote RP and custom systems to enhance the experience.
 
-[ServUO] is a community driven Ultima Online Server Emulator written in C#.
+## Instructions
+Not available yet.
 
-
-#### Requirements
-
-[.NET Framework 4.8] Runtime and SDK
-
-
-#### Windows
-
-Run `Compile.WIN - Debug.bat` for development environments.
-Run `Compile.WIN - Release.bat` for production environments.
-
-
-#### OSX
-
-`brew install mono`  
-`make`
-
-
-#### Ubuntu / Debian
-
-`apt-get install zlib1g-dev`  
-`apt-get install mono-complete`  
-`make`
-
-
-#### Summary
-
-A [Quick Start] guide is available for more information on setting up your world.
-
-
-   [ServUO]: <https://www.servuo.com>
-   [Quick Start]: <https://www.servuo.com/wiki/startup/>
-   [.NET Framework 4.8]: <https://dotnet.microsoft.com/download/dotnet-framework/net48>
+## Planned content
+- Create a new map:
+   - Add a casino with slots, blackjack, and poker.
+   - Add a bar where players can but but exotic drinks that introduce effects on them.

--- a/Scripts/Services/UltimaStore/UltimaStore.cs
+++ b/Scripts/Services/UltimaStore/UltimaStore.cs
@@ -385,17 +385,9 @@ namespace Server.Engines.UOStore
                 return;
             }
 
-            if (!Enabled)
+            if (!Enabled || Configuration.CurrencyImpl == CurrencyType.None)
             {
-                // The promo code redemption system is currently unavailable. Please try again later.
-                user.SendLocalizedMessage(1062904);
-                return;
-            }
-
-            if (Configuration.CurrencyImpl == CurrencyType.None)
-            {
-                // The promo code redemption system is currently unavailable. Please try again later.
-                user.SendLocalizedMessage(1062904);
+                user.SendMessage("The Ultima Online Store is disabled!");
                 return;
             }
 


### PR DESCRIPTION
This PR will add the basic configuration for the shard, that is, it sets its name and configs the caps. As a bonus the Ultima Store is disabled. Some notes about it are also provided in the readme.