### PR TITLE
Fix Remove Trap - 0 Skill from 5 OSI Accurate

### DIFF
--- a/Scripts/Services/TreasureMaps/TreasureMapChest.cs
+++ b/Scripts/Services/TreasureMaps/TreasureMapChest.cs
@@ -170,7 +170,7 @@ namespace Server.Items
                 switch (level)
                 {
                     case 1:
-                        cont.RequiredSkill = 5;
+                        cont.RequiredSkill = 0;
                         break;
                     case 2:
                         cont.RequiredSkill = 45;


### PR DESCRIPTION
https://www.uoguide.com/Treasure_Map
Can attempt with 0 skill not 5.
![1679962215264](https://user-images.githubusercontent.com/3319999/228103556-1824a46e-8d04-477d-bd38-bf8d7e24a7c9.png)


