### PR TITLE
Clean the Scripts.dll on make clean command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ clean:
 	rm -f ${EXENAME}.exe.mdb
 	rm -f Ultima.dll
 	rm -f Ultima.dll.mdb
+	rm -f Scripts.dll
 	rm -f *.bin
 
 


### PR DESCRIPTION
The Issue:
When using `make clean` after changing Scripts *.sc files, Server doesn't receive updates with changes.

The Workaround:
Remove **Scripts.dll** file before `make`

The Fix:
Remove **Scripts.dll** on `make clean`