### PR TITLE
Removed unnecessary locking in Timer

### DIFF
--- a/Server/Timer.cs
+++ b/Server/Timer.cs
@@ -203,22 +203,17 @@ namespace Server
 
 			private class TimerChangeEntry
 			{
-				public Timer m_Timer;
-
 				public int m_NewIndex;
 				public bool m_IsAdd;
 
-				private TimerChangeEntry(Timer t, int newIndex, bool isAdd)
+				private TimerChangeEntry(int newIndex, bool isAdd)
 				{
-					m_Timer = t;
 					m_NewIndex = newIndex;
 					m_IsAdd = isAdd;
 				}
 
 				public void Free()
 				{
-					m_Timer = null;
-
 					if (m_InstancePool.Count < 512) // Arbitrary
 					{
 						m_InstancePool.Enqueue(this);
@@ -227,17 +222,16 @@ namespace Server
 
 				private static readonly ConcurrentQueue<TimerChangeEntry> m_InstancePool = new ConcurrentQueue<TimerChangeEntry>();
 
-				public static TimerChangeEntry GetInstance(Timer t, int newIndex, bool isAdd)
+				public static TimerChangeEntry GetInstance(int newIndex, bool isAdd)
 				{
 					if (m_InstancePool.TryDequeue(out var e))
 					{
-						e.m_Timer = t;
 						e.m_NewIndex = newIndex;
 						e.m_IsAdd = isAdd;
 					}
 					else
 					{
-						e = new TimerChangeEntry(t, newIndex, isAdd);
+						e = new TimerChangeEntry(newIndex, isAdd);
 					}
 
 					return e;
@@ -246,7 +240,7 @@ namespace Server
 
 			public static void Change(Timer t, int newIndex, bool isAdd)
 			{
-				m_Changed[t] = TimerChangeEntry.GetInstance(t, newIndex, isAdd);
+				m_Changed[t] = TimerChangeEntry.GetInstance(newIndex, isAdd);
 
 				m_Signal.Set();
 			}
@@ -270,9 +264,14 @@ namespace Server
 			{
 				var curTicks = Core.TickCount;
 
-				foreach (var tce in m_Changed.Values)
+				foreach (var timer in m_Changed.Keys)
 				{
-					var timer = tce.m_Timer;
+					m_Changed.TryRemove(timer, out var tce);
+					if (tce == null)
+					{
+						continue;
+					}
+
 					var newIndex = tce.m_NewIndex;
 
 					if (timer.m_List != null)
@@ -298,8 +297,6 @@ namespace Server
 
 					tce.Free();
 				}
-
-				m_Changed.Clear();
 			}
 
 			private static readonly AutoResetEvent m_Signal = new AutoResetEvent(false);


### PR DESCRIPTION
Since m_Changed is a ConcurrentDictionary as of latest change, there's no need for locking it during operations.
Removing locking boosts performance significantly