### PR TITLE
Dragon Armor Attribute Fix

### DIFF
--- a/Scripts/Misc/ResourceInfo.cs
+++ b/Scripts/Misc/ResourceInfo.cs
@@ -338,7 +338,7 @@ namespace Server.Items
             yellow.ArmorFireResist = 1;
             yellow.ArmorColdResist = 1;
             yellow.ArmorPoisonResist = 1;
-            yellow.ArmorPoisonResist = 1;
+            yellow.ArmorEnergyResist = 1;
             yellow.ArmorLuck = 20;
 
             CraftAttributeInfo black = BlackScales = new CraftAttributeInfo();


### PR DESCRIPTION
It should have `ArmorEnergyResist` instead of `ArmorPoisonResist` twice, pretty self explanatory.