### PR TITLE
fix: stepping onto the Paroxysmus Teleporter without a rope doesn't warn the player.

### DIFF
--- a/Scripts/Items/Internal/ParoxysmusTeleporters.cs
+++ b/Scripts/Items/Internal/ParoxysmusTeleporters.cs
@@ -48,9 +48,8 @@ namespace Server.Items
                     return base.OnMoveOver(m);					
                 }
             }
-            else
-                m.SendLocalizedMessage(1074272); // You have no way to lower yourself safely into the enormous sinkhole.
-			
+            
+            m.SendLocalizedMessage(1074272); // You have no way to lower yourself safely into the enormous sinkhole.
             return true;	
         }
 


### PR DESCRIPTION
Looks like the else is just a mistake. Right now it only warns the player if the player doesn't have a backpack.