### PR TITLE
Character List Name Fix (Incognito) 

### DIFF
--- a/Server/Network/Packets.cs
+++ b/Server/Network/Packets.cs
@@ -4641,7 +4641,7 @@ m_Stream.Write( (int) renderMode );
 
 				if (m != null)
 				{
-					m_Stream.WriteAsciiFixed(m.Name, 30);
+					m_Stream.WriteAsciiFixed(m.RawName, 30);
 					m_Stream.Fill(30); // password
 				}
 				else
@@ -4747,7 +4747,7 @@ m_Stream.Write( (int) renderMode );
 			{
 				if (a[i] != null)
 				{
-					m_Stream.WriteAsciiFixed(a[i].Name, 30);
+					m_Stream.WriteAsciiFixed(a[i].RawName, 30);
 					m_Stream.Fill(30); // password
 				}
 				else
@@ -4864,7 +4864,7 @@ m_Stream.Write( (int) renderMode );
 			{
 				if (a[i] != null)
 				{
-					m_Stream.WriteAsciiFixed(a[i].Name, 30);
+					m_Stream.WriteAsciiFixed(a[i].RawName, 30);
 					m_Stream.Fill(30); // password
 				}
 				else


### PR DESCRIPTION
When casting Incognito, if you log out and back in, the Incognito name (Name/NameMod) shows on the Character List. It should always just display the character's name. Using RawName fixes this. Also, when logging back in, clients will create new "profile" folders for the Incognitoed name. This also fixes that.