### PR TITLE
Ranger Equipment fix, Additem delete

### DIFF
--- a/Scripts/Mobiles/Bosses/Barracoon.cs
+++ b/Scripts/Mobiles/Bosses/Barracoon.cs
@@ -42,11 +42,11 @@ namespace Server.Mobiles
             Fame = 22500;
             Karma = -22500;
 
-            AddItem(new FancyShirt(Utility.RandomGreenHue()));
-            AddItem(new LongPants(Utility.RandomYellowHue()));
-            AddItem(new JesterHat(Utility.RandomPinkHue()));
-            AddItem(new Cloak(Utility.RandomPinkHue()));
-            AddItem(new Sandals());
+			SetWearable(new FancyShirt(), Utility.RandomGreenHue(), 1);
+			SetWearable(new LongPants(), Utility.RandomYellowHue(), 1);
+			SetWearable(new JesterHat(), Utility.RandomPinkHue(), 1);
+			SetWearable(new Cloak(), Utility.RandomPinkHue(), 1);
+			SetWearable(new Sandals(), 1);
 
             HairItemID = 0x203B; // Short Hair
             HairHue = 0x94;

--- a/Scripts/Mobiles/Bosses/Corgul/SoulboundPirateCaptain.cs
+++ b/Scripts/Mobiles/Bosses/Corgul/SoulboundPirateCaptain.cs
@@ -39,13 +39,13 @@ namespace Server.Mobiles
             Fame = 8000;
             Karma = -8000;
 
-            AddItem(new TricorneHat(1));
-            AddItem(new LeatherArms());
-            AddItem(new FancyShirt(1));
-            AddItem(new ShortPants(1));
-            AddItem(new Cutlass());
-            AddItem(new Boots(Utility.RandomNeutralHue()));
-            AddItem(new GoldEarrings());
+			SetWearable(new TricorneHat(), 1, 1);
+			SetWearable(new LeatherArms(), dropChance: 1);
+			SetWearable(new FancyShirt(), 1, 1);
+			SetWearable(new ShortPants(), 1, 1);
+			SetWearable(new Cutlass(), dropChance: 1);
+			SetWearable(new Boots(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new GoldEarrings(), dropChance: 1);
 
         }
 

--- a/Scripts/Mobiles/Bosses/Corgul/SoulboundPirateRaider.cs
+++ b/Scripts/Mobiles/Bosses/Corgul/SoulboundPirateRaider.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Items;
 
 namespace Server.Mobiles
@@ -57,27 +58,20 @@ namespace Server.Mobiles
             Fame = 2000;
             Karma = -2000;
 
-            AddItem(new TricorneHat());
-            AddItem(new LeatherArms());
-            AddItem(new FancyShirt());
-            AddItem(new ShortPants());
-            AddItem(new Cutlass());
-            AddItem(new Boots(Utility.RandomNeutralHue()));
-            AddItem(new GoldEarrings());
-
-            Item bow;
-
-            switch (Utility.Random(4))
-            {
-                default:
-                case 0: bow = new CompositeBow();break;
-                case 1: bow = new Crossbow(); break;
-                case 2: bow = new Bow(); break;
-                case 3: bow = new HeavyCrossbow(); break;
-            }
-
-            AddItem(bow);
+			SetWearable(new TricorneHat(), dropChance: 1);
+			SetWearable(new LeatherArms(), dropChance: 1);
+			SetWearable(new FancyShirt(), dropChance: 1);
+			SetWearable(new ShortPants(), dropChance: 1);
+			SetWearable(new Cutlass(), dropChance: 1);
+			SetWearable(new Boots(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new GoldEarrings(), dropChance: 1);
+			SetWearable((Item)Activator.CreateInstance(Utility.RandomList(_WeaponsList)), dropChance: 1);
         }
+
+		private static readonly Type[] _WeaponsList = new Type[]
+		{
+			typeof(CompositeBow), typeof(Crossbow), typeof(Bow), typeof(HeavyCrossbow)
+		};
 
         public override void GenerateLoot()
         {

--- a/Scripts/Mobiles/Bosses/Corgul/SoulboundSwashbuckler.cs
+++ b/Scripts/Mobiles/Bosses/Corgul/SoulboundSwashbuckler.cs
@@ -40,13 +40,13 @@ namespace Server.Mobiles
             Fame = 2000;
             Karma = -2000;
 
-            AddItem(new Bandana());
-            AddItem(new LeatherArms());
-            AddItem(new FancyShirt());
-            AddItem(new ShortPants());
-            AddItem(new Cutlass());
-            AddItem(new Boots(Utility.RandomNeutralHue()));
-            AddItem(new SilverEarrings());
+			SetWearable(new Bandana(), dropChance: 1);
+			SetWearable(new LeatherArms(), dropChance: 1);
+			SetWearable(new FancyShirt(), dropChance: 1);
+			SetWearable(new ShortPants(), dropChance: 1);
+			SetWearable(new Cutlass(), dropChance: 1);
+			SetWearable(new Boots(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new SilverEarrings(), dropChance: 1);
 
         }
 

--- a/Scripts/Mobiles/Bosses/DespiseBosses.cs
+++ b/Scripts/Mobiles/Bosses/DespiseBosses.cs
@@ -24,12 +24,6 @@ namespace Server.Engines.Despise
             FollowersMax = 100;
         }
 
-        public void SetNonMovable(Item item)
-        {
-            item.Movable = false;
-            AddItem(item);
-        }
-
         public override int Damage(int amount, Mobile from, bool informMount, bool checkDisrupt)
         {
             if (from is DespiseCreature)
@@ -218,11 +212,11 @@ namespace Server.Engines.Despise
                 Layer = Layer.OneHanded
             };
 
-            SetNonMovable(boots);
-            SetNonMovable(scimitar);
-            SetNonMovable(new LongPants(1818));
-            SetNonMovable(new FancyShirt(194));
-            SetNonMovable(new Doublet(1281));
+			SetWearable(boots);
+			SetWearable(scimitar);
+			SetWearable(new LongPants(), 1818);
+			SetWearable(new FancyShirt(), 194);
+			SetWearable(new Doublet(), 1281);
         }
 
         public override bool InitialInnocent => true;
@@ -295,21 +289,17 @@ namespace Server.Engines.Despise
             Fame = 22000;
             Karma = -22000;
 
-            Item boots = new ThighBoots
-            {
-                Hue = 1
-            };
 
             Item staff = new Item(3721)
             {
                 Layer = Layer.TwoHanded
             };
 
-            SetNonMovable(boots);
-            SetNonMovable(new LongPants(1818));
-            SetNonMovable(new FancyShirt(2726));
-            SetNonMovable(new Doublet(1153));
-            SetNonMovable(staff);
+			SetWearable(new ThighBoots(), 1);
+			SetWearable(new LongPants(), 1818);
+			SetWearable(new FancyShirt(), 2726);
+			SetWearable(new Doublet(), 1153);
+			SetWearable(staff);
         }
 
         public override bool AlwaysMurderer => true;

--- a/Scripts/Mobiles/Bosses/Medusa.cs
+++ b/Scripts/Mobiles/Bosses/Medusa.cs
@@ -55,11 +55,7 @@ namespace Server.Mobiles
             Fame = 22000;
             Karma = -22000;
 
-            IronwoodCompositeBow Bow = new IronwoodCompositeBow
-            {
-                Movable = false
-            };
-            AddItem(Bow);
+			SetWearable(new IronwoodCompositeBow());
 
             m_Scales = Utility.RandomMinMax(1, 2) + 7;
 
@@ -702,7 +698,7 @@ namespace Server.Mobiles
             for (int i = 0; i < m.Items.Count; i++)
             {
                 if (m.Items[i].Layer != Layer.Backpack && m.Items[i].Layer != Layer.Mount && m.Items[i].Layer != Layer.Bank)
-                    AddItem(CloneItem(m.Items[i]));
+					SetWearable(CloneItem(m.Items[i]));
             }
         }
 

--- a/Scripts/Mobiles/Bosses/Neira.cs
+++ b/Scripts/Mobiles/Bosses/Neira.cs
@@ -46,23 +46,9 @@ namespace Server.Mobiles
 
             Female = true;
 
-            Item shroud = new HoodedShroudOfShadows
-            {
-                Movable = false
-            };
-
-            AddItem(shroud);
-
-            Scimitar weapon = new Scimitar
-            {
-                Skill = SkillName.Wrestling,
-                Hue = 38,
-                Movable = false
-            };
-
-            AddItem(weapon);
-
-            AddItem(new VirtualMountItem(this));
+			SetWearable(new HoodedShroudOfShadows());
+			SetWearable(new Scimitar { Skill = SkillName.Wrestling }, 38);
+			SetWearable(new VirtualMountItem(this));
         }
 
         public Neira(Serial serial)

--- a/Scripts/Mobiles/Bosses/Travesty.cs
+++ b/Scripts/Mobiles/Bosses/Travesty.cs
@@ -195,27 +195,16 @@ namespace Server.Mobiles
 
                             if (crItem != null)
                             {
-                                // Is this necessary? Was this check already done?
-                                Item i = FindItemOnLayer(Layer.TwoHanded);
-
-                                if (i != null)
-                                    i.Delete();
-
-                                i = FindItemOnLayer(Layer.OneHanded);
-
-                                if (i != null)
-                                    i.Delete();
-
-                                AddItem(Loot.Construct(crItem.ItemType));
+								SetWearable(Loot.Construct(crItem.ItemType));
                             }
                             else
                             {
-                                AddItem(new ClonedItem(item));
+								SetWearable(new ClonedItem(item));
                             }
                         }
                         else
                         {
-                            AddItem(new ClonedItem(item));
+							SetWearable(new ClonedItem(item));
                         }
                     }
                 }

--- a/Scripts/Mobiles/NPCs/Abbein.cs
+++ b/Scripts/Mobiles/NPCs/Abbein.cs
@@ -39,9 +39,9 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x74B));
-            AddItem(new FemaleElvenRobe(0x8A8));
-            AddItem(new RoyalCirclet());
+            SetWearable(new ElvenBoots(), 0x74B, 1);
+			SetWearable(new FemaleElvenRobe(), 0x8A8, 1);
+			SetWearable(new RoyalCirclet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Acob.cs
+++ b/Scripts/Mobiles/NPCs/Acob.cs
@@ -374,10 +374,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new ElvenBoots(0x73D));
-            AddItem(new HidePants());
-            AddItem(new ElvenShirt(0x71));
+            SetWearable(new Backpack());
+			SetWearable(new ElvenBoots(), 0x73D, 1);
+			SetWearable(new HidePants(), dropChance: 1);
+			SetWearable(new ElvenShirt(), 0x71, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Actor.cs
+++ b/Scripts/Mobiles/NPCs/Actor.cs
@@ -18,19 +18,19 @@ namespace Server.Mobiles
             {
                 Body = 0x191;
                 Name = NameList.RandomName("female");
-                AddItem(new FancyDress(Utility.RandomDyedHue()));
+				SetWearable(new FancyDress(), Utility.RandomDyedHue(), 1);
                 Title = "the actress";
             }
             else
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new LongPants(Utility.RandomNeutralHue()));
-                AddItem(new FancyShirt(Utility.RandomDyedHue()));
+				SetWearable(new LongPants(), Utility.RandomNeutralHue(), 1);
+				SetWearable(new FancyShirt(), Utility.RandomDyedHue(), 1);
                 Title = "the actor";
             }
 
-            AddItem(new Boots(Utility.RandomNeutralHue()));
+            SetWearable(new Boots(), Utility.RandomNeutralHue(), 1);
 
             Utility.AssignRandomHair(this);
 
@@ -38,9 +38,7 @@ namespace Server.Mobiles
 
             pack.DropItem(new Gold(250, 300));
 
-            pack.Movable = false;
-
-            AddItem(pack);
+            SetWearable(pack);
         }
 
         public Actor(Serial serial)

--- a/Scripts/Mobiles/NPCs/Aelorn.cs
+++ b/Scripts/Mobiles/NPCs/Aelorn.cs
@@ -129,14 +129,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new VikingSword());
-            AddItem(new PlateChest());
-            AddItem(new PlateLegs());
-            AddItem(new PlateGloves());
-            AddItem(new PlateArms());
-            AddItem(new PlateGorget());
-            AddItem(new OrderShield());
+            SetWearable(new Backpack(), dropChance: 1);
+            SetWearable(new VikingSword(), dropChance: 1);
+            SetWearable(new PlateChest(), dropChance: 1);
+            SetWearable(new PlateLegs(), dropChance: 1);
+            SetWearable(new PlateGloves(), dropChance: 1);
+            SetWearable(new PlateArms(), dropChance: 1);
+            SetWearable(new PlateGorget(), dropChance: 1);
+            SetWearable(new OrderShield(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Aeluva.cs
+++ b/Scripts/Mobiles/NPCs/Aeluva.cs
@@ -33,10 +33,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots());
-            AddItem(new ElvenShirt());
-            AddItem(new Skirt());
-            AddItem(new Circlet());
+            SetWearable(new ElvenBoots(), dropChance: 1);
+            SetWearable(new ElvenShirt(), dropChance: 1);
+            SetWearable(new Skirt(), dropChance: 1);
+            SetWearable(new Circlet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Aernya.cs
+++ b/Scripts/Mobiles/NPCs/Aernya.cs
@@ -32,11 +32,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x743));
-            AddItem(new FancyShirt(0x3B3));
-            AddItem(new Cloak(0x3));
-            AddItem(new Skirt());
+            SetWearable(new Backpack(), dropChance: 1);
+            SetWearable(new Sandals(), 0x743, 1);
+            SetWearable(new FancyShirt(), 0x3B3, 1);
+            SetWearable(new Cloak(), 0x3, 1);
+            SetWearable(new Skirt(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Agralem.cs
+++ b/Scripts/Mobiles/NPCs/Agralem.cs
@@ -75,10 +75,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Cyclone());
-            AddItem(new GargishLeatherKilt(2305));
-            AddItem(new GargishLeatherChest(2305));
-            AddItem(new GargishLeatherArms(2305));
+            SetWearable(new Cyclone(), dropChance: 1);
+            SetWearable(new GargishLeatherKilt(), 2305);
+            SetWearable(new GargishLeatherChest(), 2305);
+            SetWearable(new GargishLeatherArms(), 2305);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Ahie.cs
+++ b/Scripts/Mobiles/NPCs/Ahie.cs
@@ -189,11 +189,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ThighBoots(0x901));
-            AddItem(new FancyShirt(0x72B));
-            AddItem(new Cloak(0x1C));
-            AddItem(new Skirt(0x62));
-            AddItem(new Circlet());
+			SetWearable(new ThighBoots(0x901));
+			SetWearable(new FancyShirt(0x72B));
+			SetWearable(new Cloak(0x1C));
+			SetWearable(new Skirt(0x62));
+            SetWearable(new Circlet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/AlbertaGiacco.cs
+++ b/Scripts/Mobiles/NPCs/AlbertaGiacco.cs
@@ -29,11 +29,11 @@ namespace Server.Engines.Quests.Collector
 
         public override void InitOutfit()
         {
-            AddItem(new FancyShirt());
-            AddItem(new Skirt(0x59B));
-            AddItem(new Boots());
-            AddItem(new FeatheredHat(0x59B));
-            AddItem(new FullApron(0x59B));
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(new Skirt(), 0x59B, 1);
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new FeatheredHat(), 0x59B, 1);
+            SetWearable(new FullApron(), 0x59B, 1);
 
             HairItemID = 0x203D; // Pony Tail
             HairHue = 0x457;

--- a/Scripts/Mobiles/NPCs/Alchemist.cs
+++ b/Scripts/Mobiles/NPCs/Alchemist.cs
@@ -53,7 +53,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.Robe(Utility.RandomPinkHue()));
+            SetWearable(new Items.Robe(), Utility.RandomPinkHue());
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/AldenArmstrong.cs
+++ b/Scripts/Mobiles/NPCs/AldenArmstrong.cs
@@ -129,14 +129,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes());
-            AddItem(new StuddedLegs());
-            AddItem(new StuddedGloves());
-            AddItem(new StuddedGorget());
-            AddItem(new StuddedChest());
-            AddItem(new StuddedArms());
-            AddItem(new Katana());
+            SetWearable(new Backpack(), dropChance: 1);
+            SetWearable(new Shoes(), dropChance: 1);
+            SetWearable(new StuddedLegs(), dropChance: 1);
+            SetWearable(new StuddedGloves(), dropChance: 1);
+            SetWearable(new StuddedGorget(), dropChance: 1);
+            SetWearable(new StuddedChest(), dropChance: 1);
+            SetWearable(new StuddedArms(), dropChance: 1);
+            SetWearable(new Katana(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Alefian.cs
+++ b/Scripts/Mobiles/NPCs/Alefian.cs
@@ -137,9 +137,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Robe());
-            AddItem(new Sandals());
+            SetWearable(new Backpack());
+            SetWearable(new Robe(), dropChance: 1);
+            SetWearable(new Sandals(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Alejaha.cs
+++ b/Scripts/Mobiles/NPCs/Alejaha.cs
@@ -74,10 +74,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x1BB));
-            AddItem(new Cloak(0x59));
-            AddItem(new Skirt(0x901));
-            AddItem(new GemmedCirclet());
+            SetWearable(new Sandals(), 0x1BB, 1);
+            SetWearable(new Cloak(), 0x59, 1);
+            SetWearable(new Skirt(), 0x901, 1);
+            SetWearable(new GemmedCirclet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/AlelleTheAborist.cs
+++ b/Scripts/Mobiles/NPCs/AlelleTheAborist.cs
@@ -39,27 +39,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x1BB));
-
-            Item item;
-
-            item = new LeafGloves
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
-
-            item = new LeafChest
-            {
-                Hue = 0x37
-            };
-            AddItem(item);
-
-            item = new LeafLegs
-            {
-                Hue = 0x746
-            };
-            AddItem(item);
+			SetWearable(new ElvenBoots(), 0x1BB, 1);
+			SetWearable(new LeafGloves(), 0x1BB, 1);
+			SetWearable(new LeafChest(), 0x37, 1);
+			SetWearable(new LeafLegs(), 0x746, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Alethanian.cs
+++ b/Scripts/Mobiles/NPCs/Alethanian.cs
@@ -39,11 +39,11 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots());
-            AddItem(new GemmedCirclet());
-            AddItem(new HidePants());
-            AddItem(new HideFemaleChest());
-            AddItem(new HidePauldrons());
+            SetWearable(new ElvenBoots(), dropChance: 1);
+            SetWearable(new GemmedCirclet(), dropChance: 1);
+            SetWearable(new HidePants(), dropChance: 1);
+            SetWearable(new HideFemaleChest(), dropChance: 1);
+            SetWearable(new HidePauldrons(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Aliabeth.cs
+++ b/Scripts/Mobiles/NPCs/Aliabeth.cs
@@ -139,11 +139,11 @@ namespace Server.Engines.Quests
         }
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+            SetWearable(new Backpack());
 
-            AddItem(new Kilt(Utility.RandomNeutralHue()));
-            AddItem(new Shirt(Utility.RandomNeutralHue()));
-            AddItem(new Sandals());
+            SetWearable(new Kilt(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new Shirt(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new Sandals(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/AluniolTheHealer.cs
+++ b/Scripts/Mobiles/NPCs/AluniolTheHealer.cs
@@ -39,9 +39,9 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x1BB));
-            AddItem(new MaleElvenRobe(0x47E));
-            AddItem(new WildStaff());
+            SetWearable(new ElvenBoots(), 0x1BB, 1);
+            SetWearable(new MaleElvenRobe(), 0x47E, 1);
+            SetWearable(new WildStaff(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Amelia.cs
+++ b/Scripts/Mobiles/NPCs/Amelia.cs
@@ -138,11 +138,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals());
-            AddItem(new ShortPants());
-            AddItem(new HalfApron(0x8AB));
-            AddItem(new Doublet());
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), dropChance: 1);
+            SetWearable(new ShortPants(), dropChance: 1);
+            SetWearable(new HalfApron(), 0x8AB, 1);
+            SetWearable(new Doublet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Aminia.cs
+++ b/Scripts/Mobiles/NPCs/Aminia.cs
@@ -21,10 +21,10 @@ namespace Server.Mobiles
             HairItemID = 0x203B;
             HairHue = 0x454;
 
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x75B));
-            AddItem(new Tunic(0x4BF));
-            AddItem(new Skirt(0x8FD));
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), 0x75B, 1);
+            SetWearable(new Tunic(), 0x4BF, 1);
+            SetWearable(new Skirt(), 0x8FD, 1);
         }
 
         public Aminia(Serial serial)

--- a/Scripts/Mobiles/NPCs/AndreasVesalius.cs
+++ b/Scripts/Mobiles/NPCs/AndreasVesalius.cs
@@ -128,11 +128,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new BlackStaff());
-            AddItem(new Boots());
-            AddItem(new LongPants());
-            AddItem(new Tunic(0x66D));
+            SetWearable(new Backpack());
+            SetWearable(new BlackStaff(), dropChance: 1);
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new LongPants(), dropChance: 1);
+            SetWearable(new Tunic(), 0x66D, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Andric.cs
+++ b/Scripts/Mobiles/NPCs/Andric.cs
@@ -74,40 +74,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots(0x1BB));
-
-            Item item;
-
-            item = new LeatherLegs
-            {
-                Hue = 0x6C8
-            };
-            AddItem(item);
-
-            item = new LeatherGloves
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
-
-            item = new LeatherChest
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
-
-            item = new LeatherArms
-            {
-                Hue = 0x4C7
-            };
-            AddItem(item);
-
-            item = new CompositeBow
-            {
-                Hue = 0x5DD
-            };
-            AddItem(item);
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), 0x1BB, 1);
+            SetWearable(new LeatherLegs(), 0x6C8, 1);
+            SetWearable(new LeatherGloves(), 0x1BB, 1);
+            SetWearable(new LeatherChest(), 0x1BB, 1);
+            SetWearable(new LeatherArms(), 0x4C7, 1);
+            SetWearable(new CompositeBow(), 0x5DD, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Andros.cs
+++ b/Scripts/Mobiles/NPCs/Andros.cs
@@ -33,12 +33,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots(0x901));
-            AddItem(new LongPants(0x1BB));
-            AddItem(new FancyShirt(0x60B));
-            AddItem(new FullApron(0x901));
-            AddItem(new SmithHammer());
+            SetWearable(new Backpack(), dropChance: 1);
+            SetWearable(new Boots(), 0x901, 1);
+            SetWearable(new LongPants(), 0x1BB, 1);
+            SetWearable(new FancyShirt(), 0x60B, 1);
+            SetWearable(new FullApron(), 0x901, 1);
+            SetWearable(new SmithHammer(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Aneen.cs
+++ b/Scripts/Mobiles/NPCs/Aneen.cs
@@ -39,9 +39,9 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x1BB));
-            AddItem(new MaleElvenRobe(0x48F));
-            AddItem(new Item(0xDF2));
+            SetWearable(new Sandals(), 0x1BB, 1);
+            SetWearable(new MaleElvenRobe(), 0x48F, 1);
+            SetWearable(new MagicWand(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Aniel.cs
+++ b/Scripts/Mobiles/NPCs/Aniel.cs
@@ -148,10 +148,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x901));
-            AddItem(new HalfApron(0x759));
-            AddItem(new ElvenPants(0x901));
-            AddItem(new LeafChest());
+            SetWearable(new ElvenBoots(), 0x901, 1);
+            SetWearable(new HalfApron(), 0x759, 1);
+            SetWearable(new ElvenPants(), 0x901, 1);
+            SetWearable(new LeafChest(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/AnimalTrainer.cs
+++ b/Scripts/Mobiles/NPCs/AnimalTrainer.cs
@@ -46,7 +46,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(Utility.RandomBool() ? new QuarterStaff() : (Item)new ShepherdsCrook());
+            SetWearable(Utility.RandomBool() ? new QuarterStaff() : (Item)new ShepherdsCrook(), dropChance: 1);
         }
 
         public override void AddCustomContextEntries(Mobile from, List<ContextMenuEntry> list)

--- a/Scripts/Mobiles/NPCs/Anolly.cs
+++ b/Scripts/Mobiles/NPCs/Anolly.cs
@@ -111,10 +111,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x901));
-            AddItem(new FullApron(0x1BB));
-            AddItem(new ShortPants(0x3B2));
-            AddItem(new SmithHammer());
+            SetWearable(new Sandals(), 0x901, 1);
+            SetWearable(new FullApron(), 0x1BB, 1);
+            SetWearable(new ShortPants(), 0x3B2, 1);
+            SetWearable(new SmithHammer(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/AnsellaGryen.cs
+++ b/Scripts/Mobiles/NPCs/AnsellaGryen.cs
@@ -31,11 +31,10 @@ namespace Server.Engines.Quests.Zento
             HairItemID = 0x203B;
             HairHue = 0x1BB;
 
-            AddItem(new SamuraiTabi(0x8FD));
-            AddItem(new FemaleKimono(0x4B6));
-            AddItem(new Obi(0x526));
-
-            AddItem(new GoldBracelet());
+            SetWearable(new SamuraiTabi(), 0x8FD, 1);
+            SetWearable(new FemaleKimono(), 0x4B6, 1);
+            SetWearable(new Obi(), 0x526, 1);
+            SetWearable(new GoldBracelet(), dropChance: 1);
         }
 
         public override int GetAutoTalkRange(PlayerMobile m)

--- a/Scripts/Mobiles/NPCs/Ansikart.cs
+++ b/Scripts/Mobiles/NPCs/Ansikart.cs
@@ -37,10 +37,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new SerpentStoneStaff());
-            AddItem(new GargishClothChest(1428));
-            AddItem(new GargishClothArms(1445));
-            AddItem(new GargishClothKilt(1443));
+            SetWearable(new SerpentStoneStaff(), dropChance: 1);
+            SetWearable(new GargishClothChest(), 1428, 1);
+            SetWearable(new GargishClothArms(), 1445, 1);
+            SetWearable(new GargishClothKilt(), 1443, 1);
         }
 
         public override void Advertise()

--- a/Scripts/Mobiles/NPCs/Armorer.cs
+++ b/Scripts/Mobiles/NPCs/Armorer.cs
@@ -1,4 +1,5 @@
 using Server.Engines.BulkOrders;
+using Server.Items;
 using System;
 using System.Collections.Generic;
 
@@ -126,8 +127,8 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.HalfApron(Utility.RandomYellowHue()));
-            AddItem(new Items.Bascinet());
+            SetWearable(new HalfApron(), Utility.RandomYellowHue(), 1);
+            SetWearable(new Bascinet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Artist.cs
+++ b/Scripts/Mobiles/NPCs/Artist.cs
@@ -26,10 +26,10 @@ namespace Server.Mobiles
                 Body = 0x190;
                 Name = NameList.RandomName("male");
             }
-            AddItem(new Doublet(Utility.RandomDyedHue()));
-            AddItem(new Sandals(Utility.RandomNeutralHue()));
-            AddItem(new ShortPants(Utility.RandomNeutralHue()));
-            AddItem(new HalfApron(Utility.RandomDyedHue()));
+            SetWearable(new Doublet(), Utility.RandomDyedHue(), 1);
+            SetWearable(new Sandals(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new HalfApron(), Utility.RandomDyedHue(), 1);
 
             Utility.AssignRandomHair(this);
 
@@ -37,9 +37,7 @@ namespace Server.Mobiles
 
             pack.DropItem(new Gold(250, 300));
 
-            pack.Movable = false;
-
-            AddItem(pack);
+            SetWearable(pack);
         }
 
         public Artist(Serial serial)

--- a/Scripts/Mobiles/NPCs/Asandos.cs
+++ b/Scripts/Mobiles/NPCs/Asandos.cs
@@ -75,12 +75,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots(0x901));
-            AddItem(new ShortPants());
-            AddItem(new Shirt());
-            AddItem(new Cap());
-            AddItem(new HalfApron(0x28));
+            SetWearable(new Backpack(), dropChance: 1);
+            SetWearable(new Boots(), 0x901, 1);
+            SetWearable(new ShortPants(), dropChance: 1);
+            SetWearable(new Shirt(), dropChance: 1);
+            SetWearable(new Cap(), dropChance: 1);
+            SetWearable(new HalfApron(), 0x28, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Athialon.cs
+++ b/Scripts/Mobiles/NPCs/Athialon.cs
@@ -39,35 +39,13 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x901));
-            AddItem(new DiamondMace());
-            AddItem(new WoodlandBelt());
-
-            Item item;
-
-            item = new WoodlandLegs
-            {
-                Hue = 0x3B2
-            };
-            AddItem(item);
-
-            item = new WoodlandChest
-            {
-                Hue = 0x3B2
-            };
-            AddItem(item);
-
-            item = new WoodlandArms
-            {
-                Hue = 0x3B2
-            };
-            AddItem(item);
-
-            item = new WingedHelm
-            {
-                Hue = 0x3B2
-            };
-            AddItem(item);
+            SetWearable(new ElvenBoots(), 0x901, 1);
+            SetWearable(new DiamondMace(), dropChance: 1);
+            SetWearable(new WoodlandBelt(), dropChance: 1);
+			SetWearable(new WoodlandLegs(), 0x3B2, 1);
+			SetWearable(new WoodlandChest(), 0x3B2, 1);
+			SetWearable(new WoodlandArms(), 0x3B2, 1); 
+			SetWearable(new WingedHelm(), 0x3B2, 1); 
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Aulan.cs
+++ b/Scripts/Mobiles/NPCs/Aulan.cs
@@ -352,30 +352,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x725));
-            AddItem(new ElvenPants(0x3B3));
-            AddItem(new Cloak(0x16A));
-            AddItem(new Circlet());
-
-            Item item;
-
-            item = new HideGloves
-            {
-                Hue = 0x224
-            };
-            AddItem(item);
-
-            item = new HideChest
-            {
-                Hue = 0x224
-            };
-            AddItem(item);
-
-            item = new HidePauldrons
-            {
-                Hue = 0x224
-            };
-            AddItem(item);
+            SetWearable(new ElvenBoots(), 0x725, 1);
+            SetWearable(new ElvenPants(), 0x3B3, 1);
+            SetWearable(new Cloak(), 0x16A, 1);
+            SetWearable(new Circlet(), dropChance: 1);
+			SetWearable(new HideGloves(), 0x224, 1);
+			SetWearable(new HideChest(), 0x224, 1);
+			SetWearable(new HidePauldrons(), 0x224, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Aurelia.cs
+++ b/Scripts/Mobiles/NPCs/Aurelia.cs
@@ -31,10 +31,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x4B7));
-            AddItem(new Skirt(0x4B4));
-            AddItem(new FancyShirt(0x659));
+            SetWearable(new Backpack(), dropChance: 1);
+            SetWearable(new Sandals(), 0x4B7, 1);
+            SetWearable(new Skirt(), 0x4B4, 1);
+            SetWearable(new FancyShirt(), 0x659, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Aurvidlem.cs
+++ b/Scripts/Mobiles/NPCs/Aurvidlem.cs
@@ -36,10 +36,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new SerpentStoneStaff());
-            AddItem(new GargishClothChest(1307));
-            AddItem(new GargishClothArms(1330));
-            AddItem(new GargishClothKilt(1307));
+            SetWearable(new SerpentStoneStaff(), dropChance: 1);
+            SetWearable(new GargishClothChest(), 1307, 1);
+            SetWearable(new GargishClothArms(), 1330, 1);
+            SetWearable(new GargishClothKilt(), 1307, 1);
         }
 
         public override void Advertise()

--- a/Scripts/Mobiles/NPCs/Avicenna.cs
+++ b/Scripts/Mobiles/NPCs/Avicenna.cs
@@ -130,10 +130,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Robe(0x66D));
-            AddItem(new Boots());
-            AddItem(new GnarledStaff());
+            SetWearable(new Backpack());
+            SetWearable(new Robe(), 0x66D, 1);
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new GnarledStaff(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Axem.cs
+++ b/Scripts/Mobiles/NPCs/Axem.cs
@@ -150,11 +150,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-
-            AddItem(new GargishClothChest(Utility.RandomNeutralHue()));
-            AddItem(new GargishClothKilt(Utility.RandomNeutralHue()));
-            AddItem(new GargishClothLegs(Utility.RandomNeutralHue()));
+            SetWearable(new Backpack());
+            SetWearable(new GargishClothChest(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new GargishClothKilt(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new GargishClothLegs(), Utility.RandomNeutralHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Barkeeper.cs
+++ b/Scripts/Mobiles/NPCs/Barkeeper.cs
@@ -30,7 +30,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new HalfApron(Utility.RandomBrightHue()));
+            SetWearable(new HalfApron(), Utility.RandomBrightHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Barreraak.cs
+++ b/Scripts/Mobiles/NPCs/Barreraak.cs
@@ -64,11 +64,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots());
-            AddItem(new LongPants(0x6C7));
-            AddItem(new FancyShirt(0x6BB));
-            AddItem(new Cloak(0x59));
+            SetWearable(new Backpack(), dropChance: 1);
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new LongPants(), 0x6C7, 1);
+            SetWearable(new FancyShirt(), 0x6BB, 1);
+            SetWearable(new Cloak(), 0x59, 1);
         }
 
         public Barreraak(Serial serial)

--- a/Scripts/Mobiles/NPCs/BaseHealer.cs
+++ b/Scripts/Mobiles/NPCs/BaseHealer.cs
@@ -72,7 +72,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Robe(GetRobeColor()));
+            SetWearable(new Robe(), GetRobeColor(), 1);
         }
 
         public virtual bool CheckResurrect(Mobile m)

--- a/Scripts/Mobiles/NPCs/BaseVendor.cs
+++ b/Scripts/Mobiles/NPCs/BaseVendor.cs
@@ -691,39 +691,35 @@ namespace Server.Mobiles
         {
             if (Backpack == null)
             {
-                Item backpack = new Backpack
-                {
-                    Movable = false
-                };
-                AddItem(backpack);
+                SetWearable(new Backpack());
             }
 
             switch (Utility.Random(3))
             {
                 case 0:
-                    SetWearable(new FancyShirt(GetRandomHue()));
+                    SetWearable(new FancyShirt(), GetRandomHue(), 1);
                     break;
                 case 1:
-                    SetWearable(new Doublet(GetRandomHue()));
+                    SetWearable(new Doublet(), GetRandomHue(), 1);
                     break;
                 case 2:
-                    SetWearable(new Shirt(GetRandomHue()));
+                    SetWearable(new Shirt(), GetRandomHue(), 1);
                     break;
             }
 
             switch (ShoeType)
             {
                 case VendorShoeType.Shoes:
-                    SetWearable(new Shoes(GetShoeHue()));
+                    SetWearable(new Shoes(), GetShoeHue(), 1);
                     break;
                 case VendorShoeType.Boots:
-                    SetWearable(new Boots(GetShoeHue()));
+                    SetWearable(new Boots(), GetShoeHue(), 1);
                     break;
                 case VendorShoeType.Sandals:
-                    SetWearable(new Sandals(GetShoeHue()));
+                    SetWearable(new Sandals(), GetShoeHue(), 1);
                     break;
                 case VendorShoeType.ThighBoots:
-                    SetWearable(new ThighBoots(GetShoeHue()));
+                    SetWearable(new ThighBoots(), GetShoeHue(), 1);
                     break;
             }
 
@@ -742,16 +738,16 @@ namespace Server.Mobiles
                 switch (Utility.Random(6))
                 {
                     case 0:
-                        SetWearable(new ShortPants(GetRandomHue()));
+                        SetWearable(new ShortPants(), GetRandomHue(), 1);
                         break;
                     case 1:
                     case 2:
-                        SetWearable(new Kilt(GetRandomHue()));
+                        SetWearable(new Kilt(), GetRandomHue(), 1);
                         break;
                     case 3:
                     case 4:
                     case 5:
-                        SetWearable(new Skirt(GetRandomHue()));
+                        SetWearable(new Skirt(), GetRandomHue(), 1);
                         break;
                 }
             }
