### PR TITLE
Infinite Loop bug

### DIFF
--- a/Scripts/Items/Tools/BaseRunicTool.cs
+++ b/Scripts/Items/Tools/BaseRunicTool.cs
@@ -201,6 +201,11 @@ namespace Server.Items
             ApplyAttributesTo(pole, true, 0, attributeCount, min, max);
         }
 
+		public static void ApplyAttributesTo(FishingPole pole, int attributeCount, int min, int max)
+		{
+			ApplyAttributesTo(pole, false, 0, attributeCount, min, max);
+		}
+
         public static void ApplyAttributesTo(FishingPole pole, bool playerMade, int luckChance, int attributeCount, int min, int max)
         {
             int delta;


### PR DESCRIPTION
Method public static void ApplyAttributesTo(Item item, int attributeCount, int min, int max) 
using a FishingPole create an infinite loop because this method was missing : 
public static void ApplyAttributesTo(FishingPole pole, int attributeCount, int min, int max)