### PR TITLE
Stop from defaulting to 90 min cooldown

### DIFF
--- a/Scripts/Spells/Skill Masteries/EtherealBurst.cs
+++ b/Scripts/Spells/Skill Masteries/EtherealBurst.cs
@@ -35,14 +35,18 @@ namespace Server.Spells.SkillMasteries
                 int duration = 120;
                 double skill = ((Caster.Skills[CastSkill].Value + Caster.Skills[DamageSkill].Value) / 2.1) + GetMasteryLevel() * 2;
 
-                if (skill >= 120)
-                    duration = 30;
-
-                if (skill >= 100)
-                    duration = 60;
-
-                if (duration >= 60)
-                    duration = 90;
+                if (skill >= 120) 
+                {
+                duration = 30;
+                }
+                else if (skill >= 100)
+                {
+                duration = 60;
+                }
+                else if (duration >= 60)
+                {
+                duration = 90;
+                }
 
                 AddToCooldown(TimeSpan.FromMinutes(duration));
 


### PR DESCRIPTION
It looks like the code was missing an else-if statement. The current servuo code will always set the duration to 30 if the skill is greater than or equal to 120, and then set it to 60 if the skill is greater than or equal to 100, and THEN set it to 90 if 60 regardless of whether the duration has already been set to 30. This will properly set the timer.