### PR TITLE
Fix Mobile creation

### DIFF
--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -5858,7 +5858,13 @@ namespace Server
 				m_TypeRef = World.m_ItemTypes.Count - 1;
 			}
 
-			Timer.DelayCall(EventSink.InvokeItemCreated, new ItemCreatedEventArgs(this));
+			Timer.DelayCall(() =>
+			{
+				if (!Deleted)
+				{
+					EventSink.InvokeItemCreated(new ItemCreatedEventArgs(this));
+				}
+			});
 		}
 
 		[Constructable]

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -10542,8 +10542,11 @@ namespace Server
 				if (!m_Deleted)
 				{
 					EventSink.InvokeMobileCreated(new MobileCreatedEventArgs(this));
-					m_InternalCanRegen = true;
-					OnCreate();
+					if (!m_Deleted)
+					{
+						m_InternalCanRegen = true;
+						OnCreate();
+					}
 				}
 			});
 		}

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -10539,9 +10539,12 @@ namespace Server
 
 			Timer.DelayCall(() =>
 			{
-				EventSink.InvokeMobileCreated(new MobileCreatedEventArgs(this));
-				m_InternalCanRegen = true;
-				OnCreate();
+				if (!m_Deleted)
+				{
+					EventSink.InvokeMobileCreated(new MobileCreatedEventArgs(this));
+					m_InternalCanRegen = true;
+					OnCreate();
+				}
 			});
 		}
 


### PR DESCRIPTION
Mobile can already be deleted before delayed call will generate spawning loot, resulting in "inaccessible items".