### PR TITLE
Fix BaseHouse decay

### DIFF
--- a/Scripts/Multis/Houses/BaseHouse.cs
+++ b/Scripts/Multis/Houses/BaseHouse.cs
@@ -286,9 +286,8 @@ namespace Server.Multis
             _ = new TempNoHousingRegion(this, null);
 
             KillVendors();
-            Delete();
-
             Timer.DelayCall(OnAfterDecay, m_Region.Area, Map);
+            Delete();
         }
 
         public virtual void OnAfterDecay(Rectangle3D[] recs, Map map)


### PR DESCRIPTION
We have to submit `OnAfterDecay()` before we `Delete()` or else `m_Region` is null and server crashes

No idea what happened with whitespaces :(