### PR TITLE
VendorSellCheckBuyPack

### DIFF
--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -1066,6 +1066,25 @@ namespace Server.Mobiles
                 return;
             }
 
+            Container cont = BuyPack;
+
+            List<Item> packItems = cont.Items;
+
+            for (int i = packItems.Count - 1; i >= 0; --i)
+            {
+	            if (i >= packItems.Count)
+	            {
+		            continue;
+	            }
+
+	            Item item = packItems[i];
+
+	            if (item.LastMoved + InventoryDecayTime <= DateTime.UtcNow)
+	            {
+		            item.Delete();
+	            }
+            }
+
             Container pack = from.Backpack;
 
             if (pack != null)


### PR DESCRIPTION
Vendors currently check to see if items should be deleted from their BuyPack every time someone uses the Buy option.

`if ((item.LastMoved + InventoryDecayTime) <= DateTime.UtcNow) { item.Delete(); }`

The problem is in some rare situations someone may only be selling items to a vendor, never using the buy option. Especially if this vendor is in the middle of nowhere it adds to item count unnecessarily. Some users have reported finding hundreds of thousands of items on an NPC, probably due to people macroing crafting skills.

If someone only ever sells and runs the item count to hundreds of thousands of items, there is a lag/delay once someone does finally come along and use the Buy option as now the server is deleting them and the client itself is flooded by the increase of item count for a brief moment.

This simply adds another check that also triggers every time someone goes to sell items to make sure we are keeping item count low. :)