### PR TITLE
Remove the forced skillcap from the reward system

### DIFF
--- a/Scripts/Services/VeteranRewards/RewardSystem.cs
+++ b/Scripts/Services/VeteranRewards/RewardSystem.cs
@@ -644,8 +644,6 @@ namespace Server.Engines.VeteranRewards
             else if (level < 0)
                 level = 0;
 
-            e.Mobile.SkillsCap = SkillCap + SkillCapBonus;
-
             if (e.Mobile is PlayerMobile && !((PlayerMobile)e.Mobile).HasStatReward && HasHalfLevel(e.Mobile))
             {
                 Gumps.BaseGump.SendGump(new StatRewardGump((PlayerMobile)e.Mobile));


### PR DESCRIPTION
I don't see any reason the reward system should be forcing the skill cap. Other scripts that change the players skill caps dynamically are being overridden by this.