### PR TITLE
ScrollBinderExploitFix

### DIFF
--- a/Scripts/Items/Consumables/ScrollBinderDeed.cs
+++ b/Scripts/Items/Consumables/ScrollBinderDeed.cs
@@ -342,7 +342,8 @@ namespace Server.Items
                             {
                                 GiveItem(from, new ScrollOfTranscendence(Skill, Needed));
                                 from.SendLocalizedMessage(1113145); // You've completed your binding and received an upgraded version of your scroll!
-                                Delete();
+								sot.Delete();
+								Delete();
                             }
                             else if (newValue > Needed)
                             {

--- a/Scripts/Items/Consumables/ScrollBinderDeed.cs
+++ b/Scripts/Items/Consumables/ScrollBinderDeed.cs
@@ -342,8 +342,8 @@ namespace Server.Items
                             {
                                 GiveItem(from, new ScrollOfTranscendence(Skill, Needed));
                                 from.SendLocalizedMessage(1113145); // You've completed your binding and received an upgraded version of your scroll!
-								sot.Delete();
-								Delete();
+				sot.Delete();
+				Delete();
                             }
                             else if (newValue > Needed)
                             {


### PR DESCRIPTION
- If you add two 1.0 scrolls of transcendence to a scroll binder it will correctly delete the first one but when you target the other one it will create a new 2.0 SOT while leaving the last 1.0 SOT. This can allow users to "dupe" these scrolls. It only happens when you hit 2.0 exactly in a scroll binding deed.
- This small edit resolves the exploit.