### PR TITLE
fix: Fixes mining/lumberjacking multi-harvest

### DIFF
--- a/Scripts/Services/Harvest/Lumberjacking.cs
+++ b/Scripts/Services/Harvest/Lumberjacking.cs
@@ -255,6 +255,8 @@ namespace Server.Engines.Harvest
                 from.SendLocalizedMessage(1005213); // You can't do that
         }
 
+        public override object GetLock(Mobile from, Item tool, HarvestDefinition def, object toHarvest) => this;
+
         public override void OnHarvestStarted(Mobile from, Item tool, HarvestDefinition def, object toHarvest)
         {
             base.OnHarvestStarted(from, tool, def, toHarvest);

--- a/Scripts/Services/Harvest/Mining.cs
+++ b/Scripts/Services/Harvest/Mining.cs
@@ -468,6 +468,8 @@ namespace Server.Engines.Harvest
         }
         #endregion
 
+        public override object GetLock(Mobile from, Item tool, HarvestDefinition def, object toHarvest) => this;
+
         public override bool BeginHarvesting(Mobile from, Item tool)
         {
             if (!base.BeginHarvesting(from, tool))
@@ -490,7 +492,7 @@ namespace Server.Engines.Harvest
             if (toHarvest is LandTarget)
             {
                 from.SendLocalizedMessage(501862); // You can't mine there.
-            }            
+            }
             else if (!(toHarvest is LandTarget))
             {
                 from.SendLocalizedMessage(501863); // You can't mine that.


### PR DESCRIPTION
### Summary

Changes mining/lumberjacking so that players cannot harvest using every tool in their backpack at the same time.