### PR TITLE
MannequinFixes

### DIFF
--- a/Scripts/Mobiles/NPCs/Mannequin/BaseProperty.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/BaseProperty.cs
@@ -12,7 +12,7 @@ namespace Server.Mobiles
         Casting = 5,
         Misc = 6,
         HitEffects = 7,
-        SkillBonusGear = 8,
+        SkillBonusGear = 8
     }
 
     public abstract class Property
@@ -20,11 +20,11 @@ namespace Server.Mobiles
         public abstract int LabelNumber { get; }
         public abstract Catalog Catalog { get; }
         public virtual int Order { get; } = 1000;
-        public virtual int Cap { get; set; } = 0;
+        public virtual int Cap { get; set; }
         public virtual int Description { get; set; }
 
         public virtual bool IsBoolen => false;
-        public virtual bool BoolenValue => false;
+        public virtual bool IsMagical => false;
         public virtual bool AlwaysVisible => false;
 
         public virtual bool IsSpriteGraph => false;
@@ -45,9 +45,9 @@ namespace Server.Mobiles
 
     public class LabelDefinition
     {
-        public int TitleLabel { get; set; }
-        public Catalog Catalog { get; set; }
-        public int ColumnLeftCount { get; set; }
+        public int TitleLabel { get; }
+        public Catalog Catalog { get; }
+        public int ColumnLeftCount { get; }
 
         public LabelDefinition(int tl, Catalog ctlg, int cl = 0)
         {

--- a/Scripts/Mobiles/NPCs/Mannequin/Gumps.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Gumps.cs
@@ -13,10 +13,25 @@ namespace Server.Gumps
         public MannequinCompareGump(Mannequin mann, Item item)
             : base(100, 100)
         {
-            _SameItem = mann.Items.Where(x => mann.LayerValidation(x, item)).FirstOrDefault();
+            Item matches = null;
+
+            for (var index = 0; index < mann.Items.Count; index++)
+            {
+                var x = mann.Items[index];
+
+                if (mann.LayerValidation(x, item))
+                {
+                    matches = x;
+                    break;
+                }
+            }
+
+            _SameItem = matches;
 
             if (_SameItem == null)
+            {
                 return;
+            }
 
             AddPage(0);
 
@@ -39,18 +54,18 @@ namespace Server.Gumps
 
                 if (EquipmentItem[i].IsSpriteGraph)
                 {
-                    AddSpriteImage(5 + (35 * si), 41, 0x9D3B, EquipmentItem[i].SpriteW, EquipmentItem[i].SpriteH, 30, 30);
+                    AddSpriteImage(5 + 35 * si, 41, 0x9D3B, EquipmentItem[i].SpriteW, EquipmentItem[i].SpriteH, 30, 30);
                     AddTooltip(EquipmentItem[i].LabelNumber);
 
                     si++;
                 }
                 else
                 {
-                    AddHtmlLocalized(45, 94 + (18 * i), 140, 18, EquipmentItem[i].LabelNumber, EquipmentItem[i].Hue, false, false);
+                    AddHtmlLocalized(45, 94 + 18 * i, 140, 18, EquipmentItem[i].LabelNumber, EquipmentItem[i].Hue, false, false);
                     AddTooltip(EquipmentItem[i].Description);
 
                     if (!EquipmentItem[i].IsBoolen)
-                        AddHtml(190, 94 + (18 * i), 100, 18, Color(EquipmentItem[i].Value, EquipmentItem[i].Cap), false, false);
+                        AddHtml(190, 94 + 18 * i, 100, 18, Color(EquipmentItem[i].Value, EquipmentItem[i].Cap), false, false);
                 }
             }
 
@@ -63,30 +78,38 @@ namespace Server.Gumps
             for (int i = 0; i < SelectItem.Count; i++)
             {
                 if (SelectItem[i].LabelNumber == 1159280) // Medable Armor - not appear
+                {
                     continue;
+                }
 
                 if (SelectItem[i].IsSpriteGraph)
                 {
-                    AddSpriteImage(275 + (35 * si), 41, 0x9D3B, SelectItem[i].SpriteW, SelectItem[i].SpriteH, 30, 30);
+                    AddSpriteImage(275 + 35 * si, 41, 0x9D3B, SelectItem[i].SpriteW, SelectItem[i].SpriteH, 30, 30);
                     AddTooltip(SelectItem[i].LabelNumber);
 
                     si++;
                 }
                 else
                 {
-                    AddHtmlLocalized(315, 94 + (18 * i), 140, 18, SelectItem[i].LabelNumber, SelectItem[i].Hue, false, false);
+                    AddHtmlLocalized(315, 94 + 18 * i, 140, 18, SelectItem[i].LabelNumber, SelectItem[i].Hue, false, false);
                     AddTooltip(SelectItem[i].Description);
 
                     if (!SelectItem[i].IsBoolen)
                     {
                         double ev = 0;
 
-                        if (EquipmentItem.Any(a => a.LabelNumber == SelectItem[i].LabelNumber))
+                        for (var index = 0; index < EquipmentItem.Count; index++)
                         {
-                            ev = EquipmentItem.Find(a => a.LabelNumber == SelectItem[i].LabelNumber).Value;
+                            var a1 = EquipmentItem[index];
+
+                            if (a1.LabelNumber == SelectItem[i].LabelNumber)
+                            {
+                                ev = EquipmentItem.Find(a => a.LabelNumber == SelectItem[i].LabelNumber).Value;
+                                break;
+                            }
                         }
 
-                        AddHtml(460, 94 + (18 * i), 100, 18, Color(SelectItem[i].Value, SelectItem[i].Cap, ev), false, false);
+                        AddHtml(460, 94 + 18 * i, 100, 18, Color(SelectItem[i].Value, SelectItem[i].Cap, ev), false, false);
                     }
                 }
             }
@@ -102,30 +125,30 @@ namespace Server.Gumps
             {
                 if (v1 == diffv || diffv == 0)
                 {
-                    name = string.Format("<BASEFONT COLOR=#FFFFFF>{0}</BASEFONT>", v1);
+                    name = $"<BASEFONT COLOR=#FFFFFF>{v1}</BASEFONT>";
                 }
                 else if (v1 > ev)
                 {
-                    name = string.Format("<BASEFONT COLOR=#008000>{0} (+{1})</BASEFONT>", v1, diffv);
+                    name = $"<BASEFONT COLOR=#008000>{v1} (+{diffv})</BASEFONT>";
                 }
                 else
                 {
-                    name = string.Format("<BASEFONT COLOR=#800000>{0} ({1})</BASEFONT>", v1, diffv);
+                    name = $"<BASEFONT COLOR=#800000>{v1} ({diffv})</BASEFONT>";
                 }
             }
             else
             {
                 if (v1 == diffv || diffv == 0)
                 {
-                    name = string.Format("<BASEFONT COLOR=#FFFFFF>{0}/{1}</BASEFONT>", v1, v2);
+                    name = $"<BASEFONT COLOR=#FFFFFF>{v1}/{v2}</BASEFONT>";
                 }
                 else if (v1 > ev)
                 {
-                    name = string.Format("<BASEFONT COLOR=#008000>{0}/{1} (+{2})</BASEFONT>", v1, v2, diffv);
+                    name = $"<BASEFONT COLOR=#008000>{v1}/{v2} (+{diffv})</BASEFONT>";
                 }
                 else
                 {
-                    name = string.Format("<BASEFONT COLOR=#800000>{0}/{1} ({2})</BASEFONT>", v1, v2, diffv);
+                    name = $"<BASEFONT COLOR=#800000>{v1}/{v2} ({diffv})</BASEFONT>";
                 }
             }
 
@@ -139,26 +162,26 @@ namespace Server.Gumps
         private readonly Item _SameItem;
         private readonly Item _Item;
 
-        public LabelDefinition[] Page1 = new LabelDefinition[]
+        public LabelDefinition[] Page1 =
         {
             new LabelDefinition(1049593, Catalog.Attributes, 5),    // Attributes
             new LabelDefinition(1061645, Catalog.Resistances, 5),   // Resistances
-            new LabelDefinition(1077417, Catalog.Combat1, 8),       // Combat
+            new LabelDefinition(1077417, Catalog.Combat1, 8)        // Combat
         };
 
-        public LabelDefinition[] Page2 = new LabelDefinition[]
+        public LabelDefinition[] Page2 =
         {
-            new LabelDefinition(1077417, Catalog.Combat2, 3),       // Combat
+            new LabelDefinition(1077417, Catalog.Combat2, 3),    // Combat
             new LabelDefinition(1076209, Catalog.Casting),          // Casting
             new LabelDefinition(1044050, Catalog.Misc),             // Miscellaneous
             new LabelDefinition(1114251, Catalog.HitEffects),       // Hit Effects
-            new LabelDefinition(1155065, Catalog.SkillBonusGear),   // Skill Bonus Gear
+            new LabelDefinition(1155065, Catalog.SkillBonusGear)    // Skill Bonus Gear
         };
 
         public class ItemPropDefinition
         {
-            public List<ValuedProperty> SelectItem { get; set; }
-            public List<ValuedProperty> EquipmentItem { get; set; }
+            public List<ValuedProperty> SelectItem { get; }
+            public List<ValuedProperty> EquipmentItem { get; }
 
             public ItemPropDefinition(Item tl, Item ctlg)
             {
@@ -187,13 +210,26 @@ namespace Server.Gumps
             AddAlphaRegion(5, 5, 594, 810);
             AddHtmlLocalized(10, 10, 584, 18, 1114513, "#1159279", 0x43F7, false, false); // <DIV ALIGN=CENTER>~1_TOKEN~</DIV>
 
-            List<ValuedProperty> lm = null;
+            List<ValuedProperty> lm;
             List<ItemPropDefinition> CompareItem = null;
-            List<Item> list = null;
+            List<Item> list;
 
             if (_Item != null)
             {
-                _SameItem = _Mannequin.Items.FirstOrDefault(x => _Mannequin.LayerValidation(x, item));
+                Item sameItem = null;
+
+                for (var index = 0; index < _Mannequin.Items.Count; index++)
+                {
+                    var x = _Mannequin.Items[index];
+
+                    if (_Mannequin.LayerValidation(x, item))
+                    {
+                        sameItem = x;
+                        break;
+                    }
+                }
+
+                _SameItem = sameItem;
 
                 if (_SameItem != null)
                 {
@@ -202,36 +238,57 @@ namespace Server.Gumps
                         new ItemPropDefinition(_Item, _SameItem)
                     };
 
-                    list = _Mannequin.Items.Where(x => x != _SameItem).ToList();
+                    list = new List<Item>();
+
+                    for (var index = 0; index < _Mannequin.Items.Count; index++)
+                    {
+                        var x = _Mannequin.Items[index];
+
+                        if (x != _SameItem) list.Add(x);
+                    }
+
                     list.Add(_Item);
                 }
                 else
                 {
-                    list = _Mannequin.Items.ToList();
+                    list = new List<Item>();
+
+                    for (var index = 0; index < _Mannequin.Items.Count; index++)
+                    {
+                        var mannequinItem = _Mannequin.Items[index];
+
+                        list.Add(mannequinItem);
+                    }
+
                     list.Add(_Item);
                 }
-
-                lm = Mannequin.GetProperty(list);
             }
             else
             {
-                lm = Mannequin.GetProperty(_Mannequin.Items);
+                list = _Mannequin.Items;
             }
 
+            lm = Mannequin.GetProperty(list);
 
             AddHtmlLocalized(479, 10, 75, 18, 1114514, "#1158215", 0x42FF, false, false); // <DIV ALIGN=RIGHT>~1_TOKEN~</DIV>
 
             if (page > 0)
+            {
                 AddButton(554, 10, 0x15E3, 0x15E7, 1000, GumpButtonType.Reply, 0); // Next Page Button
+            }
             else
+            {
                 AddButton(554, 10, 0x15E1, 0x15E5, 1001, GumpButtonType.Reply, 0); // Previous Page Button
+            }
 
             int y = 0;
 
             LabelDefinition[] pages = page > 0 ? Page2 : Page1;
 
-            pages.ToList().ForEach(x =>
+            for (var index = 0; index < pages.ToList().Count; index++)
             {
+                var x = pages.ToList()[index];
+
                 y += 28;
 
                 if (lm.Any(l => l.Catalog == x.Catalog))
@@ -241,9 +298,10 @@ namespace Server.Gumps
 
                     y += 32;
 
-                    List<ValuedProperty> cataloglist = lm.Where(i => i.Catalog == x.Catalog).OrderBy(ii => ii.Order).ToList();
+                    List<ValuedProperty> cataloglist =
+                        lm.Where(i => i.Catalog == x.Catalog).OrderBy(ii => ii.Order).ToList();
 
-                    int columncount = x.ColumnLeftCount == 0 ? (int)Math.Ceiling(cataloglist.Count / (decimal)2) : x.ColumnLeftCount;
+                    int columncount = x.ColumnLeftCount == 0 ? (int) Math.Ceiling(cataloglist.Count / (decimal) 2) : x.ColumnLeftCount;
 
                     for (int i = 0; i < cataloglist.Count; i++)
                     {
@@ -255,14 +313,15 @@ namespace Server.Gumps
                             AddSpriteImage(10, y - 5, 0x9D3B, cataloglist[i].SpriteW, cataloglist[i].SpriteH, 30, 30);
                             AddTooltip(cataloglist[i].Description);
 
-                            if (cataloglist[i].IsBoolen)
+                            if (cataloglist[i].LabelNumber == 1159280) // Medable Armor
                             {
-                                if (cataloglist[i].BoolenValue)
+                                if (cataloglist[i].Matches(list))
                                 {
-                                    if (cataloglist[i].Value > 0)
-                                        AddHtmlLocalized(195, y, 100, 18, 1046362, 0x42FF, false, false); // Yes
-                                    else
-                                        AddHtmlLocalized(195, y, 100, 18, 1046363, 0x42FF, false, false); // No
+                                    AddHtmlLocalized(195, y, 100, 18, 1046362, 0x42FF, false, false); // Yes
+                                }
+                                else
+                                {
+                                    AddHtmlLocalized(195, y, 100, 18, 1046363, 0x42FF, false, false); // No
                                 }
                             }
                             else
@@ -273,14 +332,18 @@ namespace Server.Gumps
                         else
                         {
                             if (i == columncount)
+                            {
                                 y -= i * 30;
+                            }
 
                             AddHtmlLocalized(342, y, 200, 18, label, 0x560A, false, false);
                             AddSpriteImage(307, y - 5, 0x9D3B, cataloglist[i].SpriteW, cataloglist[i].SpriteH, 30, 30);
                             AddTooltip(cataloglist[i].Description);
 
                             if (!cataloglist[i].IsBoolen)
+                            {
                                 AddHtml(492, y, 100, 18, Color(cataloglist[i].Value, GetItemValue(CompareItem, label), cataloglist[i].Cap), false, false);
+                            }
                         }
 
                         y += 30;
@@ -288,24 +351,62 @@ namespace Server.Gumps
 
                     y += 3;
                 }
-            });
+            }
         }
 
         public double GetItemValue(List<ItemPropDefinition> list, int label)
         {
             if (list == null)
+            {
                 return 0;
+            }
 
             ItemPropDefinition l = list.FirstOrDefault();
 
             double v1 = 0;
             double v2 = 0;
 
-            if (l.EquipmentItem.Any(r => r.LabelNumber == label))
-                v1 = l.EquipmentItem.Where(r => r.LabelNumber == label).FirstOrDefault().Value;
+            if (l != null && l.EquipmentItem.Any(r => r.LabelNumber == label))
+            {
+                ValuedProperty first = null;
 
-            if (l.SelectItem.Any(r => r.LabelNumber == label))
-                v2 = l.SelectItem.Where(r => r.LabelNumber == label).FirstOrDefault().Value;
+                for (var index = 0; index < l.EquipmentItem.Count; index++)
+                {
+                    var r = l.EquipmentItem[index];
+
+                    if (r.LabelNumber == label)
+                    {
+                        first = r;
+                        break;
+                    }
+                }
+
+                if (first != null)
+                {
+                    v1 = first.Value;
+                }
+            }
+
+            if (l != null && l.SelectItem.Any(r => r.LabelNumber == label))
+            {
+                ValuedProperty first = null;
+
+                for (var index = 0; index < l.SelectItem.Count; index++)
+                {
+                    var r = l.SelectItem[index];
+
+                    if (r.LabelNumber == label)
+                    {
+                        first = r;
+                        break;
+                    }
+                }
+
+                if (first != null)
+                {
+                    v2 = first.Value;
+                }
+            }
 
             return v2 - v1;
         }
@@ -318,33 +419,33 @@ namespace Server.Gumps
             {
                 if (parmv == 0)
                 {
-                    name = string.Format("<BASEFONT COLOR=#80BFFF>{0}</BASEFONT>", ev);
+                    name = $"<BASEFONT COLOR=#80BFFF>{ev}</BASEFONT>";
                 }
                 else
                 {
-                    name = string.Format("<BASEFONT COLOR=#80BFFF>{0}/{1}</BASEFONT>", ev, parmv);
+                    name = $"<BASEFONT COLOR=#80BFFF>{ev}/{parmv}</BASEFONT>";
                 }
             }
             else if (diff < 0)
             {
                 if (parmv == 0)
                 {
-                    name = string.Format("<BASEFONT COLOR=#800000>{0} (-{1})</BASEFONT>", ev, Math.Abs(diff));
+                    name = $"<BASEFONT COLOR=#800000>{ev} (-{Math.Abs(diff)})</BASEFONT>";
                 }
                 else
                 {
-                    name = string.Format("<BASEFONT COLOR=#800000>{0}/{1} (-{2})</BASEFONT>", ev, parmv, Math.Abs(diff));
+                    name = $"<BASEFONT COLOR=#800000>{ev}/{parmv} (-{Math.Abs(diff)})</BASEFONT>";
                 }
             }
             else
             {
                 if (parmv == 0)
                 {
-                    name = string.Format("<BASEFONT COLOR=#008000>{0} (+{1})</BASEFONT>", ev, diff);
+                    name = $"<BASEFONT COLOR=#008000>{ev} (+{diff})</BASEFONT>";
                 }
                 else
                 {
-                    name = string.Format("<BASEFONT COLOR=#008000>{0}/{1} (+{2})</BASEFONT>", ev, parmv, diff);
+                    name = $"<BASEFONT COLOR=#008000>{ev}/{parmv} (+{diff})</BASEFONT>";
                 }
             }
 

--- a/Scripts/Mobiles/NPCs/Mannequin/Mannequin.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Mannequin.cs
@@ -132,11 +132,11 @@ namespace Server.Mobiles
             }
         }
 
