### PR TITLE
Fix SonarQube's "String.IsNullOrEmpty" should be used / Code Smell.

### DIFF
--- a/Scripts/Commands/WhatIsIt.cs
+++ b/Scripts/Commands/WhatIsIt.cs
@@ -26,7 +26,7 @@ namespace Server.Commands
                 string typename = targeted.GetType().Name;
                 string article = "a";
 
-                if (typename != null && typename.Length > 0)
+                if (!string.IsNullOrEmpty(typename))
                 {
                     if ("aeiouy".IndexOf(typename.ToLower()[0]) >= 0)
                     {

--- a/Scripts/Items/Addons/GeoffreyCampAddon.cs
+++ b/Scripts/Items/Addons/GeoffreyCampAddon.cs
@@ -54,7 +54,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Items/Books/BaseBook.cs
+++ b/Scripts/Items/Books/BaseBook.cs
@@ -368,7 +368,7 @@ namespace Server.Items
 
         public override void AddNameProperty(ObjectPropertyList list)
         {
-            if (m_Title != null && m_Title.Length > 0)
+            if (!string.IsNullOrEmpty(m_Title))
                 list.Add(m_Title);
             else
                 base.AddNameProperty(list);

--- a/Scripts/Items/Books/SpecialScrollBooks/RecipeBook/RecipeBook.cs
+++ b/Scripts/Items/Books/SpecialScrollBooks/RecipeBook/RecipeBook.cs
@@ -454,7 +454,7 @@ namespace Server.Items
 
             list.Add(1158849, string.Format("{0}", Recipes.Sum(x => x.Amount))); // Recipes in book: ~1_val~
 
-            if (BookName != null && BookName.Length > 0)
+            if (!string.IsNullOrEmpty(BookName))
                 list.Add(1062481, BookName);
         }
 

--- a/Scripts/Items/Equipment/Spellbooks/Runebook.cs
+++ b/Scripts/Items/Equipment/Spellbooks/Runebook.cs
@@ -279,7 +279,7 @@ namespace Server.Items
             if (m_Crafter != null)
                 list.Add(1050043, m_Crafter.TitleName); // crafted by ~1_NAME~
 
-            if (m_Description != null && m_Description.Length > 0)
+            if (!string.IsNullOrEmpty(m_Description))
                 list.Add(m_Description);
         }
 

--- a/Scripts/Services/BulkOrders/Books/BulkOrderBook.cs
+++ b/Scripts/Services/BulkOrders/Books/BulkOrderBook.cs
@@ -280,7 +280,7 @@ namespace Server.Engines.BulkOrders
 
             list.Add(1062344, m_Entries.Count.ToString()); // Deeds in book: ~1_val~
 
-            if (m_BookName != null && m_BookName.Length > 0)
+            if (!string.IsNullOrEmpty(m_BookName))
                 list.Add(1062481, m_BookName); // Book Name: ~1_val~
         }
 

--- a/Scripts/Services/Dungeons/Shadowguard/Addons/ArmoryAddon.cs
+++ b/Scripts/Services/Dungeons/Shadowguard/Addons/ArmoryAddon.cs
@@ -1181,7 +1181,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/Dungeons/Shadowguard/Addons/BarAddon.cs
+++ b/Scripts/Services/Dungeons/Shadowguard/Addons/BarAddon.cs
@@ -915,7 +915,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/FireCasino/TentBrownAddon.cs
+++ b/Scripts/Services/FireCasino/TentBrownAddon.cs
@@ -121,7 +121,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/FireCasino/TentWhiteAddon.cs
+++ b/Scripts/Services/FireCasino/TentWhiteAddon.cs
@@ -134,7 +134,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/New Magincia/Distillation/Items/BottleOfLiquor.cs
+++ b/Scripts/Services/New Magincia/Distillation/Items/BottleOfLiquor.cs
@@ -40,7 +40,7 @@ namespace Server.Engines.Distillation
 
         public override void AddNameProperty(ObjectPropertyList list)
         {
-            if (m_Label != null && m_Label.Length > 0)
+            if (!string.IsNullOrEmpty(m_Label))
                 list.Add(1049519, m_Label); // a bottle of ~1_DRINK_NAME~
             else
                 list.Add(1049519, string.Format("#{0}", DistillationSystem.GetLabel(m_Liquor, m_IsStrong))); // a bottle of ~1_DRINK_NAME~

--- a/Scripts/Services/New Magincia/Magincia Bazaar/Core/BrokerEntries.cs
+++ b/Scripts/Services/New Magincia/Magincia Bazaar/Core/BrokerEntries.cs
@@ -176,7 +176,7 @@ namespace Server.Engines.NewMagincia
 
         public static void AddToBuffer(Type type, string s)
         {
-            if (s != null && s.Length > 0 && !m_NameBuffer.ContainsKey(type))
+            if (!string.IsNullOrEmpty(s) && !m_NameBuffer.ContainsKey(type))
                 m_NameBuffer[type] = s;
         }
 

--- a/Scripts/Services/Seasonal Events/ForsakenFoes/Addon/BlackthornEntry.cs
+++ b/Scripts/Services/Seasonal Events/ForsakenFoes/Addon/BlackthornEntry.cs
@@ -21,7 +21,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/Seasonal Events/JollyRoger/Addons/AdmiralJacksShipwreckAddon.cs
+++ b/Scripts/Services/Seasonal Events/JollyRoger/Addons/AdmiralJacksShipwreckAddon.cs
@@ -658,7 +658,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/Seasonal Events/JollyRoger/Addons/CastleAddon.cs
+++ b/Scripts/Services/Seasonal Events/JollyRoger/Addons/CastleAddon.cs
@@ -852,7 +852,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;
@@ -1852,7 +1852,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;
@@ -1981,7 +1981,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;
@@ -2189,7 +2189,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/Seasonal Events/JollyRoger/Addons/IversRoundingAddon.cs
+++ b/Scripts/Services/Seasonal Events/JollyRoger/Addons/IversRoundingAddon.cs
@@ -431,7 +431,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/Seasonal Events/RisingTide/PlunderBeaconAddon.cs
+++ b/Scripts/Services/Seasonal Events/RisingTide/PlunderBeaconAddon.cs
@@ -429,7 +429,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/KhaldunCampAddon.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/KhaldunCampAddon.cs
@@ -94,7 +94,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/KhaldunEntranceAddon.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/KhaldunEntranceAddon.cs
@@ -65,7 +65,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/Items/DecorationAddon.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/Items/DecorationAddon.cs
@@ -276,7 +276,7 @@ namespace Server.Items
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/Seasonal Events/TreasuresOfKotlCity/Items/KotlWallAddon.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKotlCity/Items/KotlWallAddon.cs
@@ -65,7 +65,7 @@ namespace Server.Engines.TreasuresOfKotlCity
         {
             AddonComponent ac;
             ac = new AddonComponent(item);
-            if (name != null && name.Length > 0)
+            if (!string.IsNullOrEmpty(name))
                 ac.Name = name;
             if (hue != 0)
                 ac.Hue = hue;

--- a/Scripts/Services/XmlSpawner/XmlSpawner2.cs
+++ b/Scripts/Services/XmlSpawner/XmlSpawner2.cs
@@ -3401,7 +3401,7 @@ namespace Server.Mobiles
         public static void XmlLoadDefaults(string filePath, Mobile m)
         {
             if (m == null || m.Deleted) return;
-            if (filePath != null && filePath.Length >= 1)
+            if (!string.IsNullOrEmpty(filePath))
             {
 
                 if (File.Exists(filePath))


### PR DESCRIPTION
Hello,

This pull request is very simple and aims to reduce the technical debt. It specifically targets the "String.IsNullOrEmpty should be used" [rule](https://rules.sonarsource.com/csharp/RSPEC-3256) in SonarQube.

Let me know if you are interested in similar contributions.

Best,
Martin