### PR TITLE
Update Mobile.cs

### DIFF
--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -11781,7 +11781,7 @@ namespace Server
 		/// <param name="from"></param>
 		public virtual void OnStatsQuery(Mobile from)
 		{
-			if (from.Map == Map && Utility.InUpdateRange(this, from) && from.CanSee(this))
+			if (from.Map == Map && Utility.InUpdateRange(from, this) && from.CanSee(this))
 			{
 				from.Send(new MobileStatus(from, this));
 			}


### PR DESCRIPTION
https://github.com/ServUO/ServUO/issues/4947
Fixes this issue.

Tested in various situations and deployed on Heritage already. No issues noted with ~50 players on.

https://github.com/runuo/runuo/blob/master/Server/Mobile.cs
It appears the logic was always reversed. However, since screen sizes were still mostly limited during early RunUO it makes sense it was never caught as a size of 18 returns normal function regardless.