### PR TITLE
Fix docker bridge networks

### DIFF
--- a/Config/Server.cfg
+++ b/Config/Server.cfg
@@ -23,6 +23,14 @@ AutoDetect=True
 # configuration of the router through your web browser.
 @Address=
 
+
+# If your server is running in an environmentwhere the process see's a different
+# IP Address than the IP address your LAN clients should connect to (such as
+# Docker) you need to specify the address that LAN clients will connect to. This
+# address should be (or resolve to) the Docker host IP or other IP that clients
+# actually see.
+@PrivateAddress=
+
 # The Port to bind the Listener to.
 # Default: 2593
 @Port=2593

--- a/Scripts/Misc/ServerList.cs
+++ b/Scripts/Misc/ServerList.cs
@@ -41,6 +41,8 @@ namespace Server.Misc
 
         public static readonly string Address = Config.Get("Server.Address", default(string));
 
+        public static readonly string PrivateAddress = Config.Get("Server.PrivateAddress", default(string));
+
         public static readonly bool AutoDetect = Config.Get("Server.AutoDetect", true);
 
         public static string ServerName = Config.Get("Server.Name", "My Shard");
@@ -85,6 +87,10 @@ namespace Server.Misc
                     if (!IsPrivateNetwork(ipep.Address) && _PublicAddress != null)
                     {
                         localAddress = _PublicAddress;
+                    }
+                    else if (PrivateAddress != null)
+                    {
+                        Resolve(PrivateAddress, out localAddress);
                     }
                 }
 


### PR DESCRIPTION
This is a simpler way to fix what https://github.com/ServUO/ServUO/pull/4955 is trying to fix.

Before this merge docker hosted servuo servers would fail to be connectable on LAN without a macvlan network or setting network to host mode which are both not the default behaviour in docker and both some disadvantages. With this change, the server admin can specify exactly what their LAN IP is, so that even if the servuo process see's it's bind address in a container such as with docker's default bridge network, if the port is exposted on the host it will still work fine by entering that in the given config entry.

Hope this helps!