### PR TITLE
ServerList Adjustments for correct local and remote

### DIFF
--- a/Scripts/Misc/ServerList.cs
+++ b/Scripts/Misc/ServerList.cs
@@ -36,8 +36,9 @@ namespace Server.Misc
                 var ipep = (IPEndPoint)s.LocalEndPoint;
 
                 var address = ipep.Address;
+                var addressClient = ((IPEndPoint)s.RemoteEndPoint).Address;
 
-                if (!IPAddress.IsLoopback(address) || IsPrivateNetwork(address))
+                if (!IPAddress.IsLoopback(addressClient) && !IsPrivateNetwork(addressClient))
                 {
                     address = Address;
                 }


### PR DESCRIPTION
- Change Server List to use the localendpoint if from local ip,
- Fixed the conditions, else if you connect with a local ip you would set the ip to the ip from the config / the default. Resulting in the loopback in case you connect locally.
- if non local or loopback, then use the config value