### PR TITLE
LosingItemsBugFix

### DIFF
--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -881,7 +881,7 @@ namespace Server.Mobiles
 
         public static void EquipMacro(EquipMacroEventArgs e)
         {
-	        if (e.Mobile is PlayerMobile pm && pm.Backpack != null && pm.Alive && e.List != null && e.List.Count > 0 && !pm.HasTrade)
+	    if (e.Mobile is PlayerMobile pm && pm.Backpack != null && pm.Alive && e.List != null && e.List.Count > 0 && !pm.HasTrade)
             {
                 if (pm.IsStaff() || Core.TickCount - pm.NextActionTime >= 0)
                 {
@@ -926,7 +926,7 @@ namespace Server.Mobiles
 
         public static void UnequipMacro(UnequipMacroEventArgs e)
         {
-	        if (e.Mobile is PlayerMobile pm && pm.Backpack != null && pm.Alive && e.List != null && e.List.Count > 0 && !pm.HasTrade)
+	    if (e.Mobile is PlayerMobile pm && pm.Backpack != null && pm.Alive && e.List != null && e.List.Count > 0 && !pm.HasTrade)
             {
                 if (pm.IsStaff() || Core.TickCount - pm.NextActionTime >= 0)
                 {

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -881,9 +881,7 @@ namespace Server.Mobiles
 
         public static void EquipMacro(EquipMacroEventArgs e)
         {
-            PlayerMobile pm = e.Mobile as PlayerMobile;
-
-            if (pm != null && pm.Backpack != null && pm.Alive && e.List != null && e.List.Count > 0)
+	        if (e.Mobile is PlayerMobile pm && pm.Backpack != null && pm.Alive && e.List != null && e.List.Count > 0 && !pm.HasTrade)
             {
                 if (pm.IsStaff() || Core.TickCount - pm.NextActionTime >= 0)
                 {
@@ -928,9 +926,7 @@ namespace Server.Mobiles
 
         public static void UnequipMacro(UnequipMacroEventArgs e)
         {
-            PlayerMobile pm = e.Mobile as PlayerMobile;
-
-            if (pm != null && pm.Backpack != null && pm.Alive && e.List != null && e.List.Count > 0)
+	        if (e.Mobile is PlayerMobile pm && pm.Backpack != null && pm.Alive && e.List != null && e.List.Count > 0 && !pm.HasTrade)
             {
                 if (pm.IsStaff() || Core.TickCount - pm.NextActionTime >= 0)
                 {


### PR DESCRIPTION
Bug Fix for Losing Items
- If a player was using the Equip macro and they had a trade window open or another player opened a trade window with them, the item was bounced to 0, 0, 0 internal map and then removed on cleanup.
- Similar to issue number 2 with mannequins patched a little while back: https://github.com/ServUO/ServUO/pull/4971