@@ -760,10 +756,10 @@ namespace Server.Mobiles
                 switch (Utility.Random(2))
                 {
                     case 0:
-                        SetWearable(new LongPants(GetRandomHue()));
+                        SetWearable(new LongPants(), GetRandomHue(), 1);
                         break;
                     case 1:
-                        SetWearable(new ShortPants(GetRandomHue()));
+                        SetWearable(new ShortPants(), GetRandomHue(), 1);
                         break;
                 }
             }

--- a/Scripts/Mobiles/NPCs/Belulah.cs
+++ b/Scripts/Mobiles/NPCs/Belulah.cs
@@ -32,11 +32,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots());
-            AddItem(new LongPants(0x6C7));
-            AddItem(new FancyShirt(0x6BB));
-            AddItem(new Cloak(0x59));
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new LongPants(), 0x6C7, 1);
+            SetWearable(new FancyShirt(), 0x6BB, 1);
+            SetWearable(new Cloak(), 0x59, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Ben.cs
+++ b/Scripts/Mobiles/NPCs/Ben.cs
@@ -33,10 +33,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x901));
-            AddItem(new LongPants(0x1BB));
-            AddItem(new FancyShirt(0x756));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x901, 1);
+            SetWearable(new LongPants(), 0x1BB, 1);
+            SetWearable(new FancyShirt(), 0x756, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Beninort.cs
+++ b/Scripts/Mobiles/NPCs/Beninort.cs
@@ -36,10 +36,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new SerpentStoneStaff());
-            AddItem(new GargishClothChest(1609));
-            AddItem(new GargishClothArms(1651));
-            AddItem(new GargishClothKilt(1649));
+            SetWearable(new SerpentStoneStaff(), dropChance: 1);
+            SetWearable(new GargishClothChest(), 1609, 1);
+            SetWearable(new GargishClothArms(), 1651, 1);
+            SetWearable(new GargishClothKilt(), 1649, 1);
         }
 
         public override void Advertise()

--- a/Scripts/Mobiles/NPCs/Beotham.cs
+++ b/Scripts/Mobiles/NPCs/Beotham.cs
@@ -224,17 +224,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x901));
-            AddItem(new LongPants(0x52C));
-            AddItem(new FancyShirt(0x546));
-
-            Item item;
-
-            item = new LeafGloves
-            {
-                Hue = 0x901
-            };
-            AddItem(item);
+            SetWearable(new Sandals(), 0x901, 1);
+            SetWearable(new LeafGloves(), 0x901, 1);
+            SetWearable(new LongPants(), 0x52C, 1);
+            SetWearable(new FancyShirt(), 0x546, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Blackheart.cs
+++ b/Scripts/Mobiles/NPCs/Blackheart.cs
@@ -30,26 +30,16 @@ namespace Server.Engines.Quests.Hag
 
         public override void InitOutfit()
         {
-            AddItem(new FancyShirt());
-            AddItem(new LongPants(0x66D));
-            AddItem(new ThighBoots());
-            AddItem(new TricorneHat(0x1));
-            AddItem(new BodySash(0x66D));
-
-            LeatherGloves gloves = new LeatherGloves
-            {
-                Hue = 0x66D
-            };
-            AddItem(gloves);
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(new ThighBoots(), dropChance: 1);
+            SetWearable(new LongPants(), 0x66D, 1);
+            SetWearable(new TricorneHat(), 0x1, 1);
+            SetWearable(new BodySash(), 0x66D, 1);
+            SetWearable(new LeatherGloves(), 0x66D, 1);
+            SetWearable(new Cutlass());
 
             FacialHairItemID = 0x203E; // Long Beard
             FacialHairHue = 0x455;
-
-            Item sword = new Cutlass
-            {
-                Movable = false
-            };
-            AddItem(sword);
         }
 
         public override void OnTalk(PlayerMobile player, bool contextMenu)

--- a/Scripts/Mobiles/NPCs/Blacksmith.cs
+++ b/Scripts/Mobiles/NPCs/Blacksmith.cs
@@ -1,4 +1,5 @@
 using Server.Engines.BulkOrders;
+using Server.Items;
 using System;
 using System.Collections.Generic;
 
@@ -46,8 +47,10 @@ namespace Server.Mobiles
         public override VendorShoeType ShoeType => Utility.RandomBool() ? VendorShoeType.Sandals : VendorShoeType.Shoes;
 
         public override void InitOutfit()
-        {
-            Item item = Utility.RandomBool() ? null : new Items.RingmailChest();
+		{
+			base.InitOutfit();
+			
+			Item item = Utility.RandomBool() ? null : new RingmailChest();
 
             if (item != null && !EquipItem(item))
             {
@@ -56,12 +59,10 @@ namespace Server.Mobiles
             }
 
             if (item == null)
-                AddItem(new Items.FullApron());
+                SetWearable(new FullApron(), dropChance: 1);
 
-            AddItem(new Items.Bascinet());
-            AddItem(new Items.SmithHammer());
-
-            base.InitOutfit();
+			SetWearable(new Bascinet(), dropChance: 1);
+			SetWearable(new SmithHammer(), dropChance: 1);
         }
 
         #region Bulk Orders

--- a/Scripts/Mobiles/NPCs/BlacksmithGuildmaster.cs
+++ b/Scripts/Mobiles/NPCs/BlacksmithGuildmaster.cs
@@ -1,4 +1,5 @@
 using Server.Engines.BulkOrders;
+using Server.Items;
 using System;
 
 namespace Server.Mobiles
@@ -30,8 +31,10 @@ namespace Server.Mobiles
         }
 
         public override void InitOutfit()
-        {
-            Item item = (Utility.RandomBool() ? null : new Items.RingmailChest());
+		{
+			base.InitOutfit();
+
+			Item item = (Utility.RandomBool() ? null : new RingmailChest());
 
             if (item != null && !EquipItem(item))
             {
@@ -40,12 +43,10 @@ namespace Server.Mobiles
             }
 
             if (item == null)
-                AddItem(new Items.FullApron());
+				SetWearable(new FullApron(), dropChance: 1);
 
-            AddItem(new Items.Bascinet());
-            AddItem(new Items.SmithHammer());
-
-            base.InitOutfit();
+			SetWearable(new Bascinet(), dropChance: 1);
+			SetWearable(new SmithHammer(), dropChance: 1);
         }
 
         #region Bulk Orders

--- a/Scripts/Mobiles/NPCs/Bolaevin.cs
+++ b/Scripts/Mobiles/NPCs/Bolaevin.cs
@@ -39,18 +39,11 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x3B3));
-            AddItem(new RoyalCirclet());
-            AddItem(new LeafChest());
-            AddItem(new LeafArms());
-
-            Item item;
-
-            item = new LeafLegs
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
+            SetWearable(new ElvenBoots(), 0x3B3, 1);
+            SetWearable(new RoyalCirclet(), dropChance: 1);
+            SetWearable(new LeafChest(), dropChance: 1);
+            SetWearable(new LeafArms(), dropChance: 1);
+            SetWearable(new LeafLegs(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Bowyer.cs
+++ b/Scripts/Mobiles/NPCs/Bowyer.cs
@@ -1,4 +1,5 @@
 using Server.Engines.BulkOrders;
+using Server.Items;
 using System;
 using System.Collections.Generic;
 
@@ -32,8 +33,8 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.Bow());
-            AddItem(new Items.LeatherGorget());
+            SetWearable(new Bow(), dropChance: 1);
+            SetWearable(new LeatherGorget(), dropChance: 1);
         }
 
         public override void InitSBInfo()

--- a/Scripts/Mobiles/NPCs/Brae.cs
+++ b/Scripts/Mobiles/NPCs/Brae.cs
@@ -35,9 +35,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x901));
-            AddItem(new GemmedCirclet());
-            AddItem(new FemaleElvenRobe(0x44));
+            SetWearable(new ElvenBoots(), 0x901, 1);
+            SetWearable(new GemmedCirclet(), dropChance: 1);
+            SetWearable(new FemaleElvenRobe(), 0x44, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Braen.cs
+++ b/Scripts/Mobiles/NPCs/Braen.cs
@@ -58,8 +58,8 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x722));
-            AddItem(RandomWand.CreateWand());
+            SetWearable(new Sandals(), 0x722, 1);
+            SetWearable(RandomWand.CreateWand(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Brinnae.cs
+++ b/Scripts/Mobiles/NPCs/Brinnae.cs
@@ -404,11 +404,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x1BB));
-            AddItem(new LeafArms());
-            AddItem(new FemaleLeafChest());
-            AddItem(new HidePants());
-            AddItem(new ElvenCompositeLongbow());
+            SetWearable(new ElvenBoots(), 0x1BB, 1);
+            SetWearable(new LeafArms(), dropChance: 1);
+            SetWearable(new FemaleLeafChest(), dropChance: 1);
+            SetWearable(new HidePants(), dropChance: 1);
+            SetWearable(new ElvenCompositeLongbow(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Broolol.cs
+++ b/Scripts/Mobiles/NPCs/Broolol.cs
@@ -33,9 +33,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x71B));
-            AddItem(new MaleElvenRobe(0x1C));
-            AddItem(new WildStaff());
+            SetWearable(new ElvenBoots(), 0x71B, 1);
+            SetWearable(new MaleElvenRobe(), 0x1C, 1);
+            SetWearable(new WildStaff(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Butcher.cs
+++ b/Scripts/Mobiles/NPCs/Butcher.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -27,8 +28,8 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.HalfApron());
-            AddItem(new Items.Cleaver());
+            SetWearable(new HalfApron(), dropChance: 1);
+            SetWearable(new Cleaver(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Caelas.cs
+++ b/Scripts/Mobiles/NPCs/Caelas.cs
@@ -146,9 +146,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x1BB));
-            AddItem(new Cloak(0x71B));
-            AddItem(new RoyalCirclet());
+            SetWearable(new ElvenBoots(), 0x1BB, 1);
+            SetWearable(new Cloak(), 0x71B, 1);
+            SetWearable(new RoyalCirclet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Cailla.cs
+++ b/Scripts/Mobiles/NPCs/Cailla.cs
@@ -473,21 +473,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots());
-            AddItem(new MagicalShortbow());
-            AddItem(new HidePants());
-            AddItem(new HidePauldrons());
-            AddItem(new HideGloves());
-            AddItem(new HideFemaleChest());
-            AddItem(new WoodlandBelt());
-
-            Item item;
-
-            item = new RavenHelm
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
+            SetWearable(new ElvenBoots(), dropChance: 1);
+            SetWearable(new MagicalShortbow(), dropChance: 1);
+            SetWearable(new HidePants(), dropChance: 1);
+            SetWearable(new HidePauldrons(), dropChance: 1);
+            SetWearable(new HideGloves(), dropChance: 1);
+            SetWearable(new HideFemaleChest(), dropChance: 1);
+            SetWearable(new WoodlandBelt(), dropChance: 1);
+            SetWearable(new RavenHelm(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Calendor.cs
+++ b/Scripts/Mobiles/NPCs/Calendor.cs
@@ -83,10 +83,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x65A));
-            AddItem(new ElvenShirt(0x728));
-            AddItem(new Kilt(0x1BB));
-            AddItem(new RoyalCirclet());
+            SetWearable(new ElvenBoots(), 0x65A, 1);
+            SetWearable(new ElvenShirt(), 0x728, 1);
+            SetWearable(new Kilt(), 0x1BB, 1);
+            SetWearable(new RoyalCirclet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Canir.cs
+++ b/Scripts/Mobiles/NPCs/Canir.cs
@@ -37,10 +37,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x1BB));
-            AddItem(new MaleElvenRobe(0x5A5));
-            AddItem(new GemmedCirclet());
-            AddItem(RandomWand.CreateWand());
+            SetWearable(new Sandals(), 0x1BB, 1);
+            SetWearable(new MaleElvenRobe(), 0x5A5, 1);
+            SetWearable(new GemmedCirclet(), dropChance: 1);
+            SetWearable(RandomWand.CreateWand(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Carpenter.cs
+++ b/Scripts/Mobiles/NPCs/Carpenter.cs
@@ -1,4 +1,5 @@
 using Server.Engines.BulkOrders;
+using Server.Items;
 using System;
 using System.Collections.Generic;
 
@@ -36,7 +37,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.HalfApron());
+            SetWearable(new HalfApron(), dropChance: 1);
         }
 
         #region Bulk Orders

--- a/Scripts/Mobiles/NPCs/Chiyo.cs
+++ b/Scripts/Mobiles/NPCs/Chiyo.cs
@@ -121,7 +121,7 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+            SetWearable(new Backpack());
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Churchill.cs
+++ b/Scripts/Mobiles/NPCs/Churchill.cs
@@ -127,41 +127,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new OrderShield());
-            AddItem(new WarMace());
-
-            Item item;
-
-            item = new PlateLegs
-            {
-                Hue = 0x966
-            };
-            AddItem(item);
-
-            item = new PlateGloves
-            {
-                Hue = 0x966
-            };
-            AddItem(item);
-
-            item = new PlateGorget
-            {
-                Hue = 0x966
-            };
-            AddItem(item);
-
-            item = new PlateChest
-            {
-                Hue = 0x966
-            };
-            AddItem(item);
-
-            item = new PlateArms
-            {
-                Hue = 0x966
-            };
-            AddItem(item);
+            SetWearable(new Backpack());
+            SetWearable(new OrderShield(), dropChance: 1);
+            SetWearable(new WarMace(), dropChance: 1);
+			SetWearable(new PlateLegs(), 0x966, 1);
+			SetWearable(new PlateGloves(), 0x966, 1);
+			SetWearable(new PlateGorget(), 0x966, 1);
+			SetWearable(new PlateChest(), 0x966, 1);
+			SetWearable(new PlateArms(), 0x966, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Ciala.cs
+++ b/Scripts/Mobiles/NPCs/Ciala.cs
@@ -39,10 +39,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Boots(0x1BB));
-            AddItem(new ElvenShirt(0x737));
-            AddItem(new Skirt(0x21));
-            AddItem(new RoyalCirclet());
+            SetWearable(new Boots(), 0x1BB, 1);
+            SetWearable(new ElvenShirt(), 0x737, 1);
+            SetWearable(new Skirt(), 0x21, 1);
+            SetWearable(new RoyalCirclet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Cillitha.cs
+++ b/Scripts/Mobiles/NPCs/Cillitha.cs
@@ -226,9 +226,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x901));
-            AddItem(new ElvenShirt(0x714));
-            AddItem(new LeafLegs());
+            SetWearable(new ElvenBoots(), 0x901, 1);
+            SetWearable(new ElvenShirt(), 0x714, 1);
+            SetWearable(new LeafLegs(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Clairesse.cs
+++ b/Scripts/Mobiles/NPCs/Clairesse.cs
@@ -77,9 +77,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new PlainDress(0x3C9));
-            AddItem(new Shoes(0x740));
+            SetWearable(new Backpack());
+            SetWearable(new PlainDress(), 0x3C9, 1);
+            SetWearable(new Shoes(), 0x740, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Clehin.cs
+++ b/Scripts/Mobiles/NPCs/Clehin.cs
@@ -76,9 +76,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots());
-            AddItem(new LeafTonlet());
-            AddItem(new ElvenShirt());
+            SetWearable(new ElvenBoots(), dropChance: 1);
+            SetWearable(new LeafTonlet(), dropChance: 1);
+            SetWearable(new ElvenShirt(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Cloorne.cs
+++ b/Scripts/Mobiles/NPCs/Cloorne.cs
@@ -252,29 +252,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x3B3));
-            AddItem(new WingedHelm());
-            AddItem(new RadiantScimitar());
-
-            Item item;
-
-            item = new WoodlandLegs
-            {
-                Hue = 0x732
-            };
-            AddItem(item);
-
-            item = new HideChest
-            {
-                Hue = 0x727
-            };
-            AddItem(item);
-
-            item = new LeafArms
-            {
-                Hue = 0x749
-            };
-            AddItem(item);
+            SetWearable(new ElvenBoots(), 0x3B3, 1);
+            SetWearable(new WingedHelm(), dropChance: 1);
+            SetWearable(new RadiantScimitar(), dropChance: 1);
+			SetWearable(new WoodlandLegs(), 0x732, 1);
+			SetWearable(new HideChest(), 0x727, 1);
+			SetWearable(new LeafArms(), 0x749, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Cohenn.cs
+++ b/Scripts/Mobiles/NPCs/Cohenn.cs
@@ -78,9 +78,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x74A));
-            AddItem(new Robe(0x498));
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), 0x74A, 1);
+            SetWearable(new Robe(), 0x498, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Cook.cs
+++ b/Scripts/Mobiles/NPCs/Cook.cs
@@ -1,4 +1,5 @@
 using Server.Engines.BulkOrders;
+using Server.Items;
 using System;
 using System.Collections.Generic;
 
@@ -34,7 +35,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.HalfApron());
+            SetWearable(new HalfApron(), dropChance: 1);
         }
 
         #region Bulk Orders

--- a/Scripts/Mobiles/NPCs/CustomHairstylist.cs
+++ b/Scripts/Mobiles/NPCs/CustomHairstylist.cs
@@ -131,7 +131,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Robe(Utility.RandomPinkHue()));
+            SetWearable(new Robe(), Utility.RandomPinkHue(), 1);
         }
 
         public override bool CheckVendorAccess(Mobile from)

--- a/Scripts/Mobiles/NPCs/Daelas.cs
+++ b/Scripts/Mobiles/NPCs/Daelas.cs
@@ -39,22 +39,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x901));
-            AddItem(new ElvenPants(0x8AB));
-
-            Item item;
-
-            item = new LeafGloves
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
-
-            item = new LeafChest
-            {
-                Hue = 0x8B0
-            };
-            AddItem(item);
+            SetWearable(new ElvenBoots(), 0x901, 1);
+            SetWearable(new ElvenPants(), 0x8AB, 1);
+            SetWearable(new LeafGloves(), 0x1BB, 1);
+            SetWearable(new LeafChest(), 0x8B0, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Dallid.cs
+++ b/Scripts/Mobiles/NPCs/Dallid.cs
@@ -148,11 +148,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Boots(0x901));
-            AddItem(new ShortPants(0x733));
-            AddItem(new Shirt(0x70E));
-            AddItem(new FullApron(0x1BE));
-            AddItem(new Cleaver());
+            SetWearable(new Boots(), 0x901, 1);
+            SetWearable(new ShortPants(), 0x733, 1);
+            SetWearable(new Shirt(), 0x70E, 1);
+            SetWearable(new FullApron(), 0x1BE, 1);
+            SetWearable(new Cleaver(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Danoel.cs
+++ b/Scripts/Mobiles/NPCs/Danoel.cs
@@ -267,12 +267,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x901));
-            AddItem(new ElvenPants(0x386));
-            AddItem(new ElvenShirt(0x71D));
-            AddItem(new SmithHammer());
-            AddItem(new RoyalCirclet());
-            AddItem(new FullApron(0x1BB));
+            SetWearable(new ElvenBoots(), 0x901, 1);
+            SetWearable(new ElvenPants(), 0x386, 1);
+            SetWearable(new ElvenShirt(), 0x71D, 1);
+            SetWearable(new SmithHammer(), dropChance: 1);
+            SetWearable(new RoyalCirclet(), dropChance: 1);
+            SetWearable(new FullApron(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Darius.cs
+++ b/Scripts/Mobiles/NPCs/Darius.cs
@@ -29,11 +29,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new WildStaff());
-            AddItem(new Sandals(0x1BB));
-            AddItem(new GemmedCirclet());
-            AddItem(new Tunic(0x3));
+            SetWearable(new Backpack(), dropChance: 1);
+            SetWearable(new WildStaff(), dropChance: 1);
+            SetWearable(new Sandals(), 0x1BB, 1);
+            SetWearable(new GemmedCirclet(), dropChance: 1);
+            SetWearable(new Tunic(), 0x3, 1);
         }
 
         public override void Initialize()

--- a/Scripts/Mobiles/NPCs/Dimethro.cs
+++ b/Scripts/Mobiles/NPCs/Dimethro.cs
@@ -124,10 +124,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new LongPants(0x455));
-            AddItem(new Sandals(0x455));
-            AddItem(new BodySash(0x455));
+            SetWearable(new Backpack());
+            SetWearable(new LongPants(), 0x455, 1);
+            SetWearable(new Sandals(), 0x455, 1);
+            SetWearable(new BodySash(), 0x455, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/DocksAlchemist.cs
+++ b/Scripts/Mobiles/NPCs/DocksAlchemist.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -27,7 +28,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.HalfApron());
+            SetWearable(new HalfApron(), dropChance: 1);
         }
 
         public DocksAlchemist(Serial serial) : base(serial)

--- a/Scripts/Mobiles/NPCs/Drithen.cs
+++ b/Scripts/Mobiles/NPCs/Drithen.cs
@@ -32,11 +32,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new ElvenBoots(0x723));
-            AddItem(new LongPants(0x549));
-            AddItem(new Tunic(0x72B));
-            AddItem(new Cloak(0x30));
+            SetWearable(new Backpack());
+            SetWearable(new ElvenBoots(), 0x723, 1);
+            SetWearable(new LongPants(), 0x549, 1);
+            SetWearable(new Tunic(), 0x72B, 1);
+            SetWearable(new Cloak(), 0x30, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Dugan.cs
+++ b/Scripts/Mobiles/NPCs/Dugan.cs
@@ -76,13 +76,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(1819));
-            AddItem(new LeatherArms());
-            AddItem(new LeatherChest());
-            AddItem(new LeatherLegs());
-            AddItem(new LeatherGloves());
-            AddItem(new GnarledStaff());
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 1819, 1);
+            SetWearable(new LeatherArms(), dropChance: 1);
+            SetWearable(new LeatherChest(), dropChance: 1);
+            SetWearable(new LeatherLegs(), dropChance: 1);
+            SetWearable(new LeatherGloves(), dropChance: 1);
+            SetWearable(new GnarledStaff(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Egwexem.cs
+++ b/Scripts/Mobiles/NPCs/Egwexem.cs
@@ -69,10 +69,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new GargishClothChest());
-            AddItem(new GargishClothKilt());
-            AddItem(new GargishClothLegs(Utility.RandomNeutralHue()));
+            SetWearable(new Backpack());
+            SetWearable(new GargishClothChest(), dropChance: 1);
+            SetWearable(new GargishClothKilt(), dropChance: 1);
+            SetWearable(new GargishClothLegs(), Utility.RandomNeutralHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/ElwoodMcCarrin.cs
+++ b/Scripts/Mobiles/NPCs/ElwoodMcCarrin.cs
@@ -29,11 +29,11 @@ namespace Server.Engines.Quests.Collector
 
         public override void InitOutfit()
         {
-            AddItem(new FancyShirt());
-            AddItem(new LongPants(0x544));
-            AddItem(new Shoes(0x454));
-            AddItem(new JesterHat(0x4D2));
-            AddItem(new FullApron(0x4D2));
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(new LongPants(), 0x544, 1);
+            SetWearable(new Shoes(), 0x454, 1);
+            SetWearable(new JesterHat(), 0x4D2, 1);
+            SetWearable(new FullApron(), 0x4D2, 1);
 
             HairItemID = 0x203D; // Pony Tail
             HairHue = 0x47D;

--- a/Scripts/Mobiles/NPCs/Emerillo.cs
+++ b/Scripts/Mobiles/NPCs/Emerillo.cs
@@ -81,11 +81,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x75D));
-            AddItem(new LongPants(0x529));
-            AddItem(new Shirt(0x38B));
-            AddItem(new HalfApron(0x8FD));
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), 0x75D, 1);
+            SetWearable(new LongPants(), 0x529, 1);
+            SetWearable(new Shirt(), 0x38B, 1);
+            SetWearable(new HalfApron(), 0x8FD, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Emilio.cs
+++ b/Scripts/Mobiles/NPCs/Emilio.cs
@@ -33,12 +33,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x721));
-            AddItem(new LongPants(0x51B));
-            AddItem(new FancyShirt(0x517));
-            AddItem(new FloppyHat(0x584));
-            AddItem(new BodySash(0x13));
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), 0x721, 1);
+            SetWearable(new LongPants(), 0x51B, 1);
+            SetWearable(new FancyShirt(), 0x517, 1);
+            SetWearable(new FloppyHat(), 0x584, 1);
+            SetWearable(new BodySash(), 0x13, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Escortables.cs
+++ b/Scripts/Mobiles/NPCs/Escortables.cs
@@ -519,17 +519,17 @@ namespace Server.Engines.Quests
         {
             int lowHue = GetRandomHue();
 
-            AddItem(new ThighBoots());
+			SetWearable(new ThighBoots(), dropChance: 1);
 
             if (Female)
-                AddItem(new FancyDress(lowHue));
+				SetWearable(new FancyDress(), lowHue, 1);
             else
-                AddItem(new FancyShirt(lowHue));
+				SetWearable(new FancyShirt(), lowHue, 1);
 
-            AddItem(new LongPants(lowHue));
+			SetWearable(new LongPants(), lowHue, 1);
 
             if (!Female)
-                AddItem(new BodySash(lowHue));
+				SetWearable(new BodySash(), lowHue, 1);
 
             PackGold(50, 100);
         }
@@ -572,16 +572,16 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Robe(GetRandomHue()));
+			SetWearable(new Robe(), GetRandomHue(), 1);
 
             int lowHue = GetRandomHue();
 
-            AddItem(new ShortPants(lowHue));
+			SetWearable(new ShortPants(), lowHue, 1);
 
             if (Female)
-                AddItem(new ThighBoots(lowHue));
+				SetWearable(new ThighBoots(), lowHue, 1);
             else
-                AddItem(new Boots(lowHue));
+				SetWearable(new Boots(), lowHue, 1);
 
             PackGold(50, 100);
         }
@@ -617,32 +617,32 @@ namespace Server.Engines.Quests
         public override void InitOutfit()
         {
             if (Female)
-                AddItem(new PlainDress());
+				SetWearable(new PlainDress(), dropChance: 1);
             else
-                AddItem(new Shirt(GetRandomHue()));
+				SetWearable(new Shirt(), GetRandomHue(), 1);
 
             int lowHue = GetRandomHue();
 
-            AddItem(new ShortPants(lowHue));
+			SetWearable(new ShortPants(), lowHue, 1);
 
             if (Female)
-                AddItem(new Boots(lowHue));
+				SetWearable(new Boots(), lowHue, 1);
             else
-                AddItem(new Shoes(lowHue));
+				SetWearable(new Shoes(), lowHue);
 
             switch (Utility.Random(4))
             {
                 case 0:
-                    AddItem(new ShortHair(Utility.RandomHairHue()));
+					SetWearable(new ShortHair(Utility.RandomHairHue()));
                     break;
                 case 1:
-                    AddItem(new TwoPigTails(Utility.RandomHairHue()));
+					SetWearable(new TwoPigTails(Utility.RandomHairHue()));
                     break;
                 case 2:
-                    AddItem(new ReceedingHair(Utility.RandomHairHue()));
+					SetWearable(new ReceedingHair(Utility.RandomHairHue()));
                     break;
                 case 3:
-                    AddItem(new KrisnaHair(Utility.RandomHairHue()));
+					SetWearable(new KrisnaHair(Utility.RandomHairHue()));
                     break;
             }
 
@@ -680,25 +680,25 @@ namespace Server.Engines.Quests
         public override void InitOutfit()
         {
             if (Female)
-                AddItem(new FancyDress(GetRandomHue()));
+				SetWearable(new FancyDress(), GetRandomHue(), 1);
             else
-                AddItem(new FancyShirt(GetRandomHue()));
+				SetWearable(new FancyShirt(), GetRandomHue(), 1);
 
             int lowHue = GetRandomHue();
 
-            AddItem(new ShortPants(lowHue));
+			SetWearable(new ShortPants(), lowHue, 1);
 
             if (Female)
-                AddItem(new ThighBoots(lowHue));
+				SetWearable(new ThighBoots(), lowHue, 1);
             else
-                AddItem(new Boots(lowHue));
+				SetWearable(new Boots(), lowHue, 1);
 
             if (!Female)
-                AddItem(new BodySash(lowHue));
+				SetWearable(new BodySash(), lowHue, 1);
 
-            AddItem(new Cloak(GetRandomHue()));
+			SetWearable(new Cloak(), GetRandomHue(), 1);
 
-            AddItem(new Longsword());
+			SetWearable(new Longsword(), dropChance: 1);
 
             PackGold(50, 100);
         }
@@ -740,26 +740,26 @@ namespace Server.Engines.Quests
         public override void InitOutfit()
         {
             if (Female)
-                AddItem(new FancyDress());
+				SetWearable(new FancyDress(), dropChance: 1);
             else
-                AddItem(new FancyShirt(GetRandomHue()));
+				SetWearable(new FancyShirt(), GetRandomHue(), 1);
 
             int lowHue = GetRandomHue();
 
-            AddItem(new ShortPants(lowHue));
+			SetWearable(new ShortPants(), lowHue, 1);
 
             if (Female)
-                AddItem(new ThighBoots(lowHue));
+				SetWearable(new ThighBoots(), lowHue, 1);
             else
-                AddItem(new Boots(lowHue));
+				SetWearable(new Boots(), lowHue, 1);
 
             if (!Female)
-                AddItem(new BodySash(lowHue));
+				SetWearable(new BodySash(), lowHue, 1);
 
-            AddItem(new Cloak(GetRandomHue()));
+			SetWearable(new Cloak(), GetRandomHue(), 1);
 
             if (!Female)
-                AddItem(new Longsword());
+				SetWearable(new Longsword(), dropChance: 1);
 
             PackGold(50, 100);
         }
@@ -798,18 +798,18 @@ namespace Server.Engines.Quests
         public override void InitOutfit()
         {
             if (Female)
-                AddItem(new FancyDress());
+                SetWearable(new FancyDress(), dropChance: 1);
             else
-                AddItem(new FancyShirt());
+				SetWearable(new FancyShirt(), dropChance: 1);
 
             int lowHue = GetRandomHue();
 
-            AddItem(new LongPants(lowHue));
+			SetWearable(new LongPants(), lowHue, 1);
 
             if (Female)
-                AddItem(new Shoes(lowHue));
+				SetWearable(new Shoes(), lowHue, 1);
             else
-                AddItem(new Boots(lowHue));
+				SetWearable(new Boots(), lowHue, 1);
 
             if (Utility.RandomBool())
                 HairItemID = 0x203B;
@@ -852,18 +852,18 @@ namespace Server.Engines.Quests
         public override void InitOutfit()
         {
             if (Female)
-                AddItem(new PlainDress());
+                SetWearable(new PlainDress(), dropChance: 1);
             else
-                AddItem(new Shirt(GetRandomHue()));
+				SetWearable(new Shirt(), GetRandomHue(), 1);
 
             int lowHue = GetRandomHue();
 
-            AddItem(new ShortPants(lowHue));
+			SetWearable(new ShortPants(), lowHue, 1);
 
             if (Female)
-                AddItem(new Boots(lowHue));
+				SetWearable(new Boots(), lowHue, 1);
             else
-                AddItem(new Shoes(lowHue));
+				SetWearable(new Shoes(), lowHue, 1);
 
             Utility.AssignRandomHair(this);
 
@@ -954,9 +954,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(GetShoeHue()));
-            AddItem(new Robe(Utility.RandomYellowHue()));
-            AddItem(new GnarledStaff());
+            SetWearable(new Sandals(), GetShoeHue(), 1);
+            SetWearable(new Robe(), Utility.RandomYellowHue(), 1);
+            SetWearable(new GnarledStaff(), dropChance: 1);
         }
 
         public virtual bool CheckResurrect(Mobile m)

--- a/Scripts/Mobiles/NPCs/Evan.cs
+++ b/Scripts/Mobiles/NPCs/Evan.cs
@@ -33,10 +33,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x737));
-            AddItem(new ShortPants(0x74C));
-            AddItem(new FancyShirt(0x535));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x737, 1);
+            SetWearable(new ShortPants(), 0x74C, 1);
+            SetWearable(new FancyShirt(), 0x535, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/EvilWanderingHealer.cs
+++ b/Scripts/Mobiles/NPCs/EvilWanderingHealer.cs
@@ -10,7 +10,7 @@ namespace Server.Mobiles
             Title = "the Priest Of Mondain";
             Karma = -10000;
 
-            AddItem(new GnarledStaff());
+            SetWearable(new GnarledStaff(), dropChance: 1);
 
             SetSkill(SkillName.Camping, 80.0, 100.0);
             SetSkill(SkillName.Forensics, 80.0, 100.0);

--- a/Scripts/Mobiles/NPCs/Fabrizio.cs
+++ b/Scripts/Mobiles/NPCs/Fabrizio.cs
@@ -119,11 +119,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x753));
-            AddItem(new LongPants(0x59C));
-            AddItem(new HalfApron(0x8FD));
-            AddItem(new Tunic(0x58F));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x753, 1);
+            SetWearable(new LongPants(), 0x59C, 1);
+            SetWearable(new HalfApron(), 0x8FD, 1);
+            SetWearable(new Tunic(), 0x58F, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Farmer.cs
+++ b/Scripts/Mobiles/NPCs/Farmer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -35,7 +36,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.WideBrimHat(Utility.RandomNeutralHue()));
+            SetWearable(new WideBrimHat(), Utility.RandomNeutralHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/FarmerNash.cs
+++ b/Scripts/Mobiles/NPCs/FarmerNash.cs
@@ -126,9 +126,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x74A));
-            AddItem(new Robe(0x498));
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), 0x74A, 1);
+            SetWearable(new Robe(), 0x498, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Fisherman.cs
+++ b/Scripts/Mobiles/NPCs/Fisherman.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -28,7 +29,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.FishingPole());
+            SetWearable(new FishingPole(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Frazer.cs
+++ b/Scripts/Mobiles/NPCs/Frazer.cs
@@ -84,10 +84,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Shoes(0x735));
-            AddItem(new LongPants(0x4C0));
-            AddItem(new FancyShirt(0x3));
-            AddItem(new JesterHat(0x74A));
+            SetWearable(new Shoes(), 0x735, 1);
+            SetWearable(new LongPants(), 0x4C0, 1);
+            SetWearable(new FancyShirt(), 0x3, 1);
+            SetWearable(new JesterHat(), 0x74A, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/GabrielPiete.cs
+++ b/Scripts/Mobiles/NPCs/GabrielPiete.cs
@@ -29,9 +29,9 @@ namespace Server.Engines.Quests.Collector
 
         public override void InitOutfit()
         {
-            AddItem(new FancyShirt());
-            AddItem(new LongPants(0x5F7));
-            AddItem(new Shoes(0x5F7));
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(new LongPants(), 0x5F7, 1);
+            SetWearable(new Shoes(), 0x5F7, 1);
 
             HairItemID = 0x2049; // Pig Tails
             HairHue = 0x460;

--- a/Scripts/Mobiles/NPCs/Gardener.cs
+++ b/Scripts/Mobiles/NPCs/Gardener.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -32,7 +33,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.WideBrimHat(Utility.RandomNeutralHue()));
+            SetWearable(new WideBrimHat(), Utility.RandomNeutralHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/GargishRefugee.cs
+++ b/Scripts/Mobiles/NPCs/GargishRefugee.cs
@@ -14,17 +14,17 @@ namespace Server.Mobiles
                 Body = 667;
                 HairItemID = 17067;
                 HairHue = 1762;
-                AddItem(new GargishClothChest());
-                AddItem(new GargishClothKilt(Utility.RandomNeutralHue()));
+                SetWearable(new GargishClothChest(), dropChance: 1);
+                SetWearable(new GargishClothKilt(), Utility.RandomNeutralHue(), 1);
             }
             else
             {
                 Body = 666;
                 HairItemID = 16987;
                 HairHue = 1801;
-                AddItem(new GargishClothChest());
-                AddItem(new GargishClothKilt());
-                AddItem(new GargishClothLegs(Utility.RandomNeutralHue()));
+                SetWearable(new GargishClothChest(), dropChance: 1);
+                SetWearable(new GargishClothKilt(), dropChance: 1);
+				SetWearable(new GargishClothLegs(), Utility.RandomNeutralHue(), 1);
             }
         }
 

--- a/Scripts/Mobiles/NPCs/GargishWanderingHealer.cs
+++ b/Scripts/Mobiles/NPCs/GargishWanderingHealer.cs
@@ -10,9 +10,9 @@ namespace Server.Mobiles
             Title = "a Gargish wandering healer";
             Body = 666;
 
-            AddItem(new GnarledStaff());
-            //AddItem( new GargishRobe(5) );
-
+            SetWearable(new GnarledStaff(), dropChance: 1);
+            //SetWearable(new GargishRobe(), 5, 1);
+            
             SetSkill(SkillName.Camping, 80.0, 100.0);
             SetSkill(SkillName.Forensics, 80.0, 100.0);
             SetSkill(SkillName.SpiritSpeak, 80.0, 100.0);

--- a/Scripts/Mobiles/NPCs/GargishWarrior.cs
+++ b/Scripts/Mobiles/NPCs/GargishWarrior.cs
@@ -14,26 +14,26 @@ namespace Server.Mobiles
                 Body = 667;
                 HairItemID = 17067;
                 HairHue = 1762;
-                AddItem(new FemaleGargishPlateChest());
-                AddItem(new FemaleGargishPlateKilt());
-                AddItem(new FemaleGargishPlateLegs());
-                AddItem(new FemaleGargishPlateArms());
-                AddItem(new PlateTalons());
+				SetWearable(new FemaleGargishPlateChest(), dropChance: 1);
+                SetWearable(new FemaleGargishPlateKilt(), dropChance: 1);
+                SetWearable(new FemaleGargishPlateLegs(), dropChance: 1);
+                SetWearable(new FemaleGargishPlateArms(), dropChance: 1);
+                SetWearable(new PlateTalons(), dropChance: 1);
 
-                AddItem(new GlassSword());
+                SetWearable(new GlassSword(), dropChance: 1);
             }
             else
             {
                 Body = 666;
                 HairItemID = 16987;
                 HairHue = 1801;
-                AddItem(new GargishPlateChest());
-                AddItem(new GargishPlateKilt());
-                AddItem(new GargishPlateLegs());
-                AddItem(new GargishPlateArms());
-                AddItem(new PlateTalons());
+				SetWearable(new GargishPlateChest(), dropChance: 1);
+                SetWearable(new GargishPlateKilt(), dropChance: 1);
+                SetWearable(new GargishPlateLegs(), dropChance: 1);
+                SetWearable(new GargishPlateArms(), dropChance: 1);
+                SetWearable(new PlateTalons(), dropChance: 1);
 
-                AddItem(new GlassSword());
+                SetWearable(new GlassSword(), dropChance: 1);
             }
         }
 