-        private readonly List<Layer> SameLayers = new List<Layer>()
+        private readonly List<Layer> SameLayers = new List<Layer>
         {
             Layer.FirstValid,
             Layer.OneHanded,
-            Layer.TwoHanded,
+            Layer.TwoHanded
         };
 
         public bool CheckSameLayer(Item i1, Item i2)
@@ -161,48 +161,101 @@ namespace Server.Mobiles
 
         public static List<ValuedProperty> FindItemsProperty(List<Item> item)
         {
-            List<Type> ll = System.Reflection.Assembly.GetExecutingAssembly().GetTypes()
-              .ToList().Where(r => r.FullName.Contains("MannequinProperty") && r.IsClass == true && r.IsAbstract == false).ToList();
+            List<Type> ll = new List<Type>();
+
+            var rs = System.Reflection.Assembly.GetExecutingAssembly().GetTypes();
+
+            for (var index = 0; index < rs.Length; index++)
+            {
+                var r = rs[index];
+
+                if (r.FullName != null && r.FullName.Contains("MannequinProperty") && r.IsClass && !r.IsAbstract)
+                {
+                    ll.Add(r);
+                }
+            }
 
             List<ValuedProperty> cat = new List<ValuedProperty>();
 
-            ll.ForEach(x =>
+            for (var index = 0; index < ll.Count; index++)
             {
+                var x = ll[index];
+
                 object CI = Activator.CreateInstance(Type.GetType(x.FullName));
 
-                if (CI is ValuedProperty)
+                if (CI is ValuedProperty p && (p.Matches(item) || p.AlwaysVisible))
                 {
-                    ValuedProperty p = CI as ValuedProperty;
-
-                    if (p.Matches(item) || p.AlwaysVisible)
-                        cat.Add(p);
+                    cat.Add(p);
                 }
-            });
+            }
 
             return cat;
         }
 
         public static List<ValuedProperty> FindItemProperty(Item item, bool visible = false)
         {
-            List<Type> ll = System.Reflection.Assembly.GetExecutingAssembly().GetTypes()
-              .ToList().Where(r => r.FullName.Contains("MannequinProperty") && r.IsClass == true && r.IsAbstract == false).ToList();
+            List<Type> ll = new List<Type>();
+
+            var rs = System.Reflection.Assembly.GetExecutingAssembly().GetTypes();
+
+            for (var index = 0; index < rs.Length; index++)
+            {
+                var r = rs[index];
+
+                if (r.FullName != null && r.FullName.Contains("MannequinProperty") && r.IsClass && !r.IsAbstract)
+                {
+                    ll.Add(r);
+                }
+            }
 
             List<ValuedProperty> cat = new List<ValuedProperty>();
 
-            ll.ForEach(x =>
+            for (var index = 0; index < ll.Count; index++)
             {
+                var x = ll[index];
+
                 object CI = Activator.CreateInstance(Type.GetType(x.FullName));
 
-                if (CI is ValuedProperty)
+                if (CI is ValuedProperty p && (p.Matches(item) || visible && p.AlwaysVisible))
                 {
-                    ValuedProperty p = CI as ValuedProperty;
-
-                    if (p.Matches(item) || visible && p.AlwaysVisible)
-                        cat.Add(p);
+                    cat.Add(p);
                 }
-            });
+            }
 
             return cat.OrderByDescending(x => x.Hue).ToList();
