### PR TITLE
Update FastAStarAlgorithm.cs

### DIFF
--- a/Scripts/Services/Pathing/FastAStarAlgorithm.cs
+++ b/Scripts/Services/Pathing/FastAStarAlgorithm.cs
@@ -54,7 +54,7 @@ namespace Server.PathAlgorithms.FastAStar
 
             m_Goal = goal;
 
-		    m_xOffset = (int)Math.Ceiling( (start.X + goal.X - AreaSize) / 2.0 );
+	    m_xOffset = (int)Math.Ceiling( (start.X + goal.X - AreaSize) / 2.0 );
             m_yOffset = (int)Math.Ceiling( (start.Y + goal.Y - AreaSize) / 2.0 );
 
             int fromNode = GetIndex(start.X, start.Y, start.Z);

--- a/Scripts/Services/Pathing/FastAStarAlgorithm.cs
+++ b/Scripts/Services/Pathing/FastAStarAlgorithm.cs
@@ -42,20 +42,20 @@ namespace Server.PathAlgorithms.FastAStar
 
         public override bool CheckCondition(IPoint3D p, Map map, Point3D start, Point3D goal)
         {
-            return Utility.InRange(start, goal, AreaSize);
+            return Utility.InRange(start, goal, AreaSize - 1);
         }
 
         public override Direction[] Find(IPoint3D p, Map map, Point3D start, Point3D goal)
         {
-            if (!Utility.InRange(start, goal, AreaSize))
+            if (!Utility.InRange(start, goal, AreaSize - 1))
                 return null;
 
             m_Touched.SetAll(false);
 
             m_Goal = goal;
 
-            m_xOffset = (start.X + goal.X - AreaSize) / 2;
-            m_yOffset = (start.Y + goal.Y - AreaSize) / 2;
+		    m_xOffset = (int)Math.Ceiling( (start.X + goal.X - AreaSize) / 2.0 );
+            m_yOffset = (int)Math.Ceiling( (start.Y + goal.Y - AreaSize) / 2.0 );
 
             int fromNode = GetIndex(start.X, start.Y, start.Z);
             int destNode = GetIndex(goal.X, goal.Y, goal.Z);
@@ -90,9 +90,6 @@ namespace Server.PathAlgorithms.FastAStar
                 int count = GetSuccessors(bestNode, p, map);
 
                 MoveImpl.Goal = Point3D.Zero;
-
-                if (count == 0)
-                    break;
 
                 for (int i = 0; i < count; ++i)
                 {


### PR DESCRIPTION
The proposed changes fix some problems with the algorithm. 

The first is rather simple:  

Utility.InRange(start, goal, AreaSize) checks a "less or equal" relation for the distance, so it returns "true" if "start" and "goal" are exactly "AreaSize" fields apart. But since the coordinate system used here covers only the values [0 ... AreaSize - 1], this case is actually out of bounds. Propose to change this to Utility.InRange(start, goal, AreaSize - 1) in two places. 

The second is more suble and concerns the following lines:

m_xOffset = (start.X + goal.X - AreaSize) / 2;
m_yOffset = (start.Y + goal.Y - AreaSize) / 2;

These offsets define the transformation between the local coordinate system that the algorithm uses, and the global coordinate system of the map. This transformation is pathological for the edge case "goal.X = start.X + AreaSize - 1" (or a similar relation for the Y coordinate), where the start and goal point have the maximum distance in the local coordinate system. For then we get

m_xOffset = (start.X + (start.X + AreaSize - 1) - AreaSize) / 2 = (2*start.X - 1) / 2 ;

Since integer division discards extra digits, this rounds to "m_xOffset = start.X - 1" and implies that the shifted coordinates of start and goal are

start.X - m_xOffset = 1
goal.X - m_xOffset = AreaSize

The later of these is out of bounds. 

To fix this, it is proposed to add the ceiling function:

m_xOffset = (int)Math.Ceiling( (start.X + goal.X - AreaSize) / 2.0 ); m_yOffset = (int)Math.Ceiling( (start.Y + goal.Y - AreaSize) / 2.0 );

This ensures that the coordinate transformation is always well behaved and for the edge case gives:

start.X - m_xOffset = 0
goal.X - m_xOffset = AreaSize - 1

The third issue is an unnecessary termination condition:

 if ( count == 0 )  
    break;

This causes the algorithm to terminate with failure whenever *any* expanded node has no successors, even if there are other nodes remaining on the open list. This can prevent the algorithm from finding a path out of enclosed spaces, even if an obvious short path exists.