### PR TITLE
Bug Fixes

### DIFF
--- a/Scripts/Items/Addons/FormalDiningTable.cs
+++ b/Scripts/Items/Addons/FormalDiningTable.cs
@@ -60,6 +60,7 @@ namespace Server.Items
         }
     }
 
+    [Furniture]
     public class FormalDiningTableDeed : BaseAddonDeed, IRewardOption
     {
         public override int LabelNumber => 1157069;  // Formal Dining Table

--- a/Scripts/Items/Consumables/RunedSwitch.cs
+++ b/Scripts/Items/Consumables/RunedSwitch.cs
@@ -70,9 +70,17 @@ namespace Server.Items
                     else
                         from.SendLocalizedMessage(1075099); // You cannot recharge that item until all of its current charges have been used.
                 }
-                else if (o is HarvestersAxe)
+                else if (o is HarvestersAxe || o is GargishHarvestersAxe)
                 {
-                    ((HarvestersAxe)o).Charges = 1000;
+                    if (o is HarvestersAxe)
+                    {
+                        ((HarvestersAxe)o).Charges = 1000;
+                    }
+                    else if (o is GargishHarvestersAxe)
+                    {
+                        ((GargishHarvestersAxe)o).Charges = 1000;
+                    }
+
                     from.SendLocalizedMessage(1075100); // The item has been recharged.
                     m_Item.Delete();
                 }

--- a/Scripts/Items/Equipment/Clothing/Hats.cs
+++ b/Scripts/Items/Equipment/Clothing/Hats.cs
@@ -281,7 +281,6 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(2); // version
 
             writer.Write(m_IsShipwreckedItem);
@@ -290,7 +289,6 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
             int version = reader.ReadInt();
 
             switch (version)
@@ -370,15 +368,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -414,15 +410,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -459,15 +453,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -503,15 +495,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -547,15 +537,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -591,15 +579,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -635,15 +621,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -679,15 +663,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -730,15 +712,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -781,15 +761,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -832,15 +810,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -884,15 +860,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -928,15 +902,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -972,15 +944,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -1045,18 +1015,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
-
-            /*if (Hue != 0x8A4)
-                Hue = 0x8A4;*/
+            reader.ReadInt();
         }
     }
 
@@ -1095,15 +1060,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -1154,18 +1117,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
-
-            /*if (Hue != 0 && (Hue < 2101 || Hue > 2130))
-                Hue = GetRandomHue();*/
+            reader.ReadInt();
         }
     }
 
@@ -1200,15 +1158,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -1249,15 +1205,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -1292,15 +1246,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -1335,15 +1287,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -1378,15 +1328,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -1421,15 +1369,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -1472,7 +1418,7 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
-    }
+    }    
 }

--- a/Scripts/Items/Functional/JewelryBox/JewelryBox.cs
+++ b/Scripts/Items/Functional/JewelryBox/JewelryBox.cs
@@ -1,4 +1,5 @@
 using Server.ContextMenus;
+using Server.Gumps;
 using Server.Multis;
 using Server.Network;
 using System;
@@ -8,7 +9,7 @@ namespace Server.Items
 {
     [Furniture]
     [Flipable(0x9F1C, 0x9F1D)]
-    public class JewelryBox : Container, IDyable
+    public class JewelryBox : Container, IDyable, ISecurable
     {
         public override int LabelNumber => 1157694;  // Jewelry Box
 

--- a/Scripts/Items/Functional/SeedBox/SeedBox.cs
+++ b/Scripts/Items/Functional/SeedBox/SeedBox.cs
@@ -11,7 +11,7 @@ using System.Linq;
 namespace Server.Engines.Plants
 {
     [Flipable(19288, 19290)]
-    public class SeedBox : Container, IRewardItem
+    public class SeedBox : Container, IRewardItem, ISecurable
     {
         public static readonly int MaxSeeds = 5000;
         public static readonly int MaxUnique = 300;

--- a/Scripts/Items/Quest/SecretWallTeleporters.cs
+++ b/Scripts/Items/Quest/SecretWallTeleporters.cs
@@ -1,19 +1,16 @@
+using Server.Mobiles;
 using System;
 
 namespace Server.Items
 {
     public class SecretWall : Item
     {
-        private Point3D m_PointDest;
-        private Map m_MapDest;
-        private bool m_Locked;
-        private bool m_Active;
         [Constructable]
         public SecretWall(int itemID)
             : base(itemID)
         {
-            m_Active = true;
-            m_Locked = true;
+            Active = true;
+            Locked = true;
         }
 
         public SecretWall(Serial serial)
@@ -22,60 +19,25 @@ namespace Server.Items
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public Point3D PointDest
-        {
-            get
-            {
-                return m_PointDest;
-            }
-            set
-            {
-                m_PointDest = value;
-            }
-        }
+        public Point3D PointDest { get; set; }
+
         [CommandProperty(AccessLevel.GameMaster)]
-        public Map MapDest
-        {
-            get
-            {
-                return m_MapDest;
-            }
-            set
-            {
-                m_MapDest = value;
-            }
-        }
+        public Map MapDest { get; set; }
+
         [CommandProperty(AccessLevel.GameMaster)]
-        public bool Locked
-        {
-            get
-            {
-                return m_Locked;
-            }
-            set
-            {
-                m_Locked = value;
-            }
-        }
+        public bool Locked { get; set; }
+
         [CommandProperty(AccessLevel.GameMaster)]
-        public bool Active
-        {
-            get
-            {
-                return m_Active;
-            }
-            set
-            {
-                m_Active = value;
-            }
-        }
+        public bool Active { get; set; }
+
         public override void OnDoubleClick(Mobile from)
         {
             if (from.InRange(Location, 2))
             {
-                if (!m_Locked && m_Active)
+                if (!Locked && Active)
                 {
-                    from.MoveToWorld(m_PointDest, m_MapDest);
+                    BaseCreature.TeleportPets(from, PointDest, MapDest);
+                    from.MoveToWorld(PointDest, MapDest);
                     from.SendLocalizedMessage(1072790); // The wall becomes transparent, and you push your way through it.
                 }
                 else
@@ -86,32 +48,28 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
 
-            writer.Write(m_PointDest);
-            writer.Write(m_MapDest);
-            writer.Write(m_Locked);
-            writer.Write(m_Active);
+            writer.Write(PointDest);
+            writer.Write(MapDest);
+            writer.Write(Locked);
+            writer.Write(Active);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
+            reader.ReadInt();
 
-            int version = reader.ReadInt();
-
-            m_PointDest = reader.ReadPoint3D();
-            m_MapDest = reader.ReadMap();
-            m_Locked = reader.ReadBool();
-            m_Active = reader.ReadBool();
+            PointDest = reader.ReadPoint3D();
+            MapDest = reader.ReadMap();
+            Locked = reader.ReadBool();
+            Active = reader.ReadBool();
         }
     }
 
     public class SecretSwitch : Item
     {
-        private SecretWall m_Wall;
-        private bool m_TurnedOn;
         [Constructable]
         public SecretSwitch()
             : this(0x108F, null)
@@ -122,7 +80,7 @@ namespace Server.Items
         public SecretSwitch(int itemID, SecretWall wall)
             : base(itemID)
         {
-            m_Wall = wall;
+            Wall = wall;
         }
 
         public SecretSwitch(Serial serial)
@@ -131,34 +89,16 @@ namespace Server.Items
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public SecretWall Wall
-        {
-            get
-            {
-                return m_Wall;
-            }
-            set
-            {
-                m_Wall = value;
-            }
-        }
+        public SecretWall Wall { get; set; }
+
         [CommandProperty(AccessLevel.GameMaster)]
-        public bool TurnedOn
-        {
-            get
-            {
-                return m_TurnedOn;
-            }
-            set
-            {
-                m_TurnedOn = value;
-            }
-        }
+        public bool TurnedOn { get; set; }
+
         public override void OnDoubleClick(Mobile from)
         {
-            if (from.InRange(Location, 2) && m_Wall != null)
+            if (from.InRange(Location, 2) && Wall != null)
             {
-                if (m_TurnedOn)
+                if (TurnedOn)
                     ItemID -= 1;
                 else
                 {
@@ -167,8 +107,8 @@ namespace Server.Items
                     Timer.DelayCall(TimeSpan.FromSeconds(10), Lock);
                 }
 
-                m_TurnedOn = !m_TurnedOn;
-                m_Wall.Locked = !m_Wall.Locked;
+                TurnedOn = !TurnedOn;
+                Wall.Locked = !Wall.Locked;
 
                 if (Utility.RandomBool())
                 {
@@ -185,34 +125,32 @@ namespace Server.Items
 
         public virtual void Lock()
         {
-            if (m_Wall != null)
+            if (Wall != null)
             {
-                if (m_TurnedOn)
+                if (TurnedOn)
                     ItemID -= 1;
 
-                m_TurnedOn = false;
-                m_Wall.Locked = true;
+                TurnedOn = false;
+                Wall.Locked = true;
             }
         }
 
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
             writer.Write(0); // version
 
-            writer.Write(m_Wall);
-            writer.Write(m_TurnedOn);
+            writer.Write(Wall);
+            writer.Write(TurnedOn);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
+            reader.ReadInt();
 
-            int version = reader.ReadInt();
-
-            m_Wall = reader.ReadItem() as SecretWall;
-            m_TurnedOn = reader.ReadBool();
+            Wall = reader.ReadItem() as SecretWall;
+            TurnedOn = reader.ReadBool();
         }
     }
 }

--- a/Scripts/Items/StoreBought/MysticalPolymorphTotem.cs
+++ b/Scripts/Items/StoreBought/MysticalPolymorphTotem.cs
@@ -175,6 +175,7 @@ namespace Server.Items
 
                     m_Totem.CostumeCreatureName = costume.CreatureName;
                     m_Totem.CostumeBody = costume.CostumeBody;
+                    m_Totem.CostumeHue = costume.Hue;
 
                     m_Totem.InvalidateProperties();
 
@@ -196,7 +197,7 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int version = reader.ReadInt();
+            reader.ReadInt();
 
             CostumeCreatureName = reader.ReadString();
             CostumeBody = reader.ReadInt();

--- a/Scripts/Items/Tools/DyeTubs/FurnitureDyeTub.cs
+++ b/Scripts/Items/Tools/DyeTubs/FurnitureDyeTub.cs
@@ -25,7 +25,7 @@ namespace Server.Items
         private static Type[] _Dyables = new[]
         {
             typeof(PotionKeg), typeof(CustomizableSquaredDoorMatDeed), typeof(OrnateBedDeed),
-            typeof(FourPostBedDeed)
+            typeof(FourPostBedDeed), typeof(FormalDiningTableDeed)
         };
 
         public override Type[] ForcedDyables => _Dyables;

--- a/Scripts/Multis/Houses/BaseHouse.cs
+++ b/Scripts/Multis/Houses/BaseHouse.cs
@@ -4680,7 +4680,7 @@ namespace Server.Multis
                     isOwned = house.IsLockedDown(item);
 
                 if (!isOwned)
-                    isOwned = item is BaseAddon;
+                    isOwned = item is BaseAddon || item is JewelryBox || item is Engines.Plants.SeedBox;
 
                 if (isOwned)
                     sec = (ISecurable)item;

--- a/Scripts/Services/CleanUpBritannia/Items/Mailbox.cs
+++ b/Scripts/Services/CleanUpBritannia/Items/Mailbox.cs
@@ -155,6 +155,27 @@ namespace Server.Items
             return true;
         }
 
+        public override void OnDoubleClick(Mobile from)
+        {
+            BaseHouse house = BaseHouse.FindHouseAt(this);
+
+            if (house != null && !house.IsOwner(from))
+            {
+                if (IsSecure)
+                {
+                    SendLocalizedMessageTo(from, 1010563); // This container is secure.                    
+                    return;
+                }
+                else if (IsLockedDown)
+                {
+                    SendLocalizedMessageTo(from, 1061637); // You are not allowed to access this.
+                    return;
+                }
+            }
+
+            base.OnDoubleClick(from);
+        }
+
         public override bool CheckLift(Mobile from, Item item, ref LRReason reject)
         {
             if (item == this)

--- a/Scripts/Services/Harvest/HarvestSystem.cs
+++ b/Scripts/Services/Harvest/HarvestSystem.cs
@@ -751,7 +751,7 @@ namespace Server
             typeof(WoodenBookcase), typeof(Countertop), typeof(Mailbox), typeof(DecorativeMagesCrystalBall), typeof(DecorativeMageThrone),
             typeof(DecorativeMagicBookStand), typeof(DecorativeSpecimenShelve), typeof(Feedbag), typeof(ChestOfDrawers), typeof(BarrelMailbox),
             typeof(DolphinMailbox), typeof(ScarecrowMailbox), typeof(SquirrelMailbox), typeof(FootedChestOfDrawers), typeof(CustomizableRoundedDoorMat),
-            typeof(CowStatue), typeof(DecorativeStableFencing), typeof(OrnateBedDeed), typeof(FourPostBedDeed)
+            typeof(CowStatue), typeof(DecorativeStableFencing), typeof(OrnateBedDeed), typeof(FourPostBedDeed), typeof(FormalDiningTableDeed)
         };
 
         public static bool Check(Item item)

--- a/Scripts/Services/Harvest/Lumberjacking.cs
+++ b/Scripts/Services/Harvest/Lumberjacking.cs
@@ -120,7 +120,7 @@ namespace Server.Engines.Harvest
         {
             Type newType = type;
 
-            if (tool is HarvestersAxe && ((HarvestersAxe)tool).Charges > 0)
+            if (tool is HarvestersAxe axe && axe.Charges > 0 || tool is GargishHarvestersAxe gaxe && gaxe.Charges > 0)
             {
                 if (type == typeof(Log))
                     newType = typeof(Board);
@@ -139,7 +139,14 @@ namespace Server.Engines.Harvest
 
                 if (newType != type)
                 {
-                    ((HarvestersAxe)tool).Charges--;
+                    if (tool is HarvestersAxe)
+                    {
+                        ((HarvestersAxe)tool).Charges--;
+                    }
+                    else if (tool is GargishHarvestersAxe)
+                    {
+                        ((GargishHarvestersAxe)tool).Charges--;
+                    }
                 }
             }
 

--- a/Scripts/Services/HuntmasterChallenge/HuntMasterRewardGump.cs
+++ b/Scripts/Services/HuntmasterChallenge/HuntMasterRewardGump.cs
@@ -64,6 +64,9 @@ namespace Server.Engines.HuntsmasterChallenge
                     case 1158769: item = new RecipeScroll(605); break;
                     case 1158770: item = new RecipeScroll(606); break;
                     case 1158771: item = new RecipeScroll(607); break;
+                    case 1159204: item = new RecipeScroll(608); break;
+                    case 1159205: item = new RecipeScroll(609); break;
+                    case 1159206: item = new RecipeScroll(610); break;
                 }
 
                 if (item != null)
@@ -91,17 +94,22 @@ namespace Server.Engines.HuntsmasterChallenge
 
         private static readonly List<CollectionItem> _Collections = new List<CollectionItem>
         {
-            new CollectionItem(typeof(HarvestersBlade), 0x2D20, 1114096, 0, 1.0),
-            new CollectionItem(typeof(HornOfPlenty), 18080, 1153503, 0, 1.0),
-            new CollectionItem(typeof(HuntmastersRewardTitleDeed), 0x14EF, 0, 0, 1.0),
-            new CollectionItem(typeof(RangersGuildSash), 0x1541, 0, 0, 1.0),
-            new CollectionItem(typeof(GargishRangersGuildSash), 0x46B5, 0, 0, 1.0),
+            new CollectionItem(typeof(HarvestersBlade), 0x2D20, 1114096, 1191, 1.0),
+            new CollectionItem(typeof(HornOfPlenty), 0x4BD9, 1153503, 0, 1.0),
             new CollectionItem(typeof(RecipeScroll), 0x2831, 1158769, 0, 1.0), // hamburger recipe
             new CollectionItem(typeof(RecipeScroll), 0x2831, 1158770, 0, 1.0), // hot dog recipe
             new CollectionItem(typeof(RecipeScroll), 0x2831, 1158771, 0, 1.0), // sausage recipe
             new CollectionItem(typeof(MinersSatchel), 0xA272, 1158773, 0, 1.0),
             new CollectionItem(typeof(LumbjacksSatchel), 0xA274, 1158772, 0, 1.0),
             new CollectionItem(typeof(HarvestersAxe), 0x1443, 1158774, 0, 1.0),
+            new CollectionItem(typeof(GargishHarvestersAxe), 0x48B2, 1158774, 0, 1.0),
+            new CollectionItem(typeof(RecipeScroll), 0x2831, 1159204, 0, 1.0), // grilled serpent steak recipe
+            new CollectionItem(typeof(RecipeScroll), 0x2831, 1159205, 0, 1.0), // BBQ Dino Ribs Recipe
+            new CollectionItem(typeof(RecipeScroll), 0x2831, 1159206, 0, 1.0), // Waku Chicken Recipe
+            new CollectionItem(typeof(BakeKitsuneHat), 0xA42B, 1126051, 0, 1.0),
+            new CollectionItem(typeof(HuntmastersRewardTitleDeed), 0x14EF, 0, 0, 1.0),            
+            new CollectionItem(typeof(GargishRangersGuildSash), 0x46B5, 0, 0, 1.0),
+            new CollectionItem(typeof(RangersGuildSash), 0x1541, 0, 0, 1.0),
         };
     }
 }

--- a/Scripts/Services/HuntmasterChallenge/RewardItems.cs
+++ b/Scripts/Services/HuntmasterChallenge/RewardItems.cs
@@ -27,10 +27,7 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int v = reader.ReadInt();
-
-            if (v == 0)
-                Hue = 1191;
+            reader.ReadInt();
         }
     }
 
@@ -57,7 +54,7 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int v = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -85,7 +82,7 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int v = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
@@ -112,11 +109,11 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int v = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
-    [Flipable(18080, 18081)]
+    [Flipable(0x4BD9, 0x4BDA)]
     public class HornOfPlenty : Item, IUsesRemaining
     {
         public override int LabelNumber => 1153503;  // Horn of Plenty
@@ -142,7 +139,8 @@ namespace Server.Items
         }
 
         [Constructable]
-        public HornOfPlenty() : base(18080)
+        public HornOfPlenty()
+            : base(0x4BD9)
         {
             UsesRemaining = 10;
         }
@@ -300,9 +298,97 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int version = reader.ReadInt();
+            reader.ReadInt();
 
             _Charges = reader.ReadInt();
+        }
+    }
+
+    public class GargishHarvestersAxe : GargishAxe
+    {
+        public override int LabelNumber => 1158774;  // Harvester's Axe
+
+        private int _Charges;
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public int Charges { get { return _Charges; } set { _Charges = value; InvalidateProperties(); } }
+
+        [Constructable]
+        public GargishHarvestersAxe()
+        {
+            Charges = 1000;
+        }
+
+        public override void AddWeightProperty(ObjectPropertyList list)
+        {
+            base.AddWeightProperty(list);
+            list.Add(1158775);  // * Magically Chops Logs into Boards *
+            list.Add(1060741, _Charges.ToString()); // charges: 
+        }
+
+        public GargishHarvestersAxe(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+
+            writer.Write(_Charges);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+
+            _Charges = reader.ReadInt();
+        }
+    }
+
+    public class BakeKitsuneHat : BaseHat
+    {
+        public override int LabelNumber => 1126051;  // bake-kitsune hat
+
+        public override int BasePhysicalResistance => 1;
+        public override int BaseFireResistance => 3;
+        public override int BaseColdResistance => 8;
+        public override int BasePoisonResistance => 3;
+        public override int BaseEnergyResistance => 9;
+
+        public override int InitMinHits => 40;
+        public override int InitMaxHits => 60;
+
+        [Constructable]
+        public BakeKitsuneHat()
+            : this(0)
+        {
+        }
+
+        [Constructable]
+        public BakeKitsuneHat(int hue)
+            : base(0xA42B, hue)
+        {
+            Quality = ItemQuality.Exceptional;
+        }
+
+        public BakeKitsuneHat(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
         }
     }
 }

--- a/Scripts/Services/Seasonal Events/RisingTide/Rewards.cs
+++ b/Scripts/Services/Seasonal Events/RisingTide/Rewards.cs
@@ -1,5 +1,6 @@
 using Server.Gumps;
 using Server.Multis;
+using Server.Network;
 using System;
 using System.Linq;
 
@@ -283,31 +284,44 @@ namespace Server.Items
     [Flipable(0xA2C6, 0xA2C7)]
     public class MysteriousStatue : Item
     {
-        public override int LabelNumber => 1158935;  // Mysterious Statue
+        public override int LabelNumber => 1158935; // Mysterious Statue
 
         [Constructable]
         public MysteriousStatue()
             : base(0xA2C6)
         {
+            Weight = 5.0;
         }
 
         public override void OnDoubleClick(Mobile m)
         {
             if (m.InRange(GetWorldLocation(), 2))
             {
-                m.SendGump(new BasicInfoGump(1158937));
-                /*This mysterious statue towers above you. Even as skilled a mason as you are, the craftsmanship is uncanny, and unlike anything you have encountered before.
-                 * The stone appears to be smooth and special attention was taken to sculpt the statue as a perfect likeness. According to the pirate you purchased the statue
-                 * from, it was recovered somewhere at sea. The amount of marine growth seems to reinforce this claim, yet you cannot discern how long it may have been
-                 * submerged and are thus unsure of its age. Whatever its origins, one thing is clear - the figure is one you hope you do not encounter anytime soon...*/
+                if (m.Skills[SkillName.Carpentry].Value >= 100)
+                {
+                    Gump g = new Gump(100, 100);
+                    g.AddBackground(0, 0, 454, 400, 0x24A4);
+                    g.AddItem(35, 120, 0xA2C6);
+                    g.AddHtmlLocalized(177, 50, 250, 18, 1114513, "#1158935", 0x3442, false, false); // Mysterious Statue
+                    g.AddHtmlLocalized(177, 77, 250, 36, 1114513, "#1158936", 0x3442, false, false); // Purchased from a Pirate Merchant
+                    g.AddHtmlLocalized(177, 122, 250, 228, 1158937, 0xC63, true, true);
+                    /*This mysterious statue towers above you. Even as skilled a mason as you are, the craftsmanship is uncanny, and unlike anything you have encountered before.
+                    *The stone appears to be smooth and special attention was taken to sculpt the statue as a perfect likeness. According to the pirate you purchased the statue
+                    *from, it was recovered somewhere at sea. The amount of marine growth seems to reinforce this claim, yet you cannot discern how long it may have been
+                    * submerged and are thus unsure of its age.Whatever its origins, one thing is clear - the figure is one you hope you do not encounter anytime soon...
+                    */
+
+                    m.SendGump(g);
+
+                    m.PrivateOverheadMessage(MessageType.Regular, 0x47E, 1157722, "Carpentry", m.NetState); // *Your proficiency in ~1_SKILL~ reveals more about the item*
+                }
+                else
+                {
+                    m.PrivateOverheadMessage(MessageType.Regular, 0x47E, 1157693, "Carpentry", m.NetState); // *You lack the required ~1_SKILL~ skill to make anything of it.*
+                    m.SendSound(m.Female ? 0x31F : 0x42F);
+                }
             }
         }
-
-        /*public override void GetProperties(ObjectPropertyList list)
-        {
-            base.GetProperties(list);
-            list.Add(1158936); // Purchased from a Pirate Merchant
-        }*/
 
         public MysteriousStatue(Serial serial) : base(serial)
         {

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/KhaldunFirstAidBelt.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/KhaldunFirstAidBelt.cs
@@ -2,6 +2,8 @@ namespace Server.Items
 {
     public class KhaldunFirstAidBelt : FirstAidBelt
     {
+        public override bool IsArtifact => true;
+
         [Constructable]
         public KhaldunFirstAidBelt()
         {
@@ -25,7 +27,7 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 }

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/KhaldunRewards.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/KhaldunRewards.cs
@@ -1,7 +1,6 @@
 using Server.Items;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Server.Engines.Khaldun
 {
@@ -23,11 +22,6 @@ namespace Server.Engines.Khaldun
             Rewards.Add(new CollectionItem(typeof(SterlingSilverRing), 0x1F09, 1155606, 0, 50));
             Rewards.Add(new CollectionItem(typeof(TalonsOfEscaping), 0x41D8, 1155682, 0, 50));
             Rewards.Add(new CollectionItem(typeof(BootsOfEscaping), 0x1711, 1155607, 0, 50));
-        }
-
-        public static bool IsTokunoDyable(Type t)
-        {
-            return Rewards.FirstOrDefault(item => item.Type == t) != null;
         }
     }
 }

--- a/Scripts/Services/Seasonal Events/TreasuresOfKotlCity/Items/Rewards.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKotlCity/Items/Rewards.cs
@@ -252,6 +252,7 @@ namespace Server.Items
 
     public class KatalkotlsRing : SilverRing
     {
+        public override bool IsArtifact => true;
         public override int LabelNumber => 1156989;
 
         [Constructable]
@@ -314,12 +315,13 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
     public class BootsOfEscaping : ThighBoots
     {
+        public override bool IsArtifact => true;
         public override int LabelNumber => 1155607;  // Boots of Escaping
 
         [Constructable]
@@ -343,12 +345,13 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
     public class TalonsOfEscaping : LeatherTalons
     {
+        public override bool IsArtifact => true;
         public override int LabelNumber => 1155682;  // Talons of Escaping
 
         public TalonsOfEscaping()
@@ -371,7 +374,7 @@ namespace Server.Items
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 

--- a/Scripts/Spells/Ninjitsu/MirrorImage.cs
+++ b/Scripts/Spells/Ninjitsu/MirrorImage.cs
@@ -153,6 +153,8 @@ namespace Server.Mobiles
 {
     public class Clone : BaseCreature
     {
+        public override bool AlwaysAttackable => m_Caster is Travesty;
+
         private Mobile m_Caster;
         public Clone(Mobile caster)
             : base(AIType.AI_Melee, FightMode.None, 10, 1, 0.2, 0.4)


### PR DESCRIPTION
- Adds missing items to Huntmaster Reward gump
- Fixes an access issue with the Jewelry box, when turning pages.
- Travesty Mirror Images will no longer turn players criminal.
- Fixes an exploit where items could be used inside of mail boxes, even without the correct access