### PR TITLE
RepairBenchFix

### DIFF
--- a/Scripts/Items/Addons/RepairBench.cs
+++ b/Scripts/Items/Addons/RepairBench.cs
@@ -450,7 +450,7 @@ namespace Server.Items
 
         public override void OnResponse(NetState sender, RelayInfo info)
         {
-            if (m_Addon == null || !m_Addon.Deleted)
+            if (m_Addon == null || m_Addon.Deleted)
                 return;
 
             Mobile m = sender.Mobile;


### PR DESCRIPTION
Changes this

`if (m_Addon == null || !m_Addon.Deleted)
                return;`

To this

`if (m_Addon == null || m_Addon.Deleted)
                return;`

It should be (if the addon is null or deleted, return)

not (if the addon is null or NOT deleted, return) 

Takes care of: https://github.com/ServUO/ServUO/issues/4991