### PR TITLE
Fix: Death Ray does not use SDI on OSI

### DIFF
--- a/Scripts/Spells/Skill Masteries/DeathRay.cs
+++ b/Scripts/Spells/Skill Masteries/DeathRay.cs
@@ -121,10 +121,6 @@ namespace Server.Spells.SkillMasteries
                 damage /= Target is PlayerMobile ? 5.15 : 2.5;
 
                 damage *= GetDamageScalar(Target);
-
-                int sdiBonus = SpellHelper.GetSpellDamageBonus(Caster, Target, CastSkill, Caster.Player && Target.Player);
-
-                damage *= (100 + sdiBonus);
                 damage /= 100;
 
                 SpellHelper.Damage(this, Target, (int)damage, 0, 0, 0, 0, 100);

--- a/Scripts/Spells/Skill Masteries/DeathRay.cs
+++ b/Scripts/Spells/Skill Masteries/DeathRay.cs
@@ -121,7 +121,6 @@ namespace Server.Spells.SkillMasteries
                 damage /= Target is PlayerMobile ? 5.15 : 2.5;
 
                 damage *= GetDamageScalar(Target);
-                damage /= 100;
 
                 SpellHelper.Damage(this, Target, (int)damage, 0, 0, 0, 0, 100);
             }


### PR DESCRIPTION
By utilizing SDI on deathray you create a very overpowered Mastery Skill. OSI does not calculate SDI into the skill they only use Magery and Eval and Mastery level.