### PR TITLE
Remove System.Drawing.Imaging references from ArtData

### DIFF
--- a/Scripts/Commands/GenBounds.cs
+++ b/Scripts/Commands/GenBounds.cs
@@ -27,7 +27,7 @@ namespace Server.Bounds
 
                 for (int i = 0; i <= ArtData.MaxItemID; ++i)
                 {
-                    ArtData.Measure(Item.GetBitmap(i), out int xMin, out int yMin, out int xMax, out int yMax);
+                    Item.Measure(Item.GetBitmap(i), out int xMin, out int yMin, out int xMax, out int yMax);
 
                     bin.Write((ushort)xMin);
                     bin.Write((ushort)yMin);

--- a/Server/Assets/ArtData.cs
+++ b/Server/Assets/ArtData.cs
@@ -1,22 +1,21 @@
 #region References
 using System;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.Threading;
+
 #endregion
 
 namespace Server
 {
 	public static class ArtData
 	{
-		private static readonly AutoResetEvent m_RenderSync = new AutoResetEvent(true);
-		private static readonly AutoResetEvent m_MeasureSync = new AutoResetEvent(true);
+		private static readonly AutoResetEvent m_readSync = new AutoResetEvent(true);
 
 		private static byte[] m_StreamBuffer;
 
 		private static readonly FileIndex m_FileIndex;
 
-		private static readonly Bitmap[] m_Cache = new Bitmap[81920];
+		private static readonly ArtInfo[] m_Cache = new ArtInfo[81920];
 		private static readonly bool[] m_Invalid = new bool[81920];
 
 		public static bool UOP => Core.FindDataFile("artLegacyMUL.uop") != null;
@@ -38,34 +37,10 @@ namespace Server
 				MaxItemID = m_FileIndex.IdxCount - (MaxLandID + 1);
 			}
 		}
-
-		public static Bitmap GetStatic(int index, int hue, bool onlyHueGrayPixels)
+		
+		public static unsafe ArtInfo GetStatic(int index)
 		{
-			try
-			{
-				var orig = GetStatic(index);
-
-				if (orig == null)
-					return null;
-
-				var image = new Bitmap(orig);
-
-				HueData.ApplyTo(image, hue, onlyHueGrayPixels);
-
-				return image;
-			}
-			catch (Exception e)
-			{
-				if (Core.Debug)
-					Console.WriteLine($"[Ultima]: ArtData.GetStatic({nameof(index)}:{index}, {nameof(hue)}:{hue}, {nameof(onlyHueGrayPixels)}:{onlyHueGrayPixels})\n{e}");
-
-				return null;
-			}
-		}
-
-		public static unsafe Bitmap GetStatic(int index)
-		{
-			m_RenderSync.WaitOne();
+			m_readSync.WaitOne();
 
 			try
 			{
@@ -105,41 +80,56 @@ namespace Server
 					for (var i = 0; i < height; ++i)
 						lookups[i] = start + dat[count++];
 
-					var bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
-					var bd = bmp.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, bmp.PixelFormat);
+					var xMin = 0;
+					var yMin = 0;
+					var xMax = -1;
+					var yMax = -1;
+					var foundPixel = false;
 
 					try
 					{
-						var line = (int*)bd.Scan0;
-						var delta = bd.Stride >> 2;
-
-						for (var y = 0; y < height; ++y, line += delta)
+						for (var y = 0; y < height; y++)
 						{
 							count = lookups[y];
 
-							int* cur = line, end;
-							int xOffset, xRun, c, argb;
-
+							int x = 0, xOffset, xRun;
+							
 							while (((xOffset = dat[count++]) + (xRun = dat[count++])) != 0)
 							{
-								if (xOffset > delta)
+								if (xOffset > width)
 									break;
-
-								cur += xOffset;
-
-								if (xOffset + xRun > delta)
+								
+								x += xOffset;
+								
+								if (xOffset + xRun > width)
 									break;
+								
+								var end = x + xRun;
 
-								end = cur + xRun;
-
-								while (cur < end)
+								while (x < end)
 								{
-									c = dat[count++] ^ 0x8000;
-
-									argb = ((c & 0x7C00) << 9) | ((c & 0x03E0) << 6) | ((c & 0x1F) << 3);
-									argb = ((c & 0x8000) * 0x1FE00) | argb | ((argb >> 5) & 0x070707);
-
-									*cur++ = argb;
+									var c = dat[count++];
+									if (c != 0)
+									{
+										if (!foundPixel)
+										{
+											foundPixel = true;
+											xMin = xMax = x;
+											yMin = yMax = y;
+										}
+										else
+										{
+											if (x < xMin)
+												xMin = x;
+											if (x > xMax)
+												xMax = x;
+											if (y < yMin)
+												yMin = y;
+											if (y > yMax)
+												yMax = y;
+										}
+									}
+									x++;
 								}
 							}
 						}
@@ -153,12 +143,9 @@ namespace Server
 
 						return null;
 					}
-					finally
-					{
-						bmp.UnlockBits(bd);
-					}
-
-					return m_Cache[index] = bmp;
+					return m_Cache[index] = new ArtInfo(width,
+						height,
+						new Rectangle(xMin, yMin, xMax - xMin, yMax - yMin));
 				}
 			}
 			catch (Exception e)