--- a/Scripts/Mobiles/NPCs/GeorgeHephaestus.cs
+++ b/Scripts/Mobiles/NPCs/GeorgeHephaestus.cs
@@ -132,19 +132,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots(0x973));
-            AddItem(new LongPants());
-            AddItem(new Bascinet());
-            AddItem(new FullApron(0x8AB));
-
-            Item item;
-
-            item = new SmithHammer
-            {
-                Hue = 0x8AB
-            };
-            AddItem(item);
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), 0x973, 1);
+            SetWearable(new LongPants(), dropChance: 1);
+            SetWearable(new Bascinet(), dropChance: 1);
+            SetWearable(new FullApron(), 0x8AB, 1);
+            SetWearable(new SmithHammer(), 0x8AB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Gervis.cs
+++ b/Scripts/Mobiles/NPCs/Gervis.cs
@@ -75,20 +75,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new SmithHammer());
-            AddItem(new Boots(0x3B2));
-            AddItem(new ShortPants(0x1BB));
-            AddItem(new Shirt(0x71F));
-            AddItem(new FullApron(0x3B2));
-
-            Item item;
-
-            item = new LeatherGloves
-            {
-                Hue = 0x3B2
-            };
-            AddItem(item);
+			SetWearable(new Backpack());
+            SetWearable(new SmithHammer(), dropChance: 1);
+            SetWearable(new Boots(), 0x3B2, 1);
+            SetWearable(new ShortPants(), 0x1BB, 1);
+            SetWearable(new Shirt(), 0x71F, 1);
+			SetWearable(new FullApron(), 0x3B2, 1);
+			SetWearable(new LeatherGloves(), 0x3B2, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Gnosos.cs
+++ b/Scripts/Mobiles/NPCs/Gnosos.cs
@@ -92,9 +92,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x485));
-            AddItem(new Robe(0x497));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x485, 1);
+			SetWearable(new Robe(), 0x497, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Gorrow.cs
+++ b/Scripts/Mobiles/NPCs/Gorrow.cs
@@ -74,11 +74,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x1BB));
-            AddItem(new LongPants(0x901));
-            AddItem(new Tunic(0x70A));
-            AddItem(new Cloak(0x675));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x1BB, 1);
+            SetWearable(new LongPants(), 0x901, 1);
+            SetWearable(new Tunic(), 0x70A, 1);
+			SetWearable(new Cloak(), 0x675, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/GrandpaCharley.cs
+++ b/Scripts/Mobiles/NPCs/GrandpaCharley.cs
@@ -45,12 +45,12 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new ShepherdsCrook());
-            AddItem(new Shoes(0x72F));
-            AddItem(new LongPants(0x519));
-            AddItem(new FancyShirt(0x600));
-            AddItem(new WideBrimHat(0x6B1));
+            SetWearable(new Backpack());
+            SetWearable(new ShepherdsCrook(), dropChance: 1);
+            SetWearable(new Shoes(), 0x72F, 1);
+            SetWearable(new LongPants(), 0x519, 1);
+            SetWearable(new FancyShirt(), 0x600, 1);
+			SetWearable(new WideBrimHat(), 0x6B1, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Grizelda.cs
+++ b/Scripts/Mobiles/NPCs/Grizelda.cs
@@ -31,18 +31,12 @@ namespace Server.Engines.Quests.Hag
 
         public override void InitOutfit()
         {
-            AddItem(new Robe(0x1));
-            AddItem(new Sandals());
-            AddItem(new WizardsHat(0x1));
-            AddItem(new GoldBracelet());
-
-            HairItemID = 0x203C;
-
-            Item staff = new GnarledStaff
-            {
-                Movable = false
-            };
-            AddItem(staff);
+            SetWearable(new Robe(), 0x1, 1);
+            SetWearable(new Sandals(), dropChance: 1);
+            SetWearable(new WizardsHat(), 0x1, 1);
+			SetWearable(new GoldBracelet(), dropChance: 1);
+			SetWearable(new GnarledStaff());
+			HairItemID = 0x203C;
         }
 
         public override void OnTalk(PlayerMobile player, bool contextMenu)

--- a/Scripts/Mobiles/NPCs/Gustar.cs
+++ b/Scripts/Mobiles/NPCs/Gustar.cs
@@ -129,9 +129,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new HoodedShroudOfShadows(0x479));
-            AddItem(new Sandals());
+            SetWearable(new Backpack());
+            SetWearable(new HoodedShroudOfShadows(), 0x479, 1);
+			SetWearable(new Sandals(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Gypsy.cs
+++ b/Scripts/Mobiles/NPCs/Gypsy.cs
@@ -23,23 +23,23 @@ namespace Server.Mobiles
             {
                 Body = 0x191;
                 Name = NameList.RandomName("female");
-                AddItem(new Kilt(Utility.RandomDyedHue()));
-                AddItem(new Shirt(Utility.RandomDyedHue()));
-                AddItem(new ThighBoots());
+                SetWearable(new Kilt(), Utility.RandomDyedHue(), 1);
+                SetWearable(new Shirt(), Utility.RandomDyedHue(), 1);
+				SetWearable(new ThighBoots(), dropChance: 1);
                 Title = "the gypsy";
             }
             else
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
-                AddItem(new Shirt(Utility.RandomDyedHue()));
-                AddItem(new Sandals());
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
+                SetWearable(new Shirt(), Utility.RandomDyedHue(), 1);
+                SetWearable(new Sandals(), dropChance: 1);
                 Title = "the gypsy";
             }
 
-            AddItem(new Bandana(Utility.RandomDyedHue()));
-            AddItem(new Dagger());
+			SetWearable(new Bandana(), Utility.RandomDyedHue(), 1);
+			SetWearable(new Dagger(), dropChance: 1);
 
             Utility.AssignRandomHair(this);
 
@@ -47,9 +47,7 @@ namespace Server.Mobiles
 
             pack.DropItem(new Gold(250, 300));
 
-            pack.Movable = false;
-
-            AddItem(pack);
+			SetWearable(pack);
         }
 
         public Gypsy(Serial serial)

--- a/Scripts/Mobiles/NPCs/GypsyBanker.cs
+++ b/Scripts/Mobiles/NPCs/GypsyBanker.cs
@@ -28,13 +28,13 @@ namespace Server.Mobiles
             switch (Utility.Random(4))
             {
                 case 0:
-                    AddItem(new JesterHat(Utility.RandomBrightHue()));
+					SetWearable(new JesterHat(), Utility.RandomBrightHue(), 1);
                     break;
                 case 1:
-                    AddItem(new Bandana(Utility.RandomBrightHue()));
+					SetWearable(new Bandana(), Utility.RandomBrightHue(), 1);
                     break;
                 case 2:
-                    AddItem(new SkullCap(Utility.RandomBrightHue()));
+					SetWearable(new SkullCap(), Utility.RandomBrightHue(), 1);
                     break;
             }
 

--- a/Scripts/Mobiles/NPCs/GypsyFortuneTeller.cs
+++ b/Scripts/Mobiles/NPCs/GypsyFortuneTeller.cs
@@ -26,13 +26,13 @@ namespace Server.Mobiles
 			switch (Utility.Random(4))
 			{
 				case 0:
-					AddItem(new JesterHat(Utility.RandomBrightHue()));
+					SetWearable(new JesterHat(), Utility.RandomBrightHue(), 1);
 					break;
 				case 1:
-					AddItem(new Bandana(Utility.RandomBrightHue()));
+					SetWearable(new Bandana(), Utility.RandomBrightHue(), 1);
 					break;
 				case 2:
-					AddItem(new SkullCap(Utility.RandomBrightHue()));
+					SetWearable(new SkullCap(), Utility.RandomBrightHue(), 1);
 					break;
 			}
 

--- a/Scripts/Mobiles/NPCs/GypsyMaiden.cs
+++ b/Scripts/Mobiles/NPCs/GypsyMaiden.cs
@@ -37,21 +37,21 @@ namespace Server.Mobiles
             base.InitOutfit();
 
             switch (Utility.Random(4))
-            {
-                case 0:
-                    AddItem(new JesterHat(Utility.RandomBrightHue()));
-                    break;
-                case 1:
-                    AddItem(new Bandana(Utility.RandomBrightHue()));
-                    break;
-                case 2:
-                    AddItem(new SkullCap(Utility.RandomBrightHue()));
-                    break;
-            }
+			{
+				case 0:
+					SetWearable(new JesterHat(), Utility.RandomBrightHue(), 1);
+					break;
+				case 1:
+					SetWearable(new Bandana(), Utility.RandomBrightHue(), 1);
+					break;
+				case 2:
+					SetWearable(new SkullCap(), Utility.RandomBrightHue(), 1);
+					break;
+			}
 
             if (Utility.RandomBool())
             {
-                AddItem(new HalfApron(Utility.RandomBrightHue()));
+                SetWearable(new HalfApron(), Utility.RandomBrightHue(), 1);
             }
 
             Item item = FindItemOnLayer(Layer.Pants);

--- a/Scripts/Mobiles/NPCs/Hamato.cs
+++ b/Scripts/Mobiles/NPCs/Hamato.cs
@@ -135,13 +135,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new NoDachi());
-            AddItem(new NinjaTabi());
-            AddItem(new PlateSuneate());
-            AddItem(new LightPlateJingasa());
-            AddItem(new LeatherDo());
-            AddItem(new LeatherHiroSode());
+            SetWearable(new Backpack());
+            SetWearable(new NoDachi(), dropChance: 1);
+            SetWearable(new NinjaTabi(), dropChance: 1);
+            SetWearable(new PlateSuneate(), dropChance: 1);
+            SetWearable(new LightPlateJingasa(), dropChance: 1);
+            SetWearable(new LeatherDo(), dropChance: 1);
+            SetWearable(new LeatherHiroSode(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/HarborMaster.cs
+++ b/Scripts/Mobiles/NPCs/HarborMaster.cs
@@ -38,10 +38,10 @@ namespace Server.Mobiles
                 Title = "the Harbor Master";
             }
 
-            AddItem(new Shirt(Utility.RandomDyedHue()));
-            AddItem(new Boots());
-            AddItem(new LongPants(Utility.RandomNeutralHue()));
-            AddItem(new QuarterStaff());
+            SetWearable(new Shirt(), Utility.RandomDyedHue(), 1);
+            SetWearable(new LongPants(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new QuarterStaff(), dropChance: 1);
 
             Utility.AssignRandomHair(this);
         }

--- a/Scripts/Mobiles/NPCs/Hargrove.cs
+++ b/Scripts/Mobiles/NPCs/Hargrove.cs
@@ -73,20 +73,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new BattleAxe());
-            AddItem(new Boots(0x901));
-            AddItem(new StuddedLegs());
-            AddItem(new Shirt(0x288));
-            AddItem(new Bandana(0x20));
-
-            Item item;
-
-            item = new PlateGloves
-            {
-                Hue = 0x21E
-            };
-            AddItem(item);
+            SetWearable(new Backpack(), dropChance: 1);
+            SetWearable(new BattleAxe(), dropChance: 1);
+            SetWearable(new StuddedLegs(), dropChance: 1);
+            SetWearable(new Boots(), 0x901, 1);
+            SetWearable(new Shirt(), 0x288, 1);
+            SetWearable(new Bandana(), 0x20, 1);
+            SetWearable(new PlateGloves(), 0x21E, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/HealerGuildmaster.cs
+++ b/Scripts/Mobiles/NPCs/HealerGuildmaster.cs
@@ -1,3 +1,5 @@
+using Server.Items;
+
 namespace Server.Mobiles
 {
     public class HealerGuildmaster : BaseGuildmaster
@@ -24,7 +26,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.Robe(Utility.RandomYellowHue()));
+			SetWearable(new Robe(), Utility.RandomYellowHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/HireBard.cs
+++ b/Scripts/Mobiles/NPCs/HireBard.cs
@@ -18,10 +18,10 @@ namespace Server.Mobiles
                 switch (Utility.Random(2))
                 {
                     case 0:
-                        AddItem(new Skirt(Utility.RandomDyedHue()));
+						SetWearable(new Skirt(), Utility.RandomDyedHue(), 1);
                         break;
                     case 1:
-                        AddItem(new Kilt(Utility.RandomNeutralHue()));
+						SetWearable(new Kilt(), Utility.RandomNeutralHue(), 1);
                         break;
                 }
             }
@@ -29,7 +29,7 @@ namespace Server.Mobiles
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
             Title = "the bard";
             HairItemID = Race.RandomHair(Female);
@@ -53,15 +53,15 @@ namespace Server.Mobiles
             Fame = 100;
             Karma = 100;
 
-            AddItem(new Shoes(Utility.RandomNeutralHue()));
+			SetWearable(new Shoes(), Utility.RandomNeutralHue(), 1);
 
             switch (Utility.Random(2))
             {
                 case 0:
-                    AddItem(new Doublet(Utility.RandomDyedHue()));
+					SetWearable(new Doublet(), Utility.RandomDyedHue(), 1);
                     break;
                 case 1:
-                    AddItem(new Shirt(Utility.RandomDyedHue()));
+					SetWearable(new Shirt(), Utility.RandomDyedHue(), 1);
                     break;
             }
         }

--- a/Scripts/Mobiles/NPCs/HireBardArcher.cs
+++ b/Scripts/Mobiles/NPCs/HireBardArcher.cs
@@ -19,10 +19,10 @@ namespace Server.Mobiles
                 switch (Utility.Random(2))
                 {
                     case 0:
-                        AddItem(new Skirt(Utility.RandomDyedHue()));
+						SetWearable(new Skirt(), Utility.RandomDyedHue(), 1);
                         break;
                     case 1:
-                        AddItem(new Kilt(Utility.RandomNeutralHue()));
+						SetWearable(new Kilt(), Utility.RandomNeutralHue(), 1);
                         break;
                 }
             }
@@ -30,7 +30,7 @@ namespace Server.Mobiles
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
             Title = "the bard";
             HairItemID = Race.RandomHair(Female);
@@ -54,15 +54,15 @@ namespace Server.Mobiles
             Fame = 100;
             Karma = 100;
 
-            AddItem(new Shoes(Utility.RandomNeutralHue()));
+			SetWearable(new Shoes(), Utility.RandomNeutralHue(), 1);
 
             switch (Utility.Random(2))
             {
                 case 0:
-                    AddItem(new Doublet(Utility.RandomDyedHue()));
+					SetWearable(new Doublet(), Utility.RandomDyedHue(), 1);
                     break;
                 case 1:
-                    AddItem(new Shirt(Utility.RandomDyedHue()));
+					SetWearable(new Shirt(), Utility.RandomDyedHue(), 1);
                     break;
             }
         }

--- a/Scripts/Mobiles/NPCs/HireBeggar.cs
+++ b/Scripts/Mobiles/NPCs/HireBeggar.cs
@@ -18,10 +18,10 @@ namespace Server.Mobiles
                 switch (Utility.Random(2))
                 {
                     case 0:
-                        AddItem(new Skirt(Utility.RandomNeutralHue()));
+						SetWearable(new Skirt(), Utility.RandomNeutralHue(), 1);
                         break;
                     case 1:
-                        AddItem(new Kilt(Utility.RandomNeutralHue()));
+						SetWearable(new Kilt(), Utility.RandomNeutralHue(), 1);
                         break;
                 }
             }
@@ -29,7 +29,7 @@ namespace Server.Mobiles
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
             Title = "the beggar";
             HairItemID = Race.RandomHair(Female);
@@ -50,15 +50,15 @@ namespace Server.Mobiles
             Fame = 0;
             Karma = 0;
 
-            AddItem(new Sandals(Utility.RandomNeutralHue()));
+			SetWearable(new Sandals(), Utility.RandomNeutralHue(), 1);
 
             switch (Utility.Random(2))
             {
                 case 0:
-                    AddItem(new Doublet(Utility.RandomNeutralHue()));
+					SetWearable(new Doublet(), Utility.RandomNeutralHue(), 1);
                     break;
                 case 1:
-                    AddItem(new Shirt(Utility.RandomNeutralHue()));
+					SetWearable(new Shirt(), Utility.RandomNeutralHue(), 1);
                     break;
             }
 

--- a/Scripts/Mobiles/NPCs/HireFighter.cs
+++ b/Scripts/Mobiles/NPCs/HireFighter.cs
@@ -46,32 +46,32 @@ namespace Server.Mobiles
             switch (Utility.Random(2))
             {
                 case 0:
-                    AddItem(new Shoes(Utility.RandomNeutralHue()));
+					SetWearable(new Shoes(), Utility.RandomNeutralHue(), 1);
                     break;
                 case 1:
-                    AddItem(new Boots(Utility.RandomNeutralHue()));
+					SetWearable(new Boots(), Utility.RandomNeutralHue(), 1);
                     break;
             }
 
-            AddItem(new Shirt());
+			SetWearable(new Shirt());
 
             // Pick a random sword
             switch (Utility.Random(5))
             {
                 case 0:
-                    AddItem(new Longsword());
+					SetWearable(new Longsword(), dropChance: 1);
                     break;
                 case 1:
-                    AddItem(new Broadsword());
+					SetWearable(new Broadsword(), dropChance: 1);
                     break;
                 case 2:
-                    AddItem(new VikingSword());
+					SetWearable(new VikingSword(), dropChance: 1);
                     break;
                 case 3:
-                    AddItem(new BattleAxe());
+					SetWearable(new BattleAxe(), dropChance: 1);
                     break;
                 case 4:
-                    AddItem(new TwoHandedAxe());
+					SetWearable(new TwoHandedAxe(), dropChance: 1);
                     break;
             }
 
@@ -81,28 +81,28 @@ namespace Server.Mobiles
                 switch (Utility.Random(8))
                 {
                     case 0:
-                        AddItem(new BronzeShield());
+						SetWearable(new BronzeShield(), dropChance: 1);
                         break;
                     case 1:
-                        AddItem(new HeaterShield());
+						SetWearable(new HeaterShield(), dropChance: 1);
                         break;
                     case 2:
-                        AddItem(new MetalKiteShield());
+						SetWearable(new MetalKiteShield(), dropChance: 1);
                         break;
                     case 3:
-                        AddItem(new MetalShield());
+						SetWearable(new MetalShield(), dropChance: 1);
                         break;
                     case 4:
-                        AddItem(new WoodenKiteShield());
+						SetWearable(new WoodenKiteShield(), dropChance: 1);
                         break;
                     case 5:
-                        AddItem(new WoodenShield());
+						SetWearable(new WoodenShield(), dropChance: 1);
                         break;
                     case 6:
-                        AddItem(new OrderShield());
+						SetWearable(new OrderShield(), dropChance: 1);
                         break;
                     case 7:
-                        AddItem(new ChaosShield());
+						SetWearable(new ChaosShield(), dropChance: 1);
                         break;
                 }
             }
@@ -112,45 +112,45 @@ namespace Server.Mobiles
                 case 0:
                     break;
                 case 1:
-                    AddItem(new Bascinet());
+					SetWearable(new Bascinet(), dropChance: 1);
                     break;
                 case 2:
-                    AddItem(new CloseHelm());
+					SetWearable(new CloseHelm(), dropChance: 1);
                     break;
                 case 3:
-                    AddItem(new NorseHelm());
+					SetWearable(new NorseHelm(), dropChance: 1);
                     break;
                 case 4:
-                    AddItem(new Helmet());
+					SetWearable(new Helmet(), dropChance: 1);
                     break;
             }
             // Pick some armour
             switch (Utility.Random(4))
             {
                 case 0: // Leather
-                    AddItem(new LeatherChest());
-                    AddItem(new LeatherArms());
-                    AddItem(new LeatherGloves());
-                    AddItem(new LeatherGorget());
-                    AddItem(new LeatherLegs());
+                    SetWearable(new LeatherChest(), dropChance: 1);
+                    SetWearable(new LeatherArms(), dropChance: 1);
+                    SetWearable(new LeatherGloves(), dropChance: 1);
+					SetWearable(new LeatherGorget(), dropChance: 1);
+					SetWearable(new LeatherLegs(), dropChance: 1);
                     break;
                 case 1: // Studded Leather
-                    AddItem(new StuddedChest());
-                    AddItem(new StuddedArms());
-                    AddItem(new StuddedGloves());
-                    AddItem(new StuddedGorget());
-                    AddItem(new StuddedLegs());
+                    SetWearable(new StuddedChest(), dropChance: 1);
+                    SetWearable(new StuddedArms(), dropChance: 1);
+                    SetWearable(new StuddedGloves(), dropChance: 1);
+                    SetWearable(new StuddedGorget(), dropChance: 1);
+					SetWearable(new StuddedLegs(), dropChance: 1);
                     break;
                 case 2: // Ringmail
-                    AddItem(new RingmailChest());
-                    AddItem(new RingmailArms());
-                    AddItem(new RingmailGloves());
-                    AddItem(new RingmailLegs());
+                    SetWearable(new RingmailChest(), dropChance: 1);
+                    SetWearable(new RingmailArms(), dropChance: 1);
+                    SetWearable(new RingmailGloves(), dropChance: 1);
+					SetWearable(new RingmailLegs(), dropChance: 1);
                     break;
                 case 3: // Chain
-                    AddItem(new ChainChest());
-                    //AddItem(new ChainCoif());
-                    AddItem(new ChainLegs());
+					SetWearable(new ChainChest(), dropChance: 1);
+					//SetWearable(new ChainCoif(), dropChance: 1);
+					SetWearable(new ChainLegs(), dropChance: 1);
                     break;
             }
 

--- a/Scripts/Mobiles/NPCs/HireMage.cs
+++ b/Scripts/Mobiles/NPCs/HireMage.cs
@@ -20,7 +20,7 @@ namespace Server.Mobiles
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
 
             HairItemID = Race.RandomHair(Female);
@@ -43,14 +43,14 @@ namespace Server.Mobiles
             Fame = 100;
             Karma = 100;
 
-            AddItem(new Shirt());
+			SetWearable(new Shirt(), dropChance: 1);
 
-            AddItem(new Robe(Utility.RandomNeutralHue()));
+			SetWearable(new Robe(), Utility.RandomNeutralHue(), 1);
 
             if (Utility.RandomBool())
-                AddItem(new Shoes(Utility.RandomNeutralHue()));
+				SetWearable(new Shoes(), Utility.RandomNeutralHue(), 1);
             else
-                AddItem(new ThighBoots());
+				SetWearable(new ThighBoots(), dropChance: 1);
 
             PackGold(20, 100);
         }

--- a/Scripts/Mobiles/NPCs/HirePaladin.cs
+++ b/Scripts/Mobiles/NPCs/HirePaladin.cs
@@ -31,16 +31,16 @@ namespace Server.Mobiles
                 case 0:
                     break;
                 case 1:
-                    AddItem(new Bascinet());
+					SetWearable(new Bascinet(), dropChance: 1);
                     break;
                 case 2:
-                    AddItem(new CloseHelm());
+					SetWearable(new CloseHelm(), dropChance: 1);
                     break;
                 case 3:
-                    AddItem(new NorseHelm());
+					SetWearable(new NorseHelm(), dropChance: 1);
                     break;
                 case 4:
-                    AddItem(new Helmet());
+					SetWearable(new Helmet(), dropChance: 1);
                     break;
             }
 
@@ -62,15 +62,15 @@ namespace Server.Mobiles
             Fame = 100;
             Karma = 250;
 
-            AddItem(new Shoes(Utility.RandomNeutralHue()));
-            AddItem(new Shirt());
-            AddItem(new VikingSword());
-            AddItem(new MetalKiteShield());
+            SetWearable(new Shoes(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new Shirt(), dropChance: 1);
+            SetWearable(new VikingSword(), dropChance: 1);
+			SetWearable(new MetalKiteShield(), dropChance: 1);
 
-            AddItem(new PlateChest());
-            AddItem(new PlateLegs());
-            AddItem(new PlateArms());
-            AddItem(new LeatherGorget());
+            SetWearable(new PlateChest(), dropChance: 1);
+            SetWearable(new PlateLegs(), dropChance: 1);
+            SetWearable(new PlateArms(), dropChance: 1);
+			SetWearable(new LeatherGorget(), dropChance: 1);
             PackGold(20, 100);
         }
 

--- a/Scripts/Mobiles/NPCs/HirePeasant.cs
+++ b/Scripts/Mobiles/NPCs/HirePeasant.cs
@@ -18,10 +18,10 @@ namespace Server.Mobiles
                 switch (Utility.Random(2))
                 {
                     case 0:
-                        AddItem(new Skirt(Utility.RandomNeutralHue()));
+                        SetWearable(new Skirt(), Utility.RandomNeutralHue(), 1);
                         break;
                     case 1:
-                        AddItem(new Kilt(Utility.RandomNeutralHue()));
+						SetWearable(new Kilt(), Utility.RandomNeutralHue(), 1);
                         break;
                 }
             }
@@ -29,14 +29,14 @@ namespace Server.Mobiles
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
             Title = "the peasant";
             HairItemID = Race.RandomHair(Female);
             HairHue = Race.RandomHairHue();
             Race.RandomFacialHair(this);
 
-            AddItem(new Katana());
+			SetWearable(new Katana(), dropChance: 1);
 
             SetStr(26, 26);
             SetDex(21, 21);
@@ -51,14 +51,14 @@ namespace Server.Mobiles
             Fame = 0;
             Karma = 0;
 
-            AddItem(new Sandals(Utility.RandomNeutralHue()));
+			SetWearable(new Sandals(), Utility.RandomNeutralHue(), 1);
             switch (Utility.Random(2))
             {
                 case 0:
-                    AddItem(new Doublet(Utility.RandomNeutralHue()));
+					SetWearable(new Doublet(), Utility.RandomNeutralHue(), 1);
                     break;
                 case 1:
-                    AddItem(new Shirt(Utility.RandomNeutralHue()));
+					SetWearable(new Shirt(), Utility.RandomNeutralHue(), 1);
                     break;
             }
 

--- a/Scripts/Mobiles/NPCs/HireRanger.cs
+++ b/Scripts/Mobiles/NPCs/HireRanger.cs
@@ -19,7 +19,7 @@ namespace Server.Mobiles
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+                SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
 
             Title = "the ranger";
@@ -44,28 +44,28 @@ namespace Server.Mobiles
             Fame = 100;
             Karma = 125;
 
-            AddItem(new Shoes(Utility.RandomNeutralHue()));
-            AddItem(new Shirt());
+			SetWearable(new Shoes(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new Shirt(), dropChance: 1);
 
             // Pick a random sword
             switch (Utility.Random(3))
             {
                 case 0:
-                    AddItem(new Longsword());
+					SetWearable(new Longsword(), dropChance: 1);
                     break;
                 case 1:
-                    AddItem(new VikingSword());
+					SetWearable(new VikingSword(), dropChance: 1);
                     break;
                 case 2:
-                    AddItem(new Broadsword());
+					SetWearable(new Broadsword(), dropChance: 1);
                     break;
             }
 
-            SetWearable(new StuddedChest(), 0x59C);
-            SetWearable(new StuddedArms(), 0x59C);
-            SetWearable(new StuddedGloves(), 0x59C);
-            SetWearable(new StuddedLegs(), 0x59C);
-            SetWearable(new StuddedGorget(), 0x59C);
+            SetWearable(new StuddedChest(), 0x59C, 1);
+            SetWearable(new StuddedArms(), 0x59C, 1);
+            SetWearable(new StuddedGloves(), 0x59C, 1);
+            SetWearable(new StuddedLegs(), 0x59C, 1);
+            SetWearable(new StuddedGorget(), 0x59C, 1);
         }
 
         public override void GenerateLoot()

--- a/Scripts/Mobiles/NPCs/HireRangerArcher.cs
+++ b/Scripts/Mobiles/NPCs/HireRangerArcher.cs
@@ -44,25 +44,25 @@ namespace Server.Mobiles
             Fame = 100;
             Karma = 125;
 
-            AddItem(new Shoes(Utility.RandomNeutralHue()));
-            AddItem(new Shirt());
+            SetWearable(new Shoes(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new Shirt(), dropChance: 1);
 
             // Pick a random sword
             switch (Utility.Random(2))
             {
                 case 0:
-                    AddItem(new Bow());
+					SetWearable(new Bow(), dropChance: 1);
                     break;
                 case 1:
-                    AddItem(new CompositeBow());
+					SetWearable(new CompositeBow(), dropChance: 1);
                     break;
             }
 
-            AddItem(new RangerChest());
-            AddItem(new RangerArms());
-            AddItem(new RangerGloves());
-            AddItem(new RangerGorget());
-            AddItem(new RangerLegs());
+			SetWearable(new RangerChest(), dropChance: 1);
+			SetWearable(new RangerArms(), dropChance: 1);
+			SetWearable(new RangerGloves(), dropChance: 1);
+			SetWearable(new RangerGorget(), dropChance: 1);
+			SetWearable(new RangerLegs(), dropChance: 1);
         }
 
         public override void GenerateLoot()

--- a/Scripts/Mobiles/NPCs/HireSailor.cs
+++ b/Scripts/Mobiles/NPCs/HireSailor.cs
@@ -14,13 +14,13 @@ namespace Server.Mobiles
             {
                 Body = 0x191;
                 Name = NameList.RandomName("female");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
             else
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
             Title = "the sailor";
             HairItemID = Race.RandomHair(Female);
@@ -46,16 +46,16 @@ namespace Server.Mobiles
             Fame = 100;
             Karma = 0;
 
-            AddItem(new Shoes(Utility.RandomNeutralHue()));
-            AddItem(new Cutlass());
+			SetWearable(new Shoes(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new Cutlass(), dropChance: 1);
 
             switch (Utility.Random(2))
             {
                 case 0:
-                    AddItem(new Doublet(Utility.RandomDyedHue()));
+					SetWearable(new Doublet(), Utility.RandomDyedHue(), 1);
                     break;
                 case 1:
-                    AddItem(new Shirt(Utility.RandomDyedHue()));
+					SetWearable(new Shirt(), Utility.RandomDyedHue(), 1);
                     break;
             }
         }

--- a/Scripts/Mobiles/NPCs/HireThief.cs
+++ b/Scripts/Mobiles/NPCs/HireThief.cs
@@ -18,10 +18,10 @@ namespace Server.Mobiles
                 switch (Utility.Random(2))
                 {
                     case 0:
-                        AddItem(new Skirt(Utility.RandomNeutralHue()));
+						SetWearable(new Skirt(), Utility.RandomNeutralHue(), 1);
                         break;
                     case 1:
-                        AddItem(new Kilt(Utility.RandomNeutralHue()));
+						SetWearable(new Kilt(), Utility.RandomNeutralHue(), 1);
                         break;
                 }
             }
@@ -29,7 +29,7 @@ namespace Server.Mobiles
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
             Title = "the thief";
             HairItemID = Race.RandomHair(Female);
@@ -55,15 +55,15 @@ namespace Server.Mobiles
             Fame = 100;
             Karma = 0;
 
-            AddItem(new Sandals(Utility.RandomNeutralHue()));
-            AddItem(new Dagger());
+			SetWearable(new Sandals(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new Dagger(), dropChance: 1);
             switch (Utility.Random(2))
             {
                 case 0:
-                    AddItem(new Doublet(Utility.RandomNeutralHue()));
+					SetWearable(new Doublet(), Utility.RandomNeutralHue(), 1);
                     break;
                 case 1:
-                    AddItem(new Shirt(Utility.RandomNeutralHue()));
+					SetWearable(new Shirt(), Utility.RandomNeutralHue(), 1);
                     break;
             }
 

--- a/Scripts/Mobiles/NPCs/HolyMage.cs
+++ b/Scripts/Mobiles/NPCs/HolyMage.cs
@@ -29,28 +29,21 @@ namespace Server.Mobiles
             m_SBInfos.Add(new SBHolyMage());
         }
 
-        public Item ApplyHue(Item item, int hue)
-        {
-            item.Hue = hue;
-
-            return item;
-        }
-
         public override void InitOutfit()
         {
-            AddItem(ApplyHue(new Robe(), 0x47E));
-            AddItem(ApplyHue(new ThighBoots(), 0x47E));
-            AddItem(ApplyHue(new BlackStaff(), 0x47E));
+            SetWearable(new Robe(), 0x47E, 1);
+            SetWearable(new ThighBoots(), 0x47E, 1);
+            SetWearable(new BlackStaff(), 0x47E, 1);
 
             if (Female)
             {
-                AddItem(ApplyHue(new LeatherGloves(), 0x47E));
-                AddItem(ApplyHue(new GoldNecklace(), 0x47E));
+				SetWearable(new LeatherGloves(), 0x47E, 1);
+				SetWearable(new GoldNecklace(), 0x47E, 1);
             }
             else
             {
-                AddItem(ApplyHue(new PlateGloves(), 0x47E));
-                AddItem(ApplyHue(new PlateGorget(), 0x47E));
+				SetWearable(new PlateGloves(), 0x47E, 1);
+				SetWearable(new PlateGorget(), 0x47E, 1);
             }
 
             switch (Utility.Random(Female ? 2 : 1))

--- a/Scripts/Mobiles/NPCs/Impresario.cs
+++ b/Scripts/Mobiles/NPCs/Impresario.cs
@@ -31,9 +31,9 @@ namespace Server.Engines.Quests.Collector
 
         public override void InitOutfit()
         {
-            AddItem(new FancyShirt(Utility.RandomDyedHue()));
-            AddItem(new LongPants(Utility.RandomNondyedHue()));
-            AddItem(new Shoes(Utility.RandomNeutralHue()));
+            SetWearable(new FancyShirt(), Utility.RandomDyedHue(), 1);
+            SetWearable(new LongPants(), Utility.RandomNondyedHue(), 1);
+            SetWearable(new Shoes(), Utility.RandomNeutralHue(), 1);
 
             Utility.AssignRandomHair(this);
             Utility.AssignRandomFacialHair(this);

--- a/Scripts/Mobiles/NPCs/Ioseph.cs
+++ b/Scripts/Mobiles/NPCs/Ioseph.cs
@@ -72,10 +72,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x737));
-            AddItem(new LongPants(0x1BB));
-            AddItem(new FancyShirt(0x535));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x737, 1);
+            SetWearable(new LongPants(), 0x1BB, 1);
+            SetWearable(new FancyShirt(), 0x535, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/IronWorker.cs
+++ b/Scripts/Mobiles/NPCs/IronWorker.cs
@@ -51,8 +51,10 @@ namespace Server.Mobiles
         }
 
         public override void InitOutfit()
-        {
-            Item item = (Utility.RandomBool() ? null : new RingmailChest());
+		{
+			base.InitOutfit();
+
+			Item item = (Utility.RandomBool() ? null : new RingmailChest());
 
             if (item != null && !EquipItem(item))
             {
@@ -64,24 +66,22 @@ namespace Server.Mobiles
             {
                 case 0:
                 case 1:
-                    AddItem(new JesterHat(Utility.RandomBrightHue()));
+					SetWearable(new JesterHat(), Utility.RandomBrightHue(), 1);
                     break;
                 case 2:
-                    AddItem(new Bandana(Utility.RandomBrightHue()));
+					SetWearable(new Bandana(), Utility.RandomBrightHue(), 1);
                     break;
                 case 3:
-                    AddItem(new Bascinet());
+					SetWearable(new Bascinet(), dropChance: 1);
                     break;
             }
 
             if (item == null)
             {
-                AddItem(new FullApron(Utility.RandomBrightHue()));
+				SetWearable(new FullApron(), Utility.RandomBrightHue(), 1);
             }
 
-            AddItem(new SmithHammer());
-
-            base.InitOutfit();
+			SetWearable(new SmithHammer(), dropChance: 1);
 
             item = FindItemOnLayer(Layer.Pants);
 

--- a/Scripts/Mobiles/NPCs/Jacob.cs
+++ b/Scripts/Mobiles/NPCs/Jacob.cs
@@ -134,13 +134,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Pickaxe());
-            AddItem(new Boots());
-            AddItem(new ShortPants(0x370));
-            AddItem(new Shirt(0x966));
-            AddItem(new WideBrimHat(0x966));
-            AddItem(new HalfApron(0x1BB));
+            SetWearable(new Backpack(), dropChance: 1);
+            SetWearable(new Pickaxe(), dropChance: 1);
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new ShortPants(), 0x370, 1);
+            SetWearable(new Shirt(), 0x966, 1);
+            SetWearable(new WideBrimHat(), 0x966, 1);
+            SetWearable(new HalfApron(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Jamal.cs
+++ b/Scripts/Mobiles/NPCs/Jamal.cs
@@ -31,10 +31,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new ThighBoots(0x901));
-            AddItem(new ShortPants(0x730));
-            AddItem(new Shirt(0x1BB));
+            SetWearable(new Backpack());
+            SetWearable(new ThighBoots(), 0x901, 1);
+            SetWearable(new ShortPants(), 0x730, 1);
+            SetWearable(new Shirt(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Jelrice.cs
+++ b/Scripts/Mobiles/NPCs/Jelrice.cs
@@ -139,10 +139,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x1BB));
-            AddItem(new Skirt(0xD));
-            AddItem(new FancyShirt(0x65F));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x1BB, 1);
+            SetWearable(new Skirt(), 0xD, 1);
+            SetWearable(new FancyShirt(), 0x65F, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Jillian.cs
+++ b/Scripts/Mobiles/NPCs/Jillian.cs
@@ -135,9 +135,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Robe(0x479));
-            AddItem(new Sandals());
+            SetWearable(new Backpack());
+            SetWearable(new Robe(), 0x479, 1);
+            SetWearable(new Sandals(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Jockles.cs
+++ b/Scripts/Mobiles/NPCs/Jockles.cs
@@ -130,14 +130,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Broadsword());
-            AddItem(new PlateChest());
-            AddItem(new PlateLegs());
-            AddItem(new PlateGloves());
-            AddItem(new PlateArms());
-            AddItem(new PlateGorget());
-            AddItem(new OrderShield());
+            SetWearable(new Backpack());
+            SetWearable(new Broadsword(), dropChance: 1);
+            SetWearable(new PlateChest(), dropChance: 1);
+            SetWearable(new PlateLegs(), dropChance: 1);
+            SetWearable(new PlateGloves(), dropChance: 1);
+            SetWearable(new PlateArms(), dropChance: 1);
+            SetWearable(new PlateGorget(), dropChance: 1);
+            SetWearable(new OrderShield(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Jothan.cs
+++ b/Scripts/Mobiles/NPCs/Jothan.cs
@@ -39,11 +39,11 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ThighBoots());
-            AddItem(new ElvenPants(0x57A));
-            AddItem(new ElvenShirt(0x711));
-            AddItem(new Cloak(0x21));
-            AddItem(new Circlet());
+            SetWearable(new ThighBoots(), dropChance: 1);
+            SetWearable(new ElvenPants(), 0x57A, 1);
+            SetWearable(new ElvenShirt(), 0x711, 1);
+            SetWearable(new Cloak(), 0x21, 1);
+            SetWearable(new Circlet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Jun.cs
+++ b/Scripts/Mobiles/NPCs/Jun.cs
@@ -124,13 +124,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new SamuraiTabi());
-            AddItem(new LeatherNinjaPants());
-            AddItem(new LeatherNinjaHood());
-            AddItem(new LeatherNinjaBelt());
-            AddItem(new LeatherNinjaMitts());
-            AddItem(new LeatherNinjaJacket());
+            SetWearable(new Backpack());
+			SetWearable(new SamuraiTabi(), dropChance: 1);
+            SetWearable(new LeatherNinjaPants(), dropChance: 1);
+            SetWearable(new LeatherNinjaHood(), dropChance: 1);
+            SetWearable(new LeatherNinjaBelt(), dropChance: 1);
+            SetWearable(new LeatherNinjaMitts(), dropChance: 1);
+            SetWearable(new LeatherNinjaJacket(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Jusae.cs
+++ b/Scripts/Mobiles/NPCs/Jusae.cs
@@ -41,23 +41,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x901));
-            AddItem(new ShortPants(0x651));
-            AddItem(new MagicalShortbow());
-
-            Item item;
-
-            item = new HideChest
-            {
-                Hue = 0x27B
-            };
-            AddItem(item);
-
-            item = new HidePauldrons
-            {
-                Hue = 0x27E
-            };
-            AddItem(item);
+            SetWearable(new Sandals(), 0x901, 1);
+            SetWearable(new ShortPants(), 0x651, 1);
+            SetWearable(new MagicalShortbow(), dropChance: 1);
+			SetWearable(new HideChest(), 0x27B, 1);
+			SetWearable(new HidePauldrons(), 0x27E, 1); 
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Kaelynna.cs
+++ b/Scripts/Mobiles/NPCs/Kaelynna.cs
@@ -133,9 +133,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Robe(0x592));
-            AddItem(new Sandals());
+            SetWearable(new Backpack());
+            SetWearable(new Robe(), 0x592, 1);
+			SetWearable(new Sandals(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Kashiel.cs
+++ b/Scripts/Mobiles/NPCs/Kashiel.cs
@@ -72,40 +72,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots(0x1BB));
-
-            Item item;
-
-            item = new LeatherLegs
-            {
-                Hue = 0x901
-            };
-            AddItem(item);
-
-            item = new LeatherGloves
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
-
-            item = new LeatherChest
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
-
-            item = new LeatherArms
-            {
-                Hue = 0x901
-            };
-            AddItem(item);
-
-            item = new CompositeBow
-            {
-                Hue = 0x606
-            };
-            AddItem(item);
+			SetWearable(new Backpack());
+			SetWearable(new Boots(), 0x1BB, 1);
+			SetWearable(new LeatherLegs(), 0x901, 1);
+			SetWearable(new LeatherGloves(), 0x1BB, 1);
+			SetWearable(new LeatherChest(), 0x1BB, 1);
+			SetWearable(new LeatherArms(), 0x901, 1);
+			SetWearable(new CompositeBow(), 0x606, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/KeeperOfChivalry.cs
+++ b/Scripts/Mobiles/NPCs/KeeperOfChivalry.cs
@@ -29,57 +29,51 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new PlateArms());
-            AddItem(new PlateChest());
-            AddItem(new PlateGloves());
-            AddItem(new StuddedGorget());
-            AddItem(new PlateLegs());
+            SetWearable(new PlateArms(), dropChance: 1);
+            SetWearable(new PlateChest(), dropChance: 1);
+            SetWearable(new PlateGloves(), dropChance: 1);
+            SetWearable(new StuddedGorget(), dropChance: 1);
+			SetWearable(new PlateLegs(), dropChance: 1);
 
             switch (Utility.Random(4))
             {
                 case 0:
-                    AddItem(new PlateHelm());
+					SetWearable(new PlateHelm(), dropChance: 1);
                     break;
                 case 1:
-                    AddItem(new NorseHelm());
+					SetWearable(new NorseHelm(), dropChance: 1);
                     break;
                 case 2:
-                    AddItem(new CloseHelm());
+					SetWearable(new CloseHelm(), dropChance: 1);
                     break;
                 case 3:
-                    AddItem(new Helmet());
+					SetWearable(new Helmet(), dropChance: 1);
                     break;
             }
 
             switch (Utility.Random(3))
             {
                 case 0:
-                    AddItem(new BodySash(0x482));
+					SetWearable(new BodySash(), 0x482, 1);
                     break;
                 case 1:
-                    AddItem(new Doublet(0x482));
+					SetWearable(new Doublet(), 0x482, 1);
                     break;
                 case 2:
-                    AddItem(new Tunic(0x482));
+					SetWearable(new Tunic(), 0x482, 1);
                     break;
             }
 
-            AddItem(new Broadsword());
-
-            Item shield = new MetalKiteShield
-            {
-                Hue = Utility.RandomNondyedHue()
-            };
-
-            AddItem(shield);
+			SetWearable(new Broadsword(), dropChance: 1);
+			SetWearable(new MetalKiteShield(), Utility.RandomNondyedHue(), 1);
 
             switch (Utility.Random(2))
             {
                 case 0:
-                    AddItem(new Boots());
+					SetWearable(new Boots(), dropChance: 1);
                     break;
                 case 1:
-                    AddItem(new ThighBoots());
+					SetWearable(new ThighBoots(), dropChance: 1);
                     break;
             }
         }

--- a/Scripts/Mobiles/NPCs/Kia.cs
+++ b/Scripts/Mobiles/NPCs/Kia.cs
@@ -77,9 +77,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x743));
-            AddItem(new Robe(0x485));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x743, 1);
+            SetWearable(new Robe(), 0x485, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Koole.cs
+++ b/Scripts/Mobiles/NPCs/Koole.cs
@@ -76,23 +76,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Boots(0x901));
-            AddItem(new RoyalCirclet());
-            AddItem(new LeafTonlet());
-
-            Item item;
-
-            item = new LeafChest
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
-
-            item = new LeafArms
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
+            SetWearable(new Boots(), 0x901, 1);
+            SetWearable(new RoyalCirclet(), dropChance: 1);
+            SetWearable(new LeafTonlet(), dropChance: 1);
+			SetWearable(new LeafChest(), 0x1BB, 1);
+			SetWearable(new LeafArms(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Laifem.cs
+++ b/Scripts/Mobiles/NPCs/Laifem.cs
@@ -211,11 +211,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            AddItem(new GargishClothChest(Utility.RandomNeutralHue()));
-            AddItem(new GargishClothKilt(Utility.RandomNeutralHue()));
-            AddItem(new GargishClothLegs(Utility.RandomNeutralHue()));
+            SetWearable(new GargishClothChest(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new GargishClothKilt(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new GargishClothLegs(), Utility.RandomNeutralHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -268,10 +268,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new ThighBoots(0x901));
-            AddItem(new ShortPants(0x730));
-            AddItem(new Shirt(0x1BB));
+			SetWearable(new Backpack());
+            SetWearable(new ThighBoots(), 0x901, 1);
+            SetWearable(new ShortPants(), 0x730, 1);
+			SetWearable(new Shirt(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Landy.cs
+++ b/Scripts/Mobiles/NPCs/Landy.cs
@@ -39,17 +39,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x901));
-            AddItem(new Tunic(0x719));
-            AddItem(new ShortPants(0x1BB));
-
-            Item item;
-
-            item = new LeafGloves
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
+			SetWearable(new Sandals(), 0x901, 1);
+            SetWearable(new Tunic(), 0x719, 1);
+            SetWearable(new ShortPants(), 0x1BB, 1);
+            SetWearable(new LeafGloves(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Lefty.cs
+++ b/Scripts/Mobiles/NPCs/Lefty.cs
@@ -75,10 +75,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ThighBoots(0x901));
-            AddItem(new LongPants(0x70D));
-            AddItem(new Tunic(0x30));
-            AddItem(new Cloak(0x30));
+			SetWearable(new ThighBoots(), 0x901, 1);
+            SetWearable(new LongPants(), 0x70D, 1);
+            SetWearable(new Tunic(), 0x30, 1);
+            SetWearable(new Cloak(), 0x30, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Leon.cs
+++ b/Scripts/Mobiles/NPCs/Leon.cs
@@ -33,9 +33,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x901));
-            AddItem(new Robe(0x657));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x901, 1);
+			SetWearable(new Robe(), 0x657, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Lissbet.cs
+++ b/Scripts/Mobiles/NPCs/Lissbet.cs
@@ -53,10 +53,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals());
-            AddItem(new FancyShirt(0x6BF));
-            AddItem(new Kilt(0x6AA));
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), dropChance: 1);
+            SetWearable(new FancyShirt(), 0x6BF, 1);
+			SetWearable(new Kilt(), 0x6AA, 1);
         }
 
         public override void OnDelete()

--- a/Scripts/Mobiles/NPCs/Lohn.cs
+++ b/Scripts/Mobiles/NPCs/Lohn.cs
@@ -186,12 +186,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x901));
-            AddItem(new LongPants(0x359));
-            AddItem(new ElvenShirt(0x359));
-            AddItem(new SmithHammer());
-            AddItem(new FullApron(0x1BB));
-            AddItem(new GemmedCirclet());
+			SetWearable(new Sandals(), 0x901, 1);
+            SetWearable(new LongPants(), 0x359, 1);
+            SetWearable(new ElvenShirt(), 0x359, 1);
+            SetWearable(new SmithHammer(), dropChance: 1);
+            SetWearable(new FullApron(), 0x1BB, 1);
+            SetWearable(new GemmedCirclet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Lowel.cs
+++ b/Scripts/Mobiles/NPCs/Lowel.cs
@@ -73,11 +73,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots(0x543));
-            AddItem(new ShortPants(0x758));
-            AddItem(new FancyShirt(0x53A));
-            AddItem(new HalfApron(0x6D2));
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), 0x543, 1);
+            SetWearable(new ShortPants(), 0x758, 1);
+            SetWearable(new FancyShirt(), 0x53A, 1);
+			SetWearable(new HalfApron(), 0x6D2, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Lucius.cs
+++ b/Scripts/Mobiles/NPCs/Lucius.cs
@@ -74,10 +74,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots(0x717));
-            AddItem(new LongPants(0x1BB));
-            AddItem(new Cloak(0x71));
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), 0x717, 1);
+            SetWearable(new LongPants(), 0x1BB, 1);
+			SetWearable(new Cloak(), 0x71, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Lyle.cs
+++ b/Scripts/Mobiles/NPCs/Lyle.cs
@@ -78,9 +78,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new ThighBoots());
-            AddItem(new Robe(0x2FD));
+            SetWearable(new Backpack());
+            SetWearable(new ThighBoots(), dropChance: 1);
+			SetWearable(new Robe(), 0x2FD, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Mage.cs
+++ b/Scripts/Mobiles/NPCs/Mage.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -34,7 +35,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.Robe(Utility.RandomBlueHue()));
+			SetWearable(new Robe(), Utility.RandomBlueHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/MageGuildmaster.cs
+++ b/Scripts/Mobiles/NPCs/MageGuildmaster.cs
@@ -1,3 +1,5 @@
+using Server.Items;
+
 namespace Server.Mobiles
 {
     public class MageGuildmaster : BaseGuildmaster
@@ -28,8 +30,8 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.Robe(Utility.RandomBlueHue()));
-            AddItem(new Items.GnarledStaff());
+            SetWearable(new Robe(), Utility.RandomBlueHue(), 1);
+			SetWearable(new GnarledStaff(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Mallew.cs
+++ b/Scripts/Mobiles/NPCs/Mallew.cs
@@ -39,29 +39,12 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x1BB));
-            AddItem(new Circlet());
-            AddItem(new Cloak(0x3B2));
-
-            Item item;
-
-            item = new LeafChest
-            {
-                Hue = 0x53E
-            };
-            AddItem(item);
-
-            item = new LeafArms
-            {
-                Hue = 0x53E
-            };
-            AddItem(item);
-
-            item = new LeafTonlet
-            {
-                Hue = 0x53E
-            };
-            AddItem(item);
+            SetWearable(new ElvenBoots(), 0x1BB, 1);
+            SetWearable(new Circlet(), dropChance: 1);
+            SetWearable(new Cloak(), 0x3B2, 1);
+            SetWearable(new LeafChest(), 0x53E, 1);
+            SetWearable(new LeafArms(), 0x53E, 1);
+			SetWearable(new LeafTonlet(), 0x53E, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Mielan.cs
+++ b/Scripts/Mobiles/NPCs/Mielan.cs
@@ -36,10 +36,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x901));
-            AddItem(new ElvenPants(0x901));
-            AddItem(new ElvenShirt());
-            AddItem(new GemmedCirclet());
+            SetWearable(new ElvenBoots(), 0x901, 1);
+            SetWearable(new ElvenPants(), 0x901, 1);
+            SetWearable(new ElvenShirt(), dropChance: 1);
+			SetWearable(new GemmedCirclet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/MilitiaCanoneer.cs
+++ b/Scripts/Mobiles/NPCs/MilitiaCanoneer.cs
@@ -46,16 +46,13 @@ namespace Server.Engines.Quests.Haven
             Utility.AssignRandomHair(this);
             Utility.AssignRandomFacialHair(this, HairHue);
 
-            AddItem(new PlateChest());
-            AddItem(new PlateArms());
-            AddItem(new PlateGloves());
-            AddItem(new PlateLegs());
+            SetWearable(new PlateChest(), dropChance: 1);
+            SetWearable(new PlateArms(), dropChance: 1);
+            SetWearable(new PlateGloves(), dropChance: 1);
+			SetWearable(new PlateLegs(), dropChance: 1);
 
-            Torch torch = new Torch
-            {
-                Movable = false
-            };
-            AddItem(torch);
+			Torch torch = new Torch();
+			SetWearable(torch);
             torch.Ignite();
         }
 

--- a/Scripts/Mobiles/NPCs/Miner.cs
+++ b/Scripts/Mobiles/NPCs/Miner.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -25,12 +26,12 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Items.FancyShirt(0x3E4));
-            AddItem(new Items.LongPants(0x192));
-            AddItem(new Items.Pickaxe());
-            AddItem(new Items.ThighBoots(0x283));
-
             base.InitOutfit();
+
+			SetWearable(new FancyShirt(), 0x3E4, 1);
+            SetWearable(new LongPants(), 0x192, 1);
+            SetWearable(new Pickaxe(), dropChance: 1);
+            SetWearable(new ThighBoots(), 0x283, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Mithneral.cs
+++ b/Scripts/Mobiles/NPCs/Mithneral.cs
@@ -124,9 +124,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new HoodedShroudOfShadows(0x51C));
-            AddItem(new Sandals());
+            SetWearable(new Backpack());
+            SetWearable(new HoodedShroudOfShadows(), 0x51C, 1);
+            SetWearable(new Sandals(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Monk.cs
+++ b/Scripts/Mobiles/NPCs/Monk.cs
@@ -30,8 +30,8 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals());
-            AddItem(new MonkRobe());
+            SetWearable(new Sandals(), dropChance: 1);
+            SetWearable(new MonkRobe(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Morganna.cs
+++ b/Scripts/Mobiles/NPCs/Morganna.cs
@@ -129,10 +129,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Robe(0x47D));
-            AddItem(new SkullCap(0x455));
-            AddItem(new Sandals());
+            SetWearable(new Backpack());
+            SetWearable(new Robe(), 0x47D, 1);
+            SetWearable(new SkullCap(), 0x455, 1);
+			SetWearable(new Sandals(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Mugg.cs
+++ b/Scripts/Mobiles/NPCs/Mugg.cs
@@ -73,21 +73,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Pickaxe());
-            AddItem(new Boots(0x901));
-            AddItem(new ShortPants(0x3B2));
-            AddItem(new Shirt(0x22B));
-            AddItem(new SkullCap(0x177));
-            AddItem(new HalfApron(0x5F1));
-
-            Item item;
-
-            item = new PlateGloves
-            {
-                Hue = 0x21E
-            };
-            AddItem(item);
+            SetWearable(new Backpack());
+            SetWearable(new Pickaxe(), dropChance: 1);
+            SetWearable(new Boots(), 0x901, 1);
+            SetWearable(new ShortPants(), 0x3B2, 1);
+            SetWearable(new Shirt(), 0x22B, 1);
+            SetWearable(new SkullCap(), 0x177, 1);
+			SetWearable(new HalfApron(), 0x5F1, 1);
+			SetWearable(new PlateGloves(), 0x21E, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Mulcivikh.cs
+++ b/Scripts/Mobiles/NPCs/Mulcivikh.cs
@@ -127,41 +127,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x8FD));
-            AddItem(new BoneHelm());
-
-            Item item;
-
-            item = new LeatherLegs
-            {
-                Hue = 0x2C3
-            };
-            AddItem(item);
-
-            item = new LeatherGloves
-            {
-                Hue = 0x2C3
-            };
-            AddItem(item);
-
-            item = new LeatherGorget
-            {
-                Hue = 0x2C3
-            };
-            AddItem(item);
-
-            item = new LeatherChest
-            {
-                Hue = 0x2C3
-            };
-            AddItem(item);
-
-            item = new LeatherArms
-            {
-                Hue = 0x2C3
-            };
-            AddItem(item);
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), 0x8FD, 1);
+            SetWearable(new BoneHelm(), dropChance: 1);
+			SetWearable(new LeatherLegs(), 0x2C3, 1);
+			SetWearable(new LeatherGloves(), 0x2C3, 1);
+			SetWearable(new LeatherGorget(), 0x2C3, 1);
+			SetWearable(new LeatherChest(), 0x2C3, 1);
+			SetWearable(new LeatherArms(), 0x2C3, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Mystic.cs
+++ b/Scripts/Mobiles/NPCs/Mystic.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -33,7 +34,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.Robe(Utility.RandomBlueHue()));
+			SetWearable(new Robe(), Utility.RandomBlueHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Natalie.cs
+++ b/Scripts/Mobiles/NPCs/Natalie.cs
@@ -79,10 +79,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x727));
-            AddItem(new FancyShirt(0x53C));
-            AddItem(new Skirt(0x534));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x727, 1);
+            SetWearable(new FancyShirt(), 0x53C, 1);
+			SetWearable(new Skirt(), 0x534, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Naturalist.cs
+++ b/Scripts/Mobiles/NPCs/Naturalist.cs
@@ -30,9 +30,9 @@ namespace Server.Engines.Quests.Naturalist
 
         public override void InitOutfit()
         {
-            AddItem(new Tunic(0x598));
-            AddItem(new LongPants(0x59B));
-            AddItem(new Boots());
+            SetWearable(new Tunic(), 0x598, 1);
+            SetWearable(new LongPants(), 0x59B, 1);
+			SetWearable(new Boots(), dropChance: 1);
 
             Utility.AssignRandomHair(this);
             Utility.AssignRandomFacialHair(this, HairHue);

--- a/Scripts/Mobiles/NPCs/Naxatillor.cs
+++ b/Scripts/Mobiles/NPCs/Naxatillor.cs
@@ -88,11 +88,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            AddItem(new GargishClothChest(Utility.RandomNeutralHue()));
-            AddItem(new GargishClothKilt(Utility.RandomNeutralHue()));
-            AddItem(new GargishClothLegs(Utility.RandomNeutralHue()));
+            SetWearable(new GargishClothChest(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new GargishClothKilt(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new GargishClothLegs(), Utility.RandomNeutralHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Necromancer.cs
+++ b/Scripts/Mobiles/NPCs/Necromancer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -34,24 +35,17 @@ namespace Server.Mobiles
         public override void InitOutfit()
         {
             base.InitOutfit();
-            AddItem(new Items.Shoes(0x151));
-            AddItem(new Items.Robe(0x455));
-            AddItem(new Items.FancyShirt(0x455));
+            SetWearable(new Shoes(), 0x151, 1);
+            SetWearable(new Robe(), 0x455, 1);
+			SetWearable(new FancyShirt(), 0x455, 1);
 
             Item hair = new Item(Utility.RandomList(0x203B, 0x2049, 0x2048, 0x204A))
             {
-                Hue = 0x3c6,
-                Layer = Layer.Hair,
-                Movable = false
+                Layer = Layer.Hair
             };
-            AddItem(hair);
-
-            Item beard = new Item(0x0)
-            {
-                Layer = Layer.FacialHair
-            };
-            AddItem(beard);
-        }
+            SetWearable(hair, 0x3c6);
+			FacialHairItemID = 0;
+		}
 
         public override void Serialize(GenericWriter writer)
         {

--- a/Scripts/Mobiles/NPCs/Nedrick.cs
+++ b/Scripts/Mobiles/NPCs/Nedrick.cs
@@ -31,11 +31,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new ThighBoots());
-            AddItem(new LongPants(0x528));
-            AddItem(new FancyShirt(0x4C3));
-            AddItem(new Tunic(0x3));
+            SetWearable(new Backpack());
+            SetWearable(new ThighBoots(), dropChance: 1);
+            SetWearable(new LongPants(), 0x528, 1);
+            SetWearable(new FancyShirt(), 0x4C3, 1);
+            SetWearable(new Tunic(), 0x3, 1);
         }
 
         public override void Initialize()

--- a/Scripts/Mobiles/NPCs/Neil.cs
+++ b/Scripts/Mobiles/NPCs/Neil.cs
@@ -164,11 +164,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new SmithHammer());
-            AddItem(new ShortPants(0x3A));
-            AddItem(new Bandana(0x30));
-            AddItem(new Doublet(0x13));
-            AddItem(new RingmailChest());
+            SetWearable(new SmithHammer(), dropChance: 1);
+            SetWearable(new ShortPants(), 0x3A, 1);
+            SetWearable(new Bandana(), 0x30, 1);
+            SetWearable(new Doublet(), 0x13, 1);
+            SetWearable(new RingmailChest(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Nibbet.cs
+++ b/Scripts/Mobiles/NPCs/Nibbet.cs
@@ -74,19 +74,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots(0x591));
-            AddItem(new ShortPants(0xF8));
-            AddItem(new Shirt(0x2D));
-            AddItem(new FullApron(0x288));
-
-            Item item;
-
-            item = new PlateGloves
-            {
-                Hue = 0x21E
-            };
-            AddItem(item);
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), 0x591, 1);
+            SetWearable(new ShortPants(), 0xF8, 1);
+            SetWearable(new Shirt(), 0x2D, 1);
+            SetWearable(new FullApron(), 0x288, 1);
+            SetWearable(new PlateGloves(), 0x21E, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Nillaen.cs
+++ b/Scripts/Mobiles/NPCs/Nillaen.cs
@@ -281,12 +281,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Shoes(0x1BB));
-            AddItem(new LongPants(0x1FB));
-            AddItem(new ElvenShirt());
-            AddItem(new GemmedCirclet());
-            AddItem(new BodySash(0x25));
-            AddItem(new BlackStaff());
+            SetWearable(new Shoes(), 0x1BB, 1);
+            SetWearable(new LongPants(), 0x1FB, 1);
+            SetWearable(new ElvenShirt(), dropChance: 1);
+            SetWearable(new GemmedCirclet(), dropChance: 1);
+            SetWearable(new BodySash(), 0x25, 1);
+            SetWearable(new BlackStaff(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Ninja.cs
+++ b/Scripts/Mobiles/NPCs/Ninja.cs
@@ -35,12 +35,12 @@ namespace Server.Mobiles
             }
 
             if (!Female)
-                AddItem(new LeatherNinjaHood());
+				SetWearable(new LeatherNinjaHood(), dropChance: 1);
 
-            AddItem(new LeatherNinjaPants());
-            AddItem(new LeatherNinjaBelt());
-            AddItem(new LeatherNinjaJacket());
-            AddItem(new NinjaTabi());
+			SetWearable(new LeatherNinjaPants(), dropChance: 1);
+            SetWearable(new LeatherNinjaBelt(), dropChance: 1);
+            SetWearable(new LeatherNinjaJacket(), dropChance: 1);
+            SetWearable(new NinjaTabi(), dropChance: 1);
 
             int hairHue = Utility.RandomNondyedHue();
 

--- a/Scripts/Mobiles/NPCs/Norton.cs
+++ b/Scripts/Mobiles/NPCs/Norton.cs
@@ -80,10 +80,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new ThighBoots());
-            AddItem(new Shirt(0x11D));
-            AddItem(new LongPants(0x6C2));
+            SetWearable(new Backpack());
+            SetWearable(new ThighBoots(), dropChance: 1);
+            SetWearable(new Shirt(), 0x11D, 1);
+			SetWearable(new LongPants(), 0x6C2, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Nythalia.cs
+++ b/Scripts/Mobiles/NPCs/Nythalia.cs
@@ -39,9 +39,9 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x74A));
-            AddItem(new Robe(0x498));
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), 0x74A, 1);
+			SetWearable(new Robe(), 0x498, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Olaeni.cs
+++ b/Scripts/Mobiles/NPCs/Olaeni.cs
@@ -39,10 +39,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Shoes(0x736));
-            AddItem(new FemaleElvenRobe(0x1C));
-            AddItem(new GemmedCirclet());
-            AddItem(new Item(0xDF2));
+            SetWearable(new Shoes(), 0x736, 1);
+            SetWearable(new FemaleElvenRobe(), 0x1C, 1);
+            SetWearable(new GemmedCirclet(), dropChance: 1);
+			SetWearable(new MagicWand(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Olla.cs
+++ b/Scripts/Mobiles/NPCs/Olla.cs
@@ -39,11 +39,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots());
-            AddItem(new LongPants(0x3B3));
-            AddItem(new ElvenShirt());
-            AddItem(new SmithHammer());
-            AddItem(new FullApron(0x1BB));
+            SetWearable(new ElvenBoots(), dropChance: 1);
+            SetWearable(new LongPants(), 0x3B3, 1);
+            SetWearable(new ElvenShirt(), dropChance: 1);
+            SetWearable(new SmithHammer(), dropChance: 1);
+			SetWearable(new FullApron(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Onallan.cs
+++ b/Scripts/Mobiles/NPCs/Onallan.cs
@@ -73,9 +73,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Shoes(0x70A));
-            AddItem(new Cloak(0x651));
-            AddItem(new WildStaff());
+            SetWearable(new Shoes(), 0x70A, 1);
+            SetWearable(new Cloak(), 0x651, 1);
+			SetWearable(new WildStaff(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Oolua.cs
+++ b/Scripts/Mobiles/NPCs/Oolua.cs
@@ -79,12 +79,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x70E));
-            AddItem(new WildStaff());
-            AddItem(new GemmedCirclet());
-            AddItem(new Cloak(0x1BB));
-            AddItem(new Skirt(0x3));
-            AddItem(new FancyShirt(0x70A));
+            SetWearable(new ElvenBoots(), 0x70E, 1);
+            SetWearable(new WildStaff(), dropChance: 1);
+            SetWearable(new GemmedCirclet(), dropChance: 1);
+            SetWearable(new Cloak(), 0x1BB, 1);
+            SetWearable(new Skirt(), 0x3, 1);
+			SetWearable(new FancyShirt(), 0x70A, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Patricus.cs
+++ b/Scripts/Mobiles/NPCs/Patricus.cs
@@ -70,11 +70,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x74B));
-            AddItem(new LongPants(0x1C));
-            AddItem(new FancyShirt(0x71B));
-            AddItem(new Cloak(0x1BB));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x74B, 1);
+            SetWearable(new LongPants(), 0x1C, 1);
+            SetWearable(new FancyShirt(), 0x71B, 1);
+			SetWearable(new Cloak(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Percolem.cs
+++ b/Scripts/Mobiles/NPCs/Percolem.cs
@@ -1,4 +1,5 @@
 using System;
+using Server.Items;
 
 namespace Server.Engines.Quests
 {
@@ -29,18 +30,17 @@ namespace Server.Engines.Quests
             Hue = 0x840C;
             HairItemID = 0x203C;
             HairHue = 0x3B3;
-        }
+
+			CantWalk = true;
+			Blessed = true;
+		}
 
         public override void InitOutfit()
         {
-            CantWalk = true;
-
-            AddItem(new Items.Boots());
-            AddItem(new Items.Shirt(1436));
-            AddItem(new Items.ShortPants(1436));
-            AddItem(new Items.CompositeBow());
-
-            Blessed = true;
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new Shirt(), 1436, 1);
+            SetWearable(new ShortPants(), 1436, 1);
+			SetWearable(new CompositeBow(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/PersonalAttendant/AttendantFortuneTeller.cs
+++ b/Scripts/Mobiles/NPCs/PersonalAttendant/AttendantFortuneTeller.cs
@@ -61,14 +61,14 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Shoes(Utility.RandomPinkHue()));
-            AddItem(new Shirt(Utility.RandomPinkHue()));
-            AddItem(new SkullCap(Utility.RandomPinkHue()));
+            SetWearable(new Shoes(), Utility.RandomPinkHue(), 1);
+            SetWearable(new Shirt(), Utility.RandomPinkHue(), 1);
+			SetWearable(new SkullCap(), Utility.RandomPinkHue(), 1);
 
             if (Utility.RandomBool())
-                AddItem(new Kilt(Utility.RandomPinkHue()));
+				SetWearable(new Kilt(), Utility.RandomPinkHue(), 1);
             else
-                AddItem(new Skirt(Utility.RandomPinkHue()));
+				SetWearable(new Skirt(), Utility.RandomPinkHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/PersonalAttendant/AttendantGuide.cs
+++ b/Scripts/Mobiles/NPCs/PersonalAttendant/AttendantGuide.cs
@@ -899,10 +899,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new SamuraiTabi());
-            AddItem(new Kasa());
-            AddItem(new MaleKimono(Utility.RandomGreenHue()));
-            AddItem(new ShepherdsCrook());
+            SetWearable(new SamuraiTabi(), dropChance: 1);
+            SetWearable(new Kasa(), dropChance: 1);
+            SetWearable(new MaleKimono(), Utility.RandomGreenHue(), 1);
+			SetWearable(new ShepherdsCrook(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -950,16 +950,11 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Shoes(Utility.RandomBlueHue()));
-            AddItem(new Shirt(0x8FD));
-            AddItem(new FeatheredHat(Utility.RandomBlueHue()));
-            AddItem(new Kilt(Utility.RandomBlueHue()));
-
-            Item item = new Spellbook
-            {
-                Hue = Utility.RandomBlueHue()
-            };
-            AddItem(item);
+            SetWearable(new Shoes(), Utility.RandomBlueHue(), 1);
+            SetWearable(new Shirt(), 0x8FD, 1);
+			SetWearable(new FeatheredHat(), Utility.RandomBlueHue(), 1);
+            SetWearable(new Kilt(), Utility.RandomBlueHue(), 1);
+			SetWearable(new Spellbook(), Utility.RandomBlueHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/PersonalAttendant/AttendantHerald.cs
+++ b/Scripts/Mobiles/NPCs/PersonalAttendant/AttendantHerald.cs
@@ -579,10 +579,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new FurBoots());
-            AddItem(new LongPants(0x901));
-            AddItem(new TricorneHat());
-            AddItem(new FormalShirt(Utility.RandomBlueHue()));
+            SetWearable(new FurBoots(), dropChance: 1);
+            SetWearable(new LongPants(), 0x901, 1);
+            SetWearable(new TricorneHat(), dropChance: 1);
+			SetWearable(new FormalShirt(), Utility.RandomBlueHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -633,10 +633,10 @@ namespace Server.Mobiles
             Lantern lantern = new Lantern();
             lantern.Ignite();
 
-            AddItem(lantern);
-            AddItem(new Shoes(Utility.RandomNeutralHue()));
-            AddItem(new Bonnet(Utility.RandomPinkHue()));
-            AddItem(new PlainDress(Utility.RandomPinkHue()));
+            SetWearable(lantern, dropChance: 1);
+            SetWearable(new Shoes(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new Bonnet(), Utility.RandomPinkHue(), 1);
+			SetWearable(new PlainDress(), Utility.RandomPinkHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/PersonalAttendant/AttendantLuckyDealer.cs
+++ b/Scripts/Mobiles/NPCs/PersonalAttendant/AttendantLuckyDealer.cs
@@ -191,10 +191,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Boots());
-            AddItem(new ShortPants());
-            AddItem(new JesterHat());
-            AddItem(new JesterSuit());
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new ShortPants(), dropChance: 1);
+            SetWearable(new JesterHat(), dropChance: 1);
+			SetWearable(new JesterSuit(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -242,10 +242,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots());
-            AddItem(new ElvenPants());
-            AddItem(new ElvenShirt());
-            AddItem(new JesterHat());
+            SetWearable(new ElvenBoots(), dropChance: 1);
+            SetWearable(new ElvenPants(), dropChance: 1);
+            SetWearable(new ElvenShirt(), dropChance: 1);
+			SetWearable(new JesterHat(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Petrus.cs
+++ b/Scripts/Mobiles/NPCs/Petrus.cs
@@ -36,10 +36,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x1BB));
-            AddItem(new ShortPants(0x71C));
-            AddItem(new Tunic(0x5EF));
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), 0x1BB, 1);
+            SetWearable(new ShortPants(), 0x71C, 1);
+			SetWearable(new Tunic(), 0x5EF, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/PlayerBarkeeper.cs
+++ b/Scripts/Mobiles/NPCs/PlayerBarkeeper.cs
@@ -212,7 +212,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new HalfApron(Utility.RandomBrightHue()));
+			SetWearable(new HalfApron(), Utility.RandomBrightHue(), 1);
 
             Container pack = Backpack;
 

--- a/Scripts/Mobiles/NPCs/QuartermasterFlint.cs
+++ b/Scripts/Mobiles/NPCs/QuartermasterFlint.cs
@@ -167,10 +167,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x743));
-            AddItem(new LongPants());
-            AddItem(new FancyShirt());
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x743, 1);
+            SetWearable(new LongPants(), dropChance: 1);
+			SetWearable(new FancyShirt(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Ranger.cs
+++ b/Scripts/Mobiles/NPCs/Ranger.cs
@@ -35,7 +35,8 @@ namespace Server.Mobiles
             AddItem(new Items.Shirt(Utility.RandomNeutralHue()));
             AddItem(new Items.LongPants(Utility.RandomNeutralHue()));
             AddItem(new Items.Bow());
-            AddItem(new Items.ThighBoots(Utility.RandomNeutralHue()));
+			FindItemOnLayer(Layer.Shoes)?.Delete();
+			AddItem(new Items.ThighBoots(Utility.RandomNeutralHue()));
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Ranger.cs
+++ b/Scripts/Mobiles/NPCs/Ranger.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -32,11 +33,10 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.Shirt(Utility.RandomNeutralHue()));
-            AddItem(new Items.LongPants(Utility.RandomNeutralHue()));
-            AddItem(new Items.Bow());
-			FindItemOnLayer(Layer.Shoes)?.Delete();
-			AddItem(new Items.ThighBoots(Utility.RandomNeutralHue()));
+            SetWearable(new Shirt(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new LongPants(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new Bow(), dropChance: 1);
+			SetWearable(new ThighBoots(), Utility.RandomNeutralHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Rebinil.cs
+++ b/Scripts/Mobiles/NPCs/Rebinil.cs
@@ -39,9 +39,9 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x719));
-            AddItem(new FemaleElvenRobe(0x757));
-            AddItem(new RoyalCirclet());
+            SetWearable(new Sandals(), 0x719, 1);
+            SetWearable(new FemaleElvenRobe(), 0x757, 1);
+			SetWearable(new RoyalCirclet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Recaro.cs
+++ b/Scripts/Mobiles/NPCs/Recaro.cs
@@ -126,41 +126,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x455));
-            AddItem(new WarFork());
-
-            Item item;
-
-            item = new StuddedLegs
-            {
-                Hue = 0x455
-            };
-            AddItem(item);
-
-            item = new StuddedGloves
-            {
-                Hue = 0x455
-            };
-            AddItem(item);
-
-            item = new StuddedGorget
-            {
-                Hue = 0x455
-            };
-            AddItem(item);
-
-            item = new StuddedChest
-            {
-                Hue = 0x455
-            };
-            AddItem(item);
-
-            item = new StuddedArms
-            {
-                Hue = 0x455
-            };
-            AddItem(item);
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x455, 1);
+			SetWearable(new WarFork(), dropChance: 1);
+			SetWearable(new StuddedLegs(), 0x455, 1);
+			SetWearable(new StuddedGloves(), 0x455, 1);
+			SetWearable(new StuddedGorget(), 0x455, 1);
+			SetWearable(new StuddedChest(), 0x455, 1);
+			SetWearable(new StuddedArms(), 0x455, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Regina.cs
+++ b/Scripts/Mobiles/NPCs/Regina.cs
@@ -31,9 +31,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots());
-            AddItem(new GildedDress());
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), dropChance: 1);
+			SetWearable(new GildedDress(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Robyn.cs
+++ b/Scripts/Mobiles/NPCs/Robyn.cs
@@ -131,43 +131,16 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots(0x592));
-            AddItem(new Cloak(0x592));
-            AddItem(new Bandana(0x592));
-            AddItem(new CompositeBow());
-
-            Item item;
-
-            item = new StuddedLegs
-            {
-                Hue = 0x592
-            };
-            AddItem(item);
-
-            item = new StuddedGloves
-            {
-                Hue = 0x592
-            };
-            AddItem(item);
-
-            item = new StuddedGorget
-            {
-                Hue = 0x592
-            };
-            AddItem(item);
-
-            item = new StuddedChest
-            {
-                Hue = 0x592
-            };
-            AddItem(item);
-
-            item = new StuddedArms
-            {
-                Hue = 0x592
-            };
-            AddItem(item);
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), 0x592, 1);
+            SetWearable(new Cloak(), 0x592, 1);
+            SetWearable(new Bandana(), 0x592, 1);
+			SetWearable(new CompositeBow(), dropChance: 1);
+			SetWearable(new StuddedLegs(), 0x592, 1);
+			SetWearable(new StuddedGloves(), 0x592, 1);
+			SetWearable(new StuddedGorget(), 0x592, 1);
+			SetWearable(new StuddedChest(), 0x592, 1);
+			SetWearable(new StuddedArms(), 0x592, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Rollarn.cs
+++ b/Scripts/Mobiles/NPCs/Rollarn.cs
@@ -77,19 +77,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Shoes(0x1BB));
-            AddItem(new Circlet());
-            AddItem(new Cloak(0x296));
-            AddItem(new LeafChest());
-            AddItem(new LeafArms());
-
-            Item item;
-
-            item = new LeafLegs
-            {
-                Hue = 0x74E
-            };
-            AddItem(item);
+            SetWearable(new Shoes(), 0x1BB, 1);
+            SetWearable(new Circlet(), dropChance: 1);
+            SetWearable(new Cloak(), 0x296, 1);
+            SetWearable(new LeafChest(), dropChance: 1);
+			SetWearable(new LeafArms(), dropChance: 1);
+			SetWearable(new LeafLegs(), 0x74E, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Ryal.cs
+++ b/Scripts/Mobiles/NPCs/Ryal.cs
@@ -212,10 +212,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x1BB));
-            AddItem(new Cloak(0x219));
-            AddItem(new LeafTonlet());
-            AddItem(new GnarledStaff());
+            SetWearable(new ElvenBoots(), 0x1BB, 1);
+            SetWearable(new Cloak(), 0x219, 1);
+            SetWearable(new LeafTonlet(), dropChance: 1);
+			SetWearable(new GnarledStaff(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Ryuichi.cs
+++ b/Scripts/Mobiles/NPCs/Ryuichi.cs
@@ -131,13 +131,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new SamuraiTabi());
-            AddItem(new LeatherNinjaPants());
-            AddItem(new LeatherNinjaHood());
-            AddItem(new LeatherNinjaBelt());
-            AddItem(new LeatherNinjaMitts());
-            AddItem(new LeatherNinjaJacket());
+            SetWearable(new Backpack());
+            SetWearable(new SamuraiTabi(), dropChance: 1);
+            SetWearable(new LeatherNinjaPants(), dropChance: 1);
+            SetWearable(new LeatherNinjaHood(), dropChance: 1);
+            SetWearable(new LeatherNinjaBelt(), dropChance: 1);
+            SetWearable(new LeatherNinjaMitts(), dropChance: 1);
+			SetWearable(new LeatherNinjaJacket(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Sadrah.cs
+++ b/Scripts/Mobiles/NPCs/Sadrah.cs
@@ -77,12 +77,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Longsword());
-            AddItem(new Boots(0x901));
-            AddItem(new Shirt(0x127));
-            AddItem(new Cloak(0x65));
-            AddItem(new Skirt(0x52));
+			SetWearable(new Backpack());
+            SetWearable(new Longsword(), dropChance: 1);
+            SetWearable(new Boots(), 0x901, 1);
+            SetWearable(new Shirt(), 0x127, 1);
+            SetWearable(new Cloak(), 0x65, 1);
+            SetWearable(new Skirt(), 0x52, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Salaenih.cs
+++ b/Scripts/Mobiles/NPCs/Salaenih.cs
@@ -152,40 +152,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots());
-            AddItem(new WarCleaver());
-
-            Item item;
-
-            item = new WoodlandLegs
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
-
-            item = new WoodlandArms
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
-
-            item = new WoodlandChest
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
-
-            item = new WoodlandBelt
-            {
-                Hue = 0x597
-            };
-            AddItem(item);
-
-            item = new VultureHelm
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
+            SetWearable(new ElvenBoots(), dropChance: 1);
+			SetWearable(new WarCleaver(), dropChance: 1);
+			SetWearable(new WoodlandLegs(), 0x1BB, 1);
+			SetWearable(new WoodlandArms(), 0x1BB, 1);
+			SetWearable(new WoodlandChest(), 0x1BB, 1);
+			SetWearable(new WoodlandBelt(), 0x597, 1);
+			SetWearable(new VultureHelm(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Samurai.cs
+++ b/Scripts/Mobiles/NPCs/Samurai.cs
@@ -35,48 +35,48 @@ namespace Server.Mobiles
             switch (Utility.Random(3))
             {
                 case 0:
-                    AddItem(new Lajatang());
+					SetWearable(new Lajatang(), dropChance: 1);
                     break;
                 case 1:
-                    AddItem(new Wakizashi());
+					SetWearable(new Wakizashi(), dropChance: 1);
                     break;
                 case 2:
-                    AddItem(new NoDachi());
+					SetWearable(new NoDachi(), dropChance: 1);
                     break;
             }
 
             switch (Utility.Random(3))
             {
                 case 0:
-                    AddItem(new LeatherSuneate());
+					SetWearable(new LeatherSuneate(), dropChance: 1);
                     break;
                 case 1:
-                    AddItem(new PlateSuneate());
+					SetWearable(new PlateSuneate(), dropChance: 1);
                     break;
                 case 2:
-                    AddItem(new StuddedHaidate());
+					SetWearable(new StuddedHaidate(), dropChance: 1);
                     break;
             }
 
             switch (Utility.Random(4))
             {
                 case 0:
-                    AddItem(new LeatherJingasa());
+					SetWearable(new LeatherJingasa(), dropChance: 1);
                     break;
                 case 1:
-                    AddItem(new ChainHatsuburi());
-                    break;
+					SetWearable(new ChainHatsuburi(), dropChance: 1);
+					break;
                 case 2:
-                    AddItem(new HeavyPlateJingasa());
+					SetWearable(new HeavyPlateJingasa(), dropChance: 1);
                     break;
                 case 3:
-                    AddItem(new DecorativePlateKabuto());
+					SetWearable(new DecorativePlateKabuto(), dropChance: 1);
                     break;
             }
 
-            AddItem(new LeatherDo());
-            AddItem(new LeatherHiroSode());
-            AddItem(new SamuraiTabi(Utility.RandomNondyedHue())); // TODO: Hue
+            SetWearable(new LeatherDo(), dropChance: 1);
+            SetWearable(new LeatherHiroSode(), dropChance: 1);
+			SetWearable(new SamuraiTabi(), Utility.RandomNondyedHue(), 1); // TODO: Hue
 
             int hairHue = Utility.RandomNondyedHue();
 

--- a/Scripts/Mobiles/NPCs/Sarakki.cs
+++ b/Scripts/Mobiles/NPCs/Sarakki.cs
@@ -117,10 +117,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x740));
-            AddItem(new FancyShirt(0x72C));
-            AddItem(new Skirt(0x53C));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x740, 1);
+            SetWearable(new FancyShirt(), 0x72C, 1);
+			SetWearable(new Skirt(), 0x53C, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Saril.cs
+++ b/Scripts/Mobiles/NPCs/Saril.cs
@@ -326,13 +326,13 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x3B2));
-            AddItem(new WingedHelm());
-            AddItem(new RadiantScimitar());
-            AddItem(new WoodlandLegs());
-            AddItem(new WoodlandArms());
-            AddItem(new WoodlandChest());
-            AddItem(new WoodlandBelt());
+			SetWearable(new ElvenBoots(), 0x3B2, 1);
+            SetWearable(new WingedHelm(), dropChance: 1);
+            SetWearable(new RadiantScimitar(), dropChance: 1);
+            SetWearable(new WoodlandLegs(), dropChance: 1);
+            SetWearable(new WoodlandArms(), dropChance: 1);
+            SetWearable(new WoodlandChest(), dropChance: 1);
+            SetWearable(new WoodlandBelt(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/SarsmeaSmythe.cs
+++ b/Scripts/Mobiles/NPCs/SarsmeaSmythe.cs
@@ -129,14 +129,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new LeatherLegs());
-            AddItem(new ThighBoots());
-            AddItem(new FemaleLeatherChest());
-            AddItem(new StuddedGloves());
-            AddItem(new LeatherNinjaBelt());
-            AddItem(new StuddedGorget());
-            AddItem(new LightPlateJingasa());
+            SetWearable(new Backpack());
+            SetWearable(new LeatherLegs(), dropChance: 1);
+            SetWearable(new ThighBoots(), dropChance: 1);
+            SetWearable(new FemaleLeatherChest(), dropChance: 1);
+            SetWearable(new StuddedGloves(), dropChance: 1);
+            SetWearable(new LeatherNinjaBelt(), dropChance: 1);
+            SetWearable(new StuddedGorget(), dropChance: 1);
+			SetWearable(new LightPlateJingasa(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Scribe.cs
+++ b/Scripts/Mobiles/NPCs/Scribe.cs
@@ -1,4 +1,5 @@
 using Server.Engines.BulkOrders;
+using Server.Items;
 using System;
 using System.Collections.Generic;
 
@@ -32,7 +33,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.Robe(Utility.RandomNeutralHue()));
+			SetWearable(new Robe(), Utility.RandomNeutralHue(), 1);
         }
 
         #region Bulk Orders

--- a/Scripts/Mobiles/NPCs/Sculptor.cs
+++ b/Scripts/Mobiles/NPCs/Sculptor.cs
@@ -18,17 +18,17 @@ namespace Server.Mobiles
             {
                 Body = 0x191;
                 Name = NameList.RandomName("female");
-                AddItem(new Kilt(Utility.RandomNeutralHue()));
+				SetWearable(new Kilt(), Utility.RandomNeutralHue(), 1);
             }
             else
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new LongPants(Utility.RandomNeutralHue()));
+				SetWearable(new LongPants(), Utility.RandomNeutralHue(), 1);
             }
 
-            AddItem(new Doublet(Utility.RandomNeutralHue()));
-            AddItem(new HalfApron());
+			SetWearable(new Doublet(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new HalfApron(), dropChance: 1);
 
             Utility.AssignRandomHair(this);
 
@@ -36,9 +36,7 @@ namespace Server.Mobiles
 
             pack.DropItem(new Gold(250, 300));
 
-            pack.Movable = false;
-
-            AddItem(pack);
+			SetWearable(pack);
         }
 
         public Sculptor(Serial serial)

--- a/Scripts/Mobiles/NPCs/SeaMarketTavernKeeper.cs
+++ b/Scripts/Mobiles/NPCs/SeaMarketTavernKeeper.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -21,7 +22,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.HalfApron());
+			SetWearable(new HalfApron(), dropChance: 1);
         }
 
         public SeaMarketTavernKeeper(Serial serial) : base(serial)

--- a/Scripts/Mobiles/NPCs/Shipwright.cs
+++ b/Scripts/Mobiles/NPCs/Shipwright.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -29,7 +30,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.SmithHammer());
+			SetWearable(new SmithHammer(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Siarra.cs
+++ b/Scripts/Mobiles/NPCs/Siarra.cs
@@ -82,10 +82,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x1BB));
-            AddItem(new LeafTonlet());
-            AddItem(new ElvenShirt());
-            AddItem(new GemmedCirclet());
+            SetWearable(new Sandals(), 0x1BB, 1);
+            SetWearable(new LeafTonlet(), dropChance: 1);
+            SetWearable(new ElvenShirt(), dropChance: 1);
+			SetWearable(new GemmedCirclet(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Sledge.cs
+++ b/Scripts/Mobiles/NPCs/Sledge.cs
@@ -31,11 +31,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new ElvenBoots(0x736));
-            AddItem(new LongPants(0x521));
-            AddItem(new Tunic(0x71E));
-            AddItem(new Cloak(0x59));
+            SetWearable(new Backpack());
+            SetWearable(new ElvenBoots(), 0x736, 1);
+            SetWearable(new LongPants(), 0x521, 1);
+            SetWearable(new Tunic(), 0x71E, 1);
+			SetWearable(new Cloak(), 0x59, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Sleen.cs
+++ b/Scripts/Mobiles/NPCs/Sleen.cs
@@ -158,12 +158,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x901));
-            AddItem(new FullApron(0x1BB));
-            AddItem(new ShortPants(0x71));
-            AddItem(new Cloak(0x73C));
-            AddItem(new ElvenShirt());
-            AddItem(new SmithHammer());
+            SetWearable(new ElvenBoots(), 0x901, 1);
+            SetWearable(new FullApron(), 0x1BB, 1);
+            SetWearable(new ShortPants(), 0x71, 1);
+            SetWearable(new Cloak(), 0x73C, 1);
+            SetWearable(new ElvenShirt(), dropChance: 1);
+			SetWearable(new SmithHammer(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Sliem.cs
+++ b/Scripts/Mobiles/NPCs/Sliem.cs
@@ -33,11 +33,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            AddItem(new GargishClothChest(Utility.RandomNeutralHue()));
-            AddItem(new GargishClothKilt(Utility.RandomNeutralHue()));
-            AddItem(new GargishClothLegs(Utility.RandomNeutralHue()));
+            SetWearable(new GargishClothChest(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new GargishClothKilt(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new GargishClothLegs(), Utility.RandomNeutralHue(), 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Synaeva.cs
+++ b/Scripts/Mobiles/NPCs/Synaeva.cs
@@ -33,19 +33,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots());
-            AddItem(new LeafArms());
-            AddItem(new FemaleLeafChest());
-            AddItem(new LeafTonlet());
-            AddItem(new WildStaff());
-
-            Item item;
-
-            item = new RavenHelm
-            {
-                Hue = 0x583
-            };
-            AddItem(item);
+            SetWearable(new ElvenBoots(), dropChance: 1);
+            SetWearable(new LeafArms(), dropChance: 1);
+            SetWearable(new FemaleLeafChest(), dropChance: 1);
+            SetWearable(new LeafTonlet(), dropChance: 1);
+			SetWearable(new WildStaff(), dropChance: 1);
+			SetWearable(new RavenHelm(), 0x583, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Taellia.cs
+++ b/Scripts/Mobiles/NPCs/Taellia.cs
@@ -43,10 +43,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Boots(0x74B));
-            AddItem(new FemaleElvenRobe(0x44));
-            AddItem(new Circlet());
-            AddItem(new Item(0xDF2));
+            SetWearable(new Boots(), 0x74B, 1);
+            SetWearable(new FemaleElvenRobe(), 0x44, 1);
+            SetWearable(new Circlet(), dropChance: 1);
+			SetWearable(new MagicWand(), dropChance: 1);
         }
 
         public override void OnMovement(Mobile m, Point3D oldLocation)

--- a/Scripts/Mobiles/NPCs/Tallinin.cs
+++ b/Scripts/Mobiles/NPCs/Tallinin.cs
@@ -226,9 +226,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x901));
-            AddItem(new Tunic(0x62));
-            AddItem(new Cloak(0x71E));
+            SetWearable(new ElvenBoots(), 0x901, 1);
+            SetWearable(new Tunic(), 0x62, 1);
+			SetWearable(new Cloak(), 0x71E, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Tamm.cs
+++ b/Scripts/Mobiles/NPCs/Tamm.cs
@@ -48,11 +48,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x901));
-            AddItem(new ElvenCompositeLongbow());
-            AddItem(new HidePants());
-            AddItem(new HidePauldrons());
-            AddItem(new HideChest());
+            SetWearable(new ElvenBoots(), 0x901, 1);
+            SetWearable(new ElvenCompositeLongbow(), dropChance: 1);
+            SetWearable(new HidePants(), dropChance: 1);
+            SetWearable(new HidePauldrons(), dropChance: 1);
+			SetWearable(new HideChest(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/TavernKeeper.cs
+++ b/Scripts/Mobiles/NPCs/TavernKeeper.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -26,7 +27,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.HalfApron());
+			SetWearable(new HalfApron(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Thalia.cs
+++ b/Scripts/Mobiles/NPCs/Thalia.cs
@@ -31,9 +31,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x8FD));
-            AddItem(new FancyDress(0x8FD));
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), 0x8FD, 1);
+			SetWearable(new FancyDress(), 0x8FD, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Thallary.cs
+++ b/Scripts/Mobiles/NPCs/Thallary.cs
@@ -84,10 +84,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x901));
-            AddItem(new LongPants(0x721));
-            AddItem(new Cloak(0x3B3));
-            AddItem(new FancyShirt(0x62));
+            SetWearable(new Sandals(), 0x901, 1);
+            SetWearable(new LongPants(), 0x721, 1);
+            SetWearable(new Cloak(), 0x3B3, 1);
+			SetWearable(new FancyShirt(), 0x62, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Thepem.cs
+++ b/Scripts/Mobiles/NPCs/Thepem.cs
@@ -69,10 +69,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new FemaleGargishClothLegs(0x70F));
-            AddItem(new FemaleGargishClothKilt(0x742));
-            AddItem(new FemaleGargishClothChest(0x4C3));
-            AddItem(new FemaleGargishClothArms(0x738));
+            SetWearable(new FemaleGargishClothLegs(), 0x70F, 1);
+            SetWearable(new FemaleGargishClothKilt(), 0x742, 1);
+            SetWearable(new FemaleGargishClothChest(), 0x4C3, 1);
+			SetWearable(new FemaleGargishClothArms(), 0x738, 1);
         }
 
         private static readonly Type[][] m_PileTypes = new Type[][]

--- a/Scripts/Mobiles/NPCs/Thief.cs
+++ b/Scripts/Mobiles/NPCs/Thief.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -31,10 +32,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Items.Shirt(Utility.RandomNeutralHue()));
-            AddItem(new Items.LongPants(Utility.RandomNeutralHue()));
-            AddItem(new Items.Dagger());
-            AddItem(new Items.ThighBoots(Utility.RandomNeutralHue()));
+            SetWearable(new Shirt(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new LongPants(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new Dagger(), dropChance: 1);
+			SetWearable(new ThighBoots(), Utility.RandomNeutralHue(), 1);
 
             base.InitOutfit();
         }

--- a/Scripts/Mobiles/NPCs/ThiefGuildmaster.cs
+++ b/Scripts/Mobiles/NPCs/ThiefGuildmaster.cs
@@ -33,9 +33,9 @@ namespace Server.Mobiles
             base.InitOutfit();
 
             if (Utility.RandomBool())
-                AddItem(new Kryss());
+				SetWearable(new Kryss(), dropChance: 1);
             else
-                AddItem(new Dagger());
+				SetWearable(new Dagger(), dropChance: 1);
         }
 
         public override bool CheckCustomReqs(PlayerMobile pm)

--- a/Scripts/Mobiles/NPCs/Tholef.cs
+++ b/Scripts/Mobiles/NPCs/Tholef.cs
@@ -148,18 +148,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x901));
-            AddItem(new ShortPants(0x28C));
-            AddItem(new Shirt(0x28C));
-            AddItem(new FullApron(0x72B));
-
-            Item item;
-
-            item = new LeafArms
-            {
-                Hue = 0x28C
-            };
-            AddItem(item);
+			SetWearable(new Sandals(), 0x901, 1);
+            SetWearable(new ShortPants(), 0x28C, 1);
+            SetWearable(new Shirt(), 0x28C, 1);
+            SetWearable(new FullApron(), 0x72B, 1);
+			SetWearable(new LeafArms(), 0x28C, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Tiana.cs
+++ b/Scripts/Mobiles/NPCs/Tiana.cs
@@ -255,19 +255,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots());
-            AddItem(new HidePants());
-            AddItem(new HideFemaleChest());
-            AddItem(new HidePauldrons());
-            AddItem(new WoodlandBelt(0x657));
-
-            Item item;
-
-            item = new RavenHelm
-            {
-                Hue = 0x1BB
-            };
-            AddItem(item);
+            SetWearable(new ElvenBoots(), dropChance: 1);
+            SetWearable(new HidePants(), dropChance: 1);
+            SetWearable(new HideFemaleChest(), dropChance: 1);
+            SetWearable(new HidePauldrons(), dropChance: 1);
+			SetWearable(new WoodlandBelt(), 0x657, 1);
+			SetWearable(new RavenHelm(), 0x657, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Tillanil.cs
+++ b/Scripts/Mobiles/NPCs/Tillanil.cs
@@ -38,9 +38,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x1BB));
-            AddItem(new Tunic(0x712));
-            AddItem(new ShortPants(0x30));
+            SetWearable(new Sandals(), 0x1BB, 1);
+            SetWearable(new Tunic(), 0x712, 1);
+			SetWearable(new ShortPants(), 0x30, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Tobin.cs
+++ b/Scripts/Mobiles/NPCs/Tobin.cs
@@ -90,10 +90,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x743));
-            AddItem(new Shirt(0x743));
-            AddItem(new ShortPants(0x485));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x743, 1);
+            SetWearable(new Shirt(), 0x743, 1);
+			SetWearable(new ShortPants(), 0x485, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/TomasONeerlan.cs
+++ b/Scripts/Mobiles/NPCs/TomasONeerlan.cs
@@ -29,10 +29,10 @@ namespace Server.Engines.Quests.Collector
 
         public override void InitOutfit()
         {
-            AddItem(new FancyShirt());
-            AddItem(new LongPants(0x546));
-            AddItem(new Boots(0x452));
-            AddItem(new FullApron(0x455));
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(new LongPants(), 0x546, 1);
+            SetWearable(new Boots(), 0x452, 1);
+			SetWearable(new FullApron(), 0x455, 1);
 
             HairItemID = 0x203B;	//ShortHair
             HairHue = 0x455;

--- a/Scripts/Mobiles/NPCs/TylAriadne.cs
+++ b/Scripts/Mobiles/NPCs/TylAriadne.cs
@@ -128,46 +128,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new ElvenBoots(0x96D));
-
-            Item item;
-
-            item = new StuddedLegs
-            {
-                Hue = 0x96D
-            };
-            AddItem(item);
-
-            item = new StuddedGloves
-            {
-                Hue = 0x96D
-            };
-            AddItem(item);
-
-            item = new StuddedGorget
-            {
-                Hue = 0x96D
-            };
-            AddItem(item);
-
-            item = new StuddedChest
-            {
-                Hue = 0x96D
-            };
-            AddItem(item);
-
-            item = new StuddedArms
-            {
-                Hue = 0x96D
-            };
-            AddItem(item);
-
-            item = new DiamondMace
-            {
-                Hue = 0x96D
-            };
-            AddItem(item);
+			SetWearable(new Backpack());
+			SetWearable(new ElvenBoots(), 0x96D, 1);
+            SetWearable(new StuddedLegs(), 0x96D, 1);
+            SetWearable(new StuddedGloves(), 0x96D, 1);
+            SetWearable(new StuddedGorget(), 0x96D, 1);
+            SetWearable(new StuddedChest(), 0x96D, 1);
+            SetWearable(new StuddedArms(), 0x96D, 1);
+            SetWearable(new DiamondMace(), 0x96D, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Tyleelor.cs
+++ b/Scripts/Mobiles/NPCs/Tyleelor.cs
@@ -39,39 +39,12 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x1BB));
-
-            Item item;
-
-            item = new WoodlandLegs
-            {
-                Hue = 0x236
-            };
-            AddItem(item);
-
-            item = new WoodlandChest
-            {
-                Hue = 0x236
-            };
-            AddItem(item);
-
-            item = new WoodlandArms
-            {
-                Hue = 0x236
-            };
-            AddItem(item);
-
-            item = new WoodlandBelt
-            {
-                Hue = 0x237
-            };
-            AddItem(item);
-
-            item = new VultureHelm
-            {
-                Hue = 0x236
-            };
-            AddItem(item);
+			SetWearable(new ElvenBoots(), 0x1BB, 1);
+			SetWearable(new WoodlandLegs(), 0x236, 1);
+			SetWearable(new WoodlandChest(), 0x236, 1);
+			SetWearable(new WoodlandArms(), 0x236, 1);
+			SetWearable(new WoodlandBelt(), 0x237, 1);
+			SetWearable(new VultureHelm(), 0x236, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Unoelil.cs
+++ b/Scripts/Mobiles/NPCs/Unoelil.cs
@@ -38,9 +38,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x1BB));
-            AddItem(new Tunic(0x64F));
-            AddItem(new ShortPants(0x1BB));
+            SetWearable(new ElvenBoots(), 0x1BB, 1);
+            SetWearable(new Tunic(), 0x64F, 1);
+			SetWearable(new ShortPants(), 0x1BB, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Vagabond.cs
+++ b/Scripts/Mobiles/NPCs/Vagabond.cs
@@ -31,22 +31,22 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new FancyShirt(Utility.RandomBrightHue()));
-            AddItem(new Shoes(GetShoeHue()));
-            AddItem(new LongPants(GetRandomHue()));
+			SetWearable(new FancyShirt(), Utility.RandomBrightHue(), 1);
+            SetWearable(new Shoes(), GetShoeHue(), 1);
+            SetWearable(new LongPants(), GetRandomHue(), 1);
 
             if (Utility.RandomBool())
             {
-                AddItem(new Cloak(Utility.RandomBrightHue()));
+				SetWearable(new Cloak(), Utility.RandomBrightHue(), 1);
             }
 
             switch (Utility.Random(2))
             {
                 case 0:
-                    AddItem(new SkullCap(Utility.RandomNeutralHue()));
+					SetWearable(new SkullCap(), Utility.RandomNeutralHue(), 1);
                     break;
                 case 1:
-                    AddItem(new Bandana(Utility.RandomNeutralHue()));
+					SetWearable(new Bandana(), Utility.RandomNeutralHue(), 1);
                     break;
             }
 

--- a/Scripts/Mobiles/NPCs/Verity.cs
+++ b/Scripts/Mobiles/NPCs/Verity.cs
@@ -34,11 +34,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x754));
-            AddItem(new Shirt(0x653));
-            AddItem(new Cap(0x901));
-            AddItem(new Kilt(0x901));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x754, 1);
+            SetWearable(new Shirt(), 0x653, 1);
+            SetWearable(new Cap(), 0x901, 1);
+			SetWearable(new Kilt(), 0x901, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Vicaie.cs
+++ b/Scripts/Mobiles/NPCs/Vicaie.cs
@@ -39,16 +39,9 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots());
-            AddItem(new Tunic(0x1FA1));
-
-            Item item;
-
-            item = new LeafLegs
-            {
-                Hue = 0x3B3
-            };
-            AddItem(item);
+            SetWearable(new ElvenBoots(), dropChance: 1);
+			SetWearable(new Tunic(), 0x1FA1, 1);
+			SetWearable(new LeafLegs(), 0x3B3, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Vilo.cs
+++ b/Scripts/Mobiles/NPCs/Vilo.cs
@@ -47,15 +47,15 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots(0x901));
-            AddItem(new WoodlandBelt(0x592));
-            AddItem(new WoodlandChest());
-            AddItem(new WoodlandGloves());
-            AddItem(new WoodlandLegs());
-            AddItem(new WoodlandGorget());
-            AddItem(new WoodlandArms());
-            AddItem(new VultureHelm());
-            AddItem(new OrnateAxe());
+            SetWearable(new ElvenBoots(), 0x901, 1);
+            SetWearable(new WoodlandBelt(), 0x592, 1);
+            SetWearable(new WoodlandChest(), dropChance: 1);
+            SetWearable(new WoodlandGloves(), dropChance: 1);
+            SetWearable(new WoodlandLegs(), dropChance: 1);
+            SetWearable(new WoodlandGorget(), dropChance: 1);
+            SetWearable(new WoodlandArms(), dropChance: 1);
+            SetWearable(new VultureHelm(), dropChance: 1);
+			SetWearable(new OrnateAxe(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Vrulkax.cs
+++ b/Scripts/Mobiles/NPCs/Vrulkax.cs
@@ -96,10 +96,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new SerpentStoneStaff());
-            AddItem(new GargishClothChest(902));
-            AddItem(new GargishClothArms(902));
-            AddItem(new GargishClothKilt(902));
+            SetWearable(new SerpentStoneStaff(), dropChance: 1);
+            SetWearable(new GargishClothChest(), 902, 1);
+            SetWearable(new GargishClothArms(), 902, 1);
+			SetWearable(new GargishClothKilt(), 902, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Waelian.cs
+++ b/Scripts/Mobiles/NPCs/Waelian.cs
@@ -41,18 +41,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(0x901));
-            AddItem(new GemmedCirclet());
-            AddItem(new LongPants(0x340));
-            AddItem(new SmithHammer());
-
-            Item item;
-
-            item = new LeafChest
-            {
-                Hue = 0x344
-            };
-            AddItem(item);
+            SetWearable(new Sandals(), 0x901, 1);
+            SetWearable(new GemmedCirclet(), dropChance: 1);
+            SetWearable(new LongPants(), 0x340, 1);
+			SetWearable(new SmithHammer(), dropChance: 1);
+            SetWearable(new LeafChest(), 0x344, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Waiter.cs
+++ b/Scripts/Mobiles/NPCs/Waiter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -27,7 +28,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.HalfApron());
+			SetWearable(new HalfApron(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Walker.cs
+++ b/Scripts/Mobiles/NPCs/Walker.cs
@@ -127,11 +127,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots(0x455));
-            AddItem(new LongPants(0x455));
-            AddItem(new FancyShirt(0x47D));
-            AddItem(new FloppyHat(0x455));
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), 0x455, 1);
+            SetWearable(new LongPants(), 0x455, 1);
+            SetWearable(new FancyShirt(), 0x47D, 1);
+			SetWearable(new FloppyHat(), 0x455, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/WanderingHealer.cs
+++ b/Scripts/Mobiles/NPCs/WanderingHealer.cs
@@ -9,7 +9,7 @@ namespace Server.Mobiles
         {
             Title = "the wandering healer";
 
-            AddItem(new GnarledStaff());
+			SetWearable(new GnarledStaff(), dropChance: 1);
 
             SetSkill(SkillName.Camping, 80.0, 100.0);
             SetSkill(SkillName.Forensics, 80.0, 100.0);

--- a/Scripts/Mobiles/NPCs/Weaponsmith.cs
+++ b/Scripts/Mobiles/NPCs/Weaponsmith.cs
@@ -1,4 +1,5 @@
 using Server.Engines.BulkOrders;
+using Server.Items;
 using System;
 using System.Collections.Generic;
 
@@ -40,7 +41,7 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.HalfApron());
+			SetWearable(new HalfApron(), dropChance: 1);
         }
 
         #region Bulk Orders

--- a/Scripts/Mobiles/NPCs/Xenrr.cs
+++ b/Scripts/Mobiles/NPCs/Xenrr.cs
@@ -64,11 +64,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots());
-            AddItem(new LongPants(0x6C7));
-            AddItem(new FancyShirt(0x6BB));
-            AddItem(new Cloak(0x59));
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new LongPants(), 0x6C7, 1);
+            SetWearable(new FancyShirt(), 0x6BB, 1);
+			SetWearable(new Cloak(), 0x59, 1);
         }
 
         public Xenrr(Serial serial)

--- a/Scripts/Mobiles/NPCs/Yellienir.cs
+++ b/Scripts/Mobiles/NPCs/Yellienir.cs
@@ -44,11 +44,11 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new ElvenBoots());
-            AddItem(new Cloak(0x3B2));
-            AddItem(new FemaleLeafChest());
-            AddItem(new LeafArms());
-            AddItem(new LeafTonlet());
+            SetWearable(new ElvenBoots(), dropChance: 1);
+            SetWearable(new Cloak(), 0x3B2, 1);
+            SetWearable(new FemaleLeafChest(), dropChance: 1);
+            SetWearable(new LeafArms(), dropChance: 1);
+			SetWearable(new LeafTonlet(), dropChance: 1);
         }
 
         public override void OnMovement(Mobile m, Point3D oldLocation)

--- a/Scripts/Mobiles/NPCs/Yorus.cs
+++ b/Scripts/Mobiles/NPCs/Yorus.cs
@@ -87,11 +87,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x755));
-            AddItem(new LongPants(0x1BB));
-            AddItem(new FancyShirt(0x71E));
-            AddItem(new Cloak(0x59));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x755, 1);
+            SetWearable(new LongPants(), 0x1BB, 1);
+            SetWearable(new FancyShirt(), 0x71E, 1);
+			SetWearable(new Cloak(), 0x59, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/NPCs/Zhah.cs
+++ b/Scripts/Mobiles/NPCs/Zhah.cs
@@ -29,20 +29,14 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            ColorItem(new LeatherTalons()); // Bright Blue
-            ColorItem(new GargishLeatherChest()); // Bright Blue
-            ColorItem(new GargishLeatherLegs()); // Bright Blue
-            ColorItem(new GargishClothWingArmor()); // Bright Blue
-            ColorItem(new GargishLeatherArms()); // Bright Blue
-            ColorItem(new GargishLeatherKilt()); // Bright Blue
+            SetWearable(new LeatherTalons(), 0x4F2, 1); // Bright Blue
+            SetWearable(new GargishLeatherChest(), 0x4F2, 1); // Bright Blue
+            SetWearable(new GargishLeatherLegs(), 0x4F2, 1); // Bright Blue
+            SetWearable(new GargishClothWingArmor(), 0x4F2, 1); // Bright Blue
+            SetWearable(new GargishLeatherArms(), 0x4F2, 1); // Bright Blue
+			SetWearable(new GargishLeatherKilt(), 0x4F2, 1); // Bright Blue
 
-            AddItem(new SerpentStoneStaff());
-        }
-
-        private void ColorItem(Item item)
-        {
-            item.Hue = 0x4F2;
-            AddItem(item);
+			SetWearable(new SerpentStoneStaff(), dropChance: 1);
         }
 
         public override void Advertise()

--- a/Scripts/Mobiles/NPCs/Zosilem.cs
+++ b/Scripts/Mobiles/NPCs/Zosilem.cs
@@ -69,10 +69,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new FemaleGargishClothLegs(0x736));
-            AddItem(new FemaleGargishClothKilt(0x73D));
-            AddItem(new FemaleGargishClothChest(0x38B));
-            AddItem(new FemaleGargishClothArms(0x711));
+            SetWearable(new FemaleGargishClothLegs(), 0x736, 1);
+            SetWearable(new FemaleGargishClothKilt(), 0x73D, 1);
+            SetWearable(new FemaleGargishClothChest(), 0x38B, 1);
+			SetWearable(new FemaleGargishClothArms(), 0x711, 1);
         }
 
         private static readonly Type[][] m_PileTypes = new Type[][]

--- a/Scripts/Mobiles/Named/GrimmochDrummel.cs
+++ b/Scripts/Mobiles/Named/GrimmochDrummel.cs
@@ -16,28 +16,12 @@ namespace Server.Mobiles
 
             HairItemID = 0x204A;	//Krisna
 
-            Bow bow = new Bow
-            {
-                Movable = false
-            };
-            AddItem(bow);
-
-            AddItem(new Boots(0x8A4));
-            AddItem(new BodySash(0x8A4));
-
-            Backpack backpack = new Backpack
-            {
-                Movable = false
-            };
-            AddItem(backpack);
-
-            LeatherGloves gloves = new LeatherGloves();
-            LeatherChest chest = new LeatherChest();
-            gloves.Hue = 0x96F;
-            chest.Hue = 0x96F;
-
-            AddItem(gloves);
-            AddItem(chest);
+			SetWearable(new Bow());
+			SetWearable(new Boots(), 0x8A4, 1);
+			SetWearable(new BodySash(), 0x8A4, 1);
+			SetWearable(new Backpack());
+			SetWearable(new LeatherGloves(), 0x96F, 1);
+			SetWearable(new LeatherChest(), 0x96F, 1);
 
             SetStr(111, 120);
             SetDex(151, 160);

--- a/Scripts/Mobiles/Named/LysanderGathenwale.cs
+++ b/Scripts/Mobiles/Named/LysanderGathenwale.cs
@@ -14,23 +14,12 @@ namespace Server.Mobiles
             Body = 0x190;
             Name = "Lysander Gathenwale";
 
-            AddItem(new Boots(0x599));
-            AddItem(new Cloak(0x96F));
-
-            Spellbook spellbook = new Spellbook();
-            RingmailGloves gloves = new RingmailGloves();
-            StuddedChest chest = new StuddedChest();
-            PlateArms arms = new PlateArms();
-
-            spellbook.Hue = 0x599;
-            gloves.Hue = 0x599;
-            chest.Hue = 0x96F;
-            arms.Hue = 0x599;
-
-            AddItem(spellbook);
-            AddItem(gloves);
-            AddItem(chest);
-            AddItem(arms);
+			SetWearable(new Boots(), 0x599, 1);
+			SetWearable(new Cloak(), 0x96F, 1);
+			SetWearable(new Spellbook(), 0x599, 1);
+			SetWearable(new RingmailGloves(), 0x599, 1);
+			SetWearable(new StuddedChest(), 0x96F, 1);
+			SetWearable(new PlateArms(), 0x599, 1);
 
             SetStr(111, 120);
             SetDex(71, 80);

--- a/Scripts/Mobiles/Named/MasterTheophilus.cs
+++ b/Scripts/Mobiles/Named/MasterTheophilus.cs
@@ -40,8 +40,8 @@ namespace Server.Mobiles
             Fame = 18000;
             Karma = -18000;
 
-            AddItem(new Shoes(0x537));
-            AddItem(new Robe(0x452));
+			SetWearable(new Shoes(), 0x537, 1);
+			SetWearable(new Robe(), 0x452, 1);
 
             SetWeaponAbility(WeaponAbility.ParalyzingBlow);
         }

--- a/Scripts/Mobiles/Named/MorgBergen.cs
+++ b/Scripts/Mobiles/Named/MorgBergen.cs
@@ -14,20 +14,10 @@ namespace Server.Mobiles
             Body = 0x190;
             Name = "Morg Bergen";
 
-            AddItem(new ShortPants(0x59C));
-
-            Bardiche bardiche = new Bardiche();
-            LeatherGloves gloves = new LeatherGloves();
-            LeatherArms arms = new LeatherArms();
-
-            bardiche.Hue = 0x96F;
-            bardiche.Movable = false;
-            gloves.Hue = 0x96F;
-            arms.Hue = 0x96F;
-
-            AddItem(bardiche);
-            AddItem(gloves);
-            AddItem(arms);
+			SetWearable(new ShortPants(), 0x59C, 1);
+			SetWearable(new Bardiche(), 0x96F);
+			SetWearable(new LeatherGloves(), 0x96F, 1);
+			SetWearable(new LeatherArms(), 0x96F, 1);
 
             SetStr(111, 120);
             SetDex(111, 120);

--- a/Scripts/Mobiles/Named/RakktaviRenowned.cs
+++ b/Scripts/Mobiles/Named/RakktaviRenowned.cs
@@ -43,7 +43,7 @@ namespace Server.Mobiles
             Fame = 6500;
             Karma = -6500;
 
-            AddItem(new Bow());
+			SetWearable(new Bow(), 1);
         }
 
         public RakktaviRenowned(Serial serial)

--- a/Scripts/Mobiles/Named/TavaraSewel.cs
+++ b/Scripts/Mobiles/Named/TavaraSewel.cs
@@ -15,25 +15,12 @@ namespace Server.Mobiles
             Body = 0x191;
             Name = "Tavara Sewel";
 
-            AddItem(new Kilt(0x59C));
-            AddItem(new Sandals(0x599));
-
-            Kryss kryss = new Kryss();
-            Buckler buckler = new Buckler();
-            RingmailGloves gloves = new RingmailGloves();
-            FemalePlateChest chest = new FemalePlateChest();
-
-            kryss.Hue = 0x96F;
-            kryss.Movable = false;
-            buckler.Hue = 0x96F;
-            buckler.Movable = false;
-            gloves.Hue = 0x599;
-            chest.Hue = 0x96F;
-
-            AddItem(kryss);
-            AddItem(buckler);
-            AddItem(gloves);
-            AddItem(chest);
+			SetWearable(new Kilt(), 0x59C, 1);
+			SetWearable(new Sandals(), 0x599, 1);
+			SetWearable(new Kryss(), 0x96F);
+			SetWearable(new Buckler(), 0x96F);
+			SetWearable(new RingmailGloves(), 0x599, 1);
+			SetWearable(new FemalePlateChest(), 0x96F, 1);
 
             SetStr(111, 120);
             SetDex(111, 120);

--- a/Scripts/Mobiles/Named/Twaulo.cs
+++ b/Scripts/Mobiles/Named/Twaulo.cs
@@ -45,7 +45,7 @@ namespace Server.Mobiles
             Fame = 50000;
             Karma = 50000;
 
-            AddItem(new Bow());
+            SetWearable(new Bow(), 1);
         }
 
         public Twaulo(Serial serial)

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -5300,15 +5300,24 @@ namespace Server.Mobiles
             if (hue > -1)
                 item.Hue = hue;
 
-            item.Movable = dropChance > Utility.RandomDouble();
+			if (dropChance <= 0) 
+				item.Movable = false;
+			else if (dropChance >= 1) 
+				item.Movable = true;
+			else
+				item.Movable = dropChance > Utility.RandomDouble();
 
-            if (!CheckEquip(item) || !OnEquip(item) || !item.OnEquip(this))
+			if(!OnEquip(item) || !item.OnEquip(this))
             {
                 PackItem(item);
             }
             else
-            {
-                AddItem(item);
+			{
+				if (!CheckEquip(item))
+				{
+					FindItemOnLayer(item.Layer).Delete();
+				}
+				AddItem(item);
             }
         }
 

--- a/Scripts/Mobiles/Normal/BaseCreature.cs
+++ b/Scripts/Mobiles/Normal/BaseCreature.cs
@@ -5300,24 +5300,25 @@ namespace Server.Mobiles
             if (hue > -1)
                 item.Hue = hue;
 
-			if (dropChance <= 0) 
-				item.Movable = false;
-			else if (dropChance >= 1) 
-				item.Movable = true;
-			else
-				item.Movable = dropChance > Utility.RandomDouble();
+            if (dropChance <= 0) 
+                item.Movable = false;
+            else if (dropChance >= 1) 
+                item.Movable = true;
+            else
+                item.Movable = dropChance > Utility.RandomDouble();
 
-			if(!OnEquip(item) || !item.OnEquip(this))
+            if(!OnEquip(item) || !item.OnEquip(this))
             {
                 PackItem(item);
             }
             else
-			{
-				if (!CheckEquip(item))
-				{
-					FindItemOnLayer(item.Layer).Delete();
-				}
-				AddItem(item);
+            {
+                if (!CheckEquip(item))
+                {
+                    FindItemOnLayer(item.Layer)?.Delete();
+                }
+				
+                AddItem(item);
             }
         }
 

--- a/Scripts/Mobiles/Normal/Brigand.cs
+++ b/Scripts/Mobiles/Normal/Brigand.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Items;
 
 namespace Server.Mobiles
@@ -17,13 +18,13 @@ namespace Server.Mobiles
             {
                 Body = 0x191;
                 Name = NameList.RandomName("female");
-                AddItem(new Skirt(Utility.RandomNeutralHue()));
+                SetWearable(new Skirt(), Utility.RandomNeutralHue(), dropChance: 1);
             }
             else
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+                SetWearable(new ShortPants(), Utility.RandomNeutralHue(), dropChance: 1);
             }
 
             SetStr(86, 100);
@@ -42,35 +43,12 @@ namespace Server.Mobiles
             Fame = 1000;
             Karma = -1000;
 
-            AddItem(new Boots(Utility.RandomNeutralHue()));
-            AddItem(new FancyShirt());
-            AddItem(new Bandana());
+            SetWearable(new Boots(), Utility.RandomNeutralHue(), dropChance: 1);
+			SetWearable(new FancyShirt(), dropChance: 1);
+			SetWearable(new Bandana(), dropChance: 1);
 
-            switch (Utility.Random(7))
-            {
-                case 0:
-                    AddItem(new Longsword());
-                    break;
-                case 1:
-                    AddItem(new Cutlass());
-                    break;
-                case 2:
-                    AddItem(new Broadsword());
-                    break;
-                case 3:
-                    AddItem(new Axe());
-                    break;
-                case 4:
-                    AddItem(new Club());
-                    break;
-                case 5:
-                    AddItem(new Dagger());
-                    break;
-                case 6:
-                    AddItem(new Spear());
-                    break;
-            }
-
+			SetWearable((Item)Activator.CreateInstance(Utility.RandomList(_WeaponsList)), dropChance: 1);
+			
             Utility.AssignRandomHair(this);
         }
 
@@ -84,7 +62,12 @@ namespace Server.Mobiles
 
         public override bool ShowFameTitle => false;
 
-        public override void OnDeath(Container c)
+		private static readonly Type[] _WeaponsList =
+		{
+			typeof(Longsword), typeof(Cutlass), typeof(Broadsword), typeof(Axe), typeof(Club), typeof(Dagger), typeof(Spear)
+		};
+
+		public override void OnDeath(Container c)
         {
             base.OnDeath(c);
 

--- a/Scripts/Mobiles/Normal/Centaur.cs
+++ b/Scripts/Mobiles/Normal/Centaur.cs
@@ -38,7 +38,7 @@ namespace Server.Mobiles
             Fame = 6500;
             Karma = 0;
 
-            AddItem(new Bow());
+            SetWearable(new Bow(), dropChance: 1);
         }
 
         public Centaur(Serial serial)

--- a/Scripts/Mobiles/Normal/ChaosDragoon.cs
+++ b/Scripts/Mobiles/Normal/ChaosDragoon.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Items;
 
 namespace Server.Mobiles
@@ -37,98 +38,24 @@ namespace Server.Mobiles
             Fame = 5000;
             Karma = -5000;
 
-            CraftResource res = CraftResource.None;
+			CraftResource res = (CraftResource)Utility.RandomMinMax(201, 206); // All normal scales
 
-            switch (Utility.Random(6))
-            {
-                case 0:
-                    res = CraftResource.BlackScales;
-                    break;
-                case 1:
-                    res = CraftResource.RedScales;
-                    break;
-                case 2:
-                    res = CraftResource.BlueScales;
-                    break;
-                case 3:
-                    res = CraftResource.YellowScales;
-                    break;
-                case 4:
-                    res = CraftResource.GreenScales;
-                    break;
-                case 5:
-                    res = CraftResource.WhiteScales;
-                    break;
-            }
-
-            BaseWeapon melee = null;
-
-            switch (Utility.Random(3))
-            {
-                case 0:
-                    melee = new Kryss();
-                    break;
-                case 1:
-                    melee = new Broadsword();
-                    break;
-                case 2:
-                    melee = new Katana();
-                    break;
-            }
-
-            melee.Movable = false;
-            AddItem(melee);
-
-            DragonHelm helm = new DragonHelm
-            {
-                Resource = res,
-                Movable = false
-            };
-            AddItem(helm);
-
-            DragonChest chest = new DragonChest
-            {
-                Resource = res,
-                Movable = false
-            };
-            AddItem(chest);
-
-            DragonArms arms = new DragonArms
-            {
-                Resource = res,
-                Movable = false
-            };
-            AddItem(arms);
-
-            DragonGloves gloves = new DragonGloves
-            {
-                Resource = res,
-                Movable = false
-            };
-            AddItem(gloves);
-
-            DragonLegs legs = new DragonLegs
-            {
-                Resource = res,
-                Movable = false
-            };
-            AddItem(legs);
-
-            ChaosShield shield = new ChaosShield
-            {
-                Movable = false
-            };
-            AddItem(shield);
-
-            AddItem(new Shirt());
-            AddItem(new Boots());
+            SetWearable((Item)Activator.CreateInstance(Utility.RandomList(_WeaponsList)));
+			SetWearable(new DragonHelm() { Resource = res });
+			SetWearable(new DragonChest() { Resource = res });
+			SetWearable(new DragonArms() { Resource = res });
+			SetWearable(new DragonGloves() { Resource = res });
+			SetWearable(new DragonLegs() { Resource = res });
+			SetWearable(new ChaosShield());
+			SetWearable(new Shirt(), dropChance: 1);
+			SetWearable(new Boots(), dropChance: 1);
 
             int amount = Utility.RandomMinMax(1, 3);
 
             switch (res)
             {
                 case CraftResource.BlackScales:
-                    AddItem(new BlackScales(amount));
+					AddItem(new BlackScales(amount));
                     break;
                 case CraftResource.RedScales:
                     AddItem(new RedScales(amount));
@@ -156,6 +83,11 @@ namespace Server.Mobiles
             : base(serial)
         {
         }
+
+		private static readonly Type[] _WeaponsList = new Type[]
+		{
+			typeof(Kryss), typeof(Broadsword), typeof(Katana)
+		};
 
         public override bool AutoDispel => true;
         public override bool CanRummageCorpses => true;

--- a/Scripts/Mobiles/Normal/ChaosDragoonElite.cs
+++ b/Scripts/Mobiles/Normal/ChaosDragoonElite.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Items;
 
 namespace Server.Mobiles
@@ -41,91 +42,17 @@ namespace Server.Mobiles
             Fame = 8000;
             Karma = -8000;
 
-            CraftResource res = CraftResource.None;
+			CraftResource res = (CraftResource)Utility.RandomMinMax(201, 206); // All normal scales
 
-            switch (Utility.Random(6))
-            {
-                case 0:
-                    res = CraftResource.BlackScales;
-                    break;
-                case 1:
-                    res = CraftResource.RedScales;
-                    break;
-                case 2:
-                    res = CraftResource.BlueScales;
-                    break;
-                case 3:
-                    res = CraftResource.YellowScales;
-                    break;
-                case 4:
-                    res = CraftResource.GreenScales;
-                    break;
-                case 5:
-                    res = CraftResource.WhiteScales;
-                    break;
-            }
-
-            BaseWeapon melee = null;
-
-            switch (Utility.Random(3))
-            {
-                case 0:
-                    melee = new Kryss();
-                    break;
-                case 1:
-                    melee = new Broadsword();
-                    break;
-                case 2:
-                    melee = new Katana();
-                    break;
-            }
-
-            melee.Movable = false;
-            AddItem(melee);
-
-            DragonChest Tunic = new DragonChest
-            {
-                Resource = res,
-                Movable = false
-            };
-            AddItem(Tunic);
-
-            DragonLegs Legs = new DragonLegs
-            {
-                Resource = res,
-                Movable = false
-            };
-            AddItem(Legs);
-
-            DragonArms Arms = new DragonArms
-            {
-                Resource = res,
-                Movable = false
-            };
-            AddItem(Arms);
-
-            DragonGloves Gloves = new DragonGloves
-            {
-                Resource = res,
-                Movable = false
-            };
-            AddItem(Gloves);
-
-            DragonHelm Helm = new DragonHelm
-            {
-                Resource = res,
-                Movable = false
-            };
-            AddItem(Helm);
-
-            ChaosShield shield = new ChaosShield
-            {
-                Movable = false
-            };
-            AddItem(shield);
-
-            AddItem(new Boots(0x455));
-            AddItem(new Shirt(Utility.RandomMetalHue()));
+			SetWearable((Item)Activator.CreateInstance(Utility.RandomList(_WeaponsList)));
+			SetWearable(new DragonHelm() { Resource = res });
+			SetWearable(new DragonChest() { Resource = res });
+			SetWearable(new DragonArms() { Resource = res });
+			SetWearable(new DragonGloves() { Resource = res });
+			SetWearable(new DragonLegs() { Resource = res });
+			SetWearable(new ChaosShield());
+			SetWearable(new Shirt(), Utility.RandomMetalHue(), 1);
+			SetWearable(new Boots(), 0x455, 1);
 
             int amount = Utility.RandomMinMax(1, 3);
 
@@ -150,38 +77,10 @@ namespace Server.Mobiles
                     AddItem(new WhiteScales(amount));
                     break;
             }
-            switch (Utility.Random(9))
-            {
-                case 0:
-                    res = CraftResource.DullCopper;
-                    break;
-                case 1:
-                    res = CraftResource.ShadowIron;
-                    break;
-                case 2:
-                    res = CraftResource.Copper;
-                    break;
-                case 3:
-                    res = CraftResource.Bronze;
-                    break;
-                case 4:
-                    res = CraftResource.Gold;
-                    break;
-                case 5:
-                    res = CraftResource.Agapite;
-                    break;
-                case 6:
-                    res = CraftResource.Verite;
-                    break;
-                case 7:
-                    res = CraftResource.Valorite;
-                    break;
-                case 8:
-                    res = CraftResource.Iron;
-                    break;
-            }
+            
+			res = (CraftResource)Utility.RandomMinMax(1, 9); // All metal types
 
-            SwampDragon mt = new SwampDragon
+			SwampDragon mt = new SwampDragon
             {
                 HasBarding = true,
                 BardingResource = res
@@ -197,7 +96,12 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool AutoDispel => true;
+		private static readonly Type[] _WeaponsList = new Type[]
+		{
+			typeof(Kryss), typeof(Broadsword), typeof(Katana)
+		};
+
+		public override bool AutoDispel => true;
         public override bool CanRummageCorpses => true;
         public override bool AlwaysMurderer => true;
         public override bool ShowFameTitle => false;

--- a/Scripts/Mobiles/Normal/ClanCA.cs
+++ b/Scripts/Mobiles/Normal/ClanCA.cs
@@ -38,7 +38,7 @@ namespace Server.Mobiles
             Fame = 6500;
             Karma = -6500;
 
-            AddItem(new Bow());
+            SetWearable(new Bow(), dropChance: 1);
         }
 
         public ClanCA(Serial serial)

--- a/Scripts/Mobiles/Normal/ClanCT.cs
+++ b/Scripts/Mobiles/Normal/ClanCT.cs
@@ -38,8 +38,8 @@ namespace Server.Mobiles
             Fame = 6500;
             Karma = -6500;
 
-            AddItem(new Bow());
-        }
+			SetWearable(new Bow(), dropChance: 1);
+		}
 
         public ClanCT(Serial serial)
             : base(serial)

--- a/Scripts/Mobiles/Normal/ClanSS.cs
+++ b/Scripts/Mobiles/Normal/ClanSS.cs
@@ -37,8 +37,8 @@ namespace Server.Mobiles
             Fame = 6500;
             Karma = -6500;
 
-            AddItem(new Bow());
-        }
+			SetWearable(new Bow(), dropChance: 1);
+		}
 
         public ClanSS(Serial serial)
             : base(serial)

--- a/Scripts/Mobiles/Normal/Cursed.cs
+++ b/Scripts/Mobiles/Normal/Cursed.cs
@@ -16,8 +16,8 @@ namespace Server.Mobiles
             Name = NameList.RandomName("male");
             BaseSoundID = 471;
 
-            AddItem(new ShortPants(Utility.RandomNeutralHue()));
-            AddItem(new Shirt(Utility.RandomNeutralHue()));
+            SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new Shirt(), Utility.RandomNeutralHue(), 1);
 
             SetStr(91, 100);
             SetDex(86, 95);
@@ -43,9 +43,7 @@ namespace Server.Mobiles
             Fame = 1000;
             Karma = -2000;
 
-            BaseWeapon weapon = Loot.RandomWeapon();
-            weapon.Movable = false;
-            AddItem(weapon);
+            AddItem(Loot.RandomWeapon());
         }
 
         public Cursed(Serial serial)

--- a/Scripts/Mobiles/Normal/DespiseEvilCreatures.cs
+++ b/Scripts/Mobiles/Normal/DespiseEvilCreatures.cs
@@ -203,8 +203,8 @@ namespace Server.Engines.Despise
             Fame = GetFame;
             Karma = GetKarmaEvil;
 
-            AddItem(new Bow());
-            PackItem(new Arrow(Utility.RandomMinMax(5, 10))); // OSI it is different: in a sub backpack, this is probably just a limitation of their engine
+			SetWearable(new Bow(), dropChance: 1);
+			PackItem(new Arrow(Utility.RandomMinMax(5, 10))); // OSI it is different: in a sub backpack, this is probably just a limitation of their engine
             Power = powerLevel;
         }
 

--- a/Scripts/Mobiles/Normal/DespiseGoodCreatures.cs
+++ b/Scripts/Mobiles/Normal/DespiseGoodCreatures.cs
@@ -200,8 +200,8 @@ namespace Server.Engines.Despise
             Fame = GetFame;
             Karma = GetKarmaGood;
 
-            AddItem(new Bow());
-            PackItem(new Arrow(Utility.RandomMinMax(5, 10)));
+			SetWearable(new Bow(), dropChance: 1);
+			PackItem(new Arrow(Utility.RandomMinMax(5, 10)));
             Power = powerLevel;
 
             RangeFight = 8;

--- a/Scripts/Mobiles/Normal/DragonsFlameMage.cs
+++ b/Scripts/Mobiles/Normal/DragonsFlameMage.cs
@@ -18,10 +18,10 @@ namespace Server.Mobiles
             HairHue = Race.RandomHairHue();
             Race.RandomFacialHair(this);
 
-            AddItem(new NinjaTabi());
-            AddItem(new FancyShirt(0x51D));
-            AddItem(new Hakama(0x51D));
-            AddItem(new Kasa(0x51D));
+			SetWearable(new NinjaTabi(), dropChance: 1);
+			SetWearable(new FancyShirt(), 0x51D, 1);
+			SetWearable(new Hakama(), 0x51D, 1);
+			SetWearable(new Kasa(), 0x51D, 1);
 
             SetStr(340, 360);
             SetDex(200, 215);

--- a/Scripts/Mobiles/Normal/ElfBrigand.cs
+++ b/Scripts/Mobiles/Normal/ElfBrigand.cs
@@ -48,33 +48,33 @@ namespace Server.Mobiles
             Karma = -1000;
 
             // outfit
-            AddItem(new Shirt(Utility.RandomNeutralHue()));
+            SetWearable(new Shirt(), Utility.RandomNeutralHue(), 1);
 
             switch (Utility.Random(4))
             {
                 case 0:
-                    AddItem(new Sandals());
+					SetWearable(new Sandals(), dropChance: 1);
                     break;
                 case 1:
-                    AddItem(new Shoes());
+					SetWearable(new Shoes(), dropChance: 1);
                     break;
                 case 2:
-                    AddItem(new Boots());
+					SetWearable(new Boots(), dropChance: 1);
                     break;
                 case 3:
-                    AddItem(new ThighBoots());
+					SetWearable(new ThighBoots(), dropChance: 1);
                     break;
             }
 
             if (Female)
             {
                 if (Utility.RandomBool())
-                    AddItem(new Skirt(Utility.RandomNeutralHue()));
+					SetWearable(new Skirt(), Utility.RandomNeutralHue(), 1);
                 else
-                    AddItem(new Kilt(Utility.RandomNeutralHue()));
+					SetWearable(new Kilt(), Utility.RandomNeutralHue(), 1);
             }
             else
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
 
             // hair, facial hair			
             HairItemID = Race.RandomHair(Female);
@@ -83,10 +83,10 @@ namespace Server.Mobiles
             // weapon, shield
             Item weapon = Loot.RandomWeapon();
 
-            AddItem(weapon);
+			SetWearable(weapon, dropChance: 1);
 
             if (weapon.Layer == Layer.OneHanded && Utility.RandomBool())
-                AddItem(Loot.RandomShield());
+                SetWearable(Loot.RandomShield(), dropChance: 1);
         }
 
         public ElfBrigand(Serial serial)

--- a/Scripts/Mobiles/Normal/EliteNinja.cs
+++ b/Scripts/Mobiles/Normal/EliteNinja.cs
@@ -57,10 +57,9 @@ namespace Server.Mobiles
             {
                 UsesRemaining = 20,
                 Poison = Poison.Greater,
-                PoisonCharges = 20,
-                Movable = false
+                PoisonCharges = 20
             };
-            AddItem(belt);
+            SetWearable(belt);
 
             int amount = Skills[SkillName.Ninjitsu].Value >= 100 ? 2 : 1;
 
@@ -76,11 +75,11 @@ namespace Server.Mobiles
                 PackItem(f);
             }
 
-            AddItem(new NinjaTabi());
-            AddItem(new LeatherNinjaJacket());
-            AddItem(new LeatherNinjaHood());
-            AddItem(new LeatherNinjaPants());
-            AddItem(new LeatherNinjaMitts());
+            SetWearable(new NinjaTabi(), dropChance: 1);
+			SetWearable(new LeatherNinjaJacket(), dropChance: 1);
+			SetWearable(new LeatherNinjaHood(), dropChance: 1);
+			SetWearable(new LeatherNinjaPants(), dropChance: 1);
+			SetWearable(new LeatherNinjaMitts(), dropChance: 1);
 
             if (Utility.RandomDouble() < 0.33)
                 PackItem(new SmokeBomb());

--- a/Scripts/Mobiles/Normal/Executioner.cs
+++ b/Scripts/Mobiles/Normal/Executioner.cs
@@ -16,13 +16,13 @@ namespace Server.Mobiles
             {
                 Body = 0x191;
                 Name = NameList.RandomName("female");
-                AddItem(new Skirt(Utility.RandomRedHue()));
+                SetWearable(new Skirt(), Utility.RandomRedHue(), 1);
             }
             else
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomRedHue()));
+				SetWearable(new ShortPants(), Utility.RandomRedHue(), 1);
             }
 
             SetStr(386, 400);
@@ -51,9 +51,9 @@ namespace Server.Mobiles
             Fame = 5000;
             Karma = -5000;
 
-            AddItem(new ThighBoots(Utility.RandomRedHue()));
-            AddItem(new Surcoat(Utility.RandomRedHue()));
-            AddItem(new ExecutionersAxe());
+			SetWearable(new ThighBoots(), Utility.RandomRedHue(), 1);
+			SetWearable(new Surcoat(), Utility.RandomRedHue(), 1);
+			SetWearable(new ExecutionersAxe(), dropChance: 1);
 
             Utility.AssignRandomHair(this);
         }

--- a/Scripts/Mobiles/Normal/ForgottenServant.cs
+++ b/Scripts/Mobiles/Normal/ForgottenServant.cs
@@ -1,4 +1,5 @@
-﻿using Server.Items;
+﻿using System;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -16,13 +17,13 @@ namespace Server.Mobiles
             {
                 Body = 0x191;
                 Name = NameList.RandomName("female");
-                AddItem(new Skirt(Utility.RandomNeutralHue()));
+				SetWearable(new Skirt(), Utility.RandomNeutralHue(), 1);
             }
             else
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
 
             SetStr(147, 215);
@@ -49,36 +50,12 @@ namespace Server.Mobiles
             Fame = 2500;
             Karma = -2500;
 
-            AddItem(new Boots(Utility.RandomNeutralHue()));
-            AddItem(new FancyShirt());
-            AddItem(new Bandana());
+			SetWearable(new Boots(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new FancyShirt(), dropChance: 1);
+			SetWearable(new Bandana(), dropChance: 1);
+			SetWearable((Item)Activator.CreateInstance(Utility.RandomList(_WeaponsList)), dropChance: 1);
 
-            switch (Utility.Random(7))
-            {
-                case 0:
-                    AddItem(new Longsword());
-                    break;
-                case 1:
-                    AddItem(new Cutlass());
-                    break;
-                case 2:
-                    AddItem(new Broadsword());
-                    break;
-                case 3:
-                    AddItem(new Axe());
-                    break;
-                case 4:
-                    AddItem(new Club());
-                    break;
-                case 5:
-                    AddItem(new Dagger());
-                    break;
-                case 6:
-                    AddItem(new Spear());
-                    break;
-            }
-
-            Utility.AssignRandomHair(this);
+			Utility.AssignRandomHair(this);
         }
 
         public ForgottenServant(Serial serial)
@@ -86,7 +63,12 @@ namespace Server.Mobiles
         {
         }
 
-        public override bool ClickTitle => false;
+		private static readonly Type[] _WeaponsList =
+		{
+			typeof(Longsword), typeof(Cutlass), typeof(Broadsword), typeof(Axe), typeof(Club), typeof(Dagger), typeof(Spear)
+		};
+
+		public override bool ClickTitle => false;
         public override bool AlwaysMurderer => true;
 
         public override void GenerateLoot()

--- a/Scripts/Mobiles/Normal/GargishOutcast.cs
+++ b/Scripts/Mobiles/Normal/GargishOutcast.cs
@@ -100,7 +100,7 @@ namespace Server.Mobiles
         private void AddImmovableItem(Item item)
         {
             item.LootType = LootType.Blessed;
-            AddItem(item);
+            SetWearable(item);
         }
 
         public override Poison PoisonImmune => Poison.Deadly;

--- a/Scripts/Mobiles/Normal/GargishRouser.cs
+++ b/Scripts/Mobiles/Normal/GargishRouser.cs
@@ -101,7 +101,7 @@ namespace Server.Mobiles
         private void AddImmovableItem(Item item)
         {
             item.LootType = LootType.Blessed;
-            AddItem(item);
+            SetWearable(item);
         }
 
         public override Poison PoisonImmune => Poison.Lethal;

--- a/Scripts/Mobiles/Normal/GolemController.cs
+++ b/Scripts/Mobiles/Normal/GolemController.cs
@@ -72,7 +72,7 @@ namespace Server.Mobiles
             item.Hue = ArcaneGem.DefaultArcaneHue;
             item.LootType = LootType.Newbied;
 
-            AddItem(item);
+            SetWearable(item);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Gregorio.cs
+++ b/Scripts/Mobiles/Normal/Gregorio.cs
@@ -103,11 +103,11 @@ namespace Server.Mobiles
 
         public void InitOutfit()
         {
-            AddItem(new Sandals(0x75E));
-            AddItem(new Shirt());
-            AddItem(new ShortPants(0x66C));
-            AddItem(new SkullCap(0x649));
-            AddItem(new Pitchfork());
+            SetWearable(new Sandals(), 0x75E, 1);
+			SetWearable(new Shirt(), dropChance: 1);
+			SetWearable(new ShortPants(), 0x66C, 1);
+			SetWearable(new SkullCap(), 0x649, 1);
+			SetWearable(new Pitchfork(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Mobiles/Normal/Gremlin.cs
+++ b/Scripts/Mobiles/Normal/Gremlin.cs
@@ -32,7 +32,7 @@ namespace Server.Mobiles
             SetSkill(SkillName.MagicResist, 82.5);
             SetSkill(SkillName.Tactics, 65.3);
 
-            AddItem(new Bow());
+            SetWearable(new Bow(), dropChance: 1);
         }
 
         public Gremlin(Serial serial)

--- a/Scripts/Mobiles/Normal/JukaLord.cs
+++ b/Scripts/Mobiles/Normal/JukaLord.cs
@@ -41,7 +41,7 @@ namespace Server.Mobiles
             Fame = 15000;
             Karma = -15000;
 
-            AddItem(new JukaBow());
+            SetWearable(new JukaBow(), dropChance: 1);
         }
 
         public JukaLord(Serial serial)

--- a/Scripts/Mobiles/Normal/KhaldunRevenant.cs
+++ b/Scripts/Mobiles/Normal/KhaldunRevenant.cs
@@ -45,13 +45,7 @@ namespace Server.Mobiles
             Fame = 0;
             Karma = 0;
 
-            Halberd weapon = new Halberd
-            {
-                Hue = 0x41CE,
-                Movable = false
-            };
-
-            AddItem(weapon);
+            SetWearable(new Halberd(), 0x41CE);
         }
 
         public KhaldunRevenant(Serial serial)

--- a/Scripts/Mobiles/Normal/KhaldunSummoner.cs
+++ b/Scripts/Mobiles/Normal/KhaldunSummoner.cs
@@ -39,41 +39,12 @@ namespace Server.Mobiles
             Fame = 10000;
             Karma = -10000;
 
-            LeatherGloves gloves = new LeatherGloves
-            {
-                Hue = 0x66D
-            };
-            AddItem(gloves);
-
-            BoneHelm helm = new BoneHelm
-            {
-                Hue = 0x835
-            };
-            AddItem(helm);
-
-            Necklace necklace = new Necklace
-            {
-                Hue = 0x66D
-            };
-            AddItem(necklace);
-
-            Cloak cloak = new Cloak
-            {
-                Hue = 0x66D
-            };
-            AddItem(cloak);
-
-            Kilt kilt = new Kilt
-            {
-                Hue = 0x66D
-            };
-            AddItem(kilt);
-
-            Sandals sandals = new Sandals
-            {
-                Hue = 0x66D
-            };
-            AddItem(sandals);
+            SetWearable(new LeatherGloves(), 0x660, 1);
+            SetWearable(new BoneHelm(), 0x835, 1);
+            SetWearable(new Necklace(), 0x660, 1);
+            SetWearable(new Cloak(), 0x660, 1);
+            SetWearable(new Kilt(), 0x660, 1);
+            SetWearable(new Sandals(), 0x660, 1);
         }
 
         public KhaldunSummoner(Serial serial)
@@ -116,11 +87,7 @@ namespace Server.Mobiles
 
             if (rm.Backpack == null)
             {
-                Backpack pack = new Backpack
-                {
-                    Movable = false
-                };
-                rm.AddItem(pack);
+                rm.SetWearable(new Backpack());
             }
 
             for (int i = 0; i < 2; i++)

--- a/Scripts/Mobiles/Normal/KhaldunZealot.cs
+++ b/Scripts/Mobiles/Normal/KhaldunZealot.cs
@@ -39,51 +39,14 @@ namespace Server.Mobiles
             Fame = 10000;
             Karma = -10000;
 
-            VikingSword weapon = new VikingSword
-            {
-                Hue = 0x835,
-                Movable = false
-            };
-            AddItem(weapon);
-
-            MetalShield shield = new MetalShield
-            {
-                Hue = 0x835,
-                Movable = false
-            };
-            AddItem(shield);
-
-            BoneHelm helm = new BoneHelm
-            {
-                Hue = 0x835
-            };
-            AddItem(helm);
-
-            BoneArms arms = new BoneArms
-            {
-                Hue = 0x835
-            };
-            AddItem(arms);
-
-            BoneGloves gloves = new BoneGloves
-            {
-                Hue = 0x835
-            };
-            AddItem(gloves);
-
-            BoneChest tunic = new BoneChest
-            {
-                Hue = 0x835
-            };
-            AddItem(tunic);
-
-            BoneLegs legs = new BoneLegs
-            {
-                Hue = 0x835
-            };
-            AddItem(legs);
-
-            AddItem(new Boots());
+			SetWearable(new VikingSword(), 0x835);
+			SetWearable(new MetalShield(), 0x835);
+			SetWearable(new BoneHelm(), 0x835, 1);
+			SetWearable(new BoneArms(), 0x835, 1);
+			SetWearable(new BoneGloves(), 0x835, 1);
+			SetWearable(new BoneChest(), 0x835, 1);
+			SetWearable(new BoneLegs(), 0x835, 1);
+			SetWearable(new Boots(), dropChance: 1);
         }
 
         public KhaldunZealot(Serial serial)

--- a/Scripts/Mobiles/Normal/MeerCaptain.cs
+++ b/Scripts/Mobiles/Normal/MeerCaptain.cs
@@ -41,7 +41,7 @@ namespace Server.Mobiles
             Fame = 2000;
             Karma = 5000;
 
-            AddItem(new Crossbow());
+            SetWearable(new Crossbow(), dropChance: 1);
 
             m_NextAbilityTime = DateTime.UtcNow + TimeSpan.FromSeconds(Utility.RandomMinMax(2, 5));
         }

--- a/Scripts/Mobiles/Normal/OrcScout.cs
+++ b/Scripts/Mobiles/Normal/OrcScout.cs
@@ -53,11 +53,11 @@ namespace Server.Mobiles
 
             if (0.1 > Utility.RandomDouble())
             {
-                AddItem(new OrcishBow());
+                SetWearable(new OrcishBow(), dropChance: 1);
             }
             else
             {
-                AddItem(new Bow());
+                SetWearable(new Bow(), dropChance: 1);
             }
         }
 

--- a/Scripts/Mobiles/Normal/PackHorse.cs
+++ b/Scripts/Mobiles/Normal/PackHorse.cs
@@ -44,17 +44,7 @@ namespace Server.Mobiles
             ControlSlots = 1;
             MinTameSkill = 29.1;
 
-            Container pack = Backpack;
-
-            if (pack != null)
-                pack.Delete();
-
-            pack = new StrongBackpack
-            {
-                Movable = false
-            };
-
-            AddItem(pack);
+            SetWearable(new StrongBackpack());
         }
 
         public override int Meat => 3;

--- a/Scripts/Mobiles/Normal/PackLlama.cs
+++ b/Scripts/Mobiles/Normal/PackLlama.cs
@@ -44,17 +44,7 @@ namespace Server.Mobiles
             ControlSlots = 1;
             MinTameSkill = 29.1;
 
-            Container pack = Backpack;
-
-            if (pack != null)
-                pack.Delete();
-
-            pack = new StrongBackpack
-            {
-                Movable = false
-            };
-
-            AddItem(pack);
+			SetWearable(new StrongBackpack());
         }
 
         public override int Meat => 1;

--- a/Scripts/Mobiles/Normal/PlagueBeastLord.cs
+++ b/Scripts/Mobiles/Normal/PlagueBeastLord.cs
@@ -214,8 +214,8 @@ namespace Server.Mobiles
                 m_Timer.StartDissolving();
 
                 PlagueBeastBackpack pack = new PlagueBeastBackpack();
-                AddItem(pack);
-                pack.Initialize();
+				SetWearable(pack);
+				pack.Initialize();
 
                 foreach (NetState state in GetClientsInRange(12))
                 {

--- a/Scripts/Mobiles/Normal/Protector.cs
+++ b/Scripts/Mobiles/Normal/Protector.cs
@@ -42,21 +42,13 @@ namespace Server.Mobiles
             Fame = 10000;
             Karma = -10000;
 
-            Item boots = new ThighBoots
-            {
-                Movable = false,
-                Hue = Utility.Random(2)
-            };
-
             Item shroud = new Item(0x204E)
             {
-                Layer = Layer.OuterTorso,
-                Movable = false,
-                Hue = Utility.Random(2)
+                Layer = Layer.OuterTorso
             };
 
-            AddItem(boots);
-            AddItem(shroud);
+            SetWearable(new ThighBoots(), Utility.Random(2));
+            SetWearable(shroud, Utility.Random(2));
         }
 
         public Protector(Serial serial)

--- a/Scripts/Mobiles/Normal/RatmanArcher.cs
+++ b/Scripts/Mobiles/Normal/RatmanArcher.cs
@@ -39,7 +39,7 @@ namespace Server.Mobiles
             Fame = 6500;
             Karma = -6500;
 
-            AddItem(new Bow());
+            SetWearable(new Bow(), dropChance: 1);
         }
 
         public RatmanArcher(Serial serial)

--- a/Scripts/Mobiles/Normal/Ronin.cs
+++ b/Scripts/Mobiles/Normal/Ronin.cs
@@ -52,29 +52,29 @@ namespace Server.Mobiles
             Fame = 8500;
             Karma = -8500;
 
-            AddItem(new SamuraiTabi());
-            AddItem(new LeatherHiroSode());
-            AddItem(new LeatherDo());
+			SetWearable(new SamuraiTabi(), dropChance: 1);
+			SetWearable(new LeatherHiroSode(), dropChance: 1);
+			SetWearable(new LeatherDo(), dropChance: 1);
 
             switch (Utility.Random(4))
             {
-                case 0: AddItem(new LightPlateJingasa()); break;
-                case 1: AddItem(new ChainHatsuburi()); break;
-                case 2: AddItem(new DecorativePlateKabuto()); break;
-                case 3: AddItem(new LeatherJingasa()); break;
+                case 0: SetWearable(new LightPlateJingasa(), dropChance: 1); break;
+                case 1: SetWearable(new ChainHatsuburi(), dropChance: 1); break;
+                case 2: SetWearable(new DecorativePlateKabuto(), dropChance: 1); break;
+                case 3: SetWearable(new LeatherJingasa(), dropChance: 1); break;
             }
 
             switch (Utility.Random(3))
             {
-                case 0: AddItem(new StuddedHaidate()); break;
-                case 1: AddItem(new LeatherSuneate()); break;
-                case 2: AddItem(new PlateSuneate()); break;
+                case 0: SetWearable(new StuddedHaidate(), dropChance: 1); break;
+                case 1: SetWearable(new LeatherSuneate(), dropChance: 1); break;
+                case 2: SetWearable(new PlateSuneate(), dropChance: 1); break;
             }
 
             if (Utility.RandomDouble() > .2)
-                AddItem(new NoDachi());
-            else
-                AddItem(new Halberd());
+				SetWearable(new NoDachi(), dropChance: 1);
+			else
+				SetWearable(new Halberd(), dropChance: 1);
 
             PackItem(new Wakizashi());
             PackItem(new Longsword());

--- a/Scripts/Mobiles/Normal/Savage.cs
+++ b/Scripts/Mobiles/Normal/Savage.cs
@@ -35,9 +35,9 @@ namespace Server.Mobiles
             Fame = 1000;
             Karma = -1000;
 
-            AddItem(new Spear());
-            AddItem(new BoneArms());
-            AddItem(new BoneLegs());
+            SetWearable(new Spear(), dropChance: 1);
+            SetWearable(new BoneArms(), dropChance: 1);
+            SetWearable(new BoneLegs(), dropChance: 1);
         }
 
         public Savage(Serial serial)

--- a/Scripts/Mobiles/Normal/SavageRider.cs
+++ b/Scripts/Mobiles/Normal/SavageRider.cs
@@ -33,10 +33,10 @@ namespace Server.Mobiles
             Fame = 1000;
             Karma = -1000;
 
-            AddItem(new TribalSpear());
-            AddItem(new BoneArms());
-            AddItem(new BoneLegs());
-            AddItem(new BearMask());
+            SetWearable(new TribalSpear(), dropChance: 1);
+            SetWearable(new BoneArms(), dropChance: 1);
+            SetWearable(new BoneLegs(), dropChance: 1);
+            SetWearable(new BearMask(), dropChance: 1);
 
             new SavageRidgeback().Rider = this;
         }

--- a/Scripts/Mobiles/Normal/SavageShaman.cs
+++ b/Scripts/Mobiles/Normal/SavageShaman.cs
@@ -46,9 +46,9 @@ namespace Server.Mobiles
             Fame = 1000;
             Karma = -1000;
 
-            AddItem(new BoneArms());
-            AddItem(new BoneLegs());
-            AddItem(new DeerMask());
+            SetWearable(new BoneArms(), dropChance: 1);
+            SetWearable(new BoneLegs(), dropChance: 1);
+            SetWearable(new DeerMask(), dropChance: 1);
         }
 
         public SavageShaman(Serial serial)

--- a/Scripts/Mobiles/Normal/SerpentsFangAssassin.cs
+++ b/Scripts/Mobiles/Normal/SerpentsFangAssassin.cs
@@ -18,36 +18,14 @@ namespace Server.Mobiles
             HairHue = Race.RandomHairHue();
             Race.RandomFacialHair(this);
 
-            AddItem(new ThighBoots(0x51D));
-            AddItem(new FancyShirt(0x51D));
-            AddItem(new StuddedMempo());
-            AddItem(new JinBaori(0x2A));
-
-            Item item;
-
-            item = new StuddedGloves
-            {
-                Hue = 0x2A
-            };
-            AddItem(item);
-
-            item = new LeatherNinjaPants
-            {
-                Hue = 0x51D
-            };
-            AddItem(item);
-
-            item = new LightPlateJingasa
-            {
-                Hue = 0x51D
-            };
-            AddItem(item);
-
-            item = new Sai
-            {
-                Hue = 0x51D
-            };
-            AddItem(item);
+            SetWearable(new ThighBoots(), 0x51D, 1);
+			SetWearable(new FancyShirt(), 0x51D, 1);
+			SetWearable(new StuddedMempo(), dropChance: 1);
+			SetWearable(new JinBaori(), 0x2A, 1);
+			SetWearable(new StuddedGloves(), 0x2A, 1);
+			SetWearable(new LeatherNinjaPants(), 0x51D, 1);
+			SetWearable(new LightPlateJingasa(), 0x51D, 1);
+			SetWearable(new Sai(), 0x51D, 1); 
 
             SetStr(440, 460);
             SetDex(160, 175);

--- a/Scripts/Mobiles/Normal/SpectralArmour.cs
+++ b/Scripts/Mobiles/Normal/SpectralArmour.cs
@@ -12,18 +12,9 @@ namespace Server.Mobiles
             Hue = 0x8026;
             Name = "spectral armour";
 
-            Buckler buckler = new Buckler();
-            ChainCoif coif = new ChainCoif();
-            PlateGloves gloves = new PlateGloves();
-
-            buckler.Hue = 0x835;
-            buckler.Movable = false;
-            coif.Hue = 0x835;
-            gloves.Hue = 0x835;
-
-            AddItem(buckler);
-            AddItem(coif);
-            AddItem(gloves);
+            SetWearable(new Buckler(), 0x835);
+            SetWearable(new ChainCoif(), 0x835, 1);
+            SetWearable(new PlateGloves(), 0x835, 1);
 
             SetStr(101, 110);
             SetDex(101, 110);

--- a/Scripts/Mobiles/Normal/TigersClawThief.cs
+++ b/Scripts/Mobiles/Normal/TigersClawThief.cs
@@ -18,31 +18,15 @@ namespace Server.Mobiles
             HairHue = Race.RandomHairHue();
             Race.RandomFacialHair(this);
 
-            AddItem(new ThighBoots(0x51D));
-            AddItem(new Wakizashi());
-            AddItem(new FancyShirt(0x51D));
-            AddItem(new StuddedMempo());
-            AddItem(new JinBaori(0x69));
 
-            Item item;
-
-            item = new StuddedGloves
-            {
-                Hue = 0x69
-            };
-            AddItem(item);
-
-            item = new LeatherNinjaPants
-            {
-                Hue = 0x51D
-            };
-            AddItem(item);
-
-            item = new LightPlateJingasa
-            {
-                Hue = 0x51D
-            };
-            AddItem(item);
+			SetWearable(new ThighBoots(), 0x51D, 1);
+			SetWearable(new FancyShirt(), 0x51D, 1);
+			SetWearable(new StuddedMempo(), dropChance: 1);
+			SetWearable(new JinBaori(), 0x69, 1);
+			SetWearable(new StuddedGloves(), 0x69, 1);
+			SetWearable(new LeatherNinjaPants(), 0x51D, 1);
+			SetWearable(new LightPlateJingasa(), 0x51D, 1);
+			SetWearable(new Wakizashi(), dropChance: 1);
 
             SetStr(340, 360);
             SetDex(400, 415);

--- a/Scripts/Mobiles/Summons/HordeMinion.cs
+++ b/Scripts/Mobiles/Summons/HordeMinion.cs
@@ -60,11 +60,10 @@ namespace Server.Mobiles
 
             pack = new Backpack
             {
-                Movable = false,
                 Weight = 13.0
             };
 
-            AddItem(pack);
+			SetWearable(pack);
         }
 
         private DateTime m_NextPickup;

--- a/Scripts/Quests/CloakOfHumility/Mobiles/Dierdre.cs
+++ b/Scripts/Quests/CloakOfHumility/Mobiles/Dierdre.cs
@@ -33,10 +33,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals());
-            AddItem(new FancyShirt());
-            AddItem(new PlainDress());
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), dropChance: 1);
+            SetWearable(new FancyShirt(), dropChance: 1);
+			SetWearable(new PlainDress(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Quests/CloakOfHumility/Mobiles/Gareth.cs
+++ b/Scripts/Quests/CloakOfHumility/Mobiles/Gareth.cs
@@ -39,11 +39,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots());
-            AddItem(new BodySash());
-            AddItem(new FancyShirt(6));
-            AddItem(new LongPants());
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), dropChance :1);
+            SetWearable(new BodySash(), dropChance :1);
+            SetWearable(new FancyShirt(), 6, 1);
+			SetWearable(new LongPants(), dropChance :1);
         }
 
         private DateTime m_NextTalk;

--- a/Scripts/Quests/CloakOfHumility/Mobiles/Jason.cs
+++ b/Scripts/Quests/CloakOfHumility/Mobiles/Jason.cs
@@ -1,4 +1,5 @@
 using Server.Engines.Quests;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -51,9 +52,9 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Items.Backpack());
-            AddItem(new Items.Robe(Utility.RandomYellowHue()));
-            AddItem(new Items.Sandals());
+            SetWearable(new Backpack());
+            SetWearable(new Robe(), Utility.RandomYellowHue(), 1);
+			SetWearable(new Sandals(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Quests/CloakOfHumility/Mobiles/Kevin.cs
+++ b/Scripts/Quests/CloakOfHumility/Mobiles/Kevin.cs
@@ -1,4 +1,5 @@
 using Server.Engines.Quests;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -43,8 +44,8 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.HalfApron());
-            AddItem(new Items.Cleaver());
+            SetWearable(new HalfApron(), dropChance: 1);
+			SetWearable(new Cleaver(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Quests/CloakOfHumility/Mobiles/Maribel.cs
+++ b/Scripts/Quests/CloakOfHumility/Mobiles/Maribel.cs
@@ -1,4 +1,5 @@
 using Server.Engines.Quests;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -38,9 +39,9 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Items.Backpack());
-            AddItem(new Items.Sandals());
-            AddItem(new Items.FancyDress(2205));
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), dropChance: 1);
+			SetWearable(new FancyDress(), 2205, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Quests/CloakOfHumility/Mobiles/Nelson.cs
+++ b/Scripts/Quests/CloakOfHumility/Mobiles/Nelson.cs
@@ -1,4 +1,5 @@
 using Server.Engines.Quests;
+using Server.Items;
 
 namespace Server.Mobiles
 {
@@ -34,8 +35,8 @@ namespace Server.Mobiles
         {
             base.InitOutfit();
 
-            AddItem(new Items.Robe(Utility.RandomGreenHue()));
-            AddItem(new Items.ShepherdsCrook());
+            SetWearable(new Robe(), Utility.RandomGreenHue(), 1);
+			SetWearable(new ShepherdsCrook(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Quests/CloakOfHumility/Mobiles/Walton.cs
+++ b/Scripts/Quests/CloakOfHumility/Mobiles/Walton.cs
@@ -33,11 +33,11 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new FancyShirt());
-            AddItem(new Doublet(1109));
-            AddItem(new LongPants(Utility.RandomBlueHue()));
-            AddItem(new Boots());
+            SetWearable(new Backpack());
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(new Doublet(), 1109, 1);
+            SetWearable(new LongPants(), Utility.RandomBlueHue(), 1);
+			SetWearable(new Boots(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Quests/DoughtyWarriorsQuest.cs
+++ b/Scripts/Quests/DoughtyWarriorsQuest.cs
@@ -209,40 +209,34 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new PlateArms());
-            AddItem(new PlateChest());
-            AddItem(new PlateGloves());
-            AddItem(new StuddedGorget());
-            AddItem(new PlateLegs());
+            SetWearable(new PlateArms(), dropChance: 1);
+            SetWearable(new PlateChest(), dropChance: 1);
+            SetWearable(new PlateGloves(), dropChance: 1);
+            SetWearable(new StuddedGorget(), dropChance: 1);
+			SetWearable(new PlateLegs(), dropChance: 1);
 
             switch (Utility.Random(4))
             {
-                case 0: AddItem(new PlateHelm()); break;
-                case 1: AddItem(new NorseHelm()); break;
-                case 2: AddItem(new CloseHelm()); break;
-                case 3: AddItem(new Helmet()); break;
+                case 0: SetWearable(new PlateHelm(), dropChance: 1); break;
+                case 1: SetWearable(new NorseHelm(), dropChance: 1); break;
+                case 2: SetWearable(new CloseHelm(), dropChance: 1); break;
+                case 3: SetWearable(new Helmet(), dropChance: 1); break;
             }
 
             switch (Utility.Random(3))
             {
-                case 0: AddItem(new BodySash(0x482)); break;
-                case 1: AddItem(new Doublet(0x482)); break;
-                case 2: AddItem(new Tunic(0x482)); break;
+                case 0: SetWearable(new BodySash(), 0x482, 1); break;
+                case 1: SetWearable(new Doublet(), 0x482, 1); break;
+                case 2: SetWearable(new Tunic(), 0x482, 1); break;
             }
 
-            AddItem(new Broadsword());
-
-            Item shield = new MetalKiteShield
-            {
-                Hue = Utility.RandomNondyedHue()
-            };
-
-            AddItem(shield);
+			SetWearable(new Broadsword(), dropChance: 1);
+			SetWearable(new MetalKiteShield(), Utility.RandomNondyedHue(), 1);
 
             switch (Utility.Random(2))
             {
-                case 0: AddItem(new Boots()); break;
-                case 1: AddItem(new ThighBoots()); break;
+                case 0: SetWearable(new Boots(), dropChance: 1); break;
+                case 1: SetWearable(new ThighBoots(), dropChance: 1); break;
             }
 
             Blessed = true;

--- a/Scripts/Quests/Escortables.cs
+++ b/Scripts/Quests/Escortables.cs
@@ -530,12 +530,12 @@ namespace Server.Engines.Quests
         {
             int lowHue = GetRandomHue();
 
-            AddItem(new ThighBoots());
+			SetWearable(new ThighBoots(), dropChance: 1);
 
-            AddItem(new LongPants(lowHue));
+			SetWearable(new LongPants(), lowHue, 1);
 
             if (!Female)
-                AddItem(new BodySash(lowHue));
+				SetWearable(new BodySash(), lowHue, 1);
 
             PackGold(200, 250);
         }
@@ -578,16 +578,16 @@ namespace Server.Engines.Quests
         public override bool ClickTitle => false;
         public override void InitOutfit()
         {
-            AddItem(new Robe(GetRandomHue()));
+			SetWearable(new Robe(), GetRandomHue(), 1);
 
             int lowHue = GetRandomHue();
 
-            AddItem(new ShortPants(lowHue));
+			SetWearable(new ShortPants(), lowHue, 1);
 
             if (Female)
-                AddItem(new ThighBoots(lowHue));
+				SetWearable(new ThighBoots(), lowHue, 1);
             else
-                AddItem(new Boots(lowHue));
+				SetWearable(new Boots(), lowHue, 1);
 
             PackGold(200, 250);
         }
@@ -624,36 +624,23 @@ namespace Server.Engines.Quests
         public override void InitOutfit()
         {
             if (Female)
-                AddItem(new PlainDress());
+				SetWearable(new PlainDress(), dropChance: 1);
             else
-                AddItem(new Shirt(GetRandomHue()));
+				SetWearable(new Shirt(), GetRandomHue(), 1);
 
             int lowHue = GetRandomHue();
 
-            AddItem(new ShortPants(lowHue));
+			SetWearable(new ShortPants(), lowHue, 1);
 
             if (Female)
-                AddItem(new Boots(lowHue));
+				SetWearable(new Boots(), lowHue, 1);
             else
-                AddItem(new Shoes(lowHue));
+				SetWearable(new Shoes(), lowHue, 1);
 
-            switch (Utility.Random(4))
-            {
-                case 0:
-                    AddItem(new ShortHair(Utility.RandomHairHue()));
-                    break;
-                case 1:
-                    AddItem(new TwoPigTails(Utility.RandomHairHue()));
-                    break;
-                case 2:
-                    AddItem(new ReceedingHair(Utility.RandomHairHue()));
-                    break;
-                case 3:
-                    AddItem(new KrisnaHair(Utility.RandomHairHue()));
-                    break;
-            }
+			HairItemID = Utility.RandomList(0x203B, 0x2049, 0x2048, 0x204A);
+			HairHue = Utility.RandomHairHue();
 
-            PackGold(200, 250);
+			PackGold(200, 250);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -687,26 +674,23 @@ namespace Server.Engines.Quests
         public override bool ClickTitle => false;
         public override void InitOutfit()
         {
-            if (Female)
-                AddItem(new FancyDress(GetRandomHue()));
-            else
-                AddItem(new FancyShirt(GetRandomHue()));
-
             int lowHue = GetRandomHue();
 
-            AddItem(new ShortPants(lowHue));
-
             if (Female)
-                AddItem(new ThighBoots(lowHue));
+			{
+				SetWearable(new FancyDress(), GetRandomHue(), 1);
+				SetWearable(new ThighBoots(), lowHue, 1);
+			}
             else
-                AddItem(new Boots(lowHue));
+			{
+				SetWearable(new FancyShirt(), GetRandomHue(), 1);
+				SetWearable(new Boots(), lowHue, 1);
+				SetWearable(new BodySash(), lowHue, 1);
+			}
 
-            if (!Female)
-                AddItem(new BodySash(lowHue));
-
-            AddItem(new Cloak(GetRandomHue()));
-
-            AddItem(new Longsword());
+			SetWearable(new ShortPants(), lowHue, 1);
+			SetWearable(new Cloak(), GetRandomHue(), 1);
+			SetWearable(new Longsword(), dropChance: 1);
 
             PackGold(100, 150);
         }
@@ -746,28 +730,24 @@ namespace Server.Engines.Quests
         public override bool CanTeach => true;
         public override bool ClickTitle => false;
         public override void InitOutfit()
-        {
-            if (Female)
-                AddItem(new FancyDress());
-            else
-                AddItem(new FancyShirt(GetRandomHue()));
+		{
+			int lowHue = GetRandomHue();
 
-            int lowHue = GetRandomHue();
+			if (Female)
+			{
+				SetWearable(new FancyDress(), dropChance: 1);
+				SetWearable(new ThighBoots(), lowHue, 1);
+			}
+			else
+			{
+				SetWearable(new FancyShirt(), GetRandomHue(), 1);
+				SetWearable(new Boots(), lowHue, 1);
+				SetWearable(new BodySash(), lowHue, 1);
+				SetWearable(new Longsword(), dropChance: 1);
+			}
 
-            AddItem(new ShortPants(lowHue));
-
-            if (Female)
-                AddItem(new ThighBoots(lowHue));
-            else
-                AddItem(new Boots(lowHue));
-
-            if (!Female)
-                AddItem(new BodySash(lowHue));
-
-            AddItem(new Cloak(GetRandomHue()));
-
-            if (!Female)
-                AddItem(new Longsword());
+			SetWearable(new ShortPants(), lowHue, 1);
+			SetWearable(new Cloak(), GetRandomHue(), 1);
 
             PackGold(200, 250);
         }
@@ -805,20 +785,21 @@ namespace Server.Engines.Quests
 
         public override bool ClickTitle => false;
         public override void InitOutfit()
-        {
-            if (Female)
-                AddItem(new FancyDress());
-            else
-                AddItem(new FancyShirt());
+		{
+			int lowHue = GetRandomHue();
 
-            int lowHue = GetRandomHue();
+			if (Female)
+			{
+				SetWearable(new FancyDress(), dropChance: 1);
+				SetWearable(new Shoes(), lowHue, 1);
+			}
+			else
+			{
+				SetWearable(new FancyShirt(), dropChance: 1);
+				SetWearable(new Boots(), lowHue, 1);
+			}
 
-            AddItem(new LongPants(lowHue));
-
-            if (Female)
-                AddItem(new Shoes(lowHue));
-            else
-                AddItem(new Boots(lowHue));
+			SetWearable(new LongPants(), lowHue, 1);
 
             if (Utility.RandomBool())
                 HairItemID = 0x203B;
@@ -861,19 +842,20 @@ namespace Server.Engines.Quests
         public override bool ClickTitle => false;
         public override void InitOutfit()
         {
-            if (Female)
-                AddItem(new PlainDress());
-            else
-                AddItem(new Shirt(GetRandomHue()));
+			int lowHue = GetRandomHue();
 
-            int lowHue = GetRandomHue();
+			if (Female)
+			{
+				SetWearable(new PlainDress(), dropChance: 1);
+				SetWearable(new Boots(), lowHue, 1);
+			}
+			else
+			{
+				SetWearable(new Shirt(), GetRandomHue(), 1);
+				SetWearable(new Shoes(), lowHue, 1);
+			}
 
-            AddItem(new ShortPants(lowHue));
-
-            if (Female)
-                AddItem(new Boots(lowHue));
-            else
-                AddItem(new Shoes(lowHue));
+			SetWearable(new ShortPants(), lowHue, 1);			
 
             Utility.AssignRandomHair(this);
 
@@ -970,9 +952,9 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals(GetShoeHue()));
-            AddItem(new Robe(Utility.RandomYellowHue()));
-            AddItem(new GnarledStaff());
+            SetWearable(new Sandals(), GetShoeHue(), 1);
+            SetWearable(new Robe(), Utility.RandomYellowHue(), 1);
+            SetWearable(new GnarledStaff(), dropChance: 1);
         }
 
         public virtual bool CheckResurrect(Mobile m)

--- a/Scripts/Quests/GatheringOfEvidence.cs
+++ b/Scripts/Quests/GatheringOfEvidence.cs
@@ -134,12 +134,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            AddItem(new GargishClothChest(Utility.RandomNeutralHue()));
-            AddItem(new GargishClothKilt(Utility.RandomNeutralHue()));
-            AddItem(new GargishClothLegs(Utility.RandomNeutralHue()));
-            AddItem(new SerpentStoneStaff());
+            SetWearable(new GargishClothChest(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new GargishClothKilt(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new GargishClothLegs(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new SerpentStoneStaff(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -188,12 +188,12 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            AddItem(new Tunic(Utility.RandomNeutralHue()));
-            AddItem(new ShortPants(Utility.RandomNeutralHue()));
-            AddItem(new Boots());
-            AddItem(new Halberd());
+            SetWearable(new Tunic(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new Boots(), dropChance: 1);
+			SetWearable(new Halberd(), dropChance: 1);
         }
 
         public override bool CheckTerMur()

--- a/Scripts/Quests/HonorOfDeBoorsQuest.cs
+++ b/Scripts/Quests/HonorOfDeBoorsQuest.cs
@@ -178,10 +178,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Shoes());
-            AddItem(new LongPants(0x901));
-            AddItem(new FancyShirt(0x5F4));
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
+            SetWearable(new Shoes(), dropChance: 1);
+            SetWearable(new LongPants(), 0x901, 1);
+            SetWearable(new FancyShirt(), 0x5F4, 1);
         }
 
         public override void Serialize(GenericWriter writer)
@@ -228,10 +228,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Dagger());
-            AddItem(new ThighBoots(0x901));
-            AddItem(new LongPants(0x521));
-            AddItem(new FancyShirt(0x5A7));
+            SetWearable(new Dagger(), dropChance: 1);
+            SetWearable(new ThighBoots(), 0x901, 1);
+            SetWearable(new LongPants(), 0x521, 1);
+			SetWearable(new FancyShirt(), 0x5A7, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Quests/Mad Scientist/Sutek.cs
+++ b/Scripts/Quests/Mad Scientist/Sutek.cs
@@ -107,10 +107,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Sandals());
-            AddItem(new TattsukeHakama(0x528));
-            AddItem(new WizardsHat(0x528));
-            AddItem(new Tunic(0x528));
+            SetWearable(new Sandals(), dropChance: 1);
+            SetWearable(new TattsukeHakama(), 0x528, 1);
+            SetWearable(new WizardsHat(), 0x528, 1);
+			SetWearable(new Tunic(), 0x528, 1);
         }
 
         public void TalkTimer()

--- a/Scripts/Quests/Ortlem.cs
+++ b/Scripts/Quests/Ortlem.cs
@@ -109,10 +109,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new GlassStaff());
-            AddItem(new GargishClothChest(0x64F));
-            AddItem(new GargishClothArms(0x64F));
-            AddItem(new GargishClothKilt(0x643));
+            SetWearable(new GlassStaff(), dropChance: 1);
+            SetWearable(new GargishClothChest(), 0x64F, 1);
+            SetWearable(new GargishClothArms(), 0x64F, 1);
+			SetWearable(new GargishClothKilt(), 0x643, 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Quests/PeptaQuest.cs
+++ b/Scripts/Quests/PeptaQuest.cs
@@ -73,10 +73,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x346));
-            AddItem(new PlainDress(0x27B));
-            AddItem(new HalfApron());
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x346, 1);
+            SetWearable(new PlainDress(), 0x27B, 1);
+			SetWearable(new HalfApron(), dropChance: 1);
         }
 
         public override void Serialize(GenericWriter writer)

--- a/Scripts/Quests/ProfessionalBountyQuest/Mobiles/BaseShipCaptain.cs
+++ b/Scripts/Quests/ProfessionalBountyQuest/Mobiles/BaseShipCaptain.cs
@@ -76,13 +76,13 @@ namespace Server.Mobiles
             {
                 Body = 0x191;
                 Name = NameList.RandomName("female");
-                AddItem(new Skirt(Utility.RandomNeutralHue()));
+				SetWearable(new Skirt(), Utility.RandomNeutralHue(), 1);
             }
             else
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+				SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
 
             SetStr(500, 750);

--- a/Scripts/Quests/ProfessionalBountyQuest/Mobiles/GBBigglesby.cs
+++ b/Scripts/Quests/ProfessionalBountyQuest/Mobiles/GBBigglesby.cs
@@ -30,18 +30,17 @@ namespace Server.Mobiles
             Race.RandomHair(this);
             HairHue = Race.RandomHairHue();
 
-            Item fancyShirt = new FancyShirt();
             Item shirt = new Shirt(PirateCaptain.GetRandomShirtHue())
             {
                 Layer = Layer.OuterTorso
             };
 
-            AddItem(new Cloak(5));
-            AddItem(new Cutlass());
-            AddItem(shirt);
-            AddItem(fancyShirt);
-            AddItem(new LongPants());
-            AddItem(new Boots());
+            SetWearable(shirt, dropChance: 1);
+            SetWearable(new Cloak(), 5, 1);
+            SetWearable(new Cutlass(), dropChance: 1);
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(new LongPants(), dropChance: 1);
+			SetWearable(new Boots(), dropChance: 1);
 
             m_NextSay = DateTime.UtcNow;
         }

--- a/Scripts/Quests/ProfessionalBountyQuest/Mobiles/MerchantCaptain.cs
+++ b/Scripts/Quests/ProfessionalBountyQuest/Mobiles/MerchantCaptain.cs
@@ -22,13 +22,11 @@ namespace Server.Mobiles
             else
                 hat = new TricorneHat();
 
-            hat.Hue = Utility.RandomNeutralHue();
-
-            AddItem(new Sandals());
-            AddItem(new FancyShirt(Utility.RandomNeutralHue()));
-            AddItem(hat);
-            AddItem(new Cloak(Utility.RandomNeutralHue()));
-            AddItem(new Dagger());
+            SetWearable(new Sandals(), dropChance: 1);
+            SetWearable(new FancyShirt(), Utility.RandomNeutralHue(), 1);
+            SetWearable(hat, Utility.RandomNeutralHue(), 1);
+            SetWearable(new Cloak(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new Dagger(), dropChance: 1);
 
             Utility.AssignRandomHair(this);
 

--- a/Scripts/Quests/ProfessionalBountyQuest/Mobiles/MerchantCrew.cs
+++ b/Scripts/Quests/ProfessionalBountyQuest/Mobiles/MerchantCrew.cs
@@ -33,13 +33,13 @@ namespace Server.Mobiles
             {
                 Body = 0x191;
                 Name = NameList.RandomName("female");
-                AddItem(new Skirt(Utility.RandomNeutralHue()));
+				SetWearable(new Skirt(), Utility.RandomNeutralHue(), 1);
             }
             else
             {
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomNeutralHue()));
+                SetWearable(new ShortPants(), Utility.RandomNeutralHue(), 1);
             }
 
             bool magery = 0.33 > Utility.RandomDouble();
@@ -84,12 +84,12 @@ namespace Server.Mobiles
                 case 3: bow = new HeavyCrossbow(); break;
             }
 
-            AddItem(bow);
+			SetWearable(bow, dropChance: 1);
 
-            AddItem(new TricorneHat());
-            AddItem(new FancyShirt());
-            AddItem(new Boots(Utility.RandomNeutralHue()));
-            AddItem(new GoldEarrings());
+            SetWearable(new TricorneHat(), dropChance: 1);
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(new Boots(), Utility.RandomNeutralHue(), 1);
+			SetWearable(new GoldEarrings(), dropChance: 1);
 
             Fame = 8000;
             Karma = 8000;

--- a/Scripts/Quests/ProfessionalBountyQuest/Mobiles/PirateCaptain.cs
+++ b/Scripts/Quests/ProfessionalBountyQuest/Mobiles/PirateCaptain.cs
@@ -92,20 +92,18 @@ namespace Server.Mobiles
             else
                 hat = new TricorneHat();
 
-            hat.Hue = Utility.RandomNeutralHue();
-
-            AddItem(new Boots());
-            AddItem(shirt);
-            AddItem(fancyShirt);
-            AddItem(hat);
-            AddItem(new Cloak(Utility.RandomNeutralHue()));
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(shirt, dropChance: 1);
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(hat, Utility.RandomNeutralHue(), 1);
+			SetWearable(new Cloak(), Utility.RandomNeutralHue(), 1);
 
             switch (Utility.Random(7))
             {
-                case 0: AddItem(new Longsword()); break;
-                case 1: AddItem(new Cutlass()); break;
-                case 2: AddItem(new Broadsword()); break;
-                case 5: AddItem(new Dagger()); break;
+                case 0: SetWearable(new Longsword(), dropChance: 1); break;
+                case 1: SetWearable(new Cutlass(), dropChance: 1); break;
+                case 2: SetWearable(new Broadsword(), dropChance: 1); break;
+                case 5: SetWearable(new Dagger(), dropChance: 1); break;
             }
 
             Utility.AssignRandomHair(this);

--- a/Scripts/Quests/ProfessionalBountyQuest/Mobiles/PirateCrew.cs
+++ b/Scripts/Quests/ProfessionalBountyQuest/Mobiles/PirateCrew.cs
@@ -117,7 +117,7 @@ namespace Server.Mobiles
                     case 3: bow = new HeavyCrossbow(); break;
                 }
 
-                AddItem(bow);
+				SetWearable(bow, dropChance: 1);
             }
 
             SetSkill(SkillName.DetectHidden, 40.0, 45.0);

--- a/Scripts/Quests/Vernix.cs
+++ b/Scripts/Quests/Vernix.cs
@@ -158,7 +158,7 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
         }
 
         public override void Advertise()

--- a/Scripts/Services/AccountVault/VaultManager.cs
+++ b/Scripts/Services/AccountVault/VaultManager.cs
@@ -28,11 +28,7 @@ namespace Server.AccountVault
         {
             if (Backpack == null)
             {
-                Item backpack = new Backpack
-                {
-                    Movable = false
-                };
-                AddItem(backpack);
+				SetWearable(new Backpack());
             }
 
             SetWearable(new ElvenShirt());

--- a/Scripts/Services/ArmorRefinement/ArmorRefiner.cs
+++ b/Scripts/Services/ArmorRefinement/ArmorRefiner.cs
@@ -24,12 +24,12 @@ namespace Server.Mobiles
             m_RefineType = type;
 
             SetSkill(SkillName.ArmsLore, 36.0, 68.0);
-            AddItem(new HalfApron());
+			SetWearable(new HalfApron(), dropChance: 1);
 
             switch (m_RefineType)
             {
                 case RefinementCraftType.Blacksmith:
-                    AddItem(new SmithHammer());
+					SetWearable(new SmithHammer(), dropChance: 1);
                     SetSkill(SkillName.Blacksmith, 65.0, 88.0);
                     break;
                 case RefinementCraftType.Tailor:

--- a/Scripts/Services/CleanUpBritannia/Items/Steward.cs
+++ b/Scripts/Services/CleanUpBritannia/Items/Steward.cs
@@ -61,11 +61,7 @@ namespace Server.Mobiles
             Keyword = "";
             _Table = new Dictionary<Mobile, DateTime>();
 
-            Container pack = new StewardBackpack(Owner, this)
-            {
-                Movable = false
-            };
-            AddItem(pack);
+			SetWearable(new StewardBackpack(Owner, this));
         }
 
         public bool IsOwner(Mobile m)

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Arabella.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Arabella.cs
@@ -38,13 +38,13 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new NoDachi());
-            AddItem(new SamuraiTabi(0x589));
-            AddItem(new LeatherSuneate());
-            AddItem(new LeatherJingasa());
-            AddItem(new LeatherDo());
-            AddItem(new LeatherHiroSode());
+            SetWearable(new Backpack());
+            SetWearable(new NoDachi(), dropChance: 1);
+            SetWearable(new SamuraiTabi(), 0x589, 1);
+            SetWearable(new LeatherSuneate(), dropChance: 1);
+            SetWearable(new LeatherJingasa(), dropChance: 1);
+            SetWearable(new LeatherDo(), dropChance: 1);
+			SetWearable(new LeatherHiroSode(), dropChance: 1);
         }
 
         public override void Init()

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Bonnie.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Bonnie.cs
@@ -39,13 +39,13 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Boots());
-            AddItem(new HalfApron(0x65F));
-            AddItem(new Doublet(0x3B3));
-            AddItem(new Kilt(0x724));
-            AddItem(new LeatherDo());
-            AddItem(new LeatherHiroSode());
+            SetWearable(new Backpack());
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new HalfApron(), 0x65F, 1);
+            SetWearable(new Doublet(), 0x3B3, 1);
+            SetWearable(new Kilt(), 0x724, 1);
+            SetWearable(new LeatherDo(), dropChance: 1);
+			SetWearable(new LeatherHiroSode(), dropChance: 1);
         }
 
         public override void Init()

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Corey.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Corey.cs
@@ -36,47 +36,15 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Halberd());
-            AddItem(new Cloak(0x4E6));
-
-            Item item;
-
-            item = new PlateLegs
-            {
-                Hue = 0x8A6
-            };
-            AddItem(item);
-
-            item = new PlateArms
-            {
-                Hue = 0x8A6
-            };
-            AddItem(item);
-
-            item = new PlateChest
-            {
-                Hue = 0x8A6
-            };
-            AddItem(item);
-
-            item = new PlateGloves
-            {
-                Hue = 0x8A6
-            };
-            AddItem(item);
-
-            item = new PlateHelm
-            {
-                Hue = 0x8A6
-            };
-            AddItem(item);
-
-            item = new PlateGorget
-            {
-                Hue = 0x8A6
-            };
-            AddItem(item);
+			SetWearable(new Backpack());
+            SetWearable(new Halberd(), dropChance: 1);
+			SetWearable(new Cloak(), 0x4E6, 1);
+			SetWearable(new PlateLegs(), 0x8A6, 1);
+			SetWearable(new PlateArms(), 0x8A6, 1);
+			SetWearable(new PlateChest(), 0x8A6, 1);
+			SetWearable(new PlateGloves(), 0x8A6, 1);
+			SetWearable(new PlateHelm(), 0x8A6, 1);
+			SetWearable(new PlateGorget(), 0x8A6, 1);
         }
 
         public override void Init()

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Enrico.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Enrico.cs
@@ -41,11 +41,11 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Dagger());
-            AddItem(new Sandals());
-            AddItem(new FancyShirt(0x6CC));
-            AddItem(new LongPants(0x5E8));
+            SetWearable(new Backpack());
+            SetWearable(new Dagger(), dropChance: 1);
+            SetWearable(new Sandals(), dropChance: 1);
+            SetWearable(new FancyShirt(), 0x6CC, 1);
+			SetWearable(new LongPants(), 0x5E8, 1);
         }
 
         public override void Init()

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Filbert.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Filbert.cs
@@ -41,9 +41,9 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x455));
-            AddItem(new Robe(0x485));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x455, 1);
+			SetWearable(new Robe(), 0x485, 1);
         }
 
         public override void Init()

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Joy.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Joy.cs
@@ -40,13 +40,13 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Longsword());
-            AddItem(new ThighBoots());
-            AddItem(new FancyShirt(0x584));
-            AddItem(new LongPants(0x73B));
-            AddItem(new BodySash(0x5E6));
-            AddItem(new Cloak(0x597));
+            SetWearable(new Backpack());
+            SetWearable(new Longsword(), dropChance: 1);
+            SetWearable(new ThighBoots(), dropChance: 1);
+            SetWearable(new FancyShirt(), 0x584, 1);
+            SetWearable(new LongPants(), 0x73B, 1);
+            SetWearable(new BodySash(), 0x5E6, 1);
+			SetWearable(new Cloak(), 0x597, 1);
         }
 
         public override void Init()

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Margo.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Margo.cs
@@ -39,11 +39,11 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new QuarterStaff());
-            AddItem(new Boots());
-            AddItem(new Doublet(0x651));
-            AddItem(new Skirt(0x4B2));
+            SetWearable(new Backpack());
+            SetWearable(new QuarterStaff(), dropChance: 1);
+            SetWearable(new Boots(), dropChance: 1);
+            SetWearable(new Doublet(), 0x651, 1);
+			SetWearable(new Skirt(), 0x4B2, 1);
         }
 
         public override void Init()

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Odell.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Odell.cs
@@ -38,11 +38,11 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new BlackStaff());
-            AddItem(new Sandals(0x485));
-            AddItem(new WizardsHat(0x901));
-            AddItem(new Robe(0x455));
+            SetWearable(new Backpack());
+            SetWearable(new BlackStaff(), dropChance: 1);
+            SetWearable(new Sandals(), 0x485, 1);
+            SetWearable(new WizardsHat(), 0x901, 1);
+			SetWearable(new Robe(), 0x455, 1);
         }
 
         public override void Init()

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Sam.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Sam.cs
@@ -40,11 +40,11 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new FishingPole());
-            AddItem(new Shoes(0x71F));
-            AddItem(new Doublet(0x52E));
-            AddItem(new LongPants(0x656));
+            SetWearable(new Backpack());
+            SetWearable(new FishingPole(), dropChance: 1);
+            SetWearable(new Shoes(), 0x71F, 1);
+            SetWearable(new Doublet(), 0x52E, 1);
+			SetWearable(new LongPants(), 0x656, 1);
         }
 
         public override void Init()

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Talbart.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Talbart.cs
@@ -37,16 +37,16 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            AddItem(new DoubleAxe());
-            AddItem(new PlateLegs());
-            AddItem(new CloseHelm());
-            AddItem(new PlateGloves());
-            AddItem(new StuddedGorget());
-            AddItem(new PlateChest());
-            AddItem(new PlateArms());
-            AddItem(new BodySash(0x75D));
+            SetWearable(new DoubleAxe(), dropChance: 1);
+            SetWearable(new PlateLegs(), dropChance: 1);
+            SetWearable(new CloseHelm(), dropChance: 1);
+            SetWearable(new PlateGloves(), dropChance: 1);
+            SetWearable(new StuddedGorget(), dropChance: 1);
+            SetWearable(new PlateChest(), dropChance: 1);
+			SetWearable(new PlateArms(), dropChance: 1);
+			SetWearable(new BodySash(), 0x75D, 1);
         }
 
         public override void Init()

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Xanthe.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Xanthe.cs
@@ -38,10 +38,10 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x74D));
-            AddItem(new ShortPants(0x57B));
-            AddItem(new FancyShirt(0x725));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x74D, 1);
+            SetWearable(new ShortPants(), 0x57B, 1);
+			SetWearable(new FancyShirt(), 0x725, 1);
         }
 
         public override void Init()

--- a/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Zorda.cs
+++ b/Scripts/Services/CommunityCollections/CommunityCollectionNPCs/Zorda.cs
@@ -39,11 +39,11 @@ namespace Server.Items
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Sandals(0x72B));
-            AddItem(new Shirt(0x6BB));
-            AddItem(new HalfApron(0x8FD));
-            AddItem(new Skirt(0x38B));
+            SetWearable(new Backpack());
+            SetWearable(new Sandals(), 0x72B, 1);
+            SetWearable(new Shirt(), 0x6BB, 1);
+            SetWearable(new HalfApron(), 0x8FD, 1);
+			SetWearable(new Skirt(), 0x38B, 1);
         }
 
         public override void Init()

--- a/Scripts/Services/Dungeons/CovetousVoidSpawn/Creatures/Cora.cs
+++ b/Scripts/Services/Dungeons/CovetousVoidSpawn/Creatures/Cora.cs
@@ -49,11 +49,11 @@ namespace Server.Mobiles
             Fame = 32000;
             Karma = -32000;
 
-            AddAndEquip(new WildStaff(), 1971);
-            AddAndEquip(new ThighBoots(), 1910);
-            AddAndEquip(new ChainLegs(), 1936);
-            AddAndEquip(new LeatherGloves(), 1910);
-            AddAndEquip(new LeatherBustierArms(), 1947);
+			SetWearable(new WildStaff(), 1971);
+            SetWearable(new ThighBoots(), 1910);
+            SetWearable(new ChainLegs(), 1936);
+            SetWearable(new LeatherGloves(), 1910);
+            SetWearable(new LeatherBustierArms(), 1947);
 
             SetSpecialAbility(SpecialAbility.DragonBreath);
             SetAreaEffect(AreaEffect.AuraDamage);
@@ -88,13 +88,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.UltraRich, 3);
             AddLoot(LootPack.SuperBoss, 3);
-        }
-
-        private void AddAndEquip(Item item, int hue = 0)
-        {
-            item.Movable = false;
-            item.Hue = hue;
-            AddItem(item);
         }
 
         public override void OnThink()

--- a/Scripts/Services/Dungeons/Doom/GauntletSpawner.cs
+++ b/Scripts/Services/Dungeons/Doom/GauntletSpawner.cs
@@ -528,12 +528,12 @@ namespace Server.Engines.Doom
             dealer.FacialHairItemID = 0x203E;
             dealer.FacialHairHue = 0x482;
 
-            dealer.AddItem(new FloppyHat(1));
-            dealer.AddItem(new Robe(1));
+            dealer.SetWearable(new FloppyHat(), 1, 1);
+            dealer.SetWearable(new Robe(), 1, 1);
 
-            dealer.AddItem(new LanternOfSouls());
+            dealer.SetWearable(new LanternOfSouls(), dropChance: 1);
 
-            dealer.AddItem(new Sandals(0x482));
+            dealer.SetWearable(new Sandals(), 0x482, 1);
             /* End outfit */
 
             dealer.MoveToWorld(p, Map.Malas);

--- a/Scripts/Services/Dungeons/Shadowguard/Mobiles.cs
+++ b/Scripts/Services/Dungeons/Shadowguard/Mobiles.cs
@@ -38,12 +38,12 @@ namespace Server.Engines.Shadowguard
             Fame = 1000;
             Karma = -1000;
 
-            AddItem(new ExecutionersAxe());
+			SetWearable(new ExecutionersAxe(), dropChance: 1);
 
-            AddItem(new Boots(Utility.RandomNeutralHue()));
-            AddItem(new ShortPants());
-            AddItem(new FancyShirt());
-            AddItem(new TricorneHat());
+			SetWearable(new Boots(), Utility.RandomNeutralHue(), 1);
+            SetWearable(new ShortPants(), dropChance: 1);
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(new TricorneHat(), dropChance: 1);
 
             Fame = 5000;
             Karma = -5000;
@@ -348,49 +348,14 @@ namespace Server.Engines.Shadowguard
             SetSkill(SkillName.Tactics, 125.0);
             SetSkill(SkillName.Lumberjacking, 125.0);
 
-            CloseHelm helm = new CloseHelm
-            {
-                Hue = 0x96D
-            };
-            AddItem(helm);
-
-            PlateArms arms = new PlateArms
-            {
-                Hue = 0x96D
-            };
-            AddItem(arms);
-
-            PlateLegs legs = new PlateLegs
-            {
-                Hue = 0x96D
-            };
-            AddItem(legs);
-
-            PlateChest tunic = new PlateChest
-            {
-                Hue = 0x96D
-            };
-            AddItem(tunic);
-
-            PlateGorget gorget = new PlateGorget
-            {
-                Hue = 0x96D
-            };
-            AddItem(gorget);
-
-            PlateGloves golves = new PlateGloves
-            {
-                Hue = 0x96D
-            };
-            AddItem(golves);
-
-            Halberd halberd = new Halberd
-            {
-                Hue = 0x96D
-            };
-            AddItem(halberd);
-
-            AddItem(new HalfApron(728));
+			SetWearable(new CloseHelm(), 0x96D, 1);
+			SetWearable(new PlateArms(), 0x96D, 1);
+			SetWearable(new PlateLegs(), 0x96D, 1);
+			SetWearable(new PlateChest(), 0x96D, 1);
+			SetWearable(new PlateGorget(), 0x96D, 1);
+			SetWearable(new PlateGloves(), 0x96D, 1);
+			SetWearable(new Halberd(), 0x96D, 1);
+			SetWearable(new HalfApron(), 728, 1);
 
             Fame = 8500;
             Karma = -8500;

--- a/Scripts/Services/Dungeons/ShameRevamped/Mobiles/Creatures.cs
+++ b/Scripts/Services/Dungeons/ShameRevamped/Mobiles/Creatures.cs
@@ -777,8 +777,8 @@ namespace Server.Mobiles
             SetSkill(SkillName.Magery, 120, 130);
             SetSkill(SkillName.EvalInt, 120, 130);
 
-            AddItem(new Robe(1156));
-            AddItem(new Sandals());
+            SetWearable(new Robe(), 1156, 1);
+			SetWearable(new Sandals(), dropChance: 1);
 
             Utility.AssignRandomHair(this);
 
@@ -918,8 +918,8 @@ namespace Server.Mobiles
             SetSkill(SkillName.Magery, 100, 110);
             SetSkill(SkillName.EvalInt, 100, 110);
 
-            AddItem(new Robe(1157));
-            AddItem(new Sandals());
+            SetWearable(new Robe(), 1157, 1);
+			SetWearable(new Sandals(), dropChance: 1);
 
             Utility.AssignRandomHair(this);
             Hue = Race.RandomSkinHue();

--- a/Scripts/Services/Dungeons/WrongDungeon/Mobile/DemonicJailor.cs
+++ b/Scripts/Services/Dungeons/WrongDungeon/Mobile/DemonicJailor.cs
@@ -44,10 +44,10 @@ namespace Server.Mobiles
             Fame = 5000;
             Karma = -5000;
 
-            SetWearable(new ShortPants(Utility.RandomRedHue()));
-            AddItem(new Sandals(Utility.RandomRedHue()));
-            AddItem(new Shirt(Utility.RandomRedHue()));
-            AddItem(new SkinningKnife());
+            SetWearable(new ShortPants(), Utility.RandomRedHue(), 1);
+            SetWearable(new Sandals(), Utility.RandomRedHue(), 1);
+            SetWearable(new Shirt(), Utility.RandomRedHue(), 1);
+			SetWearable(new SkinningKnife(), dropChance: 1);
 
             Utility.AssignRandomHair(this);
         }

--- a/Scripts/Services/ExploringTheDeep/Mobiles/MercutioTheUnsavory.cs
+++ b/Scripts/Services/ExploringTheDeep/Mobiles/MercutioTheUnsavory.cs
@@ -65,7 +65,7 @@ namespace Server.Mobiles
         private void AddImmovableItem(Item item)
         {
             item.LootType = LootType.Blessed;
-            AddItem(item);
+			SetWearable(item);
         }
 
         public override bool ClickTitle => false;

--- a/Scripts/Services/ExploringTheDeep/Questers/HeplerPaulson.cs
+++ b/Scripts/Services/ExploringTheDeep/Questers/HeplerPaulson.cs
@@ -32,10 +32,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
-            AddItem(new Shoes(0x737));
-            AddItem(new LongPants(0x1BB));
-            AddItem(new FancyShirt(0x535));
+            SetWearable(new Backpack());
+            SetWearable(new Shoes(), 0x737, 1);
+            SetWearable(new LongPants(), 0x1BB, 1);
+			SetWearable(new FancyShirt(), 0x535, 1);
         }
 
         public HeplerPaulson(Serial serial) : base(serial)

--- a/Scripts/Services/HuntmasterChallenge/HuntMaster.cs
+++ b/Scripts/Services/HuntmasterChallenge/HuntMaster.cs
@@ -131,19 +131,16 @@ namespace Server.Engines.HuntsmasterChallenge
         private void CheckItems()
         {
             if (Backpack == null)
-                AddItem(new Backpack());
+				SetWearable(new Backpack());
 
-            Item i = Backpack.FindItemByType(typeof(HuntmastersRewardTitleDeed));
-            if (i == null)
+            if (Backpack.FindItemByType(typeof(HuntmastersRewardTitleDeed)) == null)
                 Backpack.DropItem(new HuntmastersRewardTitleDeed());
 
-            i = Backpack.FindItemByType(typeof(RangersGuildSash));
-            if (i == null)
-                Backpack.DropItem(new RangersGuildSash());
+			if (Backpack.FindItemByType(typeof(RangersGuildSash)) == null)
+				Backpack.DropItem(new RangersGuildSash());
 
-            i = Backpack.FindItemByType(typeof(GargishRangersGuildSash));
-            if (i == null)
-                Backpack.DropItem(new GargishRangersGuildSash());
+			if (Backpack.FindItemByType(typeof(GargishRangersGuildSash)) == null)
+				Backpack.DropItem(new GargishRangersGuildSash());
         }
 
         public HuntMaster(Serial serial) : base(serial)

--- a/Scripts/Services/New Magincia/Magincia Bazaar/Mobiles/WarehouseSuperintendent.cs
+++ b/Scripts/Services/New Magincia/Magincia Bazaar/Mobiles/WarehouseSuperintendent.cs
@@ -25,18 +25,18 @@ namespace Server.Engines.NewMagincia
                 Body = 0x191;
                 Name = NameList.RandomName("female");
 
-                AddItem(new Skirt(Utility.RandomPinkHue()));
+				SetWearable(new Skirt(), Utility.RandomPinkHue(), 1);
             }
             else
             {
                 Female = false;
                 Body = 0x190;
                 Name = NameList.RandomName("male");
-                AddItem(new ShortPants(Utility.RandomBlueHue()));
+				SetWearable(new ShortPants(), Utility.RandomBlueHue(), 1);
             }
 
-            AddItem(new Tunic(Utility.RandomBlueHue()));
-            AddItem(new Boots());
+			SetWearable(new Tunic(), Utility.RandomBlueHue(), 1);
+			SetWearable(new Boots(), dropChance: 1);
 
             Utility.AssignRandomHair(this, Utility.RandomHairHue());
             Utility.AssignRandomFacialHair(this, Utility.RandomHairHue());

--- a/Scripts/Services/Seasonal Events/ForsakenFoes/Mobile/FellowshipAdept.cs
+++ b/Scripts/Services/Seasonal Events/ForsakenFoes/Mobile/FellowshipAdept.cs
@@ -42,19 +42,13 @@ namespace Server.Engines.Fellowship
 
         public override void InitOutfit()
         {
+            if (Backpack == null)
+            {
+				SetWearable(new Backpack());
+            }
             SetWearable(new Kamishimo());
             SetWearable(new Sandals());
             SetWearable(new GoldRing());
-
-            if (Backpack == null)
-            {
-                Item backpack = new Backpack
-                {
-                    Movable = false
-                };
-
-                AddItem(backpack);
-            }
         }
 
         public override void GetProperties(ObjectPropertyList list)

--- a/Scripts/Services/Seasonal Events/ForsakenFoes/Mobile/MiningCooperativeMerchant.cs
+++ b/Scripts/Services/Seasonal Events/ForsakenFoes/Mobile/MiningCooperativeMerchant.cs
@@ -136,10 +136,10 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new FancyShirt(0x3E4));
-            AddItem(new LongPants(0x192));
-            AddItem(new Pickaxe());
-            AddItem(new ThighBoots(0x283));
+            SetWearable(new FancyShirt(), 0x3E4, 1);
+            SetWearable(new LongPants(), 0x192, 1);
+            SetWearable(new Pickaxe(), dropChance: 1);
+			SetWearable(new ThighBoots(), 0x283, 1);
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Creatures/ShadowFiend.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Creatures/ShadowFiend.cs
@@ -16,12 +16,7 @@ namespace Server.Mobiles
             Body = 0x10;
             Hue = 2051;
 
-            // this to allow shadow fiend to loot from corpses
-            Backpack backpack = new Backpack
-            {
-                Movable = false
-            };
-            AddItem(backpack);
+            AddItem(new Backpack());
 
             SetStr(300, 400);
             SetDex(200, 250);

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/Mobiles/Cryptologist.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/Mobiles/Cryptologist.cs
@@ -51,12 +51,12 @@ namespace Server.Engines.Khaldun
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            SetWearable(new HakamaShita());
-            SetWearable(new ShortPants(), 1157);
-            SetWearable(new Obi(), 1157);
-            SetWearable(new Sandals());
+            SetWearable(new HakamaShita(), dropChance: 1);
+            SetWearable(new ShortPants(), 1157, 1);
+            SetWearable(new Obi(), 1157, 1);
+            SetWearable(new Sandals(), dropChance: 1);
         }
 
         public override void OnDoubleClick(Mobile m)

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/Mobiles/GraveDigger.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/Mobiles/GraveDigger.cs
@@ -52,14 +52,14 @@ namespace Server.Engines.Khaldun
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            SetWearable(new Surcoat(), 1634);
-            SetWearable(new Kilt(), 946);
-            SetWearable(new FancyShirt(), 1411);
-            SetWearable(new ThighBoots(), 2013);
-            SetWearable(new GoldBracelet());
-            SetWearable(new GoldRing());
+            SetWearable(new Surcoat(), 1634, 1);
+            SetWearable(new Kilt(), 946, 1);
+            SetWearable(new FancyShirt(), 1411, 1);
+            SetWearable(new ThighBoots(), 2013, 1);
+            SetWearable(new GoldBracelet(), dropChance: 1);
+            SetWearable(new GoldRing(), dropChance: 1);
         }
 
         public override void OnDoubleClick(Mobile m)

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/Mobiles/Jasper.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/Mobiles/Jasper.cs
@@ -42,14 +42,14 @@ namespace Server.Engines.Khaldun
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            SetWearable(new LongPants(), 1156);
-            SetWearable(new FancyShirt());
-            SetWearable(new Epaulette(), 1156);
-            SetWearable(new BodySash(), 1175);
-            SetWearable(new Obi(), 1156);
-            SetWearable(new Shoes(), 1910);
+            SetWearable(new LongPants(), 1156, 1);
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(new Epaulette(), 1156, 1);
+            SetWearable(new BodySash(), 1175, 1);
+            SetWearable(new Obi(), 1156, 1);
+            SetWearable(new Shoes(), 1910, 1);
         }
 
         public override void OnDoubleClick(Mobile m)

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/Mobiles/SageHumbolt.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Quest/Mobiles/SageHumbolt.cs
@@ -48,7 +48,7 @@ namespace Server.Engines.Khaldun
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
             DeathRobe robe = new DeathRobe
             {

--- a/Scripts/Services/Seasonal Events/TreasuresOfTokuno/TreasuresOfTokuno.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfTokuno/TreasuresOfTokuno.cs
@@ -324,16 +324,10 @@ namespace Server.Mobiles
 
         public override void InitOutfit()
         {
-            AddItem(new Waraji(0x711));
-            AddItem(new Backpack());
-            AddItem(new Kamishimo(0x483));
-
-            Item item = new LightPlateJingasa
-            {
-                Hue = 0x711
-            };
-
-            AddItem(item);
+            SetWearable(new Backpack());
+            SetWearable(new Waraji(), 0x711, 1);
+			SetWearable(new Kamishimo(), 0x483, 1);
+			SetWearable(new LightPlateJingasa(), 0x711, 1);
         }
 
         [Constructable]

--- a/Scripts/Services/Town Cryer/Quests/APleaFromMinocQuest.cs
+++ b/Scripts/Services/Town Cryer/Quests/APleaFromMinocQuest.cs
@@ -304,15 +304,15 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            SetWearable(new ChainCoif());
-            SetWearable(new ChainChest());
-            SetWearable(new ChainLegs());
-            SetWearable(new Boots(), 2012);
-            SetWearable(new FancyKilt(), 2012);
-            SetWearable(new RingmailGloves());
-            SetWearable(new BodySash(), 43);
+            SetWearable(new ChainCoif(), dropChance: 1);
+            SetWearable(new ChainChest(), dropChance: 1);
+            SetWearable(new ChainLegs(), dropChance: 1);
+            SetWearable(new Boots(), 2012, 1);
+            SetWearable(new FancyKilt(), 2012, 1);
+			SetWearable(new RingmailGloves(), dropChance: 1);
+            SetWearable(new BodySash(), 43, 1);
         }
 
         public override void OnDoubleClick(Mobile m)

--- a/Scripts/Services/Town Cryer/Quests/BuriedRichesQuest.cs
+++ b/Scripts/Services/Town Cryer/Quests/BuriedRichesQuest.cs
@@ -341,11 +341,11 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            SetWearable(new Doublet());
-            SetWearable(new Kilt(), 443);
-            SetWearable(new ThighBoots(), 1837);
+            SetWearable(new Doublet(), dropChance: 1);
+            SetWearable(new Kilt(), 443, 1);
+            SetWearable(new ThighBoots(), 1837, 1);
         }
 
         public override void OnDoubleClick(Mobile m)
@@ -447,11 +447,11 @@ namespace Server.Engines.Quests
         {
             AddItem(new Backpack());
 
-            SetWearable(new FancyShirt());
-            SetWearable(new JinBaori());
-            SetWearable(new Kilt());
-            SetWearable(new ThighBoots(), 1908);
-            SetWearable(new GoldNecklace());
+            SetWearable(new FancyShirt(), dropChance: 1);
+            SetWearable(new JinBaori(), dropChance: 1);
+            SetWearable(new Kilt(), dropChance: 1);
+            SetWearable(new ThighBoots(), 1908, 1);
+            SetWearable(new GoldNecklace(), dropChance: 1);
         }
 
         public override void OnDoubleClick(Mobile m)

--- a/Scripts/Services/Town Cryer/Quests/PaladinsOfTrinsic.cs
+++ b/Scripts/Services/Town Cryer/Quests/PaladinsOfTrinsic.cs
@@ -160,14 +160,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            SetWearable(new PlateChest(), 0x8A5);
-            SetWearable(new PlateLegs(), 0x8A5);
-            SetWearable(new PlateArms(), 0x8A5);
-            SetWearable(new PlateGloves(), 0x8A5);
-            SetWearable(new BodySash(), 1158);
-            SetWearable(new Cloak(), 1158);
+            SetWearable(new PlateChest(), 0x8A5, 1);
+            SetWearable(new PlateLegs(), 0x8A5, 1);
+            SetWearable(new PlateArms(), 0x8A5, 1);
+            SetWearable(new PlateGloves(), 0x8A5, 1);
+            SetWearable(new BodySash(), 1158, 1);
+            SetWearable(new Cloak(), 1158, 1);
         }
 
         public override void OnDoubleClick(Mobile m)

--- a/Scripts/Services/Town Cryer/Quests/RightingWrongQuest.cs
+++ b/Scripts/Services/Town Cryer/Quests/RightingWrongQuest.cs
@@ -309,14 +309,14 @@ namespace Server.Engines.Quests
 
         public override void InitOutfit()
         {
-            AddItem(new Backpack());
+			SetWearable(new Backpack());
 
-            SetWearable(new ChainChest());
-            SetWearable(new ThighBoots());
-            SetWearable(new BodySash(), 1157);
-            SetWearable(new Epaulette(), 1157);
-            SetWearable(new ChaosShield());
-            SetWearable(new Broadsword());
+            SetWearable(new ChainChest(), dropChance: 1);
+            SetWearable(new ThighBoots(), dropChance: 1);
+            SetWearable(new BodySash(), 1157, 1);
+            SetWearable(new Epaulette(), 1157, 1);
+            SetWearable(new ChaosShield(), dropChance: 1);
+            SetWearable(new Broadsword(), dropChance: 1);
         }
 
         public override void OnDoubleClick(Mobile m)

--- a/Scripts/Services/ViceVsVirtue/Mobiles/SilverTrader.cs
+++ b/Scripts/Services/ViceVsVirtue/Mobiles/SilverTrader.cs
@@ -82,7 +82,7 @@ namespace Server.Engines.VvV
         public void StockInventory()
         {
             if (Backpack == null)
-                AddItem(new Backpack());
+				SetWearable(new Backpack());
 
             foreach (CollectionItem item in VvVRewards.Rewards)
             {

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -6253,7 +6253,7 @@ namespace Server
 			}
 		}
 
-		public void AddItem(Item item, bool deleteConflicting = true)
+		public void AddItem(Item item)
 		{
 			if (item == null || item.Deleted)
 			{
@@ -6302,10 +6302,6 @@ namespace Server
 				catch (Exception e)
 				{
 					Diagnostics.ExceptionLogging.LogException(e);
-				}
-				if (deleteConflicting)
-				{
-					equipped.Delete();
 				}
 			}
 

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -6253,7 +6253,7 @@ namespace Server
 			}
 		}
 
-		public void AddItem(Item item)
+		public void AddItem(Item item, bool deleteConflicting = true)
 		{
 			if (item == null || item.Deleted)
 			{
@@ -6302,6 +6302,10 @@ namespace Server
 				catch (Exception e)
 				{
 					Diagnostics.ExceptionLogging.LogException(e);
+				}
+				if (deleteConflicting)
+				{
+					equipped.Delete();
 				}
 			}
 


### PR DESCRIPTION
- Add parameter with default value to AddItem
- On Conflict, still log conflict, but delete the conflicting Item by default

- Delete the base boots of Rangers befor adding the new boots

Open Issue  #4990