+        }
+
+        public static List<ValuedProperty> FindMagicalItemProperty(Item item)
+        {
+            List<Type> ll = new List<Type>();
+
+            var rs = System.Reflection.Assembly.GetExecutingAssembly().GetTypes();
+
+            for (var index = 0; index < rs.Length; index++)
+            {
+                var r = rs[index];
+
+                if (r.FullName != null && r.FullName.Contains("MannequinProperty") && r.IsClass && !r.IsAbstract)
+                {
+                    ll.Add(r);
+                }
+            }
+
+            List<ValuedProperty> cat = new List<ValuedProperty>();
+
+            for (var index = 0; index < ll.Count; index++)
+            {
+                var x = ll[index];
+
+                object CI = Activator.CreateInstance(Type.GetType(x.FullName));
+
+                if (CI is ValuedProperty p && p.Matches(item) && p.IsMagical)
+                {
+                    cat.Add(p);
+                }
+            }
+
+            return cat;
         }
 
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)
@@ -224,7 +277,7 @@ namespace Server.Mobiles
 
                 if (from.Alive && from.InRange(this, 2))
                 {
-                    if (from.Race == Race || (from.Race == Race.Elf && Race == Race.Human || from.Race == Race.Human && Race == Race.Elf))
+                    if (from.Race == Race || from.Race == Race.Elf && Race == Race.Human || from.Race == Race.Human && Race == Race.Elf)
                     {
                         list.Add(new SwitchClothesEntry(from, this));
                     }
@@ -244,15 +297,17 @@ namespace Server.Mobiles
 
             if (house != null)
             {
-                List<Item> toAdd = new List<Item>(mobile.Items.Where(i => IsEquipped(i)));
+                List<Item> toAdd = new List<Item>(mobile.Items.Where(IsEquipped));
 
                 if (mobile.Backpack != null)
                 {
                     toAdd.AddRange(mobile.Backpack.Items);
                 }
 
-                foreach (Item item in toAdd)
+                for (var index = 0; index < toAdd.Count; index++)
                 {
+                    Item item = toAdd[index];
+
                     house.DropToMovingCrate(item);
                 }
 
@@ -317,12 +372,13 @@ namespace Server.Mobiles
 
                 protected override void OnTarget(Mobile from, object targeted)
                 {
-                    if (targeted is Item)
-                        from.SendGump(new MannequinCompareGump(_Mannequin, (Item)targeted));
+                    if (targeted is Item item)
+                    {
+                        from.SendGump(new MannequinCompareGump(_Mannequin, item));
+                    }
                     else
                     {
-                        // TODO : Action
-                        // This was a temporary crash fix
+                        from.SendLocalizedMessage(1149667); // Invalid target.
                     }
 
                 }
@@ -359,8 +415,8 @@ namespace Server.Mobiles
 
                 protected override void OnTarget(Mobile from, object targeted)
                 {
-                    if (targeted is Item)
-                        from.SendGump(new MannequinStatsGump(_Mannequin, (Item)targeted));
+                    if (targeted is Item item)
+                        from.SendGump(new MannequinStatsGump(_Mannequin, item));
                 }
             }
         }