@@ -170,95 +157,7 @@ namespace Server
 			}
 			finally
 			{
-				m_RenderSync.Set();
-			}
-		}
-
-		public static unsafe void Measure(Bitmap bmp, out int xMin, out int yMin, out int xMax, out int yMax)
-		{
-			m_MeasureSync.WaitOne();
-
-			xMin = yMin = 0;
-			xMax = yMax = -1;
-
-			try
-			{
-				if (bmp == null || bmp.Width <= 0 || bmp.Height <= 0)
-					return;
-
-				var bd = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
-
-				try
-				{
-					var lineDelta = bd.Stride >> 2;
-					var pBuffer = (uint*)bd.Scan0;
-					var pLineEnd = pBuffer + bd.Width;
-					var pEnd = pBuffer + (bd.Height * lineDelta);
-					var delta = lineDelta - bd.Width;
-
-					var foundPixel = false;
-
-					int x = 0, y = 0;
-
-					while (pBuffer < pEnd)
-					{
-						while (pBuffer < pLineEnd)
-						{
-							var c = *pBuffer++;
-
-							if ((c & 0x80000000) != 0)
-							{
-								if (!foundPixel)
-								{
-									foundPixel = true;
-
-									xMin = xMax = x;
-									yMin = yMax = y;
-								}
-								else
-								{
-									if (x < xMin)
-										xMin = x;
-
-									if (y < yMin)
-										yMin = y;
-
-									if (x > xMax)
-										xMax = x;
-
-									if (y > yMax)
-										yMax = y;
-								}
-							}
-
-							++x;
-						}
-
-						pBuffer += delta;
-						pLineEnd += lineDelta;
-
-						++y;
-						x = 0;
-					}
-				}
-				catch (Exception e)
-				{
-					if (Core.Debug)
-						Console.WriteLine($"[Ultima]: ArtData.Measure(...)\n{e}");
-				}
-				finally
-				{
-					bmp.UnlockBits(bd);
-				}
-			}
-			catch (Exception e)
-			{
-				if (Core.Debug)
-					Console.WriteLine($"[Ultima]: ArtData.Measure(...)\n{e}");
-			}
-			finally
-			{
-				m_MeasureSync.Set();
+				m_readSync.Set();
 			}
 		}
 	}

--- a/Server/Assets/ArtInfo.cs
+++ b/Server/Assets/ArtInfo.cs
@@ -1,0 +1,22 @@
+// **********
+// ServUO - ArtInfo.cs
+// **********
+
+using System.Drawing;
+
+namespace Server
+{
+	public class ArtInfo
+	{
+		public int Width;
+		public int Height;
+		public Rectangle Bounds;
+		
+		public ArtInfo(int width, int height, Rectangle bounds)
+		{
+			Width = width;
+			Height = height;
+			Bounds = bounds;
+		}
+	}
+}

--- a/Server/Item.cs
+++ b/Server/Item.cs
@@ -1221,7 +1221,7 @@ namespace Server
 			}
 		}
 
-		public static Bitmap GetBitmap(int itemID)
+		public static ArtInfo GetBitmap(int itemID)
 		{
 			try
 			{
@@ -1235,19 +1235,27 @@ namespace Server
 			return null;
 		}
 
-		public static void Measure(Bitmap bmp, out int xMin, out int yMin, out int xMax, out int yMax)
+		public static void Measure(ArtInfo bmp, out int xMin, out int yMin, out int xMax, out int yMax)
 		{
-			ArtData.Measure(bmp, out xMin, out yMin, out xMax, out yMax);
+			xMin = yMin = 0;
+			xMax = yMax = -1;
+			if (bmp != null)
+			{
+				xMin = bmp.Bounds.Left;
+				yMin = bmp.Bounds.Top;
+				xMax = bmp.Bounds.Right;
+				yMax = bmp.Bounds.Bottom;
+			}
 		}
 
-		public static Rectangle MeasureBound(Bitmap bmp)
+		public static Rectangle MeasureBound(ArtInfo bmp)
 		{
 			Measure(bmp, out var xMin, out var yMin, out var xMax, out var yMax);
 
 			return new Rectangle(xMin, yMin, xMax - xMin, yMax - yMin);
 		}
 
-		public static Size MeasureSize(Bitmap bmp)
+		public static Size MeasureSize(ArtInfo bmp)
 		{
 			Measure(bmp, out var xMin, out var yMin, out var xMax, out var yMax);
 


### PR DESCRIPTION
Removed reference to System.Drawing.Imaging from ArtData.
Simplified it to only read dimensions and bounds (no access to pixel colors)