@@ -461,29 +517,58 @@ namespace Server.Mobiles
 
             public override void OnClick()
             {
-                _Mannequin.SwitchClothes(_From, _Mannequin);
+                if (!_From.HasTrade)
+                {
+                    _Mannequin.SwitchClothes(_From, _Mannequin);
+                }
+                else
+                {
+                    _From.SendLocalizedMessage(1004041); // You can't do that while you have a trade pending.
+                }
             }
         }
 
         public static bool IsEquipped(Item item)
         {
-            return item != null && item.Parent is Mobile && ((Mobile)item.Parent).FindItemOnLayer(item.Layer) == item &&
+            return item != null && item.Parent is Mobile mobile && mobile.FindItemOnLayer(item.Layer) == item &&
                    item.Layer != Layer.Mount && item.Layer != Layer.Bank &&
                    item.Layer != Layer.Invalid && item.Layer != Layer.Backpack && !(item is Backpack);
         }
 
         public void SwitchClothes(Mobile from, Mobile m)
         {
-            List<Item> MobileItems = from.Items.Where(x => IsEquipped(x)).ToList();
-            List<Item> MannequinItems = m.Items.Where(x => IsEquipped(x)).ToList();
+            List<Item> MobileItems = new List<Item>();
+            foreach (var item in from.Items.Where(IsEquipped))
+            {
+                MobileItems.Add(item);
+            }
 
-            MannequinItems.ForEach(x => m.RemoveItem(x));
-            MobileItems.ForEach(x => from.RemoveItem(x));
+            List<Item> MannequinItems = new List<Item>();
+            foreach (var item in m.Items.Where(IsEquipped))
+            {
+                MannequinItems.Add(item);
+            }
+
+            for (var index = 0; index < MannequinItems.Count; index++)
+            {
+                var mannequinItem = MannequinItems[index];
+
+                m.RemoveItem(mannequinItem);
+            }
+
+            for (var index = 0; index < MobileItems.Count; index++)
+            {
+                var mobileItem = MobileItems[index];
+
+                from.RemoveItem(mobileItem);
+            }
 
             List<Item> ExceptItems = new List<Item>();
 
-            MannequinItems.ForEach(x =>
+            for (var index = 0; index < MannequinItems.Count; index++)
             {
+                var x = MannequinItems[index];
+
                 if (x.CanEquip(from))
                 {
                     from.EquipItem(x);
@@ -492,10 +577,12 @@ namespace Server.Mobiles
                 {
                     ExceptItems.Add(x);
                 }
-            });
+            }
 
-            MobileItems.ForEach(x =>
+            for (var index = 0; index < MobileItems.Count; index++)
             {
+                var x = MobileItems[index];
+
                 if (x.CanEquip(m))
                 {
                     m.EquipItem(x);
@@ -504,11 +591,17 @@ namespace Server.Mobiles
                 {
                     ExceptItems.Add(x);
                 }
-            });
+            }
 
             if (ExceptItems.Count > 0)
             {
-                ExceptItems.ForEach(x => from.AddToBackpack(x));
+                for (var index = 0; index < ExceptItems.Count; index++)
+                {
+                    var x = ExceptItems[index];
+
+                    from.AddToBackpack(x);
+                }
+
                 from.SendLocalizedMessage(1151641, ExceptItems.Count.ToString(), 0x22); // ~1_COUNT~ items could not be swapped between you and the mannequin. These items are now in your backpack, or on the floor at your feet if your backpack is too full to hold them.
             }
 
@@ -555,8 +648,19 @@ namespace Server.Mobiles
 
             public override void OnClick()
             {
-                List<Item> mannequinItems = _Mannequin.Items.Where(x => IsEquipped(x)).ToList();
-                mannequinItems.ForEach(x => _From.AddToBackpack(x));
+                List<Item> mannequinItems = new List<Item>();
+
+                foreach (var item in _Mannequin.Items.Where(IsEquipped))
+                {
+                    mannequinItems.Add(item);
+                }
+
+                for (var index = 0; index < mannequinItems.Count; index++)
+                {
+                    var x = mannequinItems[index];
+
+                    _From.AddToBackpack(x);
+                }
 
                 _Mannequin.Delete();
 
@@ -587,13 +691,11 @@ namespace Server.Mobiles
                 case 1:
                     {
                         Description = reader.ReadString();
-
                         goto case 0;
                     }
                 case 0:
                     {
                         Owner = reader.ReadMobile();
-
                         break;
                     }
             }
@@ -657,7 +759,7 @@ namespace Server.Mobiles
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 }

--- a/Scripts/Mobiles/NPCs/Mannequin/Property/AbsorptionAttributeProperty.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Property/AbsorptionAttributeProperty.cs
@@ -5,29 +5,30 @@ namespace Server.Mobiles.MannequinProperty
 {
     public abstract class AbsorptionAttr : ValuedProperty
     {
+        public override bool IsMagical => true;
         public abstract SAAbsorptionAttribute Attribute { get; }
 
         public double GetPropertyValue(Item item)
         {
-            if (item is BaseArmor)
+            if (item is BaseArmor armor)
             {
-                return ((BaseArmor)item).AbsorptionAttributes[Attribute];
+                return armor.AbsorptionAttributes[Attribute];
             }
 
-            if (item is BaseJewel)
+            if (item is BaseJewel jewel)
             {
-                return ((BaseJewel)item).AbsorptionAttributes[Attribute];
+                return jewel.AbsorptionAttributes[Attribute];
             }
 
 
-            if (item is BaseWeapon)
+            if (item is BaseWeapon weapon)
             {
-                return ((BaseWeapon)item).AbsorptionAttributes[Attribute];
+                return weapon.AbsorptionAttributes[Attribute];
             }
 
-            if (item is BaseClothing)
+            if (item is BaseClothing clothing)
             {
-                return ((BaseClothing)item).SAAbsorptionAttributes[Attribute];
+                return clothing.SAAbsorptionAttributes[Attribute];
             }
 
             return 0;

--- a/Scripts/Mobiles/NPCs/Mannequin/Property/AosArmorAttributeProperty.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Property/AosArmorAttributeProperty.cs
@@ -5,18 +5,19 @@ namespace Server.Mobiles.MannequinProperty
 {
     public abstract class AosArmorAttr : ValuedProperty
     {
+        public override bool IsMagical => true;
         public abstract AosArmorAttribute Attribute { get; }
 
         public double GetPropertyValue(Item item)
         {
-            if (item is BaseArmor)
+            if (item is BaseArmor armor)
             {
-                return ((BaseArmor)item).ArmorAttributes[Attribute];
+                return armor.ArmorAttributes[Attribute];
             }
 
-            if (item is BaseClothing)
+            if (item is BaseClothing clothing)
             {
-                return ((BaseClothing)item).ClothingAttributes[Attribute];
+                return clothing.ClothingAttributes[Attribute];
             }
 
             return 0;
@@ -84,5 +85,12 @@ namespace Server.Mobiles.MannequinProperty
         public override int Hue => 0x1FF;
         public override int SpriteW => 240;
         public override int SpriteH => 60;
+    }
+
+    public class MageArmorProperty : AosArmorAttr
+    {
+        public override Catalog Catalog => Catalog.None;
+        public override int LabelNumber => 1079758;  // Mage Armor
+        public override AosArmorAttribute Attribute => AosArmorAttribute.MageArmor;
     }
 }

--- a/Scripts/Mobiles/NPCs/Mannequin/Property/AosAttributeProperty.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Property/AosAttributeProperty.cs
@@ -5,48 +5,49 @@ namespace Server.Mobiles.MannequinProperty
 {
     public abstract class MagicalAttr : ValuedProperty
     {
+        public override bool IsMagical => true;
         public abstract AosAttribute Attribute { get; }
 
         public double GetPropertyValue(Item item)
         {
-            if (item is BaseWeapon)
+            if (item is BaseWeapon weapon)
             {
-                return ((BaseWeapon)item).Attributes[Attribute];
+                return weapon.Attributes[Attribute];
             }
 
-            if (item is BaseArmor)
+            if (item is BaseArmor armor)
             {
-                return ((BaseArmor)item).Attributes[Attribute];
+                return armor.Attributes[Attribute];
             }
 
-            if (item is BaseClothing)
+            if (item is BaseClothing clothing)
             {
-                return ((BaseClothing)item).Attributes[Attribute];
+                return clothing.Attributes[Attribute];
             }
 
-            if (item is BaseJewel)
+            if (item is BaseJewel jewel)
             {
-                return ((BaseJewel)item).Attributes[Attribute];
+                return jewel.Attributes[Attribute];
             }
 
-            if (item is BaseTalisman)
+            if (item is BaseTalisman talisman)
             {
-                return ((BaseTalisman)item).Attributes[Attribute];
+                return talisman.Attributes[Attribute];
             }
 
-            if (item is BaseQuiver)
+            if (item is BaseQuiver quiver)
             {
-                return ((BaseQuiver)item).Attributes[Attribute];
+                return quiver.Attributes[Attribute];
             }
 
-            if (item is Spellbook)
+            if (item is Spellbook spellbook)
             {
-                return ((Spellbook)item).Attributes[Attribute];
+                return spellbook.Attributes[Attribute];
             }
 
-            if (item is FishingPole)
+            if (item is FishingPole pole)
             {
-                return ((FishingPole)item).Attributes[Attribute];
+                return pole.Attributes[Attribute];
             }
 
             return 0;

--- a/Scripts/Mobiles/NPCs/Mannequin/Property/ExtendedWeaponAttribute.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Property/ExtendedWeaponAttribute.cs
@@ -5,11 +5,12 @@ namespace Server.Mobiles.MannequinProperty
 {
     public abstract class ExtendedWeaponAttr : ValuedProperty
     {
+        public override bool IsMagical => true;
         public abstract ExtendedWeaponAttribute Attribute { get; }
 
         public double GetPropertyValue(Item item)
         {
-            return item is BaseWeapon ? ((BaseWeapon)item).ExtendedWeaponAttributes[Attribute] : 0;
+            return item is BaseWeapon weapon ? weapon.ExtendedWeaponAttributes[Attribute] : 0;
         }
 
         public override bool Matches(Item item)

--- a/Scripts/Mobiles/NPCs/Mannequin/Property/NegativeAttributeProperty.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Property/NegativeAttributeProperty.cs
@@ -4,11 +4,12 @@ namespace Server.Mobiles.MannequinProperty
 {
     public abstract class NegativeAttr : ValuedProperty
     {
+        public override bool IsMagical => true;
         public abstract NegativeAttribute Attribute { get; }
 
         public double GetPropertyValue(Item item)
         {
-            return item is BaseWeapon ? ((BaseWeapon)item).NegativeAttributes[Attribute] : 0;
+            return item is BaseWeapon weapon ? weapon.NegativeAttributes[Attribute] : 0;
         }
 
         public override bool Matches(Item item)

--- a/Scripts/Mobiles/NPCs/Mannequin/Property/OtherProperty.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Property/OtherProperty.cs
@@ -16,65 +16,46 @@ namespace Server.Mobiles.MannequinProperty
         {
             int prop, prop2;
 
-            if (item is BaseArmor)
+            if (item is BaseArmor armor && (prop = armor.HitPoints) >= 0 && (prop2 = armor.MaxHitPoints) > 0)
             {
-                if ((prop = ((BaseArmor)item).HitPoints) >= 0 && (prop2 = ((BaseArmor)item).MaxHitPoints) > 0)
-                {
-                    Value = prop;
-                    Cap = prop2;
-                    return true;
-                }
+                Value = prop;
+                Cap = prop2;
+                return true;
             }
 
-            if (item is BaseJewel)
+            if (item is BaseJewel jewel && (prop = jewel.HitPoints) >= 0 && (prop2 = jewel.MaxHitPoints) > 0)
             {
-                if ((prop = ((BaseJewel)item).HitPoints) >= 0 && (prop2 = ((BaseJewel)item).MaxHitPoints) > 0)
-                {
-                    Value = prop;
-                    Cap = prop2;
-                    return true;
-                }
+                Value = prop;
+                Cap = prop2;
+                return true;
             }
 
-
-            if (item is BaseWeapon)
+            if (item is BaseWeapon weapon && (prop = weapon.HitPoints) >= 0 && (prop2 = weapon.MaxHitPoints) > 0)
             {
-                if ((prop = ((BaseWeapon)item).HitPoints) >= 0 && (prop2 = ((BaseWeapon)item).MaxHitPoints) > 0)
-                {
-                    Value = prop;
-                    Cap = prop2;
-                    return true;
-                }
+                Value = prop;
+                Cap = prop2;
+                return true;
             }
 
-            if (item is BaseClothing)
+            if (item is BaseClothing clothing && (prop = clothing.HitPoints) >= 0 && (prop2 = clothing.MaxHitPoints) > 0)
             {
-                if ((prop = ((BaseClothing)item).HitPoints) >= 0 && (prop2 = ((BaseClothing)item).MaxHitPoints) > 0)
-                {
-                    Value = prop;
-                    Cap = prop2;
-                    return true;
-                }
+                Value = prop;
+                Cap = prop2;
+                return true;
             }
 
-            if (item is BaseTalisman)
+            if (item is BaseTalisman talisman && (prop = talisman.HitPoints) >= 0 && (prop2 = talisman.MaxHitPoints) > 0)
             {
-                if ((prop = ((BaseTalisman)item).HitPoints) >= 0 && (prop2 = ((BaseTalisman)item).MaxHitPoints) > 0)
-                {
-                    Value = prop;
-                    Cap = prop2;
-                    return true;
-                }
+                Value = prop;
+                Cap = prop2;
+                return true;
             }
 
-            if (item is Spellbook)
+            if (item is Spellbook spellbook && (prop = spellbook.HitPoints) >= 0 && (prop2 = spellbook.MaxHitPoints) > 0)
             {
-                if ((prop = ((Spellbook)item).HitPoints) >= 0 && (prop2 = ((Spellbook)item).MaxHitPoints) > 0)
-                {
-                    Value = prop;
-                    Cap = prop2;
-                    return true;
-                }
+                Value = prop;
+                Cap = prop2;
+                return true;
             }
 
             return false;
@@ -111,42 +92,54 @@ namespace Server.Mobiles.MannequinProperty
 
     public class MedableArmorProperty : ValuedProperty
     {
+        public override bool IsMagical => true;
         public override Catalog Catalog => Catalog.Combat1;
         public override int Order => 6;
         public override bool AlwaysVisible => true;
         public override bool IsBoolen => true;
-        public override bool BoolenValue => true;
         public override int LabelNumber => 1159280;  // Medable Armor
         public override int SpriteW => 0;
         public override int SpriteH => 150;
 
-        public double GetPropertyValue(Item item)
+        public bool CheckMedable(Item item)
         {
-            return item is BaseArmor ? RegenRates.GetArmorMeditationValue((BaseArmor)item) : 0;
+            if (item is BaseArmor armor)
+            {
+                if (armor.ArmorAttributes.MageArmor != 0 || armor.Attributes.SpellChanneling != 0)
+                {
+                    return true;
+                }
+
+                if (armor.DefMedAllowance != ArmorMeditationAllowance.None)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public override bool Matches(Item item)
         {
-            double total = GetPropertyValue(item);
-
-            if (total != 0)
-                return true;
-
-            return false;
+            return CheckMedable(item);
         }
 
         public override bool Matches(List<Item> items)
         {
-            double total = 0;
+            bool matches = false;
 
-            items.ForEach(x => total += GetPropertyValue(x));
-
-            if (total != 0)
+            for (var index = 0; index < items.Count; index++)
             {
-                return true;
+                var x = items[index];
+
+                if (!CheckMedable(x))
+                {
+                    matches = true;
+                    break;
+                }
             }
 
-            return false;
+            return !matches;
         }
     }
 
@@ -180,6 +173,7 @@ namespace Server.Mobiles.MannequinProperty
 
     public class DamageModifierProperty : ValuedProperty
     {
+        public override bool IsMagical => true;
         public override Catalog Catalog => Catalog.Misc;
         public override int LabelNumber => 1159401;  // Damage Modifier
         public override int Description => 1152402;  // This property provides an increase to the damage you inflict on a successful ranged weapon attack.  The bonus damage is applied to the net damage inflicted (after all damage and resistance calculations are made).  This property can only be found on certain quivers.
@@ -189,7 +183,7 @@ namespace Server.Mobiles.MannequinProperty
 
         public double GetPropertyValue(Item item)
         {
-            return item is BaseQuiver ? ((BaseQuiver)item).DamageIncrease : 0;
+            return item is BaseQuiver quiver ? quiver.DamageIncrease : 0;
         }
 
         public override bool Matches(Item item)
@@ -208,7 +202,12 @@ namespace Server.Mobiles.MannequinProperty
         {
             double total = 0;
 
-            items.ForEach(x => total += GetPropertyValue(x));
+            for (var index = 0; index < items.Count; index++)
+            {
+                var x = items[index];
+
+                total += GetPropertyValue(x);
+            }
 
             Value = total;
 
@@ -223,6 +222,7 @@ namespace Server.Mobiles.MannequinProperty
 
     public class ManaPhaseProperty : ValuedProperty
     {
+        public override bool IsMagical => true;
         public override Catalog Catalog => Catalog.Combat1;
         public override int Order => 10;
         public override bool IsBoolen => true;
@@ -243,10 +243,14 @@ namespace Server.Mobiles.MannequinProperty
 
         public override bool Matches(List<Item> items)
         {
-            foreach (Item i in items)
+            for (var index = 0; index < items.Count; index++)
             {
+                Item i = items[index];
+
                 if (GetPropertyValue(i))
+                {
                     return true;
+                }
             }
 
             return false;
@@ -255,6 +259,7 @@ namespace Server.Mobiles.MannequinProperty
 
     public class SearingWeaponProperty : ValuedProperty
     {
+        public override bool IsMagical => true;
         public override Catalog Catalog => Catalog.HitEffects;
         public override bool IsBoolen => true;
         public override int LabelNumber => 1151183;  // Searing Weapon
@@ -264,7 +269,7 @@ namespace Server.Mobiles.MannequinProperty
 
         public bool GetPropertyValue(Item item)
         {
-            return item is BaseWeapon && ((BaseWeapon)item).SearingWeapon;
+            return item is BaseWeapon weapon && weapon.SearingWeapon;
         }
 
         public override bool Matches(Item item)
@@ -274,10 +279,14 @@ namespace Server.Mobiles.MannequinProperty
 
         public override bool Matches(List<Item> items)
         {
-            foreach (Item i in items)
+            for (var index = 0; index < items.Count; index++)
             {
+                Item i = items[index];
+
                 if (GetPropertyValue(i))
+                {
                     return true;
+                }
             }
 
             return false;

--- a/Scripts/Mobiles/NPCs/Mannequin/Property/ResistProperty.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Property/ResistProperty.cs
@@ -5,6 +5,7 @@ namespace Server.Mobiles.MannequinProperty
 {
     public abstract class ResistAttr : ValuedProperty
     {
+        public override bool IsMagical => true;
         public override Catalog Catalog => Catalog.Resistances;
         public override bool AlwaysVisible => true;
         public abstract ResistanceType Resist { get; }
@@ -50,66 +51,66 @@ namespace Server.Mobiles.MannequinProperty
             {
                 case ResistanceType.Physical:
                     {
-                        if (item is BaseWeapon)
-                            return ((BaseWeapon)item).PhysicalResistance;
+                        if (item is BaseWeapon weapon)
+                            return weapon.PhysicalResistance;
 
-                        if (item is BaseArmor)
-                            return ((BaseArmor)item).PhysicalResistance;
+                        if (item is BaseArmor armor)
+                            return armor.PhysicalResistance;
 
-                        if (item is BaseClothing)
-                            return ((BaseClothing)item).PhysicalResistance;
+                        if (item is BaseClothing clothing)
+                            return clothing.PhysicalResistance;
 
                         break;
                     }
                 case ResistanceType.Fire:
                     {
-                        if (item is BaseWeapon)
-                            return ((BaseWeapon)item).FireResistance;
+                        if (item is BaseWeapon weapon)
+                            return weapon.FireResistance;
 
-                        if (item is BaseArmor)
-                            return ((BaseArmor)item).FireResistance;
+                        if (item is BaseArmor armor)
+                            return armor.FireResistance;
 
-                        if (item is BaseClothing)
-                            return ((BaseClothing)item).FireResistance;
+                        if (item is BaseClothing clothing)
+                            return clothing.FireResistance;
 
                         break;
                     }
                 case ResistanceType.Cold:
                     {
-                        if (item is BaseWeapon)
-                            return ((BaseWeapon)item).ColdResistance;
+                        if (item is BaseWeapon weapon)
+                            return weapon.ColdResistance;
 
-                        if (item is BaseArmor)
-                            return ((BaseArmor)item).ColdResistance;
+                        if (item is BaseArmor armor)
+                            return armor.ColdResistance;
 
-                        if (item is BaseClothing)
-                            return ((BaseClothing)item).ColdResistance;
+                        if (item is BaseClothing clothing)
+                            return clothing.ColdResistance;
 
                         break;
                     }
                 case ResistanceType.Poison:
                     {
-                        if (item is BaseWeapon)
-                            return ((BaseWeapon)item).PoisonResistance;
+                        if (item is BaseWeapon weapon)
+                            return weapon.PoisonResistance;
 
-                        if (item is BaseArmor)
-                            return ((BaseArmor)item).PoisonResistance;
+                        if (item is BaseArmor armor)
+                            return armor.PoisonResistance;
 
-                        if (item is BaseClothing)
-                            return ((BaseClothing)item).PoisonResistance;
+                        if (item is BaseClothing clothing)
+                            return clothing.PoisonResistance;
 
                         break;
                     }
                 case ResistanceType.Energy:
                     {
-                        if (item is BaseWeapon)
-                            return ((BaseWeapon)item).EnergyResistance;
+                        if (item is BaseWeapon weapon)
+                            return weapon.EnergyResistance;
 
-                        if (item is BaseArmor)
-                            return ((BaseArmor)item).EnergyResistance;
+                        if (item is BaseArmor armor)
+                            return armor.EnergyResistance;
 
-                        if (item is BaseClothing)
-                            return ((BaseClothing)item).EnergyResistance;
+                        if (item is BaseClothing clothing)
+                            return clothing.EnergyResistance;
 
                         break;
                     }

--- a/Scripts/Mobiles/NPCs/Mannequin/Property/SkillBonusAttribute.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Property/SkillBonusAttribute.cs
@@ -5,6 +5,7 @@ namespace Server.Mobiles.MannequinProperty
 {
     public abstract class SkillBonusAttr : ValuedProperty
     {
+        public override bool IsMagical => true;
         public override Catalog Catalog => Catalog.SkillBonusGear;
         public override int Description => 1159316;  // Increases your skill points in a particular skill, up to, but not exceeding your cap in that skill.
         public abstract SkillName Skill { get; }

--- a/Scripts/Mobiles/NPCs/Mannequin/Property/SlayerAttribute.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Property/SlayerAttribute.cs
@@ -5,6 +5,7 @@ namespace Server.Mobiles.MannequinProperty
 {
     public abstract class SlayerProperty : ValuedProperty
     {
+        public override bool IsMagical => true;
         public override Catalog Catalog => Catalog.HitEffects;
         public abstract SlayerName Slayer { get; }
         public override int Hue => 0x43FF;
@@ -15,7 +16,7 @@ namespace Server.Mobiles.MannequinProperty
 
         public override bool Matches(Item item)
         {
-            return item is ISlayer slayer ? slayer.Slayer == Slayer || slayer.Slayer2 == Slayer : false;
+            return item is ISlayer slayer && (slayer.Slayer == Slayer || slayer.Slayer2 == Slayer);
         }
 
         public override bool Matches(List<Item> items)
@@ -32,6 +33,7 @@ namespace Server.Mobiles.MannequinProperty
 
     public abstract class TalismanSlayerProperty : ValuedProperty
     {
+        public override bool IsMagical => true;
         public override Catalog Catalog => Catalog.HitEffects;
         public abstract TalismanSlayerName Slayer { get; }
         public override int Hue => 0x43FF;
@@ -41,7 +43,7 @@ namespace Server.Mobiles.MannequinProperty
 
         public override bool Matches(Item item)
         {
-            return item is BaseTalisman talisman ? talisman.Slayer == Slayer : false;
+            return item is BaseTalisman talisman && talisman.Slayer == Slayer;
         }
 
         public override bool Matches(List<Item> items)

--- a/Scripts/Mobiles/NPCs/Mannequin/Property/WeaponAttributeProperty.cs
+++ b/Scripts/Mobiles/NPCs/Mannequin/Property/WeaponAttributeProperty.cs
@@ -5,11 +5,12 @@ namespace Server.Mobiles.MannequinProperty
 {
     public abstract class WeaponAttr : ValuedProperty
     {
+        public override bool IsMagical => true;
         public abstract AosWeaponAttribute Attribute { get; }
 
         public double GetPropertyValue(Item item)
         {
-            return item is BaseWeapon ? ((BaseWeapon)item).WeaponAttributes[Attribute] : 0;
+            return item is BaseWeapon weapon ? weapon.WeaponAttributes[Attribute] : 0;
         }
 
         public override bool Matches(Item item)
@@ -323,6 +324,7 @@ namespace Server.Mobiles.MannequinProperty
 
     public abstract class ElementalDamageAttr : ValuedProperty
     {
+        public override bool IsMagical => true;
         public override Catalog Catalog => Catalog.Combat2;
         public override bool AlwaysVisible => true;
         public abstract AosElementAttribute Element { get; }
@@ -330,7 +332,7 @@ namespace Server.Mobiles.MannequinProperty
 
         public double GetPropertyValue(Item item)
         {
-            return item is BaseWeapon ? GetElementAttributeValue((BaseWeapon)item, Element) : 0;
+            return item is BaseWeapon weapon ? GetElementAttributeValue(weapon, Element) : 0;
         }
 
         public override bool Matches(Item item)
@@ -443,6 +445,7 @@ namespace Server.Mobiles.MannequinProperty
 
     public class VelocityProperty : ValuedProperty
     {
+        public override bool IsMagical => true;
         public override Catalog Catalog => Catalog.HitEffects;
         public override int LabelNumber => 1080416;  // Velocity
         public override int Description => 1152392;  // This property provides a chance for a ranged weapon to inflict additional damage.  The additional damage is increased by 3 points for each tile that the attacker is away from the target up to a maximum of 30 points of damage.  The damage inflicted is physical damage that can be lessened by a targets physical resistance.  This property can only be found on ranged weapons.
@@ -452,7 +455,7 @@ namespace Server.Mobiles.MannequinProperty
 
         public double GetPropertyValue(Item item)
         {
-            return item is BaseRanged ? ((BaseRanged)item).Velocity : 0;
+            return item is BaseRanged ranged ? ranged.Velocity : 0;
         }
 
         public override bool Matches(Item item)


### PR DESCRIPTION
All of this was taken from my TrueUO git.
History = https://github.com/TrueUO/TrueUO/commits/master/Scripts/Mobiles/NPCs/Mannequin

Fixes
1. Exploit where anyone can choose the Switch Clothes option, stealing anything on a Mannequin.
2. If you have a trade menu open and click on Switch Clothes, it ejects those items to 0,0,0 on that map.
3. Various crashes when comparing items to other items in slot.
4. Medable items when comparing never worked.