### PR TITLE
Bug/pet justice fix

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,18 @@
       "Bash(./ServUO.exe -debug)",
       "Bash(dotnet build:*)",
       "Bash(dotnet --version)",
-      "Bash(echo $?)"
+      "Bash(echo $?)",
+      "Read(//c/code/Scripts/**)",
+      "Bash(find 'C:/code/Scripts/Custom/Premium Members/' -name *.cs -o -name *.txt)",
+      "Bash(find C:/code/Scripts/Custom/ -iname *stone* -o -iname *vendor* -o -iname *premium* -o -iname *kudos* -o -iname *reward*stone*)",
+      "Bash(find C:/code/Scripts/ -iname *premium*stone* -o -iname *reward*stone* -o -iname *kudos*stone* -o -iname *coin*stone*)",
+      "Bash(cp \"C:/code/Scripts/Custom/Premium Members/PremiumWarriorTalisman.cs\" \"c:/code/ServUO/Scripts/Custom/PremiumWarriorTalisman.cs\")",
+      "Bash(cp \"C:/code/Scripts/Custom/Premium Members/WhiteCourage.cs\" \"c:/code/ServUO/Scripts/Custom/WhiteCourage.cs\")",
+      "Bash(find C:/code/Scripts/ -iname *premium*stone* -o -iname *reward*stone* -o -iname *vendor*stone*)",
+      "Bash(grep -i \"\\\\.cs$\")"
+    ],
+    "additionalDirectories": [
+      "C:\\code\\Scripts\\Custom Arth\\Test\\Reward Tickets"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./ServUO.exe -debug)",
+      "Bash(dotnet build:*)",
+      "Bash(dotnet --version)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(./ServUO.exe -debug)",
       "Bash(dotnet build:*)",
-      "Bash(dotnet --version)"
+      "Bash(dotnet --version)",
+      "Bash(echo $?)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@
 
 !/Data/*
 !/bin/rosyln/*
+.claude/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,157 @@
+# ServUO Custom Shard Changes
+
+## Config Changes
+- **Siege.cfg** — Enabled siege mode (`IsSiege=true`) for Felucca rules on all maps
+- **CurrentExpansion.cs** — Enabled insurance on siege shard
+- **PlayerMobile.cs** — Disabled siege bless item, disabled fastwalk prevention
+- **Fastwalk.cs** — Disabled old fastwalk system
+
+## Skill & Loot System
+- **SkillCheck.cs** — Faster skill gains (25% min chance, GGS enabled, siege ROT removed, faster GGS timers)
+- **TrainingDummies.cs** — Raised max skill to 120
+- **AdvancedTrainingDummy.cs** — Raised max skill to 120
+- **ItemPropertyInfo.cs** — Hit spells min 25%, max 50%, no overcap
+- **RandomItemGenerator.cs** — Added Szavetra to boss entry (+250 budget)
+- **Szavetra.cs** — SuperBoss x4 loot
+- **BaseChampion.cs** — 5% custom artifact drops per eligible player, 120 power scroll chance increased to 15%
+- **RangersCloakOfAugmentation.cs** — Updated stats (kinetic eater 10%, SDI 5%, LMC 8%)
+- **WardensArmorOfAugmentation.cs** — Updated stats (same as above)
+
+## Custom Armor
+
+**Gloves of the Holy Warrior** — PlateGloves / GargishPlateKilt
+- `[add GlovesOfTheHolyWarrior` / `[add GargishKiltOfTheHolyWarrior`
+- Chivalry +15, Necromancy +15, Reactive Holy Light 10%, Str +5, Int +5, HP +5, Stam +10, Mana +15, LMC 8%, All Resist 15
+
+**Sentinel's Mempo** — PlateMempo / GargishNecklace
+- `[add SentinelsMempo` / `[add SentinelsNecklace`
+- Str +4, Dex +4, HP +8, Stam +12, Mana +8, HCI 5%, DCI 5%, LMC 8%, DI 25%, All Resist 15
+
+**Shugenja's Raiment** — PlateDo / GargishPlateChest
+- `[add ShugenjasRaiment` / `[add GargishShugenjasRaiment`
+- Int +5, HP +5, HP Regen 3, Mana Regen 3, SDI 5%, FCR 1, LMC 8%, LRC 20%, Mage Armor, All Resist 15
+
+**Hexweaver's Visage** — ElvenGlasses / GargishGlasses
+- `[add HexweaversVisage` / `[add GargishHexweaversVisage`
+- Random +10 Necro/Myst/Magery/Chiv, Casting Focus 2%, Str +5, Int +5, HP +5, Mana +8, SDI 5%, LMC 8%, LRC 20%, Mage Armor, All Resist 15
+
+**Umbrascale Champion's Aegis** — ElvenGlasses / GargishGlasses
+- `[add UmbrascaleChampionsAegis` / `[add GargishUmbrascaleChampionsAegis`
+- Random +15 Sword/Mace/Fencing/Archery/Throwing, Str +5, Dex +5, Int +5, HP +5, Stam +8, Mana +8, LMC 8%, All Resist 15
+
+**Corrupted Paladin Vambraces** — PlateArms / GargishPlateArms
+- `[add CorruptedPaladinVambraces` / `[add GargishCorruptedPaladinVambraces`
+- Str +5, Dex +5, Stam +10, Mana +10, HP Regen 4, Stam Regen 4, Mana Regen 4, LMC 8%, All Resist 15
+
+**Gloves of the Archlich** — BoneGloves / GargishPlateKilt
+- `[add GlovesOfTheArchlich` / `[add GargishKiltOfTheArchlich`
+- Fire Eater 15%, Str +5, Int +5, HP +5, Mana +8, HP Regen 3, Mana Regen 3, LMC 10%, LRC 20%, Mage Armor, All Resist 15
+
+**Balron Bone Armor** — BoneChest / GargishPlateChest
+- `[add BalronBoneArmor` / `[add GargishBalronBoneArmor`
+- Str +5, Dex +5, Int +5, HP +5, Stam +8, Mana +8, HCI 5%, DCI 5%, LMC 8%, All Resist 15 (Fire 20), 60 Str Req
+
+## Custom Clothing
+
+**Scabbard of Juo'nar** — SwordBelt / GargoyleHalfApron
+- `[add ScabbardOfJuonar` / `[add GargishScabbardOfJuonar`
+- Resist +10, Int +10, HP +5, SDI 5%, FC 1
+
+**General Lethe's Epaulettes** — Epaulette / GargishEpaulette
+- `[add GeneralLethesEpaulettes` / `[add GargishGeneralLethesEpaulettes`
+- Eval Int +10, Mana +8, Mana Regen 1, FCR 1, LRC 10%
+
+**Lord Morphius' Epaulettes** — Epaulette / GargishEpaulette
+- `[add LordMorphiusEpaulettes` / `[add GargishLordMorphiusEpaulettes`
+- Anatomy +10, Stam +8, Stam Regen 2, LMC 5%, SSI 10%
+
+**Shadowbane Epaulettes** — Epaulette / GargishEpaulette
+- `[add ShadowbaneEpaulettes` / `[add GargishShadowbaneEpaulettes`
+- HCI 10%, DCI 10%, LMC 8%
+
+**Mantle of the Archlich** — Robe (no garg version)
+- `[add MantleOfTheArchlich`
+- Resisting Spells +10, SDI 8%, FC 1
+
+**Feudal Cloak of Elements** — Cloak / GargishLeatherWingArmor
+- `[add FeudalCloakOfElements` / `[add WingArmorOfElements`
+- Damage Eater 15%, Fire Resist 15%, HP Regen 2, Stam Regen 3, Mana Regen 2, Luck 150
+
+**Feudal Ghostwalkers** — Sandals / LeatherTalons
+- `[add FeudalGhostwalkers` / `[add GargishFeudalGhostwalkers`
+- Stealth +5, Hiding +5, Ninjitsu +5, Night Sight, 255 durability
+
+**Mushroom Apron** — HalfApron / GargoyleHalfApron
+- `[add MushroomApron` / `[add GargishMushroomApron`
+- Alchemy +10, HP +5, HP Regen 2, Enhance Potions 15%
+
+**Serpent Skin Quiver** — BaseQuiver / GargishLeatherWingArmor
+- `[add SerpentSkinQuiver` / `[add GargishSerpentSkinWingArmor`
+- Damage Mod 10%, Ammo 0/1000, Weight Reduction 50%, Lower Ammo Cost 50%, Anatomy +10, Luck 125, SSI 10%, DI 20%
+
+**Ranger's Cloak of Augmentation** — Cloak / GargishLeatherWingArmor
+- `[add RangersCloakOfAugmentation` / `[add WardensArmorOfAugmentation`
+- Kinetic Eater 10%, SDI 5%, LMC 8%, SSI 5%
+
+## Custom Weapons
+
+**Expor Malas Flamus** — BladedStaff / GargishKatana
+- `[add ExporMalasFlamus` / `[add GargishExporMalasFlamus`
+- Searing Weapon, Hit Lower Attack 50%, Hit Life Leech 100%, Hit Mana Leech 100%, Hit Stam Leech 50%, Hit Fire Area 70%, DI 30%, Fire Damage 100%
+
+**Shugenja's Wand** — MagicWand (all races)
+- `[add ShugenjasWand`
+- Spell Channeling, Mage Weapon -0, Mana Regen 10, FCR 2, Physical Damage 100%, 255 durability
+
+## Slayer Weapon Set (84 weapons)
+
+12 weapon types x 7 slayers. Format: `[add {Slayer}{Weapon}`
+
+**Weapon Types:** Leafblade, WarAxe, Broadsword, DoubleAxe, WarHammer, MagicalShortbow, CompositeBow, SoulGlaive, Boomerang, GargishTalwar, GargishKatana, Lajatang
+
+**All slayer weapons have:** Hit Mana Leech 100%, Hit Life Leech 100%, Hit Stam Leech 50%, Hit Lower Defense 50%, Brittle, 255/255 durability
+
+**Reptile** — Poison 100%, Hit Poison Area 50%
+- Example: `[add ReptileBroadsword`
+
+**Repond** — Cold 100%, Hit Cold Area 50%
+- Example: `[add RepondBroadsword`
+
+**Arachnid** — Fire 100%, Hit Fire Area 50%
+- Example: `[add ArachnidBroadsword`
+
+**Undead** — Fire 100%, Hit Fire Area 50%
+- Example: `[add UndeadBroadsword`
+
+**Demon** — Cold 100%, Hit Cold Area 50%
+- Example: `[add DemonBroadsword`
+
+**Fey** — Fire 100%, Hit Fire Area 50%
+- Example: `[add FeyBroadsword`
+
+**Elemental** — Energy 100%, Hit Energy Area 50%
+- Example: `[add ElementalBroadsword`
+
+## Custom Spellbooks
+
+All spellbooks: Blessed, full 64 spells, Spell Damage 50%, FCR 1, FC 1, Mana Regen 3
+
+- `[add ReptilianDeathSpellbook` — Tome of Reptilian Death (Reptile Slayer)
+- `[add RepondSpellbook` — Tome of Repond (Repond Slayer)
+- `[add UndeadSpellbook` — Tome of the Undead (Undead Slayer)
+- `[add DemonSpellbook` — Tome of Exorcism (Demon Slayer)
+- `[add FeySpellbook` — Tome of the Fey (Fey Slayer)
+- `[add ArachnidDoomSpellbook` — Tome of Arachnid Doom (Arachnid Slayer)
+- `[add ElementalBanSpellbook` — Tome of Elemental Ban (Elemental Slayer)
+
+## Custom Talisman
+
+- `[add CarvedBoneRelicFromHolmes` — Carved Bone Relic from Holmes (Anatomy +20, Enhance Potions 15%)
+
+## Existing Items Used (Khaldun)
+
+- `[add MaskOfKhalAnkur` — Mask of Khal Ankur (human)
+- `[add PendantOfKhalAnkur` — Pendant of Khal Ankur (gargoyle)
+
+## Champion Drop System
+All custom artifacts have a 5% chance to drop into an eligible player's backpack when any champion is killed on Felucca.

--- a/Config/Accounts.cfg
+++ b/Config/Accounts.cfg
@@ -1,6 +1,6 @@
 
 # Number of accounts allowed to be created from a single IP address
-AccountsPerIp=1
+AccountsPerIp=2
 
 # If true accounts will be automatically created on first login
 AutoCreateAccounts=True

--- a/Config/Server.cfg
+++ b/Config/Server.cfg
@@ -1,6 +1,6 @@
 
 # The displayed name of the shard
-Name=My Shard
+Name=Rebirth
 
 # The internal IP address to listen on.
 # You can leave this value as default to listen to all available IP's.

--- a/Config/Siege.cfg
+++ b/Config/Siege.cfg
@@ -1,6 +1,6 @@
 # Siege Perilous Ruleset, false by defualt
 
-IsSiege=false
+IsSiege=true
 
 #If siege is active, this is the amount of players per account.  Note, EA only allows 1 per account on siege rule-set shards
 CharacterSlots=7

--- a/Scripts/Custom/PremiumCoins.cs
+++ b/Scripts/Custom/PremiumCoins.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using Server;
+using Server.Items;
+using Server.Mobiles;
+using Server.Network;
+
+namespace Server.Items
+{
+    public class PremiumCoins : Item
+    {
+        public static class Config
+        {
+            public static bool Enabled = true;
+            public static int MinutesPerCoin = 10;          // +1 coin every 10 minutes
+            public static bool DropToBank = true;           // true = bank, false = backpack
+            public static AccessLevel MaxAccessLevel = AccessLevel.Player;
+        }
+
+        public static void Initialize()
+        {
+            if (!Config.Enabled)
+                return;
+
+            new CoinDistributionTimer().Start();
+        }
+
+        [Constructable]
+        public PremiumCoins(int amount)
+        {
+            Name = "Premium Coins";
+            ItemID = 0xEED;
+            Hue = 1153;
+            LootType = LootType.Blessed;
+            Stackable = true;
+            Amount = amount;
+            Weight = 0;
+        }
+
+        [Constructable]
+        public PremiumCoins() : this(1) { }
+
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            base.GetProperties(list);
+            list.Add("Game Time Reward");
+        }
+
+        public override bool DisplayWeight { get { return false; } }
+
+        public PremiumCoins(Serial serial) : base(serial) { }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+
+        private class CoinDistributionTimer : Timer
+        {
+            public CoinDistributionTimer()
+                : base(TimeSpan.FromMinutes(Config.MinutesPerCoin), TimeSpan.FromMinutes(Config.MinutesPerCoin))
+            {
+                Priority = TimerPriority.OneMinute;
+            }
+
+            protected override void OnTick()
+            {
+                foreach (NetState state in NetState.Instances)
+                {
+                    PlayerMobile m = state.Mobile as PlayerMobile;
+
+                    if (m == null || m.Deleted)
+                        continue;
+
+                    if (m.AccessLevel > Config.MaxAccessLevel)
+                        continue;
+
+                    GiveCoins(m, 1);
+                    m.SendMessage(0x35, "You have received a Premium Coin for your time online!");
+                }
+            }
+        }
+
+        public static void GiveCoins(PlayerMobile m, int amount)
+        {
+            if (m == null || m.Deleted || amount <= 0)
+                return;
+
+            Container target = Config.DropToBank && m.BankBox != null ? m.BankBox : m.Backpack;
+
+            if (target == null)
+                return;
+
+            Item existing = target.FindItemByType(typeof(PremiumCoins), false);
+
+            if (existing != null)
+            {
+                existing.Amount += amount;
+            }
+            else
+            {
+                target.DropItem(new PremiumCoins(amount));
+            }
+        }
+    }
+}

--- a/Scripts/Custom/PremiumVendorStone.cs
+++ b/Scripts/Custom/PremiumVendorStone.cs
@@ -1,0 +1,1454 @@
+using System;
+using System.IO;
+using System.Collections;
+using Server.Items;
+using Server.Network;
+using Server.Gumps;
+using Server.Mobiles;
+using Server.Targeting;
+using Server.Targets;
+
+namespace Server.Items
+{
+	public class VS1Item
+	{
+		private string m_Item = "";
+		private string m_Name = "";
+		private int m_Price = 0;
+		private int m_Amount = 1;
+		private bool m_BlessBond;
+		private int m_BBPrice;
+		private string m_Description = "";
+
+		public string Item{ get{ return m_Item; } set{ m_Item = value; } }
+		public string Name{ get{ return m_Name; } set{ m_Name = value; } }
+		public int Price{ get{ return m_Price; } set{ m_Price = value; } }
+		public int Amount{ get{ return m_Amount; } set{ m_Amount = value; if ( m_Amount < 1 ) m_Amount = 1; } }
+		public bool BlessBond{ get{ return m_BlessBond; } set{ m_BlessBond = value; } }
+		public int BBPrice{ get{ return m_BBPrice; } set{ m_BBPrice = value; } }
+		public string Description{ get{ return m_Description; } set{ m_Description = value; } }
+
+		public VS1Item()
+		{
+		}
+
+		public VS1Item( string item, string name, int price, int amount, bool blessbond, int bbprice, string description )
+		{
+			Item = item;
+			Name = name;
+			Price = price;
+			Amount = amount;
+			BlessBond = blessbond;
+			BBPrice = bbprice;
+			Description = description;
+		}
+
+		public Type GetItemType()
+		{
+			Type type = ScriptCompiler.FindTypeByName( m_Item );
+			return type;
+		}
+
+		public void Serialize( GenericWriter writer )
+		{
+			writer.Write( (string) m_Description );
+			writer.Write( (bool) m_BlessBond );
+			writer.Write( (int) m_BBPrice );
+			writer.Write( (string) m_Item );
+			writer.Write( (string) m_Name );
+			writer.Write( (int) m_Price );
+			writer.Write( (int) m_Amount );
+		}
+
+		public void Deserialize( GenericReader reader, int version )
+		{
+			switch( version )
+			{
+				case 3:
+				{
+					m_Description = reader.ReadString();
+
+					goto case 2;
+				}
+				case 2:
+				case 1:
+				{
+					m_BlessBond = reader.ReadBool();
+					m_BBPrice = reader.ReadInt();
+
+					goto case 0;
+				}
+				case 0:
+				{
+					m_Item = reader.ReadString();
+					m_Name = reader.ReadString();
+					m_Price = reader.ReadInt();
+					m_Amount = reader.ReadInt();
+
+					break;
+				}
+			}
+		}
+	}
+	public class VSShopper2
+	{
+		private ArrayList m_ItemList = new ArrayList();
+		private Mobile m_Owner;
+		private VendorStone m_Stone;
+
+		public ArrayList ItemList{ get{ return m_ItemList; } set{ m_ItemList = value; } }
+		public Mobile Owner{ get{ return m_Owner; } set{ m_Owner = value; } }
+		public VendorStone Stone{ get{ return m_Stone; } set{ m_Stone = value; } }
+
+		public VSShopper2( Mobile owner, VendorStone stone )
+		{
+			m_Owner = owner;
+			m_Stone = stone;
+		}
+
+		public void AddItem( int itemnumber )
+		{
+			m_ItemList.Add( itemnumber );
+		}
+
+		public int TotalPrice()
+		{
+			int tp = 0;
+
+			for( int i = 0; i < m_ItemList.Count; ++i )
+			{
+				int n = (int)ItemList[i];
+
+				VS1Item vs1i = (VS1Item)m_Stone.ItemList[n];
+				tp += vs1i.Price;
+			}
+
+			return tp;
+		}
+	}
+	public class VendorBall2 : Item
+	{
+		private VendorStone m_Stone;
+
+		//[CommandProperty( AccessLevel.GameMaster )]
+		public VendorStone Stone{ get{ return m_Stone; } set{ m_Stone = value; } }
+
+		[Constructable]
+		public VendorBall2() : base( 0x1869 )
+		{
+			Weight = 0.1;
+			Hue = 89;
+			Name = "Vendor Ball";
+		}
+
+		public VendorBall2( Serial serial ) : base( serial )
+		{
+		}
+
+		private void ConnectTarget_Callback( Mobile from, object obj )
+		{
+			if ( obj is VendorStone && obj is Item )
+			{
+				Item item = (Item)obj;
+				VendorStone ps = (VendorStone)obj;
+
+				Stone = ps;
+				from.SendMessage( "You have connected the ball to the stone." );
+			}
+			else
+			{
+				from.SendMessage( "That is an invalid target!" );
+			}
+		}
+
+		public override void OnDoubleClick( Mobile from )
+		{
+			if ( !IsChildOf( from ) && !Utility.InRange( from.Location, Location, 3 ) )
+				from.SendMessage( "You are too far away to use that." );
+			else if ( Stone != null && !Stone.Deleted )
+			{
+				if ( from.AccessLevel >= Stone.AccessLevel )
+				{
+					from.SendGump( new StaffVendorGump2( from, Stone ) );
+				}
+				else if ( !Stone.EditMode )
+				{
+					if ( !Stone.EditMode )
+						from.SendGump( new VendorGump2( new VSShopper2( from, m_Stone ), Stone ) );
+					else
+						from.SendMessage( "This vendor stone is currently in edit mode." );
+				}
+				else
+					from.SendMessage( "This stone is in edit mode." );
+			}
+			else
+			{
+				from.BeginTarget( -1, false, TargetFlags.Beneficial, new TargetCallback( ConnectTarget_Callback ) );
+				from.SendMessage( "Please target a stone to connect this ball to." );
+			}
+		}
+
+		public override void OnSingleClick( Mobile from )
+		{
+			base.OnSingleClick( from );
+
+			if ( Stone != null && !Stone.Deleted )
+			{
+				if ( Stone.Name != null )
+					LabelTo( from, "Stone Ball, Connected to: "+ Stone.Name );
+				else
+					LabelTo( from, "Stone Ball, Connected to: !SET THE STONE'S NAME!" );
+			}
+			else
+			{
+				LabelTo( from, "Stone Ball, Connected to: None" );
+			}
+		}
+
+		public override void GetProperties( ObjectPropertyList list )
+		{
+			base.GetProperties( list );
+
+			if ( Stone != null && !Stone.Deleted )
+			{
+				if ( Stone.Name != null )
+					list.Add( "Stone Ball, Connected to: "+ Stone.Name );
+				else
+					list.Add( "Stone Ball, Connected to: !SET THE STONE'S NAME!" );
+			}
+			else
+			{
+				list.Add( "Stone Ball, Connected to: None" );
+			}
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 0 ); // version
+			writer.Write( m_Stone );
+		}
+
+		public override void Deserialize( GenericReader reader )
+		{
+			base.Deserialize( reader );
+
+			int version = reader.ReadInt();
+			m_Stone = reader.ReadItem() as VendorStone;
+		}
+	}
+}
+
+namespace Server.Items
+{
+	public class VendorStone : Item
+	{
+		private AccessLevel m_AccessLevel = AccessLevel.Administrator;
+		private bool m_EditMode;
+		private string m_Currency;
+		private ArrayList m_ItemList = new ArrayList();
+
+		public string Currency{get{return m_Currency;}set{m_Currency = value;}}
+		public ArrayList ItemList{get{return m_ItemList;}set{m_ItemList = value;}}
+		public AccessLevel AccessLevel{get{return m_AccessLevel;}set{m_AccessLevel = value;}}
+		public bool EditMode{get{return m_EditMode;}set{m_EditMode = value;}}
+
+		[Constructable]
+		public VendorStone() : base( 3806 )
+		{
+			Movable = false;
+			Hue = 1173;
+			Name = "Vendor Stone";
+		}
+
+		public override void OnDoubleClick( Mobile from )
+		{
+			if ( !Utility.InRange( from.Location, Location, 3 ) )
+				from.SendMessage( "You are too far away to use that." );
+			else if ( from.AccessLevel >= AccessLevel )
+				from.SendGump( new StaffVendorGump2( from, this ) );
+			else if ( !EditMode )
+				from.SendGump( new VendorGump2( new VSShopper2( from, this ), this ) );
+			else
+				from.SendMessage( "This stone is in edit mode." );
+		}
+
+		public void CloseGumps( Mobile from )
+		{
+			from.CloseGump( typeof( VendorGump2 ) );
+			from.CloseGump( typeof( VendorStoneBuyGump ) );
+			from.CloseGump( typeof( VendorStoneEditGump ) );
+			from.CloseGump( typeof( VendorStoneAddItemGump ) );
+			from.CloseGump( typeof( StaffVendorGump2 ) );
+		}
+
+		public Type GetCurrency()
+		{
+			Type type = ScriptCompiler.FindTypeByName( Currency );
+			return type;
+		}
+
+		public VendorStone( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 3 ); // version
+			writer.Write( (int)m_AccessLevel );
+			writer.Write( (string)m_Currency );
+			writer.Write( (bool)m_EditMode );
+
+			writer.Write( m_ItemList.Count );
+			for ( int i = 0; i < m_ItemList.Count; ++i )
+				((VS1Item)m_ItemList[i]).Serialize( writer );
+		}
+
+		public override void Deserialize( GenericReader reader )
+		{
+			base.Deserialize( reader );
+
+			int version = reader.ReadInt();
+
+			if (version == 0)
+			{
+				bool bNull;
+				int iNull;
+				bNull = reader.ReadBool(); //custom hues
+				bNull = reader.ReadBool(); //m_Blessed
+				bNull = reader.ReadBool(); //m_Bonded
+				bNull = reader.ReadBool(); //m_Hued
+				iNull = reader.ReadInt(); //m_BlessedPrice
+				iNull = reader.ReadInt(); //m_BondedPrice
+				iNull = reader.ReadInt(); //m_HuedPrice
+				m_AccessLevel = (AccessLevel)reader.ReadInt();
+				m_Currency = reader.ReadString();
+				m_EditMode = reader.ReadBool();
+
+				int size1 = reader.ReadInt();
+				ArrayList alPrice = new ArrayList( size1 );
+				for ( int i = 0; i < size1; ++i )
+				{
+					int price = reader.ReadInt();
+					alPrice.Add( price );
+				}
+
+				int size4 = reader.ReadInt();
+				ArrayList alNull = new ArrayList( size4 );
+				for ( int i = 0; i < size4; ++i )
+				{
+					int hue = reader.ReadInt();
+					alNull.Add( hue );
+				}
+
+				int size5 = reader.ReadInt();
+				ArrayList alAmount = new ArrayList( size5 );
+				for ( int i = 0; i < size5; ++i )
+				{
+					int itemamount = reader.ReadInt();
+					alAmount.Add( itemamount );
+				}
+
+				int size2 = reader.ReadInt();
+				ArrayList alItem = new ArrayList( size2 );
+				for ( int i = 0; i < size2; ++i )
+				{
+					string item = reader.ReadString();
+					alItem.Add( item );
+				}
+
+				int size3 = reader.ReadInt();
+				ArrayList alName = new ArrayList( size3 );
+				for ( int i = 0; i < size3; ++i )
+				{
+					string gumpname = reader.ReadString();
+					alName.Add( gumpname );
+				}
+
+				int size6 = reader.ReadInt();
+				alNull = new ArrayList( size6 );
+				for ( int i = 0; i < size6; ++i )
+				{
+					int hueprices = reader.ReadInt();
+					alNull.Add( hueprices );
+				}
+				//dispose of the not used arrays (bless.. bond...)
+				alNull.Clear();
+				for( int i = 0; i < alName.Count; i++ )
+				{
+                    VS1Item v = new VS1Item(alItem[i].ToString(), alName[i].ToString(), (int)alPrice[i], (int)alAmount[i], false, 0, "");
+					ItemList.Add( v );
+				}
+				//dispose of the "old" arrays
+				alItem.Clear();
+				alName.Clear();
+				alPrice.Clear();
+				alAmount.Clear();
+			}
+			else switch( version )
+			{
+				case 3:
+				case 2:goto case 0;
+				case 1:
+				{
+					bool blah = reader.ReadBool(); //for the usesledger
+
+					goto case 0;
+				}
+				case 0:
+				{
+					m_AccessLevel = (AccessLevel)reader.ReadInt();
+					m_Currency = reader.ReadString();
+					m_EditMode = reader.ReadBool();
+
+					int size = reader.ReadInt();
+					m_ItemList = new ArrayList( size );
+					for ( int i = 0; i < size; ++i )
+					{
+                        VS1Item vs1i = new VS1Item();
+						vs1i.Deserialize( reader, version );
+						m_ItemList.Add( vs1i );
+					}
+
+					break;
+				}
+			}
+		}
+	}
+}
+
+namespace Server.Gumps
+{
+	public class VendorGump2 : Gump
+	{
+                private VendorStone m_Stone;
+                private VSShopper2 m_Shopper;
+
+		private const int AmountPerPage = 20;
+
+		public string Center( string text )
+		{
+			return String.Format( "<CENTER>{0}</CENTER>", text );
+		}
+
+		public string Color( string text, int color )
+		{
+			return String.Format( "<BASEFONT COLOR=#{0:X6}>{1}</BASEFONT>", color, text );
+		}
+
+                public VendorGump2( VSShopper2 shopper, VendorStone stone ) : base( 25, 25 )
+                {
+			m_Stone = stone;
+			m_Shopper = shopper;
+
+			m_Stone.CloseGumps( m_Shopper.Owner );
+
+			AddPage( 0 );
+
+			AddBackground( 0, 0, 550, 480, 0x2436 );
+			AddAlphaRegion( 10, 10, 530, 460 );
+
+			AddImageTiled( 10, 40, 530, 5, 2624 );
+			AddImageTiled( 10, 58, 390, 5, 2624 );
+
+			AddImageTiled( 90, 40, 5, 430, 2624 );
+			AddImageTiled( 125, 40, 5, 430, 2624 );
+			AddImageTiled( 160, 40, 5, 430, 2624 );
+			AddImageTiled( 310, 40, 5, 430, 2624 );
+			AddImageTiled( 400, 40, 5, 430, 2624 );
+
+			if ( m_Stone.Name != null && m_Stone.Name != "" )
+				AddHtml( 10, 10, 510, 20, Color( Center( m_Stone.Name ), 0xFFFFFF ), false, false );
+			else
+				AddHtml( 10, 10, 510, 20, Color( Center( "Vendor Stone" ), 0xFFFFFF ), false, false );
+
+			AddLabel( 420, 60, 5, "Stone Currency:" );
+			if ( m_Stone.Currency != null && m_Stone.Currency != "" )
+				AddLabel( 420, 80, 5, m_Stone.Currency );
+			else
+				AddLabel( 420, 80, 33, "None" );
+
+			AddHtml( 10, 42, 85, 20, Color( Center( "Item Amount" ), 0xFFFFFF ), false, false );
+			AddHtml( 95, 42, 30, 20, Color( Center( ((m_Stone.EditMode && shopper.Owner.AccessLevel >= m_Stone.AccessLevel) ? "Edit" : "Buy") ), 0xFFFFFF ), false, false );
+			AddHtml( 130, 42, 30, 20, Color( Center( "Des" ), 0xFFFFFF ), false, false );
+			AddHtml( 165, 42, 145, 20, Color( Center( "Item" ), 0xFFFFFF ), false, false );
+			AddHtml( 315, 42, 85, 20, Color( Center( "Price" ), 0xFFFFFF ), false, false );
+
+			if ( !m_Stone.EditMode )
+			{
+				AddButton( 420, 120, 1209, 1210, 1, GumpButtonType.Reply, 0 );
+				AddLabel( 440, 120, 1152, "Buy Items" );
+			}
+
+			AddLabel( 410, 160, 1152, "The (B) beside" );
+			AddLabel( 410, 175, 1152, "items and creatures" );
+			AddLabel( 410, 190, 1152, "stands for blessing" );
+			AddLabel( 410, 205, 1152, "or bonding." );
+
+
+			AddLabel( 420, 400, 906, "Created By" );
+			AddLabel( 420, 420, 906, "~Raelis~" );
+
+			AddButton( 420, 440, 4005, 4007, 0, GumpButtonType.Reply, 0 );
+			AddLabel( 450, 440, 33, "Close" );
+
+			int index = 0;
+			int page = 1;
+
+			AddPage( 1 );
+
+			for ( int i = 0; i < m_Stone.ItemList.Count; ++i )
+			{
+				if ( index >= AmountPerPage )
+				{
+					AddButton( 420, 365, 0x1196, 0x1196, 1152, GumpButtonType.Page, page + 1 );
+					AddLabel( 420, 350, 1152, "Next page" );
+
+					++page;
+					index = 0;
+
+					AddPage( page );
+
+					AddButton( 420, 315, 0x119a, 0x119a, 1152, GumpButtonType.Page, page - 1 );
+					AddLabel( 420, 300, 1152, "Previous page" );
+				}
+
+                int price = ((VS1Item)m_Stone.ItemList[i]).Price;
+                int amount = ((VS1Item)m_Stone.ItemList[i]).Amount;
+                string gumpname = ((VS1Item)m_Stone.ItemList[i]).Name;
+
+				AddLabel( 165, 60 + (index * 20), 1152, gumpname +( ((VS1Item)m_Stone.ItemList[i]).BlessBond ? " (B)" : "") );
+				AddLabel( 25, 60 + (index * 20), 1152, ""+ amount );
+				AddLabel( 320, 60 + (index * 20), 1152, ""+ price );
+
+				AddButton( 100, 65 + (index * 20), 1209, 1210, i+2, GumpButtonType.Reply, 0 );
+				if ( ((VS1Item)m_Stone.ItemList[i]).Description != null && ((VS1Item)m_Stone.ItemList[i]).Description != "" )
+					AddButton( 135, 65 + (index * 20), 0x1523, 0x1523, i+m_Stone.ItemList.Count+3, GumpButtonType.Reply, 0 );
+
+				AddImageTiled( 10, 80 + (index * 20), 390, 3, 2624 );
+
+				index++;
+			}
+		}
+
+		public override void OnResponse( NetState state, RelayInfo info )
+		{
+			Mobile from = state.Mobile;
+
+			if ( m_Stone.Deleted )
+				return;
+
+			if ( info.ButtonID == 0 )
+			{
+				from.SendMessage( "You decide not to buy anything." );
+			}
+
+			if ( info.ButtonID == 1 )
+			{
+				from.SendGump( new VendorStoneBuyGump( m_Shopper, m_Stone ) );
+			}
+
+			if ( info.ButtonID-m_Stone.ItemList.Count-2 <= m_Stone.ItemList.Count && info.ButtonID >= 3 && info.ButtonID-2 > m_Stone.ItemList.Count )
+			{
+				from.SendGump( new VendorGump2( m_Shopper, m_Stone ) );
+				if ( ((VS1Item)m_Stone.ItemList[info.ButtonID-m_Stone.ItemList.Count-3]).Description != null && ((VS1Item)m_Stone.ItemList[info.ButtonID-m_Stone.ItemList.Count-3]).Description != "" )
+					from.SendGump( new VendorStoneDescriptionGump( from, ((VS1Item)m_Stone.ItemList[info.ButtonID-m_Stone.ItemList.Count-3]).Description, ((VS1Item)m_Stone.ItemList[info.ButtonID-m_Stone.ItemList.Count-3]).Name ) );
+			}
+			else if ( info.ButtonID-1 <= m_Stone.ItemList.Count && info.ButtonID >= 2 )
+			{
+				if ( !m_Stone.EditMode )
+				{
+					m_Shopper.AddItem( info.ButtonID-2 );
+					from.SendMessage( "You add it to your list." );
+					from.SendGump( new VendorGump2( m_Shopper, m_Stone ) );
+				}
+				else
+				{
+					if ( info.ButtonID-2 > m_Stone.ItemList.Count-1 || info.ButtonID-2 < 0 )
+						return;
+
+					m_Stone.CloseGumps( from );
+					from.SendGump( new VendorStoneEditGump( from, (VS1Item)m_Stone.ItemList[info.ButtonID-2], m_Stone ) );
+				}
+			}
+		}
+	}
+	public class VendorStoneBuyGump : Gump
+	{
+		private VSShopper2 m_Shopper;
+		private VendorStone m_Stone;
+
+                public VendorStoneBuyGump( VSShopper2 shopper, VendorStone stone ) : base( 125, 125 )
+                {
+			m_Shopper = shopper;
+			m_Stone = stone;
+
+			m_Stone.CloseGumps( m_Shopper.Owner );
+
+			AddPage( 0 );
+
+			AddBackground( 0, 0, 375, 210, 0x2436 );
+
+			AddLabel( 12, 17, 5, "Your Buy List" );
+			AddLabel( 110, 22, 5, "Total Purchase: "+m_Shopper.TotalPrice() );
+
+			AddButton( 15, 160, 4005, 4007, 0, GumpButtonType.Reply, 0 );
+			AddLabel( 45, 160, 33, "Back" );
+			AddButton( 110, 160, 4005, 4007, 1, GumpButtonType.Reply, 0 );
+			AddLabel( 140, 160, 1152, "Buy" );
+
+			for ( int i = 0; i < m_Shopper.ItemList.Count; ++i )
+			{
+				int item = (int)m_Shopper.ItemList[i];
+
+				if ( (i % 5) == 0 )
+				{
+					if ( i != 0 )
+					{
+						AddButton( 190, 235, 0x1196, 0x1196, 1152, GumpButtonType.Page, (i / 5) + 1 );
+						AddLabel( 190, 220, 1152, "Next page" );
+					}
+
+					AddPage( (i / 5) + 1 );
+
+					if ( i != 0 )
+					{
+						AddButton( 10, 235, 0x119a, 0x119a, 1152, GumpButtonType.Page, (i / 5) );
+						AddLabel( 10, 220, 1152, "Previous page" );
+					}
+				}
+
+				VS1Item vs1i = (VS1Item)m_Stone.ItemList[item];
+
+				string blessbond = (vs1i.BlessBond ? "(B)" : "");
+
+				AddButton( 13, 40 + ((i % 5) * 20), 0x26AF, 0x26B1, i+2, GumpButtonType.Reply, 0 );
+				AddLabel( 40, 40 + ((i % 5) * 20), 1152, vs1i.Amount+" "+vs1i.Name+" "+blessbond+" "+vs1i.Price+" "+m_Stone.Currency );
+			}
+		}
+
+		public override void OnResponse( NetState state, RelayInfo info )
+		{
+			Mobile from = state.Mobile;
+
+			if ( from.Backpack == null || from.BankBox == null )
+				return;
+
+			if ( info.ButtonID == 0 )
+			{
+				from.SendGump( new VendorGump2( m_Shopper, m_Stone ) );
+			}
+			if ( info.ButtonID == 1 )
+			{
+				if ( m_Stone.GetCurrency() == null && m_Shopper.TotalPrice() > 0 )
+					from.SendMessage( "There was no set currency to this stone." );
+				else if ( m_Shopper.ItemList.Count <= 0 )
+				{
+					from.SendMessage( "You did not select anything to buy." );
+					from.SendGump( new VendorStoneBuyGump( m_Shopper, m_Stone ) );
+				}
+				else if ( m_Shopper.TotalPrice() > 0 && m_Stone.GetCurrency() != null
+				&& from.Backpack.ConsumeTotal( m_Stone.GetCurrency(), m_Shopper.TotalPrice(), true ) )
+				{
+					// Currency consumed from backpack
+
+					for( int i = 0; i < m_Shopper.ItemList.Count; ++i )
+					{
+						int n = (int)m_Shopper.ItemList[i];
+
+						VS1Item vs1i = (VS1Item)m_Stone.ItemList[n];
+
+						Type type = vs1i.GetItemType();
+
+						if ( type != null )
+						{
+							object o = Activator.CreateInstance( type );
+
+							if ( o is Mobile )
+							{
+								Mobile m = (Mobile)o;
+
+								ArrayList items = new ArrayList();
+
+								m.MoveToWorld( from.Location, from.Map );
+								if ( m is BaseCreature )
+								{
+									BaseCreature c = (BaseCreature)m;
+									c.ControlMaster = from;
+									c.Controlled = true;
+									c.ControlTarget = from;
+									c.ControlOrder = OrderType.Follow;
+
+									items.Add( c );
+
+									if ( vs1i.BlessBond )
+										from.SendGump( new VendorStoneBlessBondGump( from, vs1i, m_Stone, items ) );
+								}
+								int total = 0;
+								while( vs1i.Amount-1 > total )
+								{
+									object o2 = Activator.CreateInstance( type );
+									Mobile m2 = (Mobile)o2;
+
+									m2.MoveToWorld( from.Location, from.Map );
+									if ( m2 is BaseCreature )
+									{
+										BaseCreature c = (BaseCreature)m2;
+										c.ControlMaster = from;
+										c.Controlled = true;
+										c.ControlTarget = from;
+										c.ControlOrder = OrderType.Follow;
+
+										items.Add( c );
+									}
+									total++;
+								}
+							}
+							if ( o is Item )
+							{
+								Item item = (Item)o;
+
+								ArrayList items = new ArrayList();
+
+								items.Add( item );
+
+								if ( item.Stackable )
+								{
+									if ( vs1i.Amount > 60000 )
+									{
+										item.Amount = 60000;
+
+										int aleft = vs1i.Amount-60000;
+
+										while( aleft > 0 )
+										{
+											object o2 = Activator.CreateInstance( type );
+											if ( o2 is Item )
+											{
+												Item item2 = (Item)o2;
+
+												if ( aleft > 60000 )
+												{
+													item2.Amount = 60000;
+													aleft -= 60000;
+												}
+												else
+												{
+													item2.Amount = aleft;
+													aleft = 0;
+												}
+												from.AddToBackpack( item2 );
+												items.Add( item2 );
+											}
+										}
+									}
+									else
+										item.Amount = vs1i.Amount;
+								}
+								else
+								{
+									int total = 0;
+									while( vs1i.Amount-1 > total )
+									{
+										object o2 = Activator.CreateInstance( type );
+										if ( o2 is Item )
+										{
+											Item item2 = (Item)o2;
+											from.AddToBackpack( item2 );
+											items.Add( item2 );
+										}
+										total++;
+									}
+								}
+
+								if ( vs1i.BlessBond )
+									from.SendGump( new VendorStoneBlessBondGump( from, vs1i, m_Stone, items ) );
+								from.AddToBackpack( item );
+							}
+						}
+					}
+					if ( m_Stone.Currency != null && m_Stone.Currency != "" )
+						from.SendMessage( "You buy the items with the "+m_Stone.Currency+" in your reward ticket ledger." );
+					else
+						from.SendMessage( "You buy the items with the currency in your reward ticket ledger." );
+				}
+				else if ( m_Shopper.TotalPrice() == 0 || from.Backpack.ConsumeTotal( m_Stone.GetCurrency(), m_Shopper.TotalPrice(), true ) )
+				{
+					for( int i = 0; i < m_Shopper.ItemList.Count; ++i )
+					{
+						int n = (int)m_Shopper.ItemList[i];
+
+						VS1Item vs1i = (VS1Item)m_Stone.ItemList[n];
+
+						Type type = vs1i.GetItemType();
+
+						if ( type != null )
+						{
+							object o = Activator.CreateInstance( type );
+
+							if ( o is Mobile )
+							{
+								Mobile m = (Mobile)o;
+
+								ArrayList items = new ArrayList();
+
+								m.MoveToWorld( from.Location, from.Map );
+								if ( m is BaseCreature )
+								{
+									BaseCreature c = (BaseCreature)m;
+									c.ControlMaster = from;
+									c.Controlled = true;
+									c.ControlTarget = from;
+									c.ControlOrder = OrderType.Follow;
+
+									items.Add( c );
+								}
+								int total = 0;
+								while( vs1i.Amount-1 > total )
+								{
+									object o2 = Activator.CreateInstance( type );
+									Mobile m2 = (Mobile)o2;
+
+									m2.MoveToWorld( from.Location, from.Map );
+									if ( m2 is BaseCreature )
+									{
+										BaseCreature c = (BaseCreature)m2;
+										c.ControlMaster = from;
+										c.Controlled = true;
+										c.ControlTarget = from;
+										c.ControlOrder = OrderType.Follow;
+
+										items.Add( c );
+									}
+									total++;
+								}
+
+								if ( vs1i.BlessBond )
+									from.SendGump( new VendorStoneBlessBondGump( from, vs1i, m_Stone, items ) );
+							}
+							if ( o is Item )
+							{
+								Item item = (Item)o;
+
+								ArrayList items = new ArrayList();
+
+								items.Add( item );
+
+								if ( item.Stackable )
+								{
+									if ( vs1i.Amount > 60000 )
+									{
+										item.Amount = 60000;
+
+										int aleft = vs1i.Amount-60000;
+
+										while( aleft > 0 )
+										{
+											object o2 = Activator.CreateInstance( type );
+											if ( o2 is Item )
+											{
+												Item item2 = (Item)o2;
+
+												if ( aleft > 60000 )
+												{
+													item2.Amount = 60000;
+													aleft -= 60000;
+												}
+												else
+												{
+													item2.Amount = aleft;
+													aleft = 0;
+												}
+												from.AddToBackpack( item2 );
+												items.Add( item2 );
+											}
+										}
+									}
+									else
+										item.Amount = vs1i.Amount;
+								}
+								else
+								{
+									int total = 0;
+									while( vs1i.Amount-1 > total )
+									{
+										object o2 = Activator.CreateInstance( type );
+										if ( o2 is Item )
+										{
+											Item item2 = (Item)o2;
+											from.AddToBackpack( item2 );
+											items.Add( item2 );
+										}
+										total++;
+									}
+								}
+
+								if ( vs1i.BlessBond )
+									from.SendGump( new VendorStoneBlessBondGump( from, vs1i, m_Stone, items ) );
+								from.AddToBackpack( item );
+							}
+						}
+					}
+					if ( m_Shopper.TotalPrice() == 0 )
+						from.SendMessage( "You recieve the item for free." );
+					else if ( m_Stone.Currency != null && m_Stone.Currency != "" )
+						from.SendMessage( "You buy the items with the "+m_Stone.Currency+" in your backpack." );
+					else
+						from.SendMessage( "You buy the items with the currency in your backpack." );
+				}
+				else if ( from.BankBox.ConsumeTotal( m_Stone.GetCurrency(), m_Shopper.TotalPrice(), true ) )
+				{
+					for( int i = 0; i < m_Shopper.ItemList.Count; ++i )
+					{
+						int n = (int)m_Shopper.ItemList[i];
+
+						VS1Item vs1i = (VS1Item)m_Stone.ItemList[n];
+
+						Type type = vs1i.GetItemType();
+
+						if ( type != null )
+						{
+							object o = Activator.CreateInstance( type );
+
+							if ( o is Mobile )
+							{
+								Mobile m = (Mobile)o;
+
+								ArrayList items = new ArrayList();
+
+								m.MoveToWorld( from.Location, from.Map );
+								if ( m is BaseCreature )
+								{
+									BaseCreature c = (BaseCreature)m;
+									c.ControlMaster = from;
+									c.Controlled = true;
+									c.ControlTarget = from;
+									c.ControlOrder = OrderType.Follow;
+
+									items.Add( c );
+
+									if ( vs1i.BlessBond )
+										from.SendGump( new VendorStoneBlessBondGump( from, vs1i, m_Stone, items ) );
+								}
+								int total = 0;
+								while( vs1i.Amount-1 > total )
+								{
+									object o2 = Activator.CreateInstance( type );
+									Mobile m2 = (Mobile)o2;
+
+									m2.MoveToWorld( from.Location, from.Map );
+									if ( m2 is BaseCreature )
+									{
+										BaseCreature c = (BaseCreature)m2;
+										c.ControlMaster = from;
+										c.Controlled = true;
+										c.ControlTarget = from;
+										c.ControlOrder = OrderType.Follow;
+
+										items.Add( c );
+									}
+									total++;
+								}
+							}
+							if ( o is Item )
+							{
+								Item item = (Item)o;
+
+								ArrayList items = new ArrayList();
+
+								items.Add( item );
+
+								if ( item.Stackable )
+								{
+									if ( vs1i.Amount > 60000 )
+									{
+										item.Amount = 60000;
+
+										int aleft = vs1i.Amount-60000;
+
+										while( aleft > 0 )
+										{
+											object o2 = Activator.CreateInstance( type );
+											if ( o2 is Item )
+											{
+												Item item2 = (Item)o2;
+
+												if ( aleft > 60000 )
+												{
+													item2.Amount = 60000;
+													aleft -= 60000;
+												}
+												else
+												{
+													item2.Amount = aleft;
+													aleft = 0;
+												}
+												from.AddToBackpack( item2 );
+												items.Add( item2 );
+											}
+										}
+									}
+									else
+										item.Amount = vs1i.Amount;
+								}
+								else
+								{
+									int total = 0;
+									while( vs1i.Amount-1 > total )
+									{
+										object o2 = Activator.CreateInstance( type );
+										if ( o2 is Item )
+										{
+											Item item2 = (Item)o2;
+											from.AddToBackpack( item2 );
+											items.Add( item2 );
+										}
+										total++;
+									}
+								}
+
+								if ( vs1i.BlessBond )
+									from.SendGump( new VendorStoneBlessBondGump( from, vs1i, m_Stone, items ) );
+								from.AddToBackpack( item );
+							}
+						}
+					}
+					if ( m_Stone.Currency != null && m_Stone.Currency != "" )
+						from.SendMessage( "You buy the items with the "+m_Stone.Currency+" in your bank box." );
+					else
+						from.SendMessage( "You buy the items with the currency in your bank box." );
+				}
+				else
+				{
+                    from.SendGump(new VendorStoneBuyGump(m_Shopper, m_Stone));
+                    from.SendMessage("You cannot not afford the items on your list.");
+				}
+			}
+			if ( info.ButtonID >= 2 )
+			{
+				if ( info.ButtonID-2 > m_Shopper.ItemList.Count-1 || info.ButtonID-2 < 0 )
+					return;
+				m_Shopper.ItemList.Remove( m_Shopper.ItemList[info.ButtonID-2] );
+				from.SendGump( new VendorStoneBuyGump( m_Shopper, m_Stone ) );
+			}
+		}
+	}
+	public class StaffVendorGump2 : Gump
+	{
+        private VendorStone m_Stone;
+
+        public StaffVendorGump2( Mobile from, VendorStone stone ) : base( 125, 125 )
+        {
+			m_Stone = stone;
+
+			m_Stone.CloseGumps( from );
+
+			AddPage( 0 );
+
+			AddBackground( 0, 0, 160, 140, 0x2436 );
+
+			AddButton( 10, 10, 4005, 4007, 1, GumpButtonType.Reply, 0 );
+			AddLabel( 40, 10, 1152, "Vendor Gump" );
+			AddButton( 10, 30, 4005, 4007, 2, GumpButtonType.Reply, 0 );
+			AddLabel( 40, 30, 1152, "Add Item" );
+
+			if ( from.AccessLevel >= AccessLevel.Administrator )
+				AddButton( 10, 50, 4005, 4007, 3, GumpButtonType.Reply, 0 );
+			if ( m_Stone.AccessLevel == AccessLevel.Administrator )
+				AddLabel( 40, 50, 1302, "Administrator" );
+			else if ( m_Stone.AccessLevel == AccessLevel.Seer )
+				AddLabel( 40, 50, 324, "Seer" );
+			else if ( m_Stone.AccessLevel == AccessLevel.GameMaster )
+				AddLabel( 40, 50, 33, "Game Master" );
+			else if ( m_Stone.AccessLevel == AccessLevel.Counselor )
+				AddLabel( 40, 50, 2, "Counselor" );
+			else if ( m_Stone.AccessLevel == AccessLevel.Player )
+				AddLabel( 40, 50, 88, "Player" );
+
+			AddButton( 10, 70, 4005, 4007, 4, GumpButtonType.Reply, 0 );
+			if ( m_Stone.EditMode )
+				AddLabel( 40, 70, 5, "Edit Mode" );
+			else
+				AddLabel( 40, 70, 33, "Edit Mode" );
+			AddLabel( 10, 90, 1152, "Currency:" );
+			AddTextEntry( 70, 90, 85, 15, 1152, 0, m_Stone.Currency );
+
+			AddButton( 10, 110, 4005, 4007, 0, GumpButtonType.Reply, 0 );
+			AddLabel( 40, 110, 33, "Close" );
+		}
+
+		public override void OnResponse( NetState state, RelayInfo info )
+		{
+			Mobile from = state.Mobile;
+
+			if ( m_Stone.Deleted )
+				return;
+
+			string currency = "";
+			string[] tr = new string[ 1 ];
+			foreach( TextRelay t in info.TextEntries )
+				tr[ t.EntryID ] = t.Text;
+			if ( tr[ 0 ] != null )
+				currency = tr[ 0 ];
+			m_Stone.Currency = currency;
+
+			if ( info.ButtonID == 0 )
+			{
+				from.SendMessage( "Closed." );
+			}
+			if ( info.ButtonID == 1 )
+			{
+				from.SendGump( new VendorGump2( new VSShopper2( from, m_Stone ), m_Stone ) );
+			}
+			if ( info.ButtonID == 2 )
+			{
+				from.SendGump( new VendorStoneAddItemGump( from, m_Stone ) );
+			}
+			if ( info.ButtonID == 3 )
+			{
+				if ( m_Stone.AccessLevel == AccessLevel.Administrator )
+					m_Stone.AccessLevel = AccessLevel.Player;
+				else if ( m_Stone.AccessLevel == AccessLevel.Seer )
+					m_Stone.AccessLevel = AccessLevel.Administrator;
+				else if ( m_Stone.AccessLevel == AccessLevel.GameMaster )
+					m_Stone.AccessLevel = AccessLevel.Seer;
+				else if ( m_Stone.AccessLevel == AccessLevel.Counselor )
+					m_Stone.AccessLevel = AccessLevel.GameMaster;
+				else if ( m_Stone.AccessLevel == AccessLevel.Player )
+					m_Stone.AccessLevel = AccessLevel.Counselor;
+
+				from.SendGump( new StaffVendorGump2( from, m_Stone ) );
+			}
+			if ( info.ButtonID == 4 )
+			{
+				if ( m_Stone.EditMode )
+					m_Stone.EditMode = false;
+				else
+					m_Stone.EditMode = true;
+
+				from.SendGump( new StaffVendorGump2( from, m_Stone ) );
+			}
+		}
+	}
+	public class VendorStoneAddItemGump : Gump
+	{
+		private Mobile m_Mobile;
+		private VendorStone m_Stone;
+
+		public VendorStoneAddItemGump( Mobile mobile, VendorStone stone ) : base( 25, 50 )
+		{
+			m_Mobile = mobile;
+			m_Stone = stone;
+
+			m_Stone.CloseGumps( m_Mobile );
+
+			AddPage( 0 );
+
+			AddBackground( 25, 10, 420, 430, 0x2436 );
+
+			AddImageTiled( 33, 20, 401, 411, 2624 );
+			AddAlphaRegion( 33, 20, 401, 411 );
+
+			AddLabel( 125, 40, 1152, "Vendor Stone" );
+
+			AddLabel( 40, 60, 1152, "Add a Mobile or Item:" );
+			AddTextEntry( 40, 80, 225, 15, 5, 0, "Item Here" );
+			AddLabel( 40, 100, 1152, "Gump Name:" );
+			AddTextEntry( 40, 120, 225, 15, 5, 1, "Name Here" );
+			AddLabel( 40, 140, 1152, "Price:" );
+			AddTextEntry( 40, 160, 225, 15, 5, 2, "0" );
+			AddLabel( 40, 180, 1152, "Item Amount:" );
+			AddTextEntry( 40, 200, 225, 15, 5, 3, "1" );
+
+			AddCheck( 40, 220, 0x2342, 0x2343, false, 1 );
+			AddLabel( 70, 220, 1152, "Bless/Bond:" );
+
+			AddLabel( 40, 240, 1152, "Bless/Bond Price:" );
+			AddTextEntry( 40, 260, 225, 15, 5, 4, "0" );
+
+			AddLabel( 40, 280, 1152, "Description:" );
+			AddTextEntry( 40, 300, 360, 75, 5, 5, "Des Here" );
+
+			AddButton( 40, 390, 4005, 4007, 0, GumpButtonType.Reply, 0 );
+			AddLabel( 70, 393, 1152, "Back" );
+			AddButton( 120, 390, 4005, 4007, 1, GumpButtonType.Reply, 0 );
+			AddLabel( 150, 393, 1152, "Apply" );
+		}
+
+		public override void OnResponse( NetState state, RelayInfo info )
+		{
+			Mobile from = state.Mobile;
+
+			if ( from == null )
+				return;
+
+			if ( info.ButtonID == 0 )
+			{
+				from.SendGump( new StaffVendorGump2( from, m_Stone ) );
+			}
+			if ( info.ButtonID == 1 )
+			{
+				string item = "";
+				string gumpname = "";
+				int price = 0;
+				int amount = 0;
+				int bbprice = 0;
+				bool blessbond = info.IsSwitched( 1 );
+				string description = "";
+
+				string[] tr = new string[ 6 ];
+				foreach( TextRelay t in info.TextEntries )
+				{
+					tr[ t.EntryID ] = t.Text;
+				}
+
+				try { price = (int) uint.Parse( tr[ 2 ] ); }
+				catch {}
+				try { amount = (int) uint.Parse( tr[ 3 ] ); }
+				catch {}
+				try { bbprice = (int) uint.Parse( tr[ 4 ] ); }
+				catch {}
+				if ( tr[ 0 ] != null )
+					item = tr[ 0 ];
+				if ( tr[ 1 ] != null )
+					gumpname = tr[ 1 ];
+				if ( tr[ 5 ] != null )
+					description = tr[ 5 ];
+
+				if ( amount <= 0 )
+					amount = 1;
+
+				if ( item != "" && gumpname != "" )
+				{
+					VS1Item vs1i = new VS1Item( item, gumpname, price, amount, blessbond, bbprice, description );
+					m_Stone.ItemList.Add( vs1i );
+
+					from.SendMessage( "Item Added." );
+				}
+				else
+				{
+					from.SendMessage( "You must set a property for each one." );
+				}
+
+				from.SendGump( new VendorStoneAddItemGump( from, m_Stone ) );
+			}
+		}
+	}
+	public class VendorStoneEditGump : Gump
+	{
+                private VendorStone m_Stone;
+                private VS1Item m_VS1I;
+
+                public VendorStoneEditGump( Mobile from, VS1Item vs1i, VendorStone stone ) : base( 125, 125 )
+                {
+			m_Stone = stone;
+			m_VS1I = vs1i;
+
+			m_Stone.CloseGumps( from );
+
+			AddPage( 0 );
+
+			AddBackground( 0, 0, 420, 300, 0x2436 );
+
+			AddLabel( 13, 10, 1152, "Item Type:" );
+			AddTextEntry( 83, 10, 100, 15, 1152, 0, m_VS1I.Item );
+
+			AddLabel( 13, 30, 1152, "Gump Name:" );
+			AddTextEntry( 90, 30, 90, 15, 1152, 1, m_VS1I.Name );
+
+			AddLabel( 13, 50, 1152, "Price:" );
+			AddTextEntry( 53, 50, 85, 15, 1152, 2, ""+m_VS1I.Price );
+
+			AddLabel( 13, 70, 1152, "Amount:" );
+			AddTextEntry( 63, 70, 85, 15, 1152, 3, ""+m_VS1I.Amount );
+
+			AddCheck( 15, 90, 0x2342, 0x2343, m_VS1I.BlessBond, 1 );
+			AddLabel( 45, 90, 1152, "Bless/Bond:" );
+
+			AddLabel( 13, 110, 1152, "Bless/Bond Price:" );
+			AddTextEntry( 123, 110, 225, 15, 1152, 4, ""+m_VS1I.BBPrice );
+
+			AddLabel( 13, 130, 1152, "Description:" );
+			AddTextEntry( 13, 150, 387, 75, 1152, 5, m_VS1I.Description );
+
+			AddButton( 15, 245, 4005, 4007, 2, GumpButtonType.Reply, 0 );
+			AddLabel( 45, 245, 33, "Remove" );
+
+			AddButton( 15, 265, 4005, 4007, 0, GumpButtonType.Reply, 0 );
+			AddLabel( 45, 265, 33, "Back" );
+			AddButton( 85, 265, 4005, 4007, 1, GumpButtonType.Reply, 0 );
+			AddLabel( 115, 265, 33, "Apply" );
+		}
+
+		public override void OnResponse( NetState state, RelayInfo info )
+		{
+			Mobile from = state.Mobile;
+
+			if ( m_Stone.Deleted )
+				return;
+
+			if ( info.ButtonID == 0 )
+			{
+				from.SendMessage( "Back." );
+				from.SendGump( new VendorGump2( new VSShopper2( from, m_Stone ), m_Stone ) );
+			}
+			if ( info.ButtonID == 1 )
+			{
+				string item = "";
+				string gumpname = "";
+				int price = 0;
+				int amount = 0;
+				int bbprice = 0;
+				bool blessbond = info.IsSwitched( 1 );
+				string description = "";
+
+				string[] tr = new string[ 6 ];
+				foreach( TextRelay t in info.TextEntries )
+				{
+					tr[ t.EntryID ] = t.Text;
+				}
+
+				try { price = (int) uint.Parse( tr[ 2 ] ); }
+				catch {}
+				try { amount = (int) uint.Parse( tr[ 3 ] ); }
+				catch {}
+				try { bbprice = (int) uint.Parse( tr[ 4 ] ); }
+				catch {}
+				if ( tr[ 0 ] != null )
+					item = tr[ 0 ];
+				if ( tr[ 0 ] != null )
+					gumpname = tr[ 1 ];
+				if ( tr[ 5 ] != null )
+					description = tr[ 5 ];
+
+				m_VS1I.Item = item;
+				m_VS1I.Name = gumpname;
+				m_VS1I.Price = price;
+				m_VS1I.Amount = amount;
+				m_VS1I.BBPrice = bbprice;
+				m_VS1I.BlessBond = blessbond;
+				m_VS1I.Description = description;
+
+				from.SendGump( new VendorGump2( new VSShopper2( from, m_Stone ), m_Stone ) );
+			}
+			if ( info.ButtonID == 2 )
+			{
+				if ( m_Stone.ItemList.Contains( m_VS1I ) )
+					m_Stone.ItemList.Remove( m_VS1I );
+
+				from.SendGump( new VendorGump2( new VSShopper2( from, m_Stone ), m_Stone ) );
+			}
+		}
+	}
+	public class VendorStoneBlessBondGump : Gump
+	{
+                private VendorStone m_Stone;
+                private VS1Item m_VS1I;
+		private ArrayList m_Objects;
+
+                public VendorStoneBlessBondGump( Mobile from, VS1Item vs1i, VendorStone stone, ArrayList objects ) : base( 125, 125 )
+                {
+			m_Stone = stone;
+			m_VS1I = vs1i;
+			m_Objects = objects;
+
+			m_Stone.CloseGumps( from );
+
+			AddPage( 0 );
+
+			AddBackground( 0, 0, 375, 85, 0x2436 );
+
+			if ( objects.Count > 0 && objects[0] is Item )
+				AddLabel( 13, 10, 1152, "Would you like to bless this item: '"+ vs1i.Name +"'?" );
+			else if ( objects.Count > 0 && objects[0] is Mobile )
+				AddLabel( 13, 10, 1152, "Would you like to bond this pet: '"+ vs1i.Name +"'?" );
+			AddLabel( 13, 25, 1152, "Price: "+ vs1i.BBPrice );
+
+			AddButton( 15, 50, 4005, 4007, 0, GumpButtonType.Reply, 0 );
+			AddLabel( 45, 50, 33, "No" );
+			AddButton( 85, 50, 4005, 4007, 1, GumpButtonType.Reply, 0 );
+			AddLabel( 115, 50, 33, "Yes" );
+		}
+
+		public override void OnResponse( NetState state, RelayInfo info )
+		{
+			Mobile from = state.Mobile;
+
+			if ( m_Stone.Deleted )
+				return;
+
+			if ( info.ButtonID == 0 )
+			{
+				if ( m_Objects.Count > 0 && m_Objects[0] is Item )
+					from.SendMessage( "You decide not to bless this item." );
+				else if ( m_Objects.Count > 0 && m_Objects[0] is Mobile )
+					from.SendMessage( "You decide not to bond this pet." );
+			}
+			if ( info.ButtonID == 1 )
+			{
+                if ( from.Backpack.ConsumeTotal( m_Stone.GetCurrency(), m_VS1I.BBPrice, true ) || m_VS1I.BBPrice == 0 )
+				{
+					for( int i = 0; i < m_Objects.Count; i++ )
+					{
+						object o = m_Objects[i];
+
+						if ( o is Item )
+							((Item)o).LootType = LootType.Blessed;
+						if ( o is Mobile && (Mobile)o is BaseCreature )
+							((BaseCreature)o).IsBonded = true;
+					}
+				}
+				else if ( from.BankBox.ConsumeTotal( m_Stone.GetCurrency(), m_VS1I.BBPrice, true ) )
+				{
+					for( int i = 0; i < m_Objects.Count; i++ )
+					{
+						object o = m_Objects[i];
+
+						if ( o is Item )
+							((Item)o).LootType = LootType.Blessed;
+						if ( o is Mobile && (Mobile)o is BaseCreature )
+							((BaseCreature)o).IsBonded = true;
+					}
+				}
+				else
+					from.SendMessage( "You cannot not afford to do this." );
+			}
+		}
+	}
+	public class VendorStoneDescriptionGump : Gump
+	{
+		public string Center( string text )
+		{
+			return String.Format( "<CENTER>{0}</CENTER>", text );
+		}
+
+		public string Color( string text, int color )
+		{
+			return String.Format( "<BASEFONT COLOR=#{0:X6}>{1}</BASEFONT>", color, text );
+		}
+
+                public VendorStoneDescriptionGump( Mobile from, string description, string name ) : base( 125, 125 )
+                {
+			from.CloseGump( typeof( VendorStoneDescriptionGump ) );
+
+			AddPage( 0 );
+
+			AddBackground( 0, 0, 200, 200, 0x2436 );
+
+			AddHtml( 10, 10, 190, 20, Color( Center( "Description For: '"+name+"'" ), 0xFFFFFF ), false, false );
+
+			AddHtml( 10, 30, 190, 145, Color( Center( description ), 0xFFFFFF ), false, true );
+		}
+
+		public override void OnResponse( NetState state, RelayInfo info )
+		{
+			Mobile from = state.Mobile;
+
+			if ( info.ButtonID == 0 )
+				from.SendMessage( "Closed." );
+		}
+	}
+}

--- a/Scripts/Items/Addons/AdvancedTrainingDummy.cs
+++ b/Scripts/Items/Addons/AdvancedTrainingDummy.cs
@@ -15,7 +15,7 @@ namespace Server.Items
         public AdvancedTrainingDummy(int itemID) : base(itemID)
         {
             MinSkill = -25.0;
-            MaxSkill = +60.0;
+            MaxSkill = 120.0;
         }
 
         public override void UpdateItemID()

--- a/Scripts/Items/Addons/TrainingDummies.cs
+++ b/Scripts/Items/Addons/TrainingDummies.cs
@@ -19,7 +19,7 @@ namespace Server.Items
             : base(itemID)
         {
             this.m_MinSkill = -25.0;
-            this.m_MaxSkill = +25.0;
+            this.m_MaxSkill = 120.0;
         }
 
         public TrainingDummy(Serial serial)

--- a/Scripts/Items/Artifacts/DespiseArtifacts.cs
+++ b/Scripts/Items/Artifacts/DespiseArtifacts.cs
@@ -127,15 +127,15 @@ namespace Server.Items
 		public DespicableQuiver() : base(0x2B02)
 		{
 			Hue = 2671;
-			
+
 			DamageIncrease = 10;
 			WeightReduction = 30;
 			Attributes.BonusDex = 5;
-			SkillBonuses.SetValues( 0, SkillName.Archery, 5.0 );
+			Attributes.BonusStam = 8;
 			Attributes.ReflectPhysical = 5;
 			Attributes.AttackChance = 5;
             LowerAmmoCost = 30;
-			
+
 			switch(Utility.Random(5))
 			{
 				case 0: Resistances.Physical = 10; break;
@@ -143,6 +143,15 @@ namespace Server.Items
                 case 2: Resistances.Cold = 10; break;
                 case 3: Resistances.Poison = 10; break;
                 case 4: Resistances.Energy = 10; break;
+			}
+
+			switch(Utility.Random(5))
+			{
+				case 0: SkillBonuses.SetValues(0, SkillName.Archery, 20.0); break;
+				case 1: SkillBonuses.SetValues(0, SkillName.Swords, 20.0); break;
+				case 2: SkillBonuses.SetValues(0, SkillName.Macing, 20.0); break;
+				case 3: SkillBonuses.SetValues(0, SkillName.Fencing, 20.0); break;
+				case 4: SkillBonuses.SetValues(0, SkillName.Wrestling, 20.0); break;
 			}
 		}
 		

--- a/Scripts/Items/Artifacts/Equipment/Armor/Aegis.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/Aegis.cs
@@ -5,14 +5,30 @@ namespace Server.Items
     public class Aegis : HeaterShield
     {
 		public override bool IsArtifact { get { return true; } }
+
+        private static readonly SkillName[] m_PossibleBonusSkills = new SkillName[]
+        {
+            SkillName.Parry,
+            SkillName.Tactics,
+            SkillName.Anatomy,
+            SkillName.Healing,
+            SkillName.MagicResist
+        };
+
         [Constructable]
         public Aegis()
         {
             Hue = 0x47E;
             ArmorAttributes.SelfRepair = 5;
+            ArmorAttributes.ReactiveParalyze = 1;
             Attributes.ReflectPhysical = 15;
             Attributes.DefendChance = 15;
             Attributes.LowerManaCost = 8;
+            Attributes.SpellChanneling = 1;
+            Attributes.WeaponDamage = 15;
+            Attributes.RegenStam = 4;
+            Attributes.BonusStam = 8;
+            SkillBonuses.SetValues(0, m_PossibleBonusSkills[Utility.Random(m_PossibleBonusSkills.Length)], 20.0);
         }
 
         public Aegis(Serial serial)
@@ -26,7 +42,7 @@ namespace Server.Items
             {
                 return 1061602;
             }
-        }// Ægis
+        }// ï¿½gis
         public override int ArtifactRarity
         {
             get

--- a/Scripts/Items/Artifacts/Equipment/Armor/AegisOfGrace.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/AegisOfGrace.cs
@@ -11,6 +11,7 @@ namespace Server.Items
         public AegisOfGrace()
         {
             SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
+            SkillBonuses.SetValues(1, SkillName.AnimalTaming, 10.0);
             Attributes.DefendChance = 20;
             ArmorAttributes.SelfRepair = 2;
 

--- a/Scripts/Items/Artifacts/Equipment/Armor/AnimatedLegsoftheInsaneTinker.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/AnimatedLegsoftheInsaneTinker.cs
@@ -11,24 +11,27 @@ namespace Server.Items
         {
             Hue = 2310;
             Attributes.BonusDex = 5;
-            Attributes.RegenStam = 2;
+            Attributes.BonusStam = 8;
+            Attributes.RegenStam = 3;
             Attributes.WeaponDamage = 10;
             Attributes.WeaponSpeed = 10;
+            Attributes.AttackChance = 15;
             ArmorAttributes.LowerStatReq = 50;
+            SkillBonuses.SetValues(0, SkillName.Tactics, 20.0);
         }
 
         public AnimatedLegsoftheInsaneTinker(Serial serial)
             : base(serial)
         {
         }
-        
+
         public override int LabelNumber { get{return 1113760;} }// Animated Legs of the Insane Tinker
 
         public override int BasePhysicalResistance
         {
             get
             {
-                return 17;
+                return 15;
             }
         }
         public override int BaseFireResistance
@@ -42,7 +45,7 @@ namespace Server.Items
         {
             get
             {
-                return 7;
+                return 15;
             }
         }
         public override int BasePoisonResistance
@@ -56,7 +59,7 @@ namespace Server.Items
         {
             get
             {
-                return 2;
+                return 15;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Armor/ArcaneShield.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/ArcaneShield.cs
@@ -5,6 +5,16 @@ namespace Server.Items
     public class ArcaneShield : WoodenKiteShield
     {
 		public override bool IsArtifact { get { return true; } }
+
+        private static readonly SkillName[] m_PossibleBonusSkills = new SkillName[]
+        {
+            SkillName.Parry,
+            SkillName.Chivalry,
+            SkillName.Spellweaving,
+            SkillName.MagicResist,
+            SkillName.Magery
+        };
+
         [Constructable]
         public ArcaneShield()
         {
@@ -13,6 +23,12 @@ namespace Server.Items
             Attributes.SpellChanneling = 1;
             Attributes.DefendChance = 15;
             Attributes.CastSpeed = 1;
+            Attributes.SpellDamage = 15;
+            Attributes.Luck = 250;
+            Attributes.LowerManaCost = 8;
+            Attributes.RegenMana = 2;
+            Attributes.BonusMana = 8;
+            SkillBonuses.SetValues(0, m_PossibleBonusSkills[Utility.Random(m_PossibleBonusSkills.Length)], 20.0);
         }
 
         public ArcaneShield(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/ArmorOfFortune.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/ArmorOfFortune.cs
@@ -9,10 +9,16 @@ namespace Server.Items
         public ArmorOfFortune()
         {
             Hue = 0x501;
-            Attributes.Luck = 200;
+            Attributes.Luck = 300;
             Attributes.DefendChance = 15;
             Attributes.LowerRegCost = 40;
             ArmorAttributes.MageArmor = 1;
+            Attributes.BonusStr = 15;
+            Attributes.BonusDex = 15;
+            Attributes.BonusInt = 15;
+            Attributes.SpellDamage = 15;
+            Attributes.RegenMana = 2;
+            Attributes.BonusMana = 8;
         }
 
         public ArmorOfFortune(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/AzaroksLegplates.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/AzaroksLegplates.cs
@@ -21,6 +21,7 @@ namespace Server.Items
             Attributes.BonusMana = 8;
             Attributes.LowerManaCost = 8;
             Attributes.WeaponDamage = 20;
+            SkillBonuses.SetValues(0, SkillName.Healing, 15.0);
         }
 
         public AzaroksLegplates(Serial serial)
@@ -69,6 +70,7 @@ namespace Server.Items
             Attributes.BonusMana = 8;
             Attributes.LowerManaCost = 8;
             Attributes.WeaponDamage = 20;
+            SkillBonuses.SetValues(0, SkillName.Healing, 15.0);
         }
 
         public GargishAzaroksLegplates(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/AzaroksLegplates.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/AzaroksLegplates.cs
@@ -2,83 +2,33 @@ using System;
 
 namespace Server.Items
 {
-    public class GlovesOfFeudalGrip : DragonGloves
+    public class AzaroksLegplates : PlateLegs
     {
-        public override int LabelNumber { get { return 1157349; } } // gloves of feudal grip
         public override bool IsArtifact { get { return true; } }
 
         [Constructable]
-        public GlovesOfFeudalGrip()
+        public AzaroksLegplates()
         {
-            Resource = CraftResource.None;
+            Name = "Azarok's Legplates";
+            Hue = 1161;
+            Weight = 7.0;
 
-            Attributes.BonusStr = 8;
+
+            Attributes.BonusDex = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 4;
             Attributes.BonusStam = 8;
-            Attributes.RegenHits = 3;
-            Attributes.RegenMana = 3;
-            Attributes.WeaponDamage = 30;
-            Attributes.LowerManaCost = 20;
-            SkillBonuses.SetValues(0, SkillName.Necromancy, 15.0);
+            Attributes.BonusMana = 8;
+            Attributes.LowerManaCost = 8;
+            Attributes.WeaponDamage = 20;
         }
 
-        public GlovesOfFeudalGrip(Serial serial)
+        public AzaroksLegplates(Serial serial)
             : base(serial)
         {
         }
 
-        public override int BasePhysicalResistance { get { return 20; } }
-        public override int BaseFireResistance { get { return 20; } }
-        public override int BaseColdResistance { get { return 20; } }
-        public override int BasePoisonResistance { get { return 20; } }
-        public override int BaseEnergyResistance { get { return 20; } }        
-        public override int InitMinHits { get { return 255; } }
-        public override int InitMaxHits { get { return 255; } }
-        public override CraftResource DefaultResource { get { return CraftResource.None; } }
-
-        public override void Serialize(GenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.WriteEncodedInt(1); // version
-        }
-
-        public override void Deserialize(GenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            int version = reader.ReadEncodedInt();
-
-            if (version == 0)
-            {
-                Resource = CraftResource.None;
-            }
-        }
-    }
-
-    public class GargishKiltOfFeudalVise : GargishPlateKilt
-    {
-        public override int LabelNumber { get { return 1157367; } } // Kilt of Feudal Vise
-        public override bool IsArtifact { get { return true; } }
-
-        [Constructable]
-        public GargishKiltOfFeudalVise()
-        {
-            Resource = CraftResource.None;
-
-            Attributes.BonusStr = 8;
-            Attributes.BonusStam = 8;
-            Attributes.RegenHits = 3;
-            Attributes.RegenMana = 3;
-            Attributes.WeaponDamage = 30;
-            Attributes.LowerManaCost = 20;
-            SkillBonuses.SetValues(0, SkillName.Necromancy, 15.0);
-        }
-
-        public GargishKiltOfFeudalVise(Serial serial)
-            : base(serial)
-        {
-        }
-
+        public override int AosStrReq { get { return 90; } }
         public override int BasePhysicalResistance { get { return 20; } }
         public override int BaseFireResistance { get { return 20; } }
         public override int BaseColdResistance { get { return 20; } }
@@ -86,25 +36,65 @@ namespace Server.Items
         public override int BaseEnergyResistance { get { return 20; } }
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
-        public override CraftResource DefaultResource { get { return CraftResource.None; } }
 
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
-            writer.WriteEncodedInt(1); // version
+            writer.Write(0);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
 
-            int version = reader.ReadEncodedInt();
+    public class GargishAzaroksLegplates : GargishPlateLegs
+    {
+        public override bool IsArtifact { get { return true; } }
 
-            if (version == 0)
-            {
-                Resource = CraftResource.None;
-            }
+        [Constructable]
+        public GargishAzaroksLegplates()
+        {
+            Name = "Gargish Azarok's Legplates";
+            Hue = 1161;
+            Weight = 7.0;
+
+
+            Attributes.BonusDex = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 4;
+            Attributes.BonusStam = 8;
+            Attributes.BonusMana = 8;
+            Attributes.LowerManaCost = 8;
+            Attributes.WeaponDamage = 20;
+        }
+
+        public GargishAzaroksLegplates(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int AosStrReq { get { return 90; } }
+        public override int BasePhysicalResistance { get { return 20; } }
+        public override int BaseFireResistance { get { return 20; } }
+        public override int BaseColdResistance { get { return 20; } }
+        public override int BasePoisonResistance { get { return 20; } }
+        public override int BaseEnergyResistance { get { return 20; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
         }
     }
 }

--- a/Scripts/Items/Artifacts/Equipment/Armor/BalronBoneArmor.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/BalronBoneArmor.cs
@@ -19,6 +19,8 @@ namespace Server.Items
             Attributes.BonusStam = 8;
             Attributes.BonusMana = 8;
             Attributes.LowerManaCost = 8;
+            Attributes.AttackChance = 5;
+            Attributes.DefendChance = 5;
         }
 
         public BalronBoneArmor(Serial serial)
@@ -28,7 +30,7 @@ namespace Server.Items
 
         public override int AosStrReq { get { return 60; } }
         public override int BasePhysicalResistance { get { return 15; } }
-        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 20; } }
         public override int BaseColdResistance { get { return 15; } }
         public override int BasePoisonResistance { get { return 15; } }
         public override int BaseEnergyResistance { get { return 15; } }
@@ -65,6 +67,8 @@ namespace Server.Items
             Attributes.BonusStam = 8;
             Attributes.BonusMana = 8;
             Attributes.LowerManaCost = 8;
+            Attributes.AttackChance = 5;
+            Attributes.DefendChance = 5;
         }
 
         public GargishBalronBoneArmor(Serial serial)
@@ -74,7 +78,7 @@ namespace Server.Items
 
         public override int AosStrReq { get { return 60; } }
         public override int BasePhysicalResistance { get { return 15; } }
-        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 20; } }
         public override int BaseColdResistance { get { return 15; } }
         public override int BasePoisonResistance { get { return 15; } }
         public override int BaseEnergyResistance { get { return 15; } }

--- a/Scripts/Items/Artifacts/Equipment/Armor/BalronBoneArmor.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/BalronBoneArmor.cs
@@ -1,0 +1,96 @@
+using System;
+
+namespace Server.Items
+{
+    public class BalronBoneArmor : BoneChest
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public BalronBoneArmor()
+        {
+            Name = "Balron Bone Armor";
+            Hue = 1109;
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusDex = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.BonusStam = 8;
+            Attributes.BonusMana = 8;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public BalronBoneArmor(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int AosStrReq { get { return 60; } }
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishBalronBoneArmor : GargishPlateChest
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishBalronBoneArmor()
+        {
+            Name = "Gargish Balron Bone Armor";
+            Hue = 1109;
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusDex = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.BonusStam = 8;
+            Attributes.BonusMana = 8;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public GargishBalronBoneArmor(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int AosStrReq { get { return 60; } }
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Armor/BalronBoneArmor.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/BalronBoneArmor.cs
@@ -6,12 +6,19 @@ namespace Server.Items
     {
         public override bool IsArtifact { get { return true; } }
 
+        public static SkillName GetRandomCombatSkill()
+        {
+            SkillName[] skills = new SkillName[] { SkillName.Swords, SkillName.Macing, SkillName.Fencing, SkillName.Wrestling, SkillName.Throwing };
+            return skills[Utility.Random(skills.Length)];
+        }
+
         [Constructable]
         public BalronBoneArmor()
         {
             Name = "Balron Bone Armor";
             Hue = 1109;
 
+            SkillBonuses.SetValues(0, GetRandomCombatSkill(), 20.0);
             Attributes.BonusStr = 5;
             Attributes.BonusDex = 5;
             Attributes.BonusInt = 5;
@@ -19,6 +26,7 @@ namespace Server.Items
             Attributes.BonusStam = 8;
             Attributes.BonusMana = 8;
             Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 15;
             Attributes.AttackChance = 5;
             Attributes.DefendChance = 5;
         }
@@ -60,6 +68,7 @@ namespace Server.Items
             Name = "Gargish Balron Bone Armor";
             Hue = 1109;
 
+            SkillBonuses.SetValues(0, BalronBoneArmor.GetRandomCombatSkill(), 20.0);
             Attributes.BonusStr = 5;
             Attributes.BonusDex = 5;
             Attributes.BonusInt = 5;
@@ -67,6 +76,7 @@ namespace Server.Items
             Attributes.BonusStam = 8;
             Attributes.BonusMana = 8;
             Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 15;
             Attributes.AttackChance = 5;
             Attributes.DefendChance = 5;
         }

--- a/Scripts/Items/Artifacts/Equipment/Armor/BritchesOfWarding.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/BritchesOfWarding.cs
@@ -20,9 +20,14 @@ namespace Server.Items
                 case 5: AbsorptionAttributes.EaterDamage = 9; break;
             }
 
-            Attributes.BonusStam = 12;
-            Attributes.AttackChance = 10;
+            Attributes.BonusStam = 10;
+            Attributes.BonusMana = 10;
+            Attributes.AttackChance = 15;
             Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 15;
+            Attributes.WeaponDamage = 15;
+            Attributes.WeaponSpeed = 5;
+            SkillBonuses.SetValues(0, SkillName.Anatomy, 20.0);
         }
 
         public BritchesOfWarding(Serial serial)
@@ -71,9 +76,14 @@ namespace Server.Items
                 case 5: AbsorptionAttributes.EaterDamage = 9; break;
             }
 
-            Attributes.BonusStam = 12;
-            Attributes.AttackChance = 10;
+            Attributes.BonusStam = 10;
+            Attributes.BonusMana = 10;
+            Attributes.AttackChance = 15;
             Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 15;
+            Attributes.WeaponDamage = 15;
+            Attributes.WeaponSpeed = 5;
+            SkillBonuses.SetValues(0, SkillName.Anatomy, 20.0);
         }
 
         public GargishBritchesOfWarding(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/CorruptedPaladinVambraces.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/CorruptedPaladinVambraces.cs
@@ -6,12 +6,19 @@ namespace Server.Items
     {
         public override bool IsArtifact { get { return true; } }
 
+        public static SkillName GetRandomPaladinSkill()
+        {
+            SkillName[] skills = new SkillName[] { SkillName.MagicResist, SkillName.Necromancy, SkillName.Magery, SkillName.Mysticism, SkillName.Bushido, SkillName.Chivalry, SkillName.Spellweaving };
+            return skills[Utility.Random(skills.Length)];
+        }
+
         [Constructable]
         public CorruptedPaladinVambraces()
         {
             Name = "Corrupted Paladin Vambraces";
             Hue = 1109;
 
+            SkillBonuses.SetValues(0, GetRandomPaladinSkill(), 15.0);
             Attributes.BonusStr = 5;
             Attributes.BonusDex = 5;
             Attributes.BonusStam = 10;
@@ -20,6 +27,7 @@ namespace Server.Items
             Attributes.RegenStam = 4;
             Attributes.RegenMana = 4;
             Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 15;
         }
 
         public CorruptedPaladinVambraces(Serial serial)
@@ -58,6 +66,7 @@ namespace Server.Items
             Name = "Gargish Corrupted Paladin Vambraces";
             Hue = 1109;
 
+            SkillBonuses.SetValues(0, CorruptedPaladinVambraces.GetRandomPaladinSkill(), 15.0);
             Attributes.BonusStr = 5;
             Attributes.BonusDex = 5;
             Attributes.BonusStam = 10;
@@ -66,6 +75,7 @@ namespace Server.Items
             Attributes.RegenStam = 4;
             Attributes.RegenMana = 4;
             Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 15;
         }
 
         public GargishCorruptedPaladinVambraces(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/CorruptedPaladinVambraces.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/CorruptedPaladinVambraces.cs
@@ -1,0 +1,96 @@
+using System;
+
+namespace Server.Items
+{
+    public class CorruptedPaladinVambraces : PlateArms
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public CorruptedPaladinVambraces()
+        {
+            Name = "Corrupted Paladin Vambraces";
+            Hue = 1109;
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusDex = 5;
+            Attributes.BonusStam = 10;
+            Attributes.BonusMana = 10;
+            Attributes.RegenHits = 4;
+            Attributes.RegenStam = 4;
+            Attributes.RegenMana = 4;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public CorruptedPaladinVambraces(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishCorruptedPaladinVambraces : GargishPlateArms
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishCorruptedPaladinVambraces()
+        {
+            Name = "Gargish Corrupted Paladin Vambraces";
+            Hue = 1109;
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusDex = 5;
+            Attributes.BonusStam = 10;
+            Attributes.BonusMana = 10;
+            Attributes.RegenHits = 4;
+            Attributes.RegenStam = 4;
+            Attributes.RegenMana = 4;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public GargishCorruptedPaladinVambraces(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Armor/CuffsOfTheArchmage.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/CuffsOfTheArchmage.cs
@@ -12,7 +12,10 @@ namespace Server.Items
         {
             SkillBonuses.SetValues(0, SkillName.MagicResist, 15.0);
             Attributes.BonusMana = 5;
+            Attributes.RegenHits = 4;
+            Attributes.RegenStam = 4;
             Attributes.RegenMana = 4;
+            Attributes.LowerRegCost = 20;
             Attributes.SpellDamage = 20;
             ArmorAttributes.MageArmor = 1;
         }
@@ -55,7 +58,10 @@ namespace Server.Items
         {
             SkillBonuses.SetValues(0, SkillName.MagicResist, 15.0);
             Attributes.BonusMana = 5;
+            Attributes.RegenHits = 4;
+            Attributes.RegenStam = 4;
             Attributes.RegenMana = 4;
+            Attributes.LowerRegCost = 20;
             Attributes.SpellDamage = 20;
             ArmorAttributes.MageArmor = 1;
         }

--- a/Scripts/Items/Artifacts/Equipment/Armor/CuffsOfTheArchmage.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/CuffsOfTheArchmage.cs
@@ -18,6 +18,8 @@ namespace Server.Items
             Attributes.LowerRegCost = 20;
             Attributes.SpellDamage = 20;
             ArmorAttributes.MageArmor = 1;
+            AbsorptionAttributes.EaterFire = 15;
+            Attributes.WeaponDamage = 20;
         }
 
         public CuffsOfTheArchmage(Serial serial)
@@ -64,6 +66,8 @@ namespace Server.Items
             Attributes.LowerRegCost = 20;
             Attributes.SpellDamage = 20;
             ArmorAttributes.MageArmor = 1;
+            AbsorptionAttributes.EaterFire = 15;
+            Attributes.WeaponDamage = 20;
         }
 
         public GargishCuffsOfTheArchmage(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/DeathwardensStuddedLeather.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/DeathwardensStuddedLeather.cs
@@ -2,38 +2,34 @@ using System;
 
 namespace Server.Items
 {
-    public class UmbrascaleChampionsAegis : ElvenGlasses
+    public class DeathwardensGreaves : StuddedLegs
     {
         public override bool IsArtifact { get { return true; } }
 
         [Constructable]
-        public UmbrascaleChampionsAegis()
+        public DeathwardensGreaves()
         {
-            Name = "Umbrascale Champion's Aegis";
-            Hue = 1109;
+            Name = "Deathwarden's Studded Leather Greaves";
+            Hue = 1150;
+            Weight = 4.0;
 
-            SkillBonuses.SetValues(0, GetRandomCombatSkill(), 15.0);
+            AbsorptionAttributes.EaterKinetic = 15;
 
             Attributes.BonusStr = 5;
-            Attributes.BonusDex = 5;
-            Attributes.BonusInt = 5;
             Attributes.BonusHits = 5;
-            Attributes.BonusStam = 8;
-            Attributes.BonusMana = 8;
-            Attributes.LowerManaCost = 8;
+            Attributes.BonusMana = 12;
+            Attributes.RegenMana = 4;
+            Attributes.SpellDamage = 8;
+            Attributes.LowerManaCost = 10;
+            Attributes.LowerRegCost = 20;
         }
 
-        public static SkillName GetRandomCombatSkill()
-        {
-            SkillName[] skills = new SkillName[] { SkillName.Swords, SkillName.Macing, SkillName.Fencing, SkillName.Archery, SkillName.Throwing };
-            return skills[Utility.Random(skills.Length)];
-        }
-
-        public UmbrascaleChampionsAegis(Serial serial)
+        public DeathwardensGreaves(Serial serial)
             : base(serial)
         {
         }
 
+        public override int AosStrReq { get { return 20; } }
         public override int BasePhysicalResistance { get { return 15; } }
         public override int BaseFireResistance { get { return 15; } }
         public override int BaseColdResistance { get { return 15; } }
@@ -45,44 +41,44 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
-            writer.Write(0); // version
+            writer.Write(0);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 
-    public class GargishUmbrascaleChampionsAegis : GargishGlasses
+    public class GargishDeathwardensGreaves : GargishStoneLegs
     {
         public override bool IsArtifact { get { return true; } }
 
         [Constructable]
-        public GargishUmbrascaleChampionsAegis()
+        public GargishDeathwardensGreaves()
         {
-            Name = "Gargish Umbrascale Champion's Aegis";
-            Hue = 1109;
+            Name = "Gargish Deathwarden's Greaves";
+            Hue = 1150;
+            Weight = 5.0;
 
-            SkillBonuses.SetValues(0, UmbrascaleChampionsAegis.GetRandomCombatSkill(), 15.0);
+            AbsorptionAttributes.EaterKinetic = 15;
 
             Attributes.BonusStr = 5;
-            Attributes.BonusDex = 5;
-            Attributes.BonusInt = 5;
             Attributes.BonusHits = 5;
-            Attributes.BonusStam = 8;
-            Attributes.BonusMana = 8;
-            Attributes.LowerManaCost = 8;
+            Attributes.BonusMana = 12;
+            Attributes.RegenMana = 4;
+            Attributes.SpellDamage = 8;
+            Attributes.LowerManaCost = 10;
+            Attributes.LowerRegCost = 20;
         }
 
-        public GargishUmbrascaleChampionsAegis(Serial serial)
+        public GargishDeathwardensGreaves(Serial serial)
             : base(serial)
         {
         }
 
+        public override int AosStrReq { get { return 20; } }
         public override int BasePhysicalResistance { get { return 15; } }
         public override int BaseFireResistance { get { return 15; } }
         public override int BaseColdResistance { get { return 15; } }
@@ -94,15 +90,13 @@ namespace Server.Items
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);
-
-            writer.Write(0); // version
+            writer.Write(0);
         }
 
         public override void Deserialize(GenericReader reader)
         {
             base.Deserialize(reader);
-
-            int version = reader.ReadInt();
+            reader.ReadInt();
         }
     }
 }

--- a/Scripts/Items/Artifacts/Equipment/Armor/FeyLeggings.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/FeyLeggings.cs
@@ -21,6 +21,7 @@ namespace Server.Items
             _ElfOnly = true;
 
             ArmorAttributes.MageArmor = 1;
+            SkillBonuses.SetValues(0, SkillName.Fishing, 20.0);
         }
 
         public FeyLeggings(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/GauntletsOfAnger.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/GauntletsOfAnger.cs
@@ -12,6 +12,7 @@ namespace Server.Items
             Attributes.BonusHits = 8;
             Attributes.RegenHits = 2;
             Attributes.DefendChance = 10;
+            SkillBonuses.SetValues(0, SkillName.Tactics, 10.0);
         }
 
         public GauntletsOfAnger(Serial serial)
@@ -30,35 +31,35 @@ namespace Server.Items
         {
             get
             {
-                return 4;
+                return 10;
             }
         }
         public override int BaseFireResistance
         {
             get
             {
-                return 4;
+                return 10;
             }
         }
         public override int BaseColdResistance
         {
             get
             {
-                return 5;
+                return 10;
             }
         }
         public override int BasePoisonResistance
         {
             get
             {
-                return 6;
+                return 10;
             }
         }
         public override int BaseEnergyResistance
         {
             get
             {
-                return 5;
+                return 10;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Armor/GauntletsOfNobility.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/GauntletsOfNobility.cs
@@ -10,8 +10,14 @@ namespace Server.Items
         {
             Hue = 0x4FE;
             Attributes.BonusStr = 8;
-            Attributes.Luck = 100;
+            Attributes.Luck = 250;
             Attributes.WeaponDamage = 20;
+            Attributes.BonusStam = 10;
+            Attributes.BonusMana = 10;
+            Attributes.RegenMana = 4;
+            Attributes.RegenHits = 4;
+            Attributes.RegenStam = 4;
+            SkillBonuses.SetValues(0, SkillName.Chivalry, 30.0);
         }
 
         public GauntletsOfNobility(Serial serial)
@@ -37,14 +43,35 @@ namespace Server.Items
         {
             get
             {
-                return 18;
+                return 15;
+            }
+        }
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseColdResistance
+        {
+            get
+            {
+                return 15;
             }
         }
         public override int BasePoisonResistance
         {
             get
             {
-                return 20;
+                return 15;
+            }
+        }
+        public override int BaseEnergyResistance
+        {
+            get
+            {
+                return 15;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Armor/GladiatorsCollar.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/GladiatorsCollar.cs
@@ -11,7 +11,10 @@ namespace Server.Items
             Hue = 0x26d;
             Attributes.BonusHits = 10;
             Attributes.AttackChance = 10;
+            Attributes.BonusDex = 5;
+            Attributes.BonusStam = 8;
             ArmorAttributes.MageArmor = 1;
+            SkillBonuses.SetValues(0, SkillName.Bushido, 10.0);
         }
 
         public GladiatorsCollar(Serial serial)
@@ -30,35 +33,35 @@ namespace Server.Items
         {
             get
             {
-                return 18;
+                return 20;
             }
         }
         public override int BaseFireResistance
         {
             get
             {
-                return 18;
+                return 20;
             }
         }
         public override int BaseColdResistance
         {
             get
             {
-                return 17;
+                return 20;
             }
         }
         public override int BasePoisonResistance
         {
             get
             {
-                return 18;
+                return 20;
             }
         }
         public override int BaseEnergyResistance
         {
             get
             {
-                return 16;
+                return 20;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Armor/GlovesOfFeudalGrip.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/GlovesOfFeudalGrip.cs
@@ -17,7 +17,10 @@ namespace Server.Items
             Attributes.RegenHits = 3;
             Attributes.RegenMana = 3;
             Attributes.WeaponDamage = 30;
+            Attributes.WeaponSpeed = 10;
+            Attributes.CastSpeed = 1;
             Attributes.LowerManaCost = 20;
+            AbsorptionAttributes.EaterPoison = 15;
             SkillBonuses.SetValues(0, SkillName.Necromancy, 15.0);
         }
 
@@ -70,7 +73,10 @@ namespace Server.Items
             Attributes.RegenHits = 3;
             Attributes.RegenMana = 3;
             Attributes.WeaponDamage = 30;
+            Attributes.WeaponSpeed = 10;
+            Attributes.CastSpeed = 1;
             Attributes.LowerManaCost = 20;
+            AbsorptionAttributes.EaterPoison = 15;
             SkillBonuses.SetValues(0, SkillName.Necromancy, 15.0);
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Armor/GlovesOfTheArchlich.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/GlovesOfTheArchlich.cs
@@ -1,0 +1,105 @@
+using System;
+
+namespace Server.Items
+{
+    public class GlovesOfTheArchlich : BoneGloves
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GlovesOfTheArchlich()
+        {
+            Name = "Gloves of the Archlich";
+            Hue = 1150;
+
+            AbsorptionAttributes.EaterFire = 15;
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.BonusMana = 8;
+            Attributes.RegenHits = 3;
+            Attributes.RegenMana = 3;
+            Attributes.LowerManaCost = 10;
+            Attributes.LowerRegCost = 20;
+
+            ArmorAttributes.MageArmor = 1;
+        }
+
+        public GlovesOfTheArchlich(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishKiltOfTheArchlich : GargishPlateKilt
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishKiltOfTheArchlich()
+        {
+            Name = "Gargish Kilt of the Archlich";
+            Hue = 1150;
+
+            AbsorptionAttributes.EaterFire = 15;
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.BonusMana = 8;
+            Attributes.RegenHits = 3;
+            Attributes.RegenMana = 3;
+            Attributes.LowerManaCost = 10;
+            Attributes.LowerRegCost = 20;
+
+            ArmorAttributes.MageArmor = 1;
+        }
+
+        public GargishKiltOfTheArchlich(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int AosStrReq { get { return 55; } }
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Armor/GlovesOfTheHolyWarrior.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/GlovesOfTheHolyWarrior.cs
@@ -15,7 +15,7 @@ namespace Server.Items
             Hue = 1153;
 
             SkillBonuses.SetValues(0, SkillName.Chivalry, 15.0);
-            SkillBonuses.SetValues(1, SkillName.Necromancy, -30.0);
+            SkillBonuses.SetValues(1, SkillName.Necromancy, 15.0);
 
             Attributes.BonusStr = 5;
             Attributes.BonusInt = 5;
@@ -112,7 +112,7 @@ namespace Server.Items
             Hue = 1153;
 
             SkillBonuses.SetValues(0, SkillName.Chivalry, 15.0);
-            SkillBonuses.SetValues(1, SkillName.Necromancy, -30.0);
+            SkillBonuses.SetValues(1, SkillName.Necromancy, 15.0);
 
             Attributes.BonusStr = 5;
             Attributes.BonusInt = 5;

--- a/Scripts/Items/Artifacts/Equipment/Armor/GlovesOfTheHolyWarrior.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/GlovesOfTheHolyWarrior.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using Server.Mobiles;
+
+namespace Server.Items
+{
+    public class GlovesOfTheHolyWarrior : PlateGloves
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GlovesOfTheHolyWarrior()
+        {
+            Name = "Gloves of the Holy Warrior";
+            Hue = 1153;
+
+            SkillBonuses.SetValues(0, SkillName.Chivalry, 15.0);
+            SkillBonuses.SetValues(1, SkillName.Necromancy, -30.0);
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.BonusStam = 10;
+            Attributes.BonusMana = 15;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public GlovesOfTheHolyWarrior(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override int OnHit(BaseWeapon weapon, int damageTaken)
+        {
+            Mobile wearer = Parent as Mobile;
+            Mobile attacker = weapon.Parent as Mobile;
+
+            if (wearer != null && attacker != null && attacker is BaseCreature && 0.10 > Utility.RandomDouble())
+            {
+                ReactiveHolyLight(wearer);
+            }
+
+            return base.OnHit(weapon, damageTaken);
+        }
+
+        public static void ReactiveHolyLight(Mobile wearer)
+        {
+            List<Mobile> targets = new List<Mobile>();
+
+            foreach (Mobile m in wearer.GetMobilesInRange(3))
+            {
+                if (m != wearer && m is BaseCreature && wearer.CanBeHarmful(m))
+                    targets.Add(m);
+            }
+
+            if (targets.Count > 0)
+            {
+                wearer.PlaySound(0x212);
+                wearer.PlaySound(0x206);
+
+                Effects.SendLocationParticles(
+                    EffectItem.Create(wearer.Location, wearer.Map, EffectItem.DefaultDuration),
+                    0x376A, 1, 29, 0x47D, 2, 9962, 0);
+                Effects.SendLocationParticles(
+                    EffectItem.Create(new Point3D(wearer.X, wearer.Y, wearer.Z - 7), wearer.Map, EffectItem.DefaultDuration),
+                    0x37C4, 1, 29, 0x47D, 2, 9502, 0);
+
+                foreach (Mobile target in targets)
+                {
+                    wearer.DoHarmful(target);
+
+                    int damage = Utility.RandomMinMax(15, 25);
+
+                    AOS.Damage(target, wearer, damage, 0, 0, 0, 0, 100);
+                }
+            }
+
+            targets.Clear();
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write(0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+
+    public class GargishKiltOfTheHolyWarrior : GargishPlateKilt
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishKiltOfTheHolyWarrior()
+        {
+            Name = "Gargish Kilt of the Holy Warrior";
+            Hue = 1153;
+
+            SkillBonuses.SetValues(0, SkillName.Chivalry, 15.0);
+            SkillBonuses.SetValues(1, SkillName.Necromancy, -30.0);
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.BonusStam = 10;
+            Attributes.BonusMana = 15;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public GargishKiltOfTheHolyWarrior(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override int OnHit(BaseWeapon weapon, int damageTaken)
+        {
+            Mobile wearer = Parent as Mobile;
+            Mobile attacker = weapon.Parent as Mobile;
+
+            if (wearer != null && attacker != null && attacker is BaseCreature && 0.10 > Utility.RandomDouble())
+            {
+                GlovesOfTheHolyWarrior.ReactiveHolyLight(wearer);
+            }
+
+            return base.OnHit(weapon, damageTaken);
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write(0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Armor/HelmOfInsight.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/HelmOfInsight.cs
@@ -13,6 +13,10 @@ namespace Server.Items
             Attributes.BonusMana = 15;
             Attributes.RegenMana = 2;
             Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 15;
+            SkillBonuses.SetValues(0, SkillName.EvalInt, 20.0);
+            AbsorptionAttributes.CastingFocus = 5;
+            AbsorptionAttributes.EaterFire = 10;
         }
 
         public HelmOfInsight(Serial serial)
@@ -34,11 +38,39 @@ namespace Server.Items
                 return 11;
             }
         }
+        public override int BasePhysicalResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseColdResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BasePoisonResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
         public override int BaseEnergyResistance
         {
             get
             {
-                return 17;
+                return 15;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Armor/HelmOfSwiftness.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/HelmOfSwiftness.cs
@@ -25,6 +25,7 @@ namespace Server.Items
             Attributes.CastSpeed = 1;
             Attributes.CastRecovery = 2;
             ArmorAttributes.MageArmor = 1;
+            SkillBonuses.SetValues(0, SkillName.Snooping, 20.0);
         }
 
         public HelmOfSwiftness(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/HexweaversVisage.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/HexweaversVisage.cs
@@ -14,7 +14,7 @@ namespace Server.Items
 
             AbsorptionAttributes.CastingFocus = 2;
 
-            SkillBonuses.SetValues(0, GetRandomMageSkill(), 10.0);
+            SkillBonuses.SetValues(0, GetRandomMageSkill(), 20.0);
 
             Attributes.BonusStr = 5;
             Attributes.BonusInt = 5;
@@ -29,7 +29,7 @@ namespace Server.Items
 
         public static SkillName GetRandomMageSkill()
         {
-            SkillName[] skills = new SkillName[] { SkillName.Necromancy, SkillName.Mysticism, SkillName.Magery, SkillName.Chivalry };
+            SkillName[] skills = new SkillName[] { SkillName.Necromancy, SkillName.Mysticism, SkillName.Magery, SkillName.Chivalry, SkillName.Spellweaving };
             return skills[Utility.Random(skills.Length)];
         }
 
@@ -73,7 +73,7 @@ namespace Server.Items
 
             AbsorptionAttributes.CastingFocus = 2;
 
-            SkillBonuses.SetValues(0, HexweaversVisage.GetRandomMageSkill(), 10.0);
+            SkillBonuses.SetValues(0, HexweaversVisage.GetRandomMageSkill(), 20.0);
 
             Attributes.BonusStr = 5;
             Attributes.BonusInt = 5;

--- a/Scripts/Items/Artifacts/Equipment/Armor/HexweaversVisage.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/HexweaversVisage.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Server.Items
 {
-    public class HexweaversVisage : ElvenGlasses
+    public class HexweaversVisage : WingedHelm
     {
         public override bool IsArtifact { get { return true; } }
 

--- a/Scripts/Items/Artifacts/Equipment/Armor/HexweaversVisage.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/HexweaversVisage.cs
@@ -1,0 +1,106 @@
+using System;
+
+namespace Server.Items
+{
+    public class HexweaversVisage : WingedHelm
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public HexweaversVisage()
+        {
+            Name = "Hexweaver's Visage";
+            Hue = 1266;
+
+            AbsorptionAttributes.CastingFocus = 2;
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.BonusMana = 8;
+            Attributes.SpellDamage = 5;
+            Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 20;
+
+            ArmorAttributes.MageArmor = 1;
+        }
+
+        public HexweaversVisage(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write(0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+
+    public class GargishHexweaversVisage : GargishGlasses
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishHexweaversVisage()
+        {
+            Name = "Gargish Hexweaver's Visage";
+            Hue = 1266;
+
+            AbsorptionAttributes.CastingFocus = 2;
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.BonusMana = 8;
+            Attributes.SpellDamage = 5;
+            Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 20;
+
+            ArmorAttributes.MageArmor = 1;
+        }
+
+        public GargishHexweaversVisage(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write(0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Armor/HexweaversVisage.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/HexweaversVisage.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Server.Items
 {
-    public class HexweaversVisage : WingedHelm
+    public class HexweaversVisage : ElvenGlasses
     {
         public override bool IsArtifact { get { return true; } }
 

--- a/Scripts/Items/Artifacts/Equipment/Armor/HexweaversVisage.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/HexweaversVisage.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Server.Items
 {
-    public class HexweaversVisage : WingedHelm
+    public class HexweaversVisage : ElvenGlasses
     {
         public override bool IsArtifact { get { return true; } }
 
@@ -14,6 +14,8 @@ namespace Server.Items
 
             AbsorptionAttributes.CastingFocus = 2;
 
+            SkillBonuses.SetValues(0, GetRandomMageSkill(), 10.0);
+
             Attributes.BonusStr = 5;
             Attributes.BonusInt = 5;
             Attributes.BonusHits = 5;
@@ -23,6 +25,12 @@ namespace Server.Items
             Attributes.LowerRegCost = 20;
 
             ArmorAttributes.MageArmor = 1;
+        }
+
+        public static SkillName GetRandomMageSkill()
+        {
+            SkillName[] skills = new SkillName[] { SkillName.Necromancy, SkillName.Mysticism, SkillName.Magery, SkillName.Chivalry };
+            return skills[Utility.Random(skills.Length)];
         }
 
         public HexweaversVisage(Serial serial)
@@ -64,6 +72,8 @@ namespace Server.Items
             Hue = 1266;
 
             AbsorptionAttributes.CastingFocus = 2;
+
+            SkillBonuses.SetValues(0, HexweaversVisage.GetRandomMageSkill(), 10.0);
 
             Attributes.BonusStr = 5;
             Attributes.BonusInt = 5;

--- a/Scripts/Items/Artifacts/Equipment/Armor/HolyKnightsBreastplate.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/HolyKnightsBreastplate.cs
@@ -11,6 +11,12 @@ namespace Server.Items
             Hue = 0x47E;
             Attributes.BonusHits = 10;
             Attributes.ReflectPhysical = 15;
+            Attributes.AttackChance = 15;
+            Attributes.CastRecovery = 1;
+            Attributes.LowerManaCost = 8;
+            Attributes.RegenMana = 4;
+            SkillBonuses.SetValues(0, SkillName.Chivalry, 20.0);
+            AbsorptionAttributes.EaterDamage = 10;
         }
 
         public HolyKnightsBreastplate(Serial serial)
@@ -36,7 +42,35 @@ namespace Server.Items
         {
             get
             {
-                return 35;
+                return 15;
+            }
+        }
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseColdResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BasePoisonResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseEnergyResistance
+        {
+            get
+            {
+                return 15;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Armor/InquisitorsResolution.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/InquisitorsResolution.cs
@@ -10,7 +10,12 @@ namespace Server.Items
         {
             Hue = 0x4F2;
             Attributes.CastRecovery = 3;
+            Attributes.CastSpeed = 2;
             Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 20;
+            Attributes.BonusMana = 8;
+            Attributes.BonusInt = 8;
+            Attributes.RegenMana = 3;
             ArmorAttributes.MageArmor = 1;
         }
 
@@ -33,18 +38,39 @@ namespace Server.Items
                 return 10;
             }
         }
+        public override int BasePhysicalResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
         public override int BaseColdResistance
         {
             get
             {
-                return 22;
+                return 15;
+            }
+        }
+        public override int BasePoisonResistance
+        {
+            get
+            {
+                return 15;
             }
         }
         public override int BaseEnergyResistance
         {
             get
             {
-                return 17;
+                return 15;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Armor/JackalsCollar.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/JackalsCollar.cs
@@ -10,7 +10,11 @@ namespace Server.Items
         {
             Hue = 0x6D1;
             Attributes.BonusDex = 15;
+            Attributes.BonusStam = 10;
             Attributes.RegenHits = 2;
+            Attributes.RegenMana = 2;
+            Attributes.WeaponSpeed = 10;
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 20.0);
         }
 
         public JackalsCollar(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/LeggingsOfBane.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/LeggingsOfBane.cs
@@ -10,8 +10,13 @@ namespace Server.Items
         {
             Hue = 0x4F5;
             ArmorAttributes.DurabilityBonus = 100;
-            Attributes.BonusStam = 8;
+            Attributes.BonusStam = 5;
+            Attributes.BonusMana = 5;
             Attributes.AttackChance = 20;
+            Attributes.WeaponDamage = 15;
+            Attributes.WeaponSpeed = 5;
+            Attributes.LowerManaCost = 5;
+            SkillBonuses.SetValues(0, SkillName.Anatomy, 20.0);
         }
 
         public LeggingsOfBane(Serial serial)
@@ -33,11 +38,39 @@ namespace Server.Items
                 return 11;
             }
         }
+        public override int BasePhysicalResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseColdResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
         public override int BasePoisonResistance
         {
             get
             {
-                return 36;
+                return 15;
+            }
+        }
+        public override int BaseEnergyResistance
+        {
+            get
+            {
+                return 15;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Armor/LightsRampart.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/LightsRampart.cs
@@ -8,9 +8,12 @@ namespace Server.Items
         [Constructable]
         public LightsRampart()
         {
-            Hue = 1272;			
+            Hue = 1272;
             Attributes.SpellChanneling = 1;
             Attributes.DefendChance = 20;
+            Attributes.EnhancePotions = 15;
+            Attributes.RegenMana = 2;
+            SkillBonuses.SetValues(0, SkillName.AnimalTaming, 20.0);
         }
 
         public LightsRampart(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/MidnightBracers.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/MidnightBracers.cs
@@ -11,6 +11,9 @@ namespace Server.Items
             Hue = 0x455;
             SkillBonuses.SetValues(0, SkillName.Necromancy, 20.0);
             Attributes.SpellDamage = 10;
+            Attributes.LowerRegCost = 15;
+            Attributes.BonusMana = 5;
+            Attributes.LowerManaCost = 8;
             ArmorAttributes.MageArmor = 1;
         }
 
@@ -37,7 +40,35 @@ namespace Server.Items
         {
             get
             {
-                return 23;
+                return 15;
+            }
+        }
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseColdResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BasePoisonResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseEnergyResistance
+        {
+            get
+            {
+                return 15;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Armor/OrcChieftainHelm.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/OrcChieftainHelm.cs
@@ -12,6 +12,9 @@ namespace Server.Items
 
             Attributes.Luck = 100;
             Attributes.RegenHits = 3;
+            Attributes.BonusStam = 15;
+            WeaponAttributes.HitLowerDefend = 30;
+            SkillBonuses.SetValues(0, SkillName.Tactics, 20.0);
 
             if (Utility.RandomBool())
                 Attributes.BonusHits = 30;

--- a/Scripts/Items/Artifacts/Equipment/Armor/OrnateCrownOfTheHarrower.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/OrnateCrownOfTheHarrower.cs
@@ -12,6 +12,11 @@ namespace Server.Items
             Attributes.RegenHits = 2;
             Attributes.RegenStam = 3;
             Attributes.WeaponDamage = 25;
+            Attributes.LowerRegCost = 15;
+            Attributes.LowerManaCost = 8;
+            Attributes.BonusStam = 8;
+            SkillBonuses.SetValues(0, SkillName.Necromancy, 20.0);
+            AbsorptionAttributes.EaterFire = 10;
         }
 
         public OrnateCrownOfTheHarrower(Serial serial)
@@ -33,11 +38,39 @@ namespace Server.Items
                 return 11;
             }
         }
+        public override int BasePhysicalResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseColdResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
         public override int BasePoisonResistance
         {
             get
             {
-                return 17;
+                return 15;
+            }
+        }
+        public override int BaseEnergyResistance
+        {
+            get
+            {
+                return 15;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Armor/ProtectoroftheBattleMage.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/ProtectoroftheBattleMage.cs
@@ -7,16 +7,27 @@ namespace Server.Items
 		public override bool IsArtifact { get { return true; } }
 		public override int LabelNumber { get { return 1113761; } } // Protector of the Battle Mage
 		
+        private static readonly SkillName[] m_PossibleBonusSkills = new SkillName[]
+        {
+            SkillName.Inscribe,
+            SkillName.AnimalLore,
+            SkillName.Alchemy
+        };
+
         [Constructable]
         public ProtectoroftheBattleMage()
             : base()
         {
-            Hue = 1159;		
-            Attributes.LowerManaCost = 8;	
+            Hue = 1159;
+            Attributes.LowerManaCost = 8;
             Attributes.RegenMana = 2;
             Attributes.LowerRegCost = 10;
-            Attributes.SpellDamage = 5;
+            Attributes.SpellDamage = 25;
+            Attributes.BonusMana = 8;
+            Attributes.RegenHits = 2;
+            Attributes.DefendChance = 15;
             AbsorptionAttributes.CastingFocus = 3;
+            SkillBonuses.SetValues(0, m_PossibleBonusSkills[Utility.Random(m_PossibleBonusSkills.Length)], 20.0);
         }
 
         public ProtectoroftheBattleMage(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/SentinelsMempo.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/SentinelsMempo.cs
@@ -19,6 +19,7 @@ namespace Server.Items
             Attributes.BonusMana = 8;
             Attributes.AttackChance = 5;
             Attributes.DefendChance = 5;
+            Attributes.WeaponDamage = 25;
             Attributes.LowerManaCost = 8;
         }
 
@@ -67,6 +68,7 @@ namespace Server.Items
             Attributes.BonusMana = 8;
             Attributes.AttackChance = 5;
             Attributes.DefendChance = 5;
+            Attributes.WeaponDamage = 25;
             Attributes.LowerManaCost = 8;
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Armor/SentinelsMempo.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/SentinelsMempo.cs
@@ -1,0 +1,100 @@
+using System;
+
+namespace Server.Items
+{
+    public class SentinelsMempo : PlateMempo
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public SentinelsMempo()
+        {
+            Name = "Sentinel's Mempo";
+            Hue = 1157;
+
+            Attributes.BonusStr = 4;
+            Attributes.BonusDex = 4;
+            Attributes.BonusHits = 8;
+            Attributes.BonusStam = 12;
+            Attributes.BonusMana = 8;
+            Attributes.AttackChance = 5;
+            Attributes.DefendChance = 5;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public SentinelsMempo(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write(0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+
+    public class SentinelsNecklace : GargishNecklace
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public SentinelsNecklace()
+        {
+            Name = "Sentinel's Necklace";
+            Hue = 1157;
+
+            Attributes.BonusStr = 4;
+            Attributes.BonusDex = 4;
+            Attributes.BonusHits = 8;
+            Attributes.BonusStam = 12;
+            Attributes.BonusMana = 8;
+            Attributes.AttackChance = 5;
+            Attributes.DefendChance = 5;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public SentinelsNecklace(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write(0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Armor/SentinelsMempo.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/SentinelsMempo.cs
@@ -6,12 +6,19 @@ namespace Server.Items
     {
         public override bool IsArtifact { get { return true; } }
 
+        public static SkillName GetRandomSentinelSkill()
+        {
+            SkillName[] skills = new SkillName[] { SkillName.Anatomy, SkillName.Tactics, SkillName.Healing, SkillName.EvalInt, SkillName.SpiritSpeak, SkillName.Focus };
+            return skills[Utility.Random(skills.Length)];
+        }
+
         [Constructable]
         public SentinelsMempo()
         {
             Name = "Sentinel's Mempo";
             Hue = 1157;
 
+            SkillBonuses.SetValues(0, GetRandomSentinelSkill(), 15.0);
             Attributes.BonusStr = 4;
             Attributes.BonusDex = 4;
             Attributes.BonusHits = 8;
@@ -61,6 +68,7 @@ namespace Server.Items
             Name = "Sentinel's Necklace";
             Hue = 1157;
 
+            SkillBonuses.SetValues(0, SentinelsMempo.GetRandomSentinelSkill(), 15.0);
             Attributes.BonusStr = 4;
             Attributes.BonusDex = 4;
             Attributes.BonusHits = 8;

--- a/Scripts/Items/Artifacts/Equipment/Armor/ShadowDancerLeggings.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/ShadowDancerLeggings.cs
@@ -10,7 +10,9 @@ namespace Server.Items
         {
             Hue = 0x455;
             SkillBonuses.SetValues(0, SkillName.Stealth, 20.0);
-            SkillBonuses.SetValues(1, SkillName.Stealing, 20.0);
+            SkillBonuses.SetValues(1, SkillName.Snooping, 20.0);
+            SkillBonuses.SetValues(2, SkillName.DetectHidden, 20.0);
+            SkillBonuses.SetValues(3, SkillName.Lockpicking, 20.0);
         }
 
         public ShadowDancerLeggings(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/ShroudOfDeciet.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/ShroudOfDeciet.cs
@@ -10,6 +10,11 @@ namespace Server.Items
         {
             Hue = 0x38F;
             Attributes.RegenHits = 3;
+            Attributes.LowerRegCost = 15;
+            Attributes.LowerManaCost = 5;
+            Attributes.RegenMana = 2;
+            Attributes.BonusStam = 8;
+            Attributes.BonusInt = 8;
             ArmorAttributes.MageArmor = 1;
             SkillBonuses.Skill_1_Name = SkillName.MagicResist;
             SkillBonuses.Skill_1_Value = 10;
@@ -38,7 +43,7 @@ namespace Server.Items
         {
             get
             {
-                return 6;
+                return 15;
             }
         }
         public override int BaseColdResistance

--- a/Scripts/Items/Artifacts/Equipment/Armor/ShugenjasRaiment.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/ShugenjasRaiment.cs
@@ -14,14 +14,27 @@ namespace Server.Items
 
             Attributes.BonusInt = 5;
             Attributes.BonusHits = 5;
+            Attributes.BonusMana = 10;
             Attributes.RegenHits = 3;
             Attributes.RegenMana = 3;
-            Attributes.SpellDamage = 5;
+            Attributes.SpellDamage = 30;
             Attributes.CastRecovery = 1;
             Attributes.LowerManaCost = 8;
             Attributes.LowerRegCost = 20;
 
             ArmorAttributes.MageArmor = 1;
+
+            SkillBonuses.SetValues(0, GetRandomSkill(), 20.0);
+        }
+
+        public static SkillName GetRandomSkill()
+        {
+            SkillName[] skills = new SkillName[]
+            {
+                SkillName.MagicResist, SkillName.EvalInt, SkillName.Focus,
+                SkillName.SpiritSpeak, SkillName.Anatomy
+            };
+            return skills[Utility.Random(skills.Length)];
         }
 
         public ShugenjasRaiment(Serial serial)
@@ -64,14 +77,17 @@ namespace Server.Items
 
             Attributes.BonusInt = 5;
             Attributes.BonusHits = 5;
+            Attributes.BonusMana = 10;
             Attributes.RegenHits = 3;
             Attributes.RegenMana = 3;
-            Attributes.SpellDamage = 5;
+            Attributes.SpellDamage = 30;
             Attributes.CastRecovery = 1;
             Attributes.LowerManaCost = 8;
             Attributes.LowerRegCost = 20;
 
             ArmorAttributes.MageArmor = 1;
+
+            SkillBonuses.SetValues(0, ShugenjasRaiment.GetRandomSkill(), 20.0);
         }
 
         public GargishShugenjasRaiment(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/ShugenjasRaiment.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/ShugenjasRaiment.cs
@@ -1,0 +1,104 @@
+using System;
+
+namespace Server.Items
+{
+    public class ShugenjasRaiment : PlateDo
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public ShugenjasRaiment()
+        {
+            Name = "Shugenja's Raiment";
+            Hue = 1266;
+
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.RegenHits = 3;
+            Attributes.RegenMana = 3;
+            Attributes.SpellDamage = 5;
+            Attributes.CastRecovery = 1;
+            Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 20;
+
+            ArmorAttributes.MageArmor = 1;
+        }
+
+        public ShugenjasRaiment(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write(0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+
+    public class GargishShugenjasRaiment : GargishPlateChest
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishShugenjasRaiment()
+        {
+            Name = "Gargish Shugenja's Raiment";
+            Hue = 1266;
+
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.RegenHits = 3;
+            Attributes.RegenMana = 3;
+            Attributes.SpellDamage = 5;
+            Attributes.CastRecovery = 1;
+            Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 20;
+
+            ArmorAttributes.MageArmor = 1;
+        }
+
+        public GargishShugenjasRaiment(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write(0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Armor/TongueoftheBeast.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/TongueoftheBeast.cs
@@ -15,6 +15,8 @@ namespace Server.Items
             Attributes.SpellChanneling = 1;
             Attributes.RegenStam = 3;
             Attributes.RegenMana = 3;
+            Attributes.Luck = 300;
+            SkillBonuses.SetValues(0, SkillName.AnimalLore, 20.0);
         }
 
         public TongueOfTheBeast(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/TunicOfFire.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/TunicOfFire.cs
@@ -12,6 +12,12 @@ namespace Server.Items
             ArmorAttributes.SelfRepair = 5;
             Attributes.NightSight = 1;
             Attributes.ReflectPhysical = 15;
+            Attributes.WeaponSpeed = 5;
+            Attributes.LowerRegCost = 15;
+            Attributes.LowerManaCost = 8;
+            AbsorptionAttributes.EaterFire = 15;
+            AbsorptionAttributes.ResonanceFire = 15;
+            SkillBonuses.SetValues(0, SkillName.Anatomy, 20.0);
         }
 
         public TunicOfFire(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Armor/UmbrascaleChampionsAegis.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/UmbrascaleChampionsAegis.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Server.Items
 {
-    public class UmbrascaleChampionsAegis : WingedHelm
+    public class UmbrascaleChampionsAegis : ElvenGlasses
     {
         public override bool IsArtifact { get { return true; } }
 

--- a/Scripts/Items/Artifacts/Equipment/Armor/UmbrascaleChampionsAegis.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/UmbrascaleChampionsAegis.cs
@@ -1,0 +1,98 @@
+using System;
+
+namespace Server.Items
+{
+    public class UmbrascaleChampionsAegis : WingedHelm
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public UmbrascaleChampionsAegis()
+        {
+            Name = "Umbrascale Champion's Aegis";
+            Hue = 1109;
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusDex = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.BonusStam = 8;
+            Attributes.BonusMana = 8;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public UmbrascaleChampionsAegis(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write(0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+
+    public class GargishUmbrascaleChampionsAegis : GargishGlasses
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishUmbrascaleChampionsAegis()
+        {
+            Name = "Gargish Umbrascale Champion's Aegis";
+            Hue = 1109;
+
+            Attributes.BonusStr = 5;
+            Attributes.BonusDex = 5;
+            Attributes.BonusInt = 5;
+            Attributes.BonusHits = 5;
+            Attributes.BonusStam = 8;
+            Attributes.BonusMana = 8;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public GargishUmbrascaleChampionsAegis(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write(0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Armor/UmbrascaleChampionsAegis.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/UmbrascaleChampionsAegis.cs
@@ -12,7 +12,7 @@ namespace Server.Items
             Name = "Umbrascale Champion's Aegis";
             Hue = 1109;
 
-            SkillBonuses.SetValues(0, GetRandomCombatSkill(), 15.0);
+            SkillBonuses.SetValues(0, GetRandomCombatSkill(), 20.0);
 
             Attributes.BonusStr = 5;
             Attributes.BonusDex = 5;
@@ -67,7 +67,7 @@ namespace Server.Items
             Name = "Gargish Umbrascale Champion's Aegis";
             Hue = 1109;
 
-            SkillBonuses.SetValues(0, UmbrascaleChampionsAegis.GetRandomCombatSkill(), 15.0);
+            SkillBonuses.SetValues(0, UmbrascaleChampionsAegis.GetRandomCombatSkill(), 20.0);
 
             Attributes.BonusStr = 5;
             Attributes.BonusDex = 5;

--- a/Scripts/Items/Artifacts/Equipment/Armor/UmbrascaleChampionsAegis.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/UmbrascaleChampionsAegis.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Server.Items
 {
-    public class UmbrascaleChampionsAegis : ElvenGlasses
+    public class UmbrascaleChampionsAegis : WingedHelm
     {
         public override bool IsArtifact { get { return true; } }
 

--- a/Scripts/Items/Artifacts/Equipment/Armor/VoiceOfTheFallenKing.cs
+++ b/Scripts/Items/Artifacts/Equipment/Armor/VoiceOfTheFallenKing.cs
@@ -10,8 +10,13 @@ namespace Server.Items
         {
             Hue = 0x76D;
             Attributes.BonusStr = 8;
+            Attributes.BonusStam = 12;
+            Attributes.BonusMana = 12;
             Attributes.RegenHits = 5;
             Attributes.RegenStam = 3;
+            Attributes.LowerManaCost = 8;
+            AbsorptionAttributes.EaterDamage = 15;
+            SkillBonuses.SetValues(0, SkillName.Healing, 20.0);
         }
 
         public VoiceOfTheFallenKing(Serial serial)
@@ -33,18 +38,39 @@ namespace Server.Items
                 return 11;
             }
         }
+        public override int BasePhysicalResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
         public override int BaseColdResistance
         {
             get
             {
-                return 18;
+                return 15;
+            }
+        }
+        public override int BasePoisonResistance
+        {
+            get
+            {
+                return 15;
             }
         }
         public override int BaseEnergyResistance
         {
             get
             {
-                return 18;
+                return 15;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Clothing/ANecromancerShroud.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/ANecromancerShroud.cs
@@ -9,6 +9,8 @@ namespace Server.Items
         public ANecromancerShroud()
         {
             Hue = 0x455;
+            SkillBonuses.SetValues(0, SkillName.Necromancy, 15.0);
+            Attributes.RegenHits = 2;
         }
 
         public ANecromancerShroud(Serial serial)
@@ -23,6 +25,13 @@ namespace Server.Items
                 return 1094913;
             }
         }// A Necromancer Shroud [Replica]
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
         public override int BaseColdResistance
         {
             get

--- a/Scripts/Items/Artifacts/Equipment/Clothing/AcidProofRobe.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/AcidProofRobe.cs
@@ -6,16 +6,23 @@ namespace Server.Items
 	{
 		public override int LabelNumber { get { return 1095236; } }// Acid-Proof Robe [Replica]
         public override int BaseFireResistance { get { return 4; } }
+        public override int BasePoisonResistance { get { return 20; } }
         public override int InitMinHits { get { return 150; } }
         public override int InitMaxHits { get { return 150; } }
         public override bool CanFortify { get {  return false; } }
 		public override bool IsArtifact { get { return true; } }
-		
+
         [Constructable]
         public AcidProofRobe()
         {
             Hue = 0x455;
             LootType = LootType.Blessed;
+            SkillBonuses.SetValues(0, SkillName.Poisoning, 30.0);
+            Attributes.BonusMana = 8;
+            Attributes.BonusStam = 8;
+            Attributes.DefendChance = 15;
+            Attributes.EnhancePotions = 15;
+            Attributes.Luck = 300;
         }
 
         public AcidProofRobe(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/CaptainJohnsHat.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/CaptainJohnsHat.cs
@@ -12,8 +12,13 @@ namespace Server.Items
             Attributes.BonusDex = 8;
             Attributes.NightSight = 1;
             Attributes.AttackChance = 15;
-            SkillBonuses.Skill_1_Name = SkillName.Swords;
-            SkillBonuses.Skill_1_Value = 20;
+
+            SkillName[] combatSkills = new SkillName[]
+            {
+                SkillName.Swords, SkillName.Macing, SkillName.Fencing,
+                SkillName.Archery, SkillName.Wrestling
+            };
+            SkillBonuses.SetValues(0, combatSkills[Utility.Random(combatSkills.Length)], 20.0);
         }
 
         public CaptainJohnsHat(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/CaptainJohnsHat.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/CaptainJohnsHat.cs
@@ -19,6 +19,7 @@ namespace Server.Items
                 SkillName.Archery, SkillName.Wrestling
             };
             SkillBonuses.SetValues(0, combatSkills[Utility.Random(combatSkills.Length)], 20.0);
+            WeaponAttributes.HitLowerDefend = 30;
         }
 
         public CaptainJohnsHat(Serial serial)
@@ -37,35 +38,35 @@ namespace Server.Items
         {
             get
             {
-                return 2;
+                return 12;
             }
         }
         public override int BaseFireResistance
         {
             get
             {
-                return 6;
+                return 12;
             }
         }
         public override int BaseColdResistance
         {
             get
             {
-                return 9;
+                return 12;
             }
         }
         public override int BasePoisonResistance
         {
             get
             {
-                return 7;
+                return 12;
             }
         }
         public override int BaseEnergyResistance
         {
             get
             {
-                return 23;
+                return 12;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Clothing/CrimsonCincture.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/CrimsonCincture.cs
@@ -11,11 +11,24 @@ namespace Server.Items
         public CrimsonCincture()
             : base()
         {
-            Hue = 0x485;		
+            Hue = 0x485;
             Attributes.BonusDex = 5;
             Attributes.BonusHits = 10;
+            Attributes.BonusStam = 8;
             Attributes.RegenHits = 2;
             Attributes.RegenMana = 3;
+
+            SkillBonuses.SetValues(0, GetRandomSkill(), 20.0);
+        }
+
+        public static SkillName GetRandomSkill()
+        {
+            SkillName[] skills = new SkillName[]
+            {
+                SkillName.MagicResist, SkillName.Tactics, SkillName.Anatomy, SkillName.Focus,
+                SkillName.SpiritSpeak, SkillName.Ninjitsu, SkillName.Bushido, SkillName.Healing
+            };
+            return skills[Utility.Random(skills.Length)];
         }
 
         public CrimsonCincture(Serial serial)
@@ -56,8 +69,11 @@ namespace Server.Items
             Hue = 0x485;
             Attributes.BonusDex = 5;
             Attributes.BonusHits = 10;
+            Attributes.BonusStam = 8;
             Attributes.RegenHits = 2;
             Attributes.RegenMana = 3;
+
+            SkillBonuses.SetValues(0, CrimsonCincture.GetRandomSkill(), 20.0);
         }
 
         public GargishCrimsonCincture(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/CrimsonCincture.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/CrimsonCincture.cs
@@ -15,6 +15,7 @@ namespace Server.Items
             Attributes.BonusDex = 5;
             Attributes.BonusHits = 10;
             Attributes.RegenHits = 2;
+            Attributes.RegenMana = 3;
         }
 
         public CrimsonCincture(Serial serial)
@@ -56,6 +57,7 @@ namespace Server.Items
             Attributes.BonusDex = 5;
             Attributes.BonusHits = 10;
             Attributes.RegenHits = 2;
+            Attributes.RegenMana = 3;
         }
 
         public GargishCrimsonCincture(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/CrownOfTalKeesh.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/CrownOfTalKeesh.cs
@@ -11,7 +11,9 @@ namespace Server.Items
             Hue = 0x4F2;
             Attributes.BonusInt = 8;
             Attributes.RegenMana = 4;
-            Attributes.SpellDamage = 10;
+            Attributes.SpellDamage = 50;
+            Attributes.Luck = 300;
+            SkillBonuses.SetValues(0, SkillName.AnimalTaming, 20.0);
         }
 
         public CrownOfTalKeesh(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/DetectiveBoots.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/DetectiveBoots.cs
@@ -11,6 +11,10 @@ namespace Server.Items
         {
             Hue = 0x455;
             Level = Utility.RandomMinMax(0, 2);
+            Attributes.BonusStam = 8;
+            Attributes.BonusMana = 8;
+            Attributes.RegenMana = 2;
+            SkillBonuses.SetValues(1, SkillName.MagicResist, 10.0);
         }
 
         public DetectiveBoots(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/DivineCountenance.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/DivineCountenance.cs
@@ -13,6 +13,11 @@ namespace Server.Items
             Attributes.RegenMana = 2;
             Attributes.ReflectPhysical = 15;
             Attributes.LowerManaCost = 8;
+            Attributes.DefendChance = 15;
+            Attributes.LowerRegCost = 15;
+            Attributes.SpellDamage = 15;
+            Attributes.BonusMana = 8;
+            SAAbsorptionAttributes.CastingFocus = 5;
         }
 
         public DivineCountenance(Serial serial)
@@ -38,28 +43,35 @@ namespace Server.Items
         {
             get
             {
-                return 8;
+                return 18;
             }
         }
         public override int BaseFireResistance
         {
             get
             {
-                return 6;
+                return 18;
             }
         }
         public override int BaseColdResistance
         {
             get
             {
-                return 9;
+                return 18;
+            }
+        }
+        public override int BasePoisonResistance
+        {
+            get
+            {
+                return 18;
             }
         }
         public override int BaseEnergyResistance
         {
             get
             {
-                return 25;
+                return 18;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Clothing/EmbroideredOakLeafCloak.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/EmbroideredOakLeafCloak.cs
@@ -15,7 +15,11 @@ namespace Server.Items
             Hue = 0x483;
             StrRequirement = 0;
             SkillBonuses.Skill_1_Name = SkillName.Stealth;
-            SkillBonuses.Skill_1_Value = 5;
+            SkillBonuses.Skill_1_Value = 10;
+            Attributes.BonusStam = 8;
+            Attributes.LowerManaCost = 5;
+            Attributes.AttackChance = 5;
+            Attributes.RegenMana = 2;
         }
 
         public EmbroideredOakLeafCloak(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/FeudalCloakOfElements.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/FeudalCloakOfElements.cs
@@ -1,0 +1,82 @@
+using System;
+
+namespace Server.Items
+{
+    public class FeudalCloakOfElements : Cloak
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public FeudalCloakOfElements()
+        {
+            Name = "Feudal Cloak of Elements";
+            Hue = 1160;
+
+            SAAbsorptionAttributes.EaterDamage = 15;
+
+            Resistances.Fire = 15;
+
+            Attributes.RegenHits = 2;
+            Attributes.RegenStam = 3;
+            Attributes.RegenMana = 2;
+            Attributes.Luck = 150;
+        }
+
+        public FeudalCloakOfElements(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class WingArmorOfElements : GargishLeatherWingArmor
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public WingArmorOfElements()
+        {
+            Name = "Wing Armor of Elements";
+            Hue = 1160;
+
+            AbsorptionAttributes.EaterDamage = 15;
+
+            Attributes.RegenHits = 2;
+            Attributes.RegenStam = 3;
+            Attributes.RegenMana = 2;
+            Attributes.Luck = 150;
+        }
+
+        public WingArmorOfElements(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BaseFireResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/FeudalGhostwalkers.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/FeudalGhostwalkers.cs
@@ -1,0 +1,78 @@
+using System;
+
+namespace Server.Items
+{
+    public class FeudalGhostwalkers : Sandals
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public FeudalGhostwalkers()
+        {
+            Name = "Feudal Ghostwalkers";
+            Hue = 1150;
+
+            SkillBonuses.SetValues(0, SkillName.Stealth, 5.0);
+            SkillBonuses.SetValues(1, SkillName.Hiding, 5.0);
+            SkillBonuses.SetValues(2, SkillName.Ninjitsu, 5.0);
+            Attributes.NightSight = 1;
+
+            MaxHitPoints = 255;
+            HitPoints = 255;
+        }
+
+        public FeudalGhostwalkers(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishFeudalGhostwalkers : LeatherTalons
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishFeudalGhostwalkers()
+        {
+            Name = "Gargish Feudal Ghostwalkers";
+            Hue = 1150;
+
+            SkillBonuses.SetValues(0, SkillName.Stealth, 5.0);
+            SkillBonuses.SetValues(1, SkillName.Hiding, 5.0);
+            SkillBonuses.SetValues(2, SkillName.Ninjitsu, 5.0);
+            Attributes.NightSight = 1;
+
+            MaxHitPoints = 255;
+            HitPoints = 255;
+        }
+
+        public GargishFeudalGhostwalkers(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/FeudalGhostwalkers.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/FeudalGhostwalkers.cs
@@ -12,9 +12,9 @@ namespace Server.Items
             Name = "Feudal Ghostwalkers";
             Hue = 1150;
 
-            SkillBonuses.SetValues(0, SkillName.Stealth, 5.0);
-            SkillBonuses.SetValues(1, SkillName.Hiding, 5.0);
-            SkillBonuses.SetValues(2, SkillName.Ninjitsu, 5.0);
+            SkillBonuses.SetValues(0, SkillName.Stealth, 10.0);
+            SkillBonuses.SetValues(1, SkillName.Hiding, 10.0);
+            SkillBonuses.SetValues(2, SkillName.Ninjitsu, 10.0);
             Attributes.DefendChance = 10;
             Attributes.BonusDex = 5;
             Attributes.NightSight = 1;
@@ -51,9 +51,9 @@ namespace Server.Items
             Name = "Gargish Feudal Ghostwalkers";
             Hue = 1150;
 
-            SkillBonuses.SetValues(0, SkillName.Stealth, 5.0);
-            SkillBonuses.SetValues(1, SkillName.Hiding, 5.0);
-            SkillBonuses.SetValues(2, SkillName.Ninjitsu, 5.0);
+            SkillBonuses.SetValues(0, SkillName.Stealth, 10.0);
+            SkillBonuses.SetValues(1, SkillName.Hiding, 10.0);
+            SkillBonuses.SetValues(2, SkillName.Ninjitsu, 10.0);
             Attributes.DefendChance = 10;
             Attributes.BonusDex = 5;
             Attributes.NightSight = 1;

--- a/Scripts/Items/Artifacts/Equipment/Clothing/GeneralAndLordEpaulettes.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/GeneralAndLordEpaulettes.cs
@@ -12,6 +12,7 @@ namespace Server.Items
             Name = "General Lethe's Epaulettes";
             Hue = 1157;
 
+            SkillBonuses.SetValues(0, SkillName.EvalInt, 10.0);
             Attributes.BonusMana = 8;
             Attributes.RegenMana = 1;
             Attributes.CastRecovery = 1;
@@ -46,6 +47,7 @@ namespace Server.Items
             Name = "Gargish General Lethe's Epaulettes";
             Hue = 1157;
 
+            SkillBonuses.SetValues(0, SkillName.EvalInt, 10.0);
             Attributes.BonusMana = 8;
             Attributes.RegenMana = 1;
             Attributes.CastRecovery = 1;
@@ -80,6 +82,7 @@ namespace Server.Items
             Name = "Lord Morphius' Epaulettes";
             Hue = 1161;
 
+            SkillBonuses.SetValues(0, SkillName.Anatomy, 10.0);
             Attributes.BonusStam = 8;
             Attributes.RegenStam = 2;
             Attributes.LowerManaCost = 5;
@@ -114,6 +117,7 @@ namespace Server.Items
             Name = "Gargish Lord Morphius' Epaulettes";
             Hue = 1161;
 
+            SkillBonuses.SetValues(0, SkillName.Anatomy, 10.0);
             Attributes.BonusStam = 8;
             Attributes.RegenStam = 2;
             Attributes.LowerManaCost = 5;

--- a/Scripts/Items/Artifacts/Equipment/Clothing/GeneralAndLordEpaulettes.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/GeneralAndLordEpaulettes.cs
@@ -1,0 +1,140 @@
+using System;
+
+namespace Server.Items
+{
+    public class GeneralLethesEpaulettes : Epaulette
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GeneralLethesEpaulettes()
+        {
+            Name = "General Lethe's Epaulettes";
+            Hue = 1157;
+
+            Attributes.BonusMana = 8;
+            Attributes.RegenMana = 1;
+            Attributes.CastRecovery = 1;
+            Attributes.LowerRegCost = 10;
+        }
+
+        public GeneralLethesEpaulettes(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishGeneralLethesEpaulettes : GargishEpaulette
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishGeneralLethesEpaulettes()
+        {
+            Name = "Gargish General Lethe's Epaulettes";
+            Hue = 1157;
+
+            Attributes.BonusMana = 8;
+            Attributes.RegenMana = 1;
+            Attributes.CastRecovery = 1;
+            Attributes.LowerRegCost = 10;
+        }
+
+        public GargishGeneralLethesEpaulettes(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class LordMorphiusEpaulettes : Epaulette
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public LordMorphiusEpaulettes()
+        {
+            Name = "Lord Morphius' Epaulettes";
+            Hue = 1161;
+
+            Attributes.BonusStam = 8;
+            Attributes.RegenStam = 2;
+            Attributes.LowerManaCost = 5;
+            Attributes.WeaponSpeed = 10;
+        }
+
+        public LordMorphiusEpaulettes(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishLordMorphiusEpaulettes : GargishEpaulette
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishLordMorphiusEpaulettes()
+        {
+            Name = "Gargish Lord Morphius' Epaulettes";
+            Hue = 1161;
+
+            Attributes.BonusStam = 8;
+            Attributes.RegenStam = 2;
+            Attributes.LowerManaCost = 5;
+            Attributes.WeaponSpeed = 10;
+        }
+
+        public GargishLordMorphiusEpaulettes(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/GeneralAndLordEpaulettes.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/GeneralAndLordEpaulettes.cs
@@ -6,13 +6,19 @@ namespace Server.Items
     {
         public override bool IsArtifact { get { return true; } }
 
+        public static SkillName GetRandomCasterSkill()
+        {
+            SkillName[] skills = new SkillName[] { SkillName.EvalInt, SkillName.Magery, SkillName.Mysticism, SkillName.Spellweaving };
+            return skills[Utility.Random(skills.Length)];
+        }
+
         [Constructable]
         public GeneralLethesEpaulettes()
         {
             Name = "General Lethe's Epaulettes";
             Hue = 1157;
 
-            SkillBonuses.SetValues(0, SkillName.EvalInt, 10.0);
+            SkillBonuses.SetValues(0, GeneralLethesEpaulettes.GetRandomCasterSkill(), 20.0);
             Attributes.BonusMana = 8;
             Attributes.RegenMana = 1;
             Attributes.CastRecovery = 1;
@@ -47,7 +53,7 @@ namespace Server.Items
             Name = "Gargish General Lethe's Epaulettes";
             Hue = 1157;
 
-            SkillBonuses.SetValues(0, SkillName.EvalInt, 10.0);
+            SkillBonuses.SetValues(0, GeneralLethesEpaulettes.GetRandomCasterSkill(), 20.0);
             Attributes.BonusMana = 8;
             Attributes.RegenMana = 1;
             Attributes.CastRecovery = 1;
@@ -76,13 +82,19 @@ namespace Server.Items
     {
         public override bool IsArtifact { get { return true; } }
 
+        public static SkillName GetRandomWarriorSkill()
+        {
+            SkillName[] skills = new SkillName[] { SkillName.Anatomy, SkillName.Tactics, SkillName.Healing, SkillName.MagicResist, SkillName.Bushido, SkillName.Chivalry, SkillName.Necromancy };
+            return skills[Utility.Random(skills.Length)];
+        }
+
         [Constructable]
         public LordMorphiusEpaulettes()
         {
             Name = "Lord Morphius' Epaulettes";
             Hue = 1161;
 
-            SkillBonuses.SetValues(0, SkillName.Anatomy, 10.0);
+            SkillBonuses.SetValues(0, LordMorphiusEpaulettes.GetRandomWarriorSkill(), 20.0);
             Attributes.BonusStam = 8;
             Attributes.RegenStam = 2;
             Attributes.LowerManaCost = 5;
@@ -117,7 +129,7 @@ namespace Server.Items
             Name = "Gargish Lord Morphius' Epaulettes";
             Hue = 1161;
 
-            SkillBonuses.SetValues(0, SkillName.Anatomy, 10.0);
+            SkillBonuses.SetValues(0, LordMorphiusEpaulettes.GetRandomWarriorSkill(), 20.0);
             Attributes.BonusStam = 8;
             Attributes.RegenStam = 2;
             Attributes.LowerManaCost = 5;

--- a/Scripts/Items/Artifacts/Equipment/Clothing/HatOfTheMagi.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/HatOfTheMagi.cs
@@ -11,7 +11,10 @@ namespace Server.Items
             Hue = 0x481;
             Attributes.BonusInt = 8;
             Attributes.RegenMana = 4;
-            Attributes.SpellDamage = 10;
+            Attributes.SpellDamage = 25;
+            Attributes.LowerRegCost = 15;
+            SkillBonuses.SetValues(0, SkillName.Magery, 20.0);
+            SAAbsorptionAttributes.EaterEnergy = 10;
         }
 
         public HatOfTheMagi(Serial serial)
@@ -31,6 +34,27 @@ namespace Server.Items
             get
             {
                 return 11;
+            }
+        }
+        public override int BasePhysicalResistance
+        {
+            get
+            {
+                return 20;
+            }
+        }
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 20;
+            }
+        }
+        public override int BaseColdResistance
+        {
+            get
+            {
+                return 20;
             }
         }
         public override int BasePoisonResistance

--- a/Scripts/Items/Artifacts/Equipment/Clothing/HuntersHeaddress.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/HuntersHeaddress.cs
@@ -11,8 +11,10 @@ namespace Server.Items
             Hue = 0x594;
             SkillBonuses.SetValues(0, SkillName.Archery, 20);
             Attributes.BonusDex = 8;
+            Attributes.BonusStam = 10;
             Attributes.NightSight = 1;
             Attributes.AttackChance = 15;
+            Attributes.RegenStam = 4;
         }
 
         public HuntersHeaddress(Serial serial)
@@ -34,11 +36,39 @@ namespace Server.Items
                 return 11;
             }
         }
+        public override int BasePhysicalResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
         public override int BaseColdResistance
         {
             get
             {
-                return 23;
+                return 15;
+            }
+        }
+        public override int BasePoisonResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseEnergyResistance
+        {
+            get
+            {
+                return 15;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Clothing/KaelvoksCincture.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/KaelvoksCincture.cs
@@ -2,28 +2,28 @@ using System;
 
 namespace Server.Items
 {
-    public class FeudalGhostwalkers : Sandals
+    public class KaelvoksCincture : HalfApron
     {
         public override bool IsArtifact { get { return true; } }
 
         [Constructable]
-        public FeudalGhostwalkers()
+        public KaelvoksCincture()
         {
-            Name = "Feudal Ghostwalkers";
-            Hue = 1150;
+            Name = "Kaelvok's Cincture";
+            Hue = 1157;
+            Weight = 3.0;
+            LootType = LootType.Blessed;
 
-            SkillBonuses.SetValues(0, SkillName.Stealth, 5.0);
-            SkillBonuses.SetValues(1, SkillName.Hiding, 5.0);
-            SkillBonuses.SetValues(2, SkillName.Ninjitsu, 5.0);
-            Attributes.DefendChance = 10;
-            Attributes.BonusDex = 5;
-            Attributes.NightSight = 1;
+            Attributes.BonusStr = 5;
+            Attributes.BonusHits = 3;
+            Attributes.AttackChance = 5;
+            Attributes.WeaponSpeed = 5;
 
             MaxHitPoints = 255;
             HitPoints = 255;
         }
 
-        public FeudalGhostwalkers(Serial serial)
+        public KaelvoksCincture(Serial serial)
             : base(serial)
         {
         }
@@ -41,28 +41,30 @@ namespace Server.Items
         }
     }
 
-    public class GargishFeudalGhostwalkers : LeatherTalons
+    public class GargishKaelvoksCincture : GargoyleHalfApron
     {
         public override bool IsArtifact { get { return true; } }
 
         [Constructable]
-        public GargishFeudalGhostwalkers()
+        public GargishKaelvoksCincture()
         {
-            Name = "Gargish Feudal Ghostwalkers";
-            Hue = 1150;
+            Name = "Gargish Kaelvok's Cincture";
+            Hue = 1157;
+            Weight = 2.0;
+            LootType = LootType.Blessed;
 
-            SkillBonuses.SetValues(0, SkillName.Stealth, 5.0);
-            SkillBonuses.SetValues(1, SkillName.Hiding, 5.0);
-            SkillBonuses.SetValues(2, SkillName.Ninjitsu, 5.0);
-            Attributes.DefendChance = 10;
-            Attributes.BonusDex = 5;
-            Attributes.NightSight = 1;
+            Attributes.BonusStr = 5;
+            Attributes.BonusHits = 3;
+            Attributes.AttackChance = 5;
+            Attributes.WeaponSpeed = 5;
+
+            StrRequirement = 10;
 
             MaxHitPoints = 255;
             HitPoints = 255;
         }
 
-        public GargishFeudalGhostwalkers(Serial serial)
+        public GargishKaelvoksCincture(Serial serial)
             : base(serial)
         {
         }

--- a/Scripts/Items/Artifacts/Equipment/Clothing/LieutenantOfTheBritannianRoyalGuard.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/LieutenantOfTheBritannianRoyalGuard.cs
@@ -14,6 +14,8 @@ namespace Server.Items
             Attributes.BonusInt = 5;
             Attributes.RegenMana = 2;
             Attributes.LowerRegCost = 10;
+            Attributes.EnhancePotions = 15;
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
         }
 
         public LieutenantOfTheBritannianRoyalGuard(Serial serial)
@@ -75,6 +77,8 @@ namespace Server.Items
             Attributes.BonusInt = 5;
             Attributes.RegenMana = 2;
             Attributes.LowerRegCost = 10;
+            Attributes.EnhancePotions = 15;
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
         }
 
         public GargishLieutenantOfTheBritannianRoyalGuard(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/MantleOfTheArchlich.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/MantleOfTheArchlich.cs
@@ -12,7 +12,7 @@ namespace Server.Items
             Name = "Mantle of the Archlich";
             Hue = 1150;
 
-            SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 15.0);
             Attributes.BonusStr = 10;
             Attributes.LowerManaCost = 5;
             Attributes.SpellDamage = 8;

--- a/Scripts/Items/Artifacts/Equipment/Clothing/MantleOfTheArchlich.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/MantleOfTheArchlich.cs
@@ -13,6 +13,8 @@ namespace Server.Items
             Hue = 1150;
 
             SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
+            Attributes.BonusStr = 10;
+            Attributes.LowerManaCost = 5;
             Attributes.SpellDamage = 8;
             Attributes.CastSpeed = 1;
         }

--- a/Scripts/Items/Artifacts/Equipment/Clothing/MantleOfTheArchlich.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/MantleOfTheArchlich.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Server.Items
+{
+    public class MantleOfTheArchlich : Robe
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public MantleOfTheArchlich()
+        {
+            Name = "Mantle of the Archlich";
+            Hue = 1150;
+
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
+            Attributes.SpellDamage = 8;
+            Attributes.CastSpeed = 1;
+        }
+
+        public MantleOfTheArchlich(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/MarkOfTravesty.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/MarkOfTravesty.cs
@@ -9,66 +9,69 @@ namespace Server.Items
         public MarkOfTravesty()
             : base()
         {
-            Hue = 0x495;		
-            Attributes.BonusMana = 8;
-            Attributes.RegenHits = 3;		
-            ClothingAttributes.SelfRepair = 3;
-			
+            Hue = 0x495;
+            Attributes.BonusMana = 10;
+            Attributes.RegenHits = 2;
+            Attributes.RegenMana = 2;
+            Attributes.SpellDamage = 15;
+            Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 10;
+
             switch( Utility.Random(15) )
             {
-                case 0: 
+                case 0:
                     SkillBonuses.SetValues(0, SkillName.EvalInt, 10);
                     SkillBonuses.SetValues(1, SkillName.Magery, 10);
                     break;
-                case 1: 
+                case 1:
                     SkillBonuses.SetValues(0, SkillName.AnimalLore, 10);
                     SkillBonuses.SetValues(1, SkillName.AnimalTaming, 10);
                     break;
-                case 2: 
+                case 2:
                     SkillBonuses.SetValues(0, SkillName.Swords, 10);
                     SkillBonuses.SetValues(1, SkillName.Tactics, 10);
                     break;
-                case 3: 
+                case 3:
                     SkillBonuses.SetValues(0, SkillName.Discordance, 10);
                     SkillBonuses.SetValues(1, SkillName.Musicianship, 10);
                     break;
-                case 4: 
+                case 4:
                     SkillBonuses.SetValues(0, SkillName.Fencing, 10);
                     SkillBonuses.SetValues(1, SkillName.Tactics, 10);
                     break;
-                case 5: 
+                case 5:
                     SkillBonuses.SetValues(0, SkillName.Chivalry, 10);
                     SkillBonuses.SetValues(1, SkillName.MagicResist, 10);
                     break;
-                case 6: 
+                case 6:
                     SkillBonuses.SetValues(0, SkillName.Anatomy, 10);
                     SkillBonuses.SetValues(1, SkillName.Healing, 10);
                     break;
-                case 7: 
+                case 7:
                     SkillBonuses.SetValues(0, SkillName.Ninjitsu, 10);
                     SkillBonuses.SetValues(1, SkillName.Stealth, 10);
                     break;
-                case 8: 
+                case 8:
                     SkillBonuses.SetValues(0, SkillName.Bushido, 10);
                     SkillBonuses.SetValues(1, SkillName.Parry, 10);
                     break;
-                case 9: 
+                case 9:
                     SkillBonuses.SetValues(0, SkillName.Archery, 10);
                     SkillBonuses.SetValues(1, SkillName.Tactics, 10);
                     break;
-                case 10: 
+                case 10:
                     SkillBonuses.SetValues(0, SkillName.Macing, 10);
                     SkillBonuses.SetValues(1, SkillName.Tactics, 10);
                     break;
-                case 11: 
+                case 11:
                     SkillBonuses.SetValues(0, SkillName.Necromancy, 10);
                     SkillBonuses.SetValues(1, SkillName.SpiritSpeak, 10);
                     break;
-                case 12: 
+                case 12:
                     SkillBonuses.SetValues(0, SkillName.Stealth, 10);
                     SkillBonuses.SetValues(1, SkillName.Stealing, 10);
                     break;
-                case 13: 
+                case 13:
                     SkillBonuses.SetValues(0, SkillName.Peacemaking, 10);
                     SkillBonuses.SetValues(1, SkillName.Musicianship, 10);
                     break;
@@ -91,41 +94,11 @@ namespace Server.Items
                 return 1074493;
             }
         }// Mark of Travesty
-        public override int BasePhysicalResistance
-        {
-            get
-            {
-                return 8;
-            }
-        }
-        public override int BaseFireResistance
-        {
-            get
-            {
-                return 5;
-            }
-        }
-        public override int BaseColdResistance
-        {
-            get
-            {
-                return 11;
-            }
-        }
-        public override int BasePoisonResistance
-        {
-            get
-            {
-                return 20;
-            }
-        }
-        public override int BaseEnergyResistance
-        {
-            get
-            {
-                return 15;
-            }
-        }
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
 		public override int InitMinHits
         {
             get

--- a/Scripts/Items/Artifacts/Equipment/Clothing/MushroomApron.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/MushroomApron.cs
@@ -13,9 +13,32 @@ namespace Server.Items
             Hue = 1167;
 
             SkillBonuses.SetValues(0, SkillName.Alchemy, 10.0);
+            SkillBonuses.SetValues(1, GetRandomSkill(), 10.0);
             Attributes.BonusHits = 5;
             Attributes.RegenHits = 2;
             Attributes.EnhancePotions = 15;
+            ApplyRandomStat(Attributes);
+        }
+
+        public static SkillName GetRandomSkill()
+        {
+            SkillName[] skills = new SkillName[]
+            {
+                SkillName.Swords, SkillName.Macing, SkillName.Fencing, SkillName.Archery,
+                SkillName.Wrestling, SkillName.Throwing, SkillName.Magery, SkillName.Necromancy,
+                SkillName.Mysticism, SkillName.Chivalry, SkillName.Bushido, SkillName.Ninjitsu
+            };
+            return skills[Utility.Random(skills.Length)];
+        }
+
+        public static void ApplyRandomStat(AosAttributes attributes)
+        {
+            switch (Utility.Random(3))
+            {
+                case 0: attributes.BonusStr = 10; break;
+                case 1: attributes.BonusDex = 10; break;
+                case 2: attributes.BonusInt = 10; break;
+            }
         }
 
         public MushroomApron(Serial serial)
@@ -47,9 +70,11 @@ namespace Server.Items
             Hue = 1167;
 
             SkillBonuses.SetValues(0, SkillName.Alchemy, 10.0);
+            SkillBonuses.SetValues(1, MushroomApron.GetRandomSkill(), 10.0);
             Attributes.BonusHits = 5;
             Attributes.RegenHits = 2;
             Attributes.EnhancePotions = 15;
+            MushroomApron.ApplyRandomStat(Attributes);
         }
 
         public GargishMushroomApron(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/MushroomApron.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/MushroomApron.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace Server.Items
+{
+    public class MushroomApron : HalfApron
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public MushroomApron()
+        {
+            Name = "Mushroom Apron";
+            Hue = 1167;
+
+            SkillBonuses.SetValues(0, SkillName.Alchemy, 10.0);
+            Attributes.BonusHits = 5;
+            Attributes.RegenHits = 2;
+            Attributes.EnhancePotions = 15;
+        }
+
+        public MushroomApron(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishMushroomApron : GargoyleHalfApron
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishMushroomApron()
+        {
+            Name = "Gargish Mushroom Apron";
+            Hue = 1167;
+
+            SkillBonuses.SetValues(0, SkillName.Alchemy, 10.0);
+            Attributes.BonusHits = 5;
+            Attributes.RegenHits = 2;
+            Attributes.EnhancePotions = 15;
+        }
+
+        public GargishMushroomApron(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/RangersCloakOfAugmentation.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/RangersCloakOfAugmentation.cs
@@ -14,7 +14,7 @@ namespace Server.Items
         public RangersCloakOfAugmentation()
         {
             Hue = 0x54A;
-            SkillBonuses.SetValues(0, GetRandomRangerSkill(), 10.0);
+            SkillBonuses.SetValues(0, GetRandomRangerSkill(), 20.0);
             SAAbsorptionAttributes.EaterKinetic = 10;
             Attributes.SpellDamage = 5;
             Attributes.LowerManaCost = 8;
@@ -26,8 +26,8 @@ namespace Server.Items
         {
             SkillName[] skills = new SkillName[]
             {
-                SkillName.Hiding, SkillName.Stealth, SkillName.AnimalTaming,
-                SkillName.AnimalLore, SkillName.Poisoning
+                SkillName.AnimalTaming, SkillName.AnimalLore, SkillName.Archery,
+                SkillName.Swords, SkillName.Macing, SkillName.Fencing
             };
             return skills[Utility.Random(skills.Length)];
         }

--- a/Scripts/Items/Artifacts/Equipment/Clothing/RangersCloakOfAugmentation.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/RangersCloakOfAugmentation.cs
@@ -14,10 +14,11 @@ namespace Server.Items
         public RangersCloakOfAugmentation()
         {
             Hue = 0x54A;
-            SAAbsorptionAttributes.EaterKinetic = 5;
-            Attributes.SpellDamage = 3;
-            Attributes.LowerManaCost = 1;
+            SAAbsorptionAttributes.EaterKinetic = 10;
+            Attributes.SpellDamage = 5;
+            Attributes.LowerManaCost = 8;
             Attributes.WeaponSpeed = 5;
+            StrRequirement = 10;
         }
 
         public RangersCloakOfAugmentation(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/RangersCloakOfAugmentation.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/RangersCloakOfAugmentation.cs
@@ -14,11 +14,22 @@ namespace Server.Items
         public RangersCloakOfAugmentation()
         {
             Hue = 0x54A;
+            SkillBonuses.SetValues(0, GetRandomRangerSkill(), 10.0);
             SAAbsorptionAttributes.EaterKinetic = 10;
             Attributes.SpellDamage = 5;
             Attributes.LowerManaCost = 8;
             Attributes.WeaponSpeed = 5;
             StrRequirement = 10;
+        }
+
+        public static SkillName GetRandomRangerSkill()
+        {
+            SkillName[] skills = new SkillName[]
+            {
+                SkillName.Hiding, SkillName.Stealth, SkillName.AnimalTaming,
+                SkillName.AnimalLore, SkillName.Poisoning
+            };
+            return skills[Utility.Random(skills.Length)];
         }
 
         public RangersCloakOfAugmentation(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/RobeOfTheEclipse.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/RobeOfTheEclipse.cs
@@ -13,7 +13,9 @@ namespace Server.Items
             : base(0x1F03, 0x486)
         {
             Weight = 3.0;
-            Attributes.Luck = 95;
+            Attributes.Luck = 150;
+            SkillBonuses.SetValues(0, SkillName.AnimalTaming, 5.0);
+            SkillBonuses.SetValues(1, SkillName.AnimalLore, 5.0);
         }
 
         public RobeOfTheEclipse(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/RobeOfTheEquinox.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/RobeOfTheEquinox.cs
@@ -20,7 +20,9 @@ namespace Server.Items
         {
             Weight = 3.0;
             _ElfOnly = true;
-            Attributes.Luck = 95;
+            Attributes.Luck = 150;
+            SkillBonuses.SetValues(0, SkillName.AnimalTaming, 5.0);
+            SkillBonuses.SetValues(1, SkillName.AnimalLore, 5.0);
         }
 
         public RobeOfTheEquinox(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/RoyalGuardInvestigatorCloak.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/RoyalGuardInvestigatorCloak.cs
@@ -9,8 +9,11 @@ namespace Server.Items
         public RoyalGuardInvestigatorsCloak()
             : base()
         { 
-            Hue = 1163;       
-            SkillBonuses.SetValues(0, SkillName.Stealth, 20.0);        
+            Hue = 1163;
+            SkillBonuses.SetValues(0, SkillName.Stealth, 20.0);
+            Attributes.AttackChance = 15;
+            Attributes.WeaponSpeed = 10;
+            Attributes.BonusStam = 10;
         }
 
         public RoyalGuardInvestigatorsCloak(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/SamaritanRobe.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/SamaritanRobe.cs
@@ -9,6 +9,8 @@ namespace Server.Items
         public SamaritanRobe()
         {
             Hue = 0x2a3;
+            SkillBonuses.SetValues(0, SkillName.AnimalTaming, 30.0);
+            Attributes.Luck = 500;
         }
 
         public SamaritanRobe(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/ScabbardOfJuonar.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/ScabbardOfJuonar.cs
@@ -12,8 +12,9 @@ namespace Server.Items
             Name = "Scabbard of Juo'nar";
             Hue = 1109;
 
-            SkillBonuses.SetValues(0, SkillName.Necromancy, 5.0);
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
             Attributes.BonusHits = 5;
+            Attributes.BonusInt = 10;
             Attributes.SpellDamage = 5;
             Attributes.CastSpeed = 1;
         }
@@ -46,8 +47,9 @@ namespace Server.Items
             Name = "Gargish Scabbard of Juo'nar";
             Hue = 1109;
 
-            SkillBonuses.SetValues(0, SkillName.Necromancy, 5.0);
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
             Attributes.BonusHits = 5;
+            Attributes.BonusInt = 10;
             Attributes.SpellDamage = 5;
             Attributes.CastSpeed = 1;
         }

--- a/Scripts/Items/Artifacts/Equipment/Clothing/ScabbardOfJuonar.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/ScabbardOfJuonar.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace Server.Items
+{
+    public class ScabbardOfJuonar : SwordBelt
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public ScabbardOfJuonar()
+        {
+            Name = "Scabbard of Juo'nar";
+            Hue = 1109;
+
+            SkillBonuses.SetValues(0, SkillName.Necromancy, 5.0);
+            Attributes.BonusHits = 5;
+            Attributes.SpellDamage = 5;
+            Attributes.CastSpeed = 1;
+        }
+
+        public ScabbardOfJuonar(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishScabbardOfJuonar : GargoyleHalfApron
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishScabbardOfJuonar()
+        {
+            Name = "Gargish Scabbard of Juo'nar";
+            Hue = 1109;
+
+            SkillBonuses.SetValues(0, SkillName.Necromancy, 5.0);
+            Attributes.BonusHits = 5;
+            Attributes.SpellDamage = 5;
+            Attributes.CastSpeed = 1;
+        }
+
+        public GargishScabbardOfJuonar(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/ScabbardOfJuonar.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/ScabbardOfJuonar.cs
@@ -12,7 +12,7 @@ namespace Server.Items
             Name = "Scabbard of Juo'nar";
             Hue = 1109;
 
-            SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 20.0);
             Attributes.BonusHits = 5;
             Attributes.BonusInt = 10;
             Attributes.SpellDamage = 5;
@@ -47,7 +47,7 @@ namespace Server.Items
             Name = "Gargish Scabbard of Juo'nar";
             Hue = 1109;
 
-            SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 20.0);
             Attributes.BonusHits = 5;
             Attributes.BonusInt = 10;
             Attributes.SpellDamage = 5;

--- a/Scripts/Items/Artifacts/Equipment/Clothing/SerpentSkinQuiver.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/SerpentSkinQuiver.cs
@@ -1,0 +1,80 @@
+using System;
+
+namespace Server.Items
+{
+    public class SerpentSkinQuiver : BaseQuiver
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public SerpentSkinQuiver()
+        {
+            Name = "Serpent Skin Quiver";
+            Hue = 1267;
+
+            DamageIncrease = 10;
+            Capacity = 1000;
+            WeightReduction = 50;
+            LowerAmmoCost = 50;
+
+            SkillBonuses.SetValues(0, SkillName.Anatomy, 10.0);
+            Attributes.Luck = 125;
+            Attributes.WeaponSpeed = 10;
+            Attributes.WeaponDamage = 20;
+        }
+
+        public SerpentSkinQuiver(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishSerpentSkinWingArmor : GargishLeatherWingArmor
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishSerpentSkinWingArmor()
+        {
+            Name = "Gargish Serpent Skin Wing Armor";
+            Hue = 1267;
+
+            SkillBonuses.SetValues(0, SkillName.Anatomy, 10.0);
+            Attributes.Luck = 125;
+            Attributes.WeaponSpeed = 10;
+            Attributes.WeaponDamage = 20;
+        }
+
+        public GargishSerpentSkinWingArmor(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/ShadowbaneEpaulettes.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/ShadowbaneEpaulettes.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace Server.Items
+{
+    public class ShadowbaneEpaulettes : Epaulette
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public ShadowbaneEpaulettes()
+        {
+            Name = "Shadowbane Epaulettes";
+            Hue = 1109;
+
+            Attributes.AttackChance = 10;
+            Attributes.DefendChance = 10;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public ShadowbaneEpaulettes(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishShadowbaneEpaulettes : GargishEpaulette
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishShadowbaneEpaulettes()
+        {
+            Name = "Gargish Shadowbane Epaulettes";
+            Hue = 1109;
+
+            Attributes.AttackChance = 10;
+            Attributes.DefendChance = 10;
+            Attributes.LowerManaCost = 8;
+        }
+
+        public GargishShadowbaneEpaulettes(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Clothing/SpiritOfTheTotem.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/SpiritOfTheTotem.cs
@@ -10,8 +10,11 @@ namespace Server.Items
         {
             Hue = 0x455;
             Attributes.BonusStr = 20;
+            Attributes.BonusDex = 20;
+            Attributes.BonusInt = 20;
             Attributes.ReflectPhysical = 15;
             Attributes.AttackChance = 15;
+            Attributes.WeaponDamage = 25;
         }
 
         public SpiritOfTheTotem(Serial serial)
@@ -37,7 +40,35 @@ namespace Server.Items
         {
             get
             {
-                return 20;
+                return 15;
+            }
+        }
+        public override int BaseFireResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseColdResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BasePoisonResistance
+        {
+            get
+            {
+                return 15;
+            }
+        }
+        public override int BaseEnergyResistance
+        {
+            get
+            {
+                return 15;
             }
         }
         public override int InitMinHits

--- a/Scripts/Items/Artifacts/Equipment/Clothing/Tangle1.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/Tangle1.cs
@@ -13,10 +13,19 @@ namespace Server.Items
         public Tangle1()
             : base()
         {
-            Hue = 506;		
+            Hue = 506;
             Attributes.BonusInt = 10;
             Attributes.DefendChance = 5;
             Attributes.RegenMana = 2;
+
+            switch (Utility.Random(5))
+            {
+                case 0: SkillBonuses.SetValues(0, SkillName.AnimalLore, 20.0); break;
+                case 1: SkillBonuses.SetValues(0, SkillName.Mysticism, 20.0); break;
+                case 2: SkillBonuses.SetValues(0, SkillName.Magery, 20.0); break;
+                case 3: SkillBonuses.SetValues(0, SkillName.Spellweaving, 20.0); break;
+                case 4: SkillBonuses.SetValues(0, SkillName.Necromancy, 20.0); break;
+            }
         }
 
         public Tangle1(Serial serial)
@@ -52,6 +61,15 @@ namespace Server.Items
             Attributes.BonusInt = 10;
             Attributes.DefendChance = 5;
             Attributes.RegenMana = 2;
+
+            switch (Utility.Random(5))
+            {
+                case 0: SkillBonuses.SetValues(0, SkillName.AnimalLore, 20.0); break;
+                case 1: SkillBonuses.SetValues(0, SkillName.Mysticism, 20.0); break;
+                case 2: SkillBonuses.SetValues(0, SkillName.Magery, 20.0); break;
+                case 3: SkillBonuses.SetValues(0, SkillName.Spellweaving, 20.0); break;
+                case 4: SkillBonuses.SetValues(0, SkillName.Necromancy, 20.0); break;
+            }
         }
 
         public GargishTangle1(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/TheMostKnowledgePerson.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/TheMostKnowledgePerson.cs
@@ -13,7 +13,13 @@ namespace Server.Items
             : base(0x2684)
         {
             Hue = 0x117;
-            Attributes.BonusHits = 3 + Utility.RandomMinMax(0, 2);
+            Attributes.BonusHits = 10;
+            Attributes.BonusInt = 10;
+            Attributes.BonusMana = 10;
+            Attributes.BonusStr = 10;
+            Attributes.BonusDex = 10;
+            Attributes.BonusStam = 10;
+            SkillBonuses.SetValues(0, SkillName.Healing, 10.0);
         }
 
         public TheMostKnowledgePerson(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/TheRobeOfBritanniaAri.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/TheRobeOfBritanniaAri.cs
@@ -13,6 +13,9 @@ namespace Server.Items
             : base(0x2684)
         {
             Hue = 0x48b;
+            SkillBonuses.SetValues(0, SkillName.EvalInt, 15.0);
+            Attributes.SpellDamage = 30;
+            Attributes.RegenMana = 2;
         }
 
         public TheRobeOfBritanniaAri(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/TheScholarsHalo.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/TheScholarsHalo.cs
@@ -11,10 +11,12 @@ namespace Server.Items
         public TheScholarsHalo()
         {
             Attributes.BonusMana = 15;
-            Attributes.RegenMana = 2;
+            Attributes.RegenMana = 6;
             Attributes.SpellDamage = 15;
             Attributes.CastSpeed = 1;
             Attributes.LowerManaCost = 10;
+            Attributes.LowerRegCost = 15;
+            SAAbsorptionAttributes.CastingFocus = 5;
         }
 
         public TheScholarsHalo(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Clothing/WardensArmorOfAugmentation.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/WardensArmorOfAugmentation.cs
@@ -12,6 +12,7 @@ namespace Server.Items
         public WardensArmorOfAugmentation()
         {
             Hue = 0x9C2;
+            SkillBonuses.SetValues(0, RangersCloakOfAugmentation.GetRandomRangerSkill(), 10.0);
             AbsorptionAttributes.EaterKinetic = 10;
             Attributes.SpellDamage = 5;
             Attributes.LowerManaCost = 8;

--- a/Scripts/Items/Artifacts/Equipment/Clothing/WardensArmorOfAugmentation.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/WardensArmorOfAugmentation.cs
@@ -12,9 +12,9 @@ namespace Server.Items
         public WardensArmorOfAugmentation()
         {
             Hue = 0x9C2;
-            AbsorptionAttributes.EaterKinetic = 5;
-            Attributes.SpellDamage = 3;
-            Attributes.LowerManaCost = 1;
+            AbsorptionAttributes.EaterKinetic = 10;
+            Attributes.SpellDamage = 5;
+            Attributes.LowerManaCost = 8;
             Attributes.WeaponSpeed = 5;
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Clothing/WardensArmorOfAugmentation.cs
+++ b/Scripts/Items/Artifacts/Equipment/Clothing/WardensArmorOfAugmentation.cs
@@ -12,7 +12,7 @@ namespace Server.Items
         public WardensArmorOfAugmentation()
         {
             Hue = 0x9C2;
-            SkillBonuses.SetValues(0, RangersCloakOfAugmentation.GetRandomRangerSkill(), 10.0);
+            SkillBonuses.SetValues(0, RangersCloakOfAugmentation.GetRandomRangerSkill(), 20.0);
             AbsorptionAttributes.EaterKinetic = 10;
             Attributes.SpellDamage = 5;
             Attributes.LowerManaCost = 8;

--- a/Scripts/Items/Artifacts/Equipment/Glasses/CollectionsBritLibraryGlasses.cs
+++ b/Scripts/Items/Artifacts/Equipment/Glasses/CollectionsBritLibraryGlasses.cs
@@ -11,10 +11,12 @@ namespace Server.Items
         public MaceAndShieldGlasses()
             : base()
         {
-            Hue = 0x1DD;		
+            Hue = 0x1DD;
             Attributes.BonusStr = 10;
-            Attributes.BonusDex = 5;		
+            Attributes.BonusDex = 5;
+            Attributes.WeaponDamage = 25;
             WeaponAttributes.HitLowerDefend = 30;
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 15.0);
         }
 
         public MaceAndShieldGlasses(Serial serial)
@@ -102,7 +104,9 @@ namespace Server.Items
             Hue = 0x1DD;
             Attributes.BonusStr = 10;
             Attributes.BonusDex = 5;
+            Attributes.WeaponDamage = 25;
             WeaponAttributes.HitLowerDefend = 30;
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 15.0);
         }
 
         public GargishMaceAndShieldGlasses(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/BraceletOfHealth.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/BraceletOfHealth.cs
@@ -11,6 +11,11 @@ namespace Server.Items
             Hue = 0x21;
             Attributes.BonusHits = 5;
             Attributes.RegenHits = 10;
+            Attributes.AttackChance = 25;
+            Attributes.DefendChance = 25;
+            Attributes.LowerManaCost = 8;
+            Attributes.LowerRegCost = 25;
+            Attributes.SpellDamage = 25;
         }
 
         public BraceletOfHealth(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/BraceletOfPrimalConsumption.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/BraceletOfPrimalConsumption.cs
@@ -10,13 +10,18 @@ namespace Server.Items
         [Constructable]
         public BraceletOfPrimalConsumption()
         {
-            AbsorptionAttributes.EaterDamage = 6;
+            AbsorptionAttributes.EaterDamage = 15;
             Attributes.Luck = 200;
+            Attributes.BonusDex = 10;
+            Attributes.BonusStam = 10;
+            Attributes.BonusInt = 10;
+            Attributes.BonusMana = 10;
             Resistances.Physical = 20;
             Resistances.Fire = 20;
             Resistances.Cold = 20;
             Resistances.Poison = 20;
             Resistances.Energy = 20;
+            SkillBonuses.SetValues(0, SkillName.Focus, 20.0);
         }
 
         public BraceletOfPrimalConsumption(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/CrystallineRing.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/CrystallineRing.cs
@@ -7,15 +7,26 @@ namespace Server.Items
 		public override int LabelNumber { get { return 1075096; } } // Crystalline Ring
 		public override bool IsArtifact { get { return true; } }
 		
+        private static readonly SkillName[] m_PossibleBonusSkills = new SkillName[]
+        {
+            SkillName.EvalInt,
+            SkillName.SpiritSpeak,
+            SkillName.Focus,
+            SkillName.Spellweaving
+        };
+
         [Constructable]
         public CrystallineRing()
         {
-            Hue = 0x480;		
+            Hue = 0x480;
             Attributes.RegenHits = 5;
             Attributes.RegenMana = 3;
-            Attributes.SpellDamage = 20;		
+            Attributes.SpellDamage = 20;
+            Attributes.CastRecovery = 3;
+            Attributes.LowerRegCost = 20;
+            Attributes.EnhancePotions = 35;
             SkillBonuses.SetValues(0, SkillName.Magery, 20.0);
-            SkillBonuses.SetValues(1, SkillName.Focus, 20.0);
+            SkillBonuses.SetValues(1, m_PossibleBonusSkills[Utility.Random(m_PossibleBonusSkills.Length)], 20.0);
         }
 
         public CrystallineRing(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/JadeArmband.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/JadeArmband.cs
@@ -15,10 +15,12 @@ namespace Server.Items
 		public JadeArmband()
 		{
 			Hue = 2126;
-            Attributes.AttackChance = 10;
-            Attributes.DefendChance = 10;
+            Attributes.AttackChance = 15;
+            Attributes.DefendChance = 15;
             Attributes.WeaponSpeed = 5;
+            Attributes.LowerRegCost = 15;
             Resistances.Poison = 20;
+            SkillBonuses.SetValues(0, SkillName.Chivalry, 15.0);
 		}		
 
 		public JadeArmband( Serial serial ) : base( serial )

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/OrnamentOfTheMagician.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/OrnamentOfTheMagician.cs
@@ -13,6 +13,14 @@ namespace Server.Items
             Attributes.CastSpeed = 2;
             Attributes.LowerManaCost = 10;
             Attributes.LowerRegCost = 20;
+            Attributes.BonusMana = 10;
+            Attributes.BonusStam = 10;
+            Attributes.RegenHits = 2;
+            Attributes.RegenMana = 2;
+            Attributes.RegenStam = 2;
+            Attributes.EnhancePotions = 15;
+            Attributes.DefendChance = 15;
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
             Resistances.Energy = 15;
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/PendantOfTheMagi.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/PendantOfTheMagi.cs
@@ -14,6 +14,11 @@ namespace Server.Items
             Attributes.SpellDamage = 5;
             Attributes.LowerManaCost = 10;
             Attributes.LowerRegCost = 30;
+            Resistances.Physical = 15;
+            Resistances.Fire = 15;
+            Resistances.Cold = 15;
+            Resistances.Poison = 15;
+            Resistances.Energy = 15;
         }
 
         public PendantOfTheMagi(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/RingOfTheElements.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/RingOfTheElements.cs
@@ -10,6 +10,12 @@ namespace Server.Items
         {
             Hue = 0x4E9;
             Attributes.Luck = 100;
+            Attributes.DefendChance = 25;
+            Attributes.EnhancePotions = 35;
+            AbsorptionAttributes.EaterFire = 10;
+            AbsorptionAttributes.EaterDamage = 10;
+            AbsorptionAttributes.EaterCold = 10;
+            AbsorptionAttributes.EaterEnergy = 10;
             Resistances.Fire = 16;
             Resistances.Cold = 16;
             Resistances.Poison = 16;

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/RingOfTheVile.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/RingOfTheVile.cs
@@ -12,7 +12,12 @@ namespace Server.Items
             Attributes.BonusDex = 8;
             Attributes.RegenStam = 6;
             Attributes.AttackChance = 15;
+            Attributes.DefendChance = 15;
+            Attributes.EnhancePotions = 25;
+            Attributes.LowerManaCost = 8;
             Resistances.Poison = 20;
+            SkillBonuses.SetValues(0, SkillName.Healing, 10.0);
+            SkillBonuses.SetValues(1, SkillName.Anatomy, 10.0);
         }
 
         public RingOfTheVile(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/SolariasSecretPoisons.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/SolariasSecretPoisons.cs
@@ -1,0 +1,81 @@
+using System;
+
+namespace Server.Items
+{
+    public class SolariasSecretPoisons : GoldEarrings
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public SolariasSecretPoisons()
+        {
+            Name = "Solaria's Secret Poisons";
+            Hue = 1267;
+            Weight = 1.0;
+
+            SkillBonuses.SetValues(0, SkillName.Ninjitsu, 10.0);
+            Attributes.AttackChance = 10;
+
+            MaxHitPoints = 255;
+            HitPoints = 255;
+        }
+
+        public SolariasSecretPoisons(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishSolariasSecretPoisons : GargishEarrings
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishSolariasSecretPoisons()
+        {
+            Name = "Gargish Solaria's Secret Poisons";
+            Hue = 1267;
+            Weight = 1.0;
+
+            SkillBonuses.SetValues(0, SkillName.Ninjitsu, 10.0);
+            Attributes.AttackChance = 10;
+        }
+
+        public GargishSolariasSecretPoisons(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 18; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 18; } }
+        public override int BaseEnergyResistance { get { return 15; } }
+        public override int InitMinHits { get { return 255; } }
+        public override int InitMaxHits { get { return 255; } }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Jewelry/Venom.cs
+++ b/Scripts/Items/Artifacts/Equipment/Jewelry/Venom.cs
@@ -14,7 +14,21 @@ namespace Server.Items
             Attributes.CastRecovery = 1;
             Attributes.CastSpeed = 2;
             Attributes.SpellDamage = 10;
+            Attributes.EnhancePotions = 35;
+            Attributes.DefendChance = 25;
+            Attributes.AttackChance = 15;
             Resistances.Poison = 20;
+
+            switch (Utility.Random(7))
+            {
+                case 0: SkillBonuses.SetValues(0, SkillName.Magery, 20.0); break;
+                case 1: SkillBonuses.SetValues(0, SkillName.Chivalry, 20.0); break;
+                case 2: SkillBonuses.SetValues(0, SkillName.Spellweaving, 20.0); break;
+                case 3: SkillBonuses.SetValues(0, SkillName.Necromancy, 20.0); break;
+                case 4: SkillBonuses.SetValues(0, SkillName.Mysticism, 20.0); break;
+                case 5: SkillBonuses.SetValues(0, SkillName.Bushido, 20.0); break;
+                case 6: SkillBonuses.SetValues(0, SkillName.Ninjitsu, 20.0); break;
+            }
         }
 
         public Venom(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Spellbooks/SlayerSpellbooks.cs
+++ b/Scripts/Items/Artifacts/Equipment/Spellbooks/SlayerSpellbooks.cs
@@ -1,0 +1,158 @@
+using System;
+
+namespace Server.Items
+{
+    public class ReptilianDeathSpellbook : Spellbook
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public ReptilianDeathSpellbook() : base(ulong.MaxValue)
+        {
+            Name = "Tome of Reptilian Death";
+            Hue = 1267;
+            LootType = LootType.Blessed;
+            Slayer = SlayerName.ReptilianDeath;
+            Attributes.SpellDamage = 50;
+            Attributes.CastRecovery = 1;
+            Attributes.CastSpeed = 1;
+            Attributes.RegenMana = 3;
+        }
+
+        public ReptilianDeathSpellbook(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondSpellbook : Spellbook
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public RepondSpellbook() : base(ulong.MaxValue)
+        {
+            Name = "Tome of Repond";
+            Hue = 1152;
+            LootType = LootType.Blessed;
+            Slayer = SlayerName.Repond;
+            Attributes.SpellDamage = 50;
+            Attributes.CastRecovery = 1;
+            Attributes.CastSpeed = 1;
+            Attributes.RegenMana = 3;
+        }
+
+        public RepondSpellbook(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadSpellbook : Spellbook
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public UndeadSpellbook() : base(ulong.MaxValue)
+        {
+            Name = "Tome of the Undead";
+            Hue = 1150;
+            LootType = LootType.Blessed;
+            Slayer = SlayerName.Silver;
+            Attributes.SpellDamage = 50;
+            Attributes.CastRecovery = 1;
+            Attributes.CastSpeed = 1;
+            Attributes.RegenMana = 3;
+        }
+
+        public UndeadSpellbook(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonSpellbook : Spellbook
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public DemonSpellbook() : base(ulong.MaxValue)
+        {
+            Name = "Tome of Exorcism";
+            Hue = 1157;
+            LootType = LootType.Blessed;
+            Slayer = SlayerName.Exorcism;
+            Attributes.SpellDamage = 50;
+            Attributes.CastRecovery = 1;
+            Attributes.CastSpeed = 1;
+            Attributes.RegenMana = 3;
+        }
+
+        public DemonSpellbook(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeySpellbook : Spellbook
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public FeySpellbook() : base(ulong.MaxValue)
+        {
+            Name = "Tome of the Fey";
+            Hue = 1159;
+            LootType = LootType.Blessed;
+            Slayer = SlayerName.Fey;
+            Attributes.SpellDamage = 50;
+            Attributes.CastRecovery = 1;
+            Attributes.CastSpeed = 1;
+            Attributes.RegenMana = 3;
+        }
+
+        public FeySpellbook(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidDoomSpellbook : Spellbook
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public ArachnidDoomSpellbook() : base(ulong.MaxValue)
+        {
+            Name = "Tome of Arachnid Doom";
+            Hue = 1161;
+            LootType = LootType.Blessed;
+            Slayer = SlayerName.ArachnidDoom;
+            Attributes.SpellDamage = 50;
+            Attributes.CastRecovery = 1;
+            Attributes.CastSpeed = 1;
+            Attributes.RegenMana = 3;
+        }
+
+        public ArachnidDoomSpellbook(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalBanSpellbook : Spellbook
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public ElementalBanSpellbook() : base(ulong.MaxValue)
+        {
+            Name = "Tome of Elemental Ban";
+            Hue = 1160;
+            LootType = LootType.Blessed;
+            Slayer = SlayerName.ElementalBan;
+            Attributes.SpellDamage = 50;
+            Attributes.CastRecovery = 1;
+            Attributes.CastSpeed = 1;
+            Attributes.RegenMana = 3;
+        }
+
+        public ElementalBanSpellbook(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Talismans/CarvedBoneRelicFromHolmes.cs
+++ b/Scripts/Items/Artifacts/Equipment/Talismans/CarvedBoneRelicFromHolmes.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Server.Items
+{
+    public class CarvedBoneRelicFromHolmes : BaseTalisman
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public CarvedBoneRelicFromHolmes()
+            : base(0x2F58)
+        {
+            Name = "Carved Bone Relic from Holmes";
+            Hue = 1150;
+
+            SkillBonuses.SetValues(0, SkillName.Anatomy, 20.0);
+            Attributes.EnhancePotions = 15;
+        }
+
+        public CarvedBoneRelicFromHolmes(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Talismans/ShadowMastersTalisman.cs
+++ b/Scripts/Items/Artifacts/Equipment/Talismans/ShadowMastersTalisman.cs
@@ -2,25 +2,29 @@ using System;
 
 namespace Server.Items
 {
-    public class CarvedBoneRelicFromHolmes : BaseTalisman
+    public class ShadowMastersTalisman : BaseTalisman
     {
         public override bool IsArtifact { get { return true; } }
 
         [Constructable]
-        public CarvedBoneRelicFromHolmes()
+        public ShadowMastersTalisman()
             : base(0x2F58)
         {
-            Name = "Carved Bone Relic from Holmes";
-            Hue = 1150;
+            Name = "Shadow Master's Talisman";
+            Hue = 1109;
+            Weight = 1.0;
 
-            SkillBonuses.SetValues(0, MushroomApron.GetRandomSkill(), 20.0);
-            Attributes.EnhancePotions = 15;
+            SkillBonuses.SetValues(0, SkillName.Stealth, 10.0);
+            SkillBonuses.SetValues(1, SkillName.Ninjitsu, 10.0);
+
+            Attributes.RegenHits = 3;
+            Attributes.RegenMana = 3;
             Attributes.DefendChance = 10;
-            Attributes.BonusDex = 15;
-            Attributes.RegenStam = 2;
+
+            LootType = LootType.Blessed;
         }
 
-        public CarvedBoneRelicFromHolmes(Serial serial)
+        public ShadowMastersTalisman(Serial serial)
             : base(serial)
         {
         }

--- a/Scripts/Items/Artifacts/Equipment/Weapons/AxeOfTheHeavens.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/AxeOfTheHeavens.cs
@@ -10,9 +10,22 @@ namespace Server.Items
         {
             Hue = 0x4D5;
             WeaponAttributes.HitLightning = 50;
+            WeaponAttributes.HitLowerDefend = 50;
+            WeaponAttributes.HitLeechMana = 80;
+            WeaponAttributes.HitLeechHits = 80;
+            WeaponAttributes.BattleLust = 1;
             Attributes.AttackChance = 15;
             Attributes.DefendChance = 15;
             Attributes.WeaponDamage = 50;
+
+            switch (Utility.Random(5))
+            {
+                case 0: AosElementDamages.Physical = 100; break;
+                case 1: AosElementDamages.Physical = 0; AosElementDamages.Fire = 100; break;
+                case 2: AosElementDamages.Physical = 0; AosElementDamages.Cold = 100; break;
+                case 3: AosElementDamages.Physical = 0; AosElementDamages.Energy = 100; break;
+                case 4: AosElementDamages.Physical = 0; AosElementDamages.Poison = 100; break;
+            }
         }
 
         public AxeOfTheHeavens(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/BladeOfInsanity.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/BladeOfInsanity.cs
@@ -10,6 +10,10 @@ namespace Server.Items
         {
             Hue = 0x76D;
             WeaponAttributes.HitLeechStam = 100;
+            WeaponAttributes.HitLowerDefend = 50;
+            WeaponAttributes.HitMagicArrow = 70;
+            WeaponAttributes.BattleLust = 1;
+            WeaponAttributes.HitLeechMana = 100;
             Attributes.RegenStam = 2;
             Attributes.WeaponSpeed = 30;
             Attributes.WeaponDamage = 50;

--- a/Scripts/Items/Artifacts/Equipment/Weapons/BladeOfTheRighteous.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/BladeOfTheRighteous.cs
@@ -11,6 +11,8 @@ namespace Server.Items
             Hue = 0x47E;
             Slayer = SlayerName.Exorcism;
             WeaponAttributes.HitLeechHits = 87;
+            WeaponAttributes.HitLeechMana = 87;
+            WeaponAttributes.HitLeechStam = 87;
             WeaponAttributes.UseBestSkill = 1;
             Attributes.BonusHits = 10;
             Attributes.WeaponDamage = 50;

--- a/Scripts/Items/Artifacts/Equipment/Weapons/BoneCrusher.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/BoneCrusher.cs
@@ -10,6 +10,8 @@ namespace Server.Items
         {
             Hue = 0x60C;
             WeaponAttributes.HitLowerDefend = 50;
+            WeaponAttributes.HitLightning = 70;
+            ExtendedWeaponAttributes.BoneBreaker = 1;
             Attributes.BonusStr = 10;
             Attributes.WeaponDamage = 75;
         }

--- a/Scripts/Items/Artifacts/Equipment/Weapons/BowOfTheInfiniteSwarm.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/BowOfTheInfiniteSwarm.cs
@@ -13,10 +13,13 @@ namespace Server.Items
             ExtendedWeaponAttributes.HitSwarm = 20;
             WeaponAttributes.HitLeechMana = 50;
             WeaponAttributes.HitLeechStam = 50;
+            WeaponAttributes.HitLightning = 70;
+            WeaponAttributes.HitLowerDefend = 50;
             Attributes.BonusStam = 8;
             Attributes.RegenStam = 3;
             Attributes.WeaponSpeed = 30;
             Attributes.WeaponDamage = 50;
+            Balanced = true;
         }
 
         public override void GetDamageTypes(Mobile wielder, out int phys, out int fire, out int cold, out int pois, out int nrgy, out int chaos, out int direct)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/BraveKnightOfTheBritannia.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/BraveKnightOfTheBritannia.cs
@@ -11,9 +11,10 @@ namespace Server.Items
             Hue = 0x47e;
             Attributes.WeaponSpeed = 30;
             Attributes.WeaponDamage = 35;
-            WeaponAttributes.HitLeechStam = 48;
-            WeaponAttributes.HitHarm = 26;
-            WeaponAttributes.HitLeechHits = 22;
+            WeaponAttributes.HitLeechStam = 50;
+            WeaponAttributes.HitHarm = 70;
+            WeaponAttributes.HitLeechHits = 50;
+            WeaponAttributes.HitLowerDefend = 50;
         }
 
         public BraveKnightOfTheBritannia(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/BreathOfTheDead.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/BreathOfTheDead.cs
@@ -10,7 +10,9 @@ namespace Server.Items
         {
             Hue = 0x455;
             WeaponAttributes.HitLeechHits = 100;
-            WeaponAttributes.HitHarm = 25;
+            WeaponAttributes.HitHarm = 70;
+            WeaponAttributes.HitLowerDefend = 50;
+            Attributes.SpellChanneling = 1;
             Attributes.SpellDamage = 5;
             Attributes.WeaponDamage = 50;
         }

--- a/Scripts/Items/Artifacts/Equipment/Weapons/Calm.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/Calm.cs
@@ -13,6 +13,9 @@ namespace Server.Items
             Attributes.WeaponSpeed = 20;
             Attributes.WeaponDamage = 50;
             WeaponAttributes.HitLeechMana = 100;
+            WeaponAttributes.HitLeechHits = 100;
+            WeaponAttributes.HitLowerDefend = 50;
+            WeaponAttributes.HitColdArea = 80;
             WeaponAttributes.UseBestSkill = 1;
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/ChannelersDefender.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/ChannelersDefender.cs
@@ -10,14 +10,16 @@ namespace Server.Items
         [Constructable]
         public ChannelersDefender()
         {	
-            Hue = 95;	
-            Attributes.DefendChance = 10;				
-            Attributes.AttackChance = 5;	
+            Hue = 95;
+            Attributes.DefendChance = 10;
+            Attributes.AttackChance = 5;
             Attributes.LowerManaCost = 5;
-            Attributes.WeaponSpeed = 20;					
-            Attributes.CastRecovery = 1;		
-            Attributes.SpellChanneling = 1;	
+            Attributes.WeaponSpeed = 20;
+            Attributes.CastRecovery = 1;
+            Attributes.SpellChanneling = 1;
             WeaponAttributes.HitLowerAttack = 60;
+            WeaponAttributes.HitLightning = 70;
+            WeaponAttributes.HitLowerDefend = 50;
             AosElementDamages.Energy = 100;		
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/DreadsRevenge.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/DreadsRevenge.cs
@@ -15,7 +15,9 @@ namespace Server.Items
         {
             Hue = 0x3A;		
             SkillBonuses.SetValues(0, SkillName.Fencing, 20.0);		
-            WeaponAttributes.HitPoisonArea = 30;
+            WeaponAttributes.HitPoisonArea = 50;
+            WeaponAttributes.HitFireball = 70;
+            WeaponAttributes.HitLowerDefend = 50;
             Attributes.AttackChance = 15;
             Attributes.WeaponSpeed = 50;
         }

--- a/Scripts/Items/Artifacts/Equipment/Weapons/EternalGuardianStaff.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/EternalGuardianStaff.cs
@@ -11,9 +11,11 @@ namespace Server.Items
         public EternalGuardianStaff()
         {		
             Hue = 95;
-            SkillBonuses.SetValues(0, SkillName.Mysticism, 15.0);		
+            SkillBonuses.SetValues(0, SkillName.Mysticism, 15.0);
+            WeaponAttributes.HitFireball = 70;
+            WeaponAttributes.HitLowerDefend = 50;
             Attributes.SpellDamage = 10;
-            Attributes.LowerManaCost = 5;	
+            Attributes.LowerManaCost = 5;
             Attributes.SpellChanneling = 1;	
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/ExporMalasFlamus.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/ExporMalasFlamus.cs
@@ -16,7 +16,7 @@ namespace Server.Items
 
             WeaponAttributes.HitLowerAttack = 50;
             WeaponAttributes.HitLeechHits = 100;
-            WeaponAttributes.HitManaDrain = 100;
+            WeaponAttributes.HitLeechMana = 100;
             WeaponAttributes.HitLeechStam = 50;
             WeaponAttributes.HitFireArea = 70;
 
@@ -61,7 +61,7 @@ namespace Server.Items
 
             WeaponAttributes.HitLowerAttack = 50;
             WeaponAttributes.HitLeechHits = 100;
-            WeaponAttributes.HitManaDrain = 100;
+            WeaponAttributes.HitLeechMana = 100;
             WeaponAttributes.HitLeechStam = 50;
             WeaponAttributes.HitFireArea = 70;
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/ExporMalasFlamus.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/ExporMalasFlamus.cs
@@ -1,0 +1,94 @@
+using System;
+
+namespace Server.Items
+{
+    public class ExporMalasFlamus : BladedStaff
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public ExporMalasFlamus()
+        {
+            Name = "Expor Malas Flamus";
+            Hue = 1161;
+
+            SearingWeapon = true;
+
+            WeaponAttributes.HitLowerAttack = 50;
+            WeaponAttributes.HitLeechHits = 100;
+            WeaponAttributes.HitManaDrain = 100;
+            WeaponAttributes.HitLeechStam = 50;
+            WeaponAttributes.HitFireArea = 70;
+
+            Attributes.WeaponDamage = 30;
+
+            AosElementDamages.Physical = 0;
+            AosElementDamages.Fire = 100;
+
+            MaxHitPoints = 255;
+            HitPoints = 255;
+        }
+
+        public ExporMalasFlamus(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+
+    public class GargishExporMalasFlamus : GargishKatana
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public GargishExporMalasFlamus()
+        {
+            Name = "Gargish Expor Malas Flamus";
+            Hue = 1161;
+
+            SearingWeapon = true;
+
+            WeaponAttributes.HitLowerAttack = 50;
+            WeaponAttributes.HitLeechHits = 100;
+            WeaponAttributes.HitManaDrain = 100;
+            WeaponAttributes.HitLeechStam = 50;
+            WeaponAttributes.HitFireArea = 70;
+
+            Attributes.WeaponDamage = 30;
+
+            AosElementDamages.Physical = 0;
+            AosElementDamages.Fire = 100;
+
+            MaxHitPoints = 255;
+            HitPoints = 255;
+        }
+
+        public GargishExporMalasFlamus(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Weapons/FangOfRactus.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/FangOfRactus.cs
@@ -13,8 +13,10 @@ namespace Server.Items
             Attributes.AttackChance = 5;
             Attributes.DefendChance = 5;
             Attributes.WeaponDamage = 35;
-            WeaponAttributes.HitPoisonArea = 20;
+            WeaponAttributes.HitPoisonArea = 50;
             WeaponAttributes.ResistPoisonBonus = 15;
+            WeaponAttributes.HitLowerDefend = 50;
+            WeaponAttributes.HitLightning = 70;
         }
 
         public FangOfRactus(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/Frostbringer.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/Frostbringer.cs
@@ -10,8 +10,13 @@ namespace Server.Items
         {
             Hue = 0x4F2;
             WeaponAttributes.HitDispel = 50;
+            WeaponAttributes.HitLightning = 70;
+            WeaponAttributes.HitLowerDefend = 50;
+            Balanced = true;
             Attributes.RegenStam = 10;
             Attributes.WeaponDamage = 50;
+            Attributes.WeaponSpeed = 50;
+            Attributes.LowerAmmoCost = 25;
         }
 
         public Frostbringer(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/Glenda.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/Glenda.cs
@@ -12,8 +12,11 @@ namespace Server.Items
         {
             ExtendedWeaponAttributes.BoneBreaker = 1;
             WeaponAttributes.HitLeechMana = 20;
+            WeaponAttributes.HitLeechHits = 20;
             WeaponAttributes.HitLowerDefend = 70;
+            WeaponAttributes.HitHarm = 30;
             Attributes.BonusStr = 16;
+            Attributes.BonusStam = 10;
             Attributes.WeaponDamage = 100;
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/IronwoodCompositeBow.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/IronwoodCompositeBow.cs
@@ -13,12 +13,13 @@ namespace Server.Items
         {
             Hue = 1410;			
             Slayer = SlayerName.Fey;
-            WeaponAttributes.HitFireball = 40;
-            WeaponAttributes.HitLowerDefend = 30;	
+            WeaponAttributes.HitLightning = 70;
+            WeaponAttributes.HitLowerDefend = 50;
             Attributes.BonusDex = 5;
-            Attributes.WeaponSpeed = 25;
+            Attributes.WeaponSpeed = 40;
             Attributes.WeaponDamage = 45;
-            Velocity = 30;
+            Velocity = 50;
+            Balanced = true;
         }
 
         public IronwoodCompositeBow(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/LegacyOfTheDreadLord.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/LegacyOfTheDreadLord.cs
@@ -11,8 +11,11 @@ namespace Server.Items
             Hue = 0x676;
             Attributes.SpellChanneling = 1;
             Attributes.CastRecovery = 3;
+            Attributes.CastSpeed = 1;
             Attributes.WeaponSpeed = 30;
             Attributes.WeaponDamage = 50;
+            WeaponAttributes.MageWeapon = 30;
+            WeaponAttributes.HitHarm = 70;
         }
 
         public LegacyOfTheDreadLord(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/MelisandesCorrodedHatchet.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/MelisandesCorrodedHatchet.cs
@@ -9,11 +9,15 @@ namespace Server.Items
         public MelisandesCorrodedHatchet()
         {
             Hue = 0x494;
-            SkillBonuses.SetValues(0, SkillName.Lumberjacking, 5.0);
+            SkillBonuses.SetValues(0, SkillName.Lumberjacking, 20.0);
             Attributes.SpellChanneling = 1;
             Attributes.WeaponSpeed = 15;
-            Attributes.WeaponDamage = -50;
+            Attributes.WeaponDamage = 50;
             WeaponAttributes.SelfRepair = 4;
+            WeaponAttributes.HitLightning = 70;
+            WeaponAttributes.HitLowerDefend = 50;
+            Attributes.BalancedWeapon = 1;
+            WeaponAttributes.SplinteringWeapon = 30;
         }
 
         public MelisandesCorrodedHatchet(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/OblivionsNeedle.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/OblivionsNeedle.cs
@@ -10,9 +10,11 @@ namespace Server.Items
         {
             Attributes.BonusStam = 20;
             Attributes.AttackChance = 20;
-            Attributes.DefendChance = -20;
+            Attributes.DefendChance = 10;
             Attributes.WeaponDamage = 40;
             WeaponAttributes.HitLeechStam = 50;
+            WeaponAttributes.HitLightning = 70;
+            WeaponAttributes.HitLowerDefend = 50;
         }
 
         public OblivionsNeedle(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/Pacify.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/Pacify.cs
@@ -9,11 +9,14 @@ namespace Server.Items
         public Pacify()
         {
             Hue = 0x835;
+            Attributes.BalancedWeapon = 1;
             Attributes.SpellChanneling = 1;
             Attributes.AttackChance = 10;
             Attributes.WeaponSpeed = 20;
             Attributes.WeaponDamage = 50;
             WeaponAttributes.HitLeechMana = 100;
+            WeaponAttributes.HitLowerDefend = 50;
+            WeaponAttributes.HitLightning = 70;
             WeaponAttributes.UseBestSkill = 1;
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/Quell.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/Quell.cs
@@ -14,6 +14,8 @@ namespace Server.Items
             Attributes.WeaponDamage = 50;
             Attributes.AttackChance = 10;
             WeaponAttributes.HitLeechMana = 100;
+            WeaponAttributes.HitLowerDefend = 50;
+            WeaponAttributes.HitLightning = 70;
             WeaponAttributes.UseBestSkill = 1;
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/RoyalGuardSurvivalKnife.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/RoyalGuardSurvivalKnife.cs
@@ -9,10 +9,13 @@ namespace Server.Items
         public RoyalGuardSurvivalKnife()
         {
             Attributes.SpellChanneling = 1;
-            Attributes.Luck = 140;
+            Attributes.Luck = 300;
             Attributes.EnhancePotions = 25;
             WeaponAttributes.UseBestSkill = 1;
             WeaponAttributes.LowerStatReq = 50;
+            WeaponAttributes.MageWeapon = 30;
+            SkillBonuses.SetValues(0, SkillName.Lockpicking, 20.0);
+            SkillBonuses.SetValues(1, SkillName.RemoveTrap, 20.0);
         }
 
         public RoyalGuardSurvivalKnife(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/SerpentsFang.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/SerpentsFang.cs
@@ -10,7 +10,11 @@ namespace Server.Items
         {
             Hue = 0x488;
             WeaponAttributes.HitPoisonArea = 100;
+            WeaponAttributes.HitLightning = 70;
+            WeaponAttributes.HitLeechMana = 100;
+            WeaponAttributes.HitLowerDefend = 50;
             WeaponAttributes.ResistPoisonBonus = 20;
+            Attributes.SpellChanneling = 1;
             Attributes.AttackChance = 15;
             Attributes.WeaponDamage = 50;
         }

--- a/Scripts/Items/Artifacts/Equipment/Weapons/ShugenjasWand.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/ShugenjasWand.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Server.Items
+{
+    public class ShugenjasWand : MagicWand
+    {
+        public override bool IsArtifact { get { return true; } }
+
+        [Constructable]
+        public ShugenjasWand()
+        {
+            Name = "Shugenja's Wand";
+            Hue = 1266;
+
+            Attributes.SpellChanneling = 1;
+            Attributes.CastRecovery = 2;
+            Attributes.RegenMana = 10;
+
+            WeaponAttributes.MageWeapon = 30;
+
+            AosElementDamages.Physical = 100;
+
+            MaxHitPoints = 255;
+            HitPoints = 255;
+        }
+
+        public ShugenjasWand(Serial serial)
+            : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Weapons/ShugenjasWand.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/ShugenjasWand.cs
@@ -17,6 +17,7 @@ namespace Server.Items
             Attributes.RegenMana = 10;
 
             WeaponAttributes.MageWeapon = 30;
+            WeaponAttributes.HitLightning = 50;
 
             AosElementDamages.Physical = 100;
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/SlayerWeaponSet.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/SlayerWeaponSet.cs
@@ -8,7 +8,7 @@ namespace Server.Items
         public static void ApplyCommonProperties(BaseWeapon weapon, SlayerName slayer, int damageType, AosWeaponAttribute hitArea)
         {
             weapon.Slayer = slayer;
-            weapon.WeaponAttributes.HitManaDrain = 100;
+            weapon.WeaponAttributes.HitLeechMana = 100;
             weapon.WeaponAttributes.HitLeechHits = 100;
             weapon.WeaponAttributes.HitLeechStam = 50;
             weapon.WeaponAttributes.HitLowerDefend = 50;

--- a/Scripts/Items/Artifacts/Equipment/Weapons/SlayerWeaponSet.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/SlayerWeaponSet.cs
@@ -1,0 +1,902 @@
+using System;
+
+namespace Server.Items
+{
+    #region Helper
+    public static class SlayerWeaponHelper
+    {
+        public static void ApplyCommonProperties(BaseWeapon weapon, SlayerName slayer, int damageType, AosWeaponAttribute hitArea)
+        {
+            weapon.Slayer = slayer;
+            weapon.WeaponAttributes.HitManaDrain = 100;
+            weapon.WeaponAttributes.HitLeechHits = 100;
+            weapon.WeaponAttributes.HitLeechStam = 50;
+            weapon.WeaponAttributes.HitLowerDefend = 50;
+            weapon.Attributes.Brittle = 1;
+
+            weapon.MaxHitPoints = 255;
+            weapon.HitPoints = 255;
+
+            // Set hit area
+            switch (hitArea)
+            {
+                case AosWeaponAttribute.HitPoisonArea: weapon.WeaponAttributes.HitPoisonArea = 50; break;
+                case AosWeaponAttribute.HitColdArea: weapon.WeaponAttributes.HitColdArea = 50; break;
+                case AosWeaponAttribute.HitFireArea: weapon.WeaponAttributes.HitFireArea = 50; break;
+                case AosWeaponAttribute.HitEnergyArea: weapon.WeaponAttributes.HitEnergyArea = 50; break;
+            }
+
+            // Set 100% damage conversion
+            weapon.AosElementDamages.Physical = 0;
+            switch (damageType)
+            {
+                case 0: weapon.AosElementDamages.Poison = 100; break; // poison
+                case 1: weapon.AosElementDamages.Cold = 100; break;   // cold
+                case 2: weapon.AosElementDamages.Fire = 100; break;   // fire
+                case 3: weapon.AosElementDamages.Energy = 100; break; // energy
+            }
+        }
+    }
+    #endregion
+
+    // ==================== REPTILE SLAYER ====================
+    // Poison damage 100%, Hit Poison Area 50%
+
+    public class ReptileLeafblade : Leafblade
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileLeafblade() { Name = "Reptile Leafblade"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileLeafblade(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ReptileWarAxe : WarAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileWarAxe() { Name = "Reptile War Axe"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileWarAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ReptileBroadsword : Broadsword
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileBroadsword() { Name = "Reptile Broadsword"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileBroadsword(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ReptileDoubleAxe : DoubleAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileDoubleAxe() { Name = "Reptile Double Axe"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileDoubleAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ReptileWarHammer : WarHammer
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileWarHammer() { Name = "Reptile Paladin Hammer"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileWarHammer(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ReptileMagicalShortbow : MagicalShortbow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileMagicalShortbow() { Name = "Reptile Magical Shortbow"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileMagicalShortbow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ReptileCompositeBow : CompositeBow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileCompositeBow() { Name = "Reptile Composite Bow"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileCompositeBow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ReptileSoulGlaive : SoulGlaive
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileSoulGlaive() { Name = "Reptile Soul Glaive"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileSoulGlaive(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ReptileBoomerang : Boomerang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileBoomerang() { Name = "Reptile Boomerang"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileBoomerang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ReptileGargishTalwar : GargishTalwar
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileGargishTalwar() { Name = "Reptile Gargish Talwar"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileGargishTalwar(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ReptileGargishKatana : GargishKatana
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileGargishKatana() { Name = "Reptile Gargish Katana"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileGargishKatana(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ReptileLajatang : Lajatang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ReptileLajatang() { Name = "Reptile Lajatang"; Hue = 1267; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ReptilianDeath, 0, AosWeaponAttribute.HitPoisonArea); }
+        public ReptileLajatang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    // ==================== REPOND SLAYER ====================
+    // Cold damage 100%, Hit Cold Area 50%
+
+    public class RepondLeafblade : Leafblade
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondLeafblade() { Name = "Repond Leafblade"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondLeafblade(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondWarAxe : WarAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondWarAxe() { Name = "Repond War Axe"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondWarAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondBroadsword : Broadsword
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondBroadsword() { Name = "Repond Broadsword"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondBroadsword(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondDoubleAxe : DoubleAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondDoubleAxe() { Name = "Repond Double Axe"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondDoubleAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondWarHammer : WarHammer
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondWarHammer() { Name = "Repond Paladin Hammer"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondWarHammer(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondMagicalShortbow : MagicalShortbow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondMagicalShortbow() { Name = "Repond Magical Shortbow"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondMagicalShortbow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondCompositeBow : CompositeBow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondCompositeBow() { Name = "Repond Composite Bow"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondCompositeBow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondSoulGlaive : SoulGlaive
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondSoulGlaive() { Name = "Repond Soul Glaive"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondSoulGlaive(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondBoomerang : Boomerang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondBoomerang() { Name = "Repond Boomerang"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondBoomerang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondGargishTalwar : GargishTalwar
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondGargishTalwar() { Name = "Repond Gargish Talwar"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondGargishTalwar(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondGargishKatana : GargishKatana
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondGargishKatana() { Name = "Repond Gargish Katana"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondGargishKatana(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class RepondLajatang : Lajatang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public RepondLajatang() { Name = "Repond Lajatang"; Hue = 1152; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Repond, 1, AosWeaponAttribute.HitColdArea); }
+        public RepondLajatang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    // ==================== ARACHNID SLAYER ====================
+    // Fire damage 100%, Hit Fire Area 50%
+
+    public class ArachnidLeafblade : Leafblade
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidLeafblade() { Name = "Arachnid Leafblade"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidLeafblade(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidWarAxe : WarAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidWarAxe() { Name = "Arachnid War Axe"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidWarAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidBroadsword : Broadsword
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidBroadsword() { Name = "Arachnid Broadsword"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidBroadsword(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidDoubleAxe : DoubleAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidDoubleAxe() { Name = "Arachnid Double Axe"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidDoubleAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidWarHammer : WarHammer
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidWarHammer() { Name = "Arachnid Paladin Hammer"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidWarHammer(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidMagicalShortbow : MagicalShortbow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidMagicalShortbow() { Name = "Arachnid Magical Shortbow"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidMagicalShortbow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidCompositeBow : CompositeBow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidCompositeBow() { Name = "Arachnid Composite Bow"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidCompositeBow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidSoulGlaive : SoulGlaive
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidSoulGlaive() { Name = "Arachnid Soul Glaive"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidSoulGlaive(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidBoomerang : Boomerang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidBoomerang() { Name = "Arachnid Boomerang"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidBoomerang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidGargishTalwar : GargishTalwar
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidGargishTalwar() { Name = "Arachnid Gargish Talwar"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidGargishTalwar(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidGargishKatana : GargishKatana
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidGargishKatana() { Name = "Arachnid Gargish Katana"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidGargishKatana(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ArachnidLajatang : Lajatang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ArachnidLajatang() { Name = "Arachnid Lajatang"; Hue = 1161; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ArachnidDoom, 2, AosWeaponAttribute.HitFireArea); }
+        public ArachnidLajatang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    // ==================== UNDEAD SLAYER (Silver) ====================
+    // Fire damage 100%, Hit Fire Area 50%
+
+    public class UndeadLeafblade : Leafblade
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadLeafblade() { Name = "Undead Leafblade"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadLeafblade(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadWarAxe : WarAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadWarAxe() { Name = "Undead War Axe"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadWarAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadBroadsword : Broadsword
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadBroadsword() { Name = "Undead Broadsword"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadBroadsword(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadDoubleAxe : DoubleAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadDoubleAxe() { Name = "Undead Double Axe"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadDoubleAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadWarHammer : WarHammer
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadWarHammer() { Name = "Undead Paladin Hammer"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadWarHammer(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadMagicalShortbow : MagicalShortbow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadMagicalShortbow() { Name = "Undead Magical Shortbow"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadMagicalShortbow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadCompositeBow : CompositeBow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadCompositeBow() { Name = "Undead Composite Bow"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadCompositeBow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadSoulGlaive : SoulGlaive
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadSoulGlaive() { Name = "Undead Soul Glaive"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadSoulGlaive(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadBoomerang : Boomerang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadBoomerang() { Name = "Undead Boomerang"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadBoomerang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadGargishTalwar : GargishTalwar
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadGargishTalwar() { Name = "Undead Gargish Talwar"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadGargishTalwar(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadGargishKatana : GargishKatana
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadGargishKatana() { Name = "Undead Gargish Katana"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadGargishKatana(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class UndeadLajatang : Lajatang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public UndeadLajatang() { Name = "Undead Lajatang"; Hue = 1150; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Silver, 2, AosWeaponAttribute.HitFireArea); }
+        public UndeadLajatang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    // ==================== DEMON SLAYER (Exorcism) ====================
+    // Cold damage 100%, Hit Cold Area 50%
+
+    public class DemonLeafblade : Leafblade
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonLeafblade() { Name = "Demon Leafblade"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonLeafblade(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonWarAxe : WarAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonWarAxe() { Name = "Demon War Axe"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonWarAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonBroadsword : Broadsword
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonBroadsword() { Name = "Demon Broadsword"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonBroadsword(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonDoubleAxe : DoubleAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonDoubleAxe() { Name = "Demon Double Axe"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonDoubleAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonWarHammer : WarHammer
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonWarHammer() { Name = "Demon Paladin Hammer"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonWarHammer(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonMagicalShortbow : MagicalShortbow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonMagicalShortbow() { Name = "Demon Magical Shortbow"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonMagicalShortbow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonCompositeBow : CompositeBow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonCompositeBow() { Name = "Demon Composite Bow"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonCompositeBow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonSoulGlaive : SoulGlaive
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonSoulGlaive() { Name = "Demon Soul Glaive"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonSoulGlaive(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonBoomerang : Boomerang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonBoomerang() { Name = "Demon Boomerang"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonBoomerang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonGargishTalwar : GargishTalwar
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonGargishTalwar() { Name = "Demon Gargish Talwar"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonGargishTalwar(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonGargishKatana : GargishKatana
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonGargishKatana() { Name = "Demon Gargish Katana"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonGargishKatana(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class DemonLajatang : Lajatang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public DemonLajatang() { Name = "Demon Lajatang"; Hue = 1157; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Exorcism, 1, AosWeaponAttribute.HitColdArea); }
+        public DemonLajatang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    // ==================== FEY SLAYER ====================
+    // Fire damage 100%, Hit Fire Area 50%
+
+    public class FeyLeafblade : Leafblade
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeyLeafblade() { Name = "Fey Leafblade"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeyLeafblade(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeyWarAxe : WarAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeyWarAxe() { Name = "Fey War Axe"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeyWarAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeyBroadsword : Broadsword
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeyBroadsword() { Name = "Fey Broadsword"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeyBroadsword(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeyDoubleAxe : DoubleAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeyDoubleAxe() { Name = "Fey Double Axe"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeyDoubleAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeyWarHammer : WarHammer
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeyWarHammer() { Name = "Fey Paladin Hammer"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeyWarHammer(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeyMagicalShortbow : MagicalShortbow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeyMagicalShortbow() { Name = "Fey Magical Shortbow"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeyMagicalShortbow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeyCompositeBow : CompositeBow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeyCompositeBow() { Name = "Fey Composite Bow"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeyCompositeBow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeySoulGlaive : SoulGlaive
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeySoulGlaive() { Name = "Fey Soul Glaive"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeySoulGlaive(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeyBoomerang : Boomerang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeyBoomerang() { Name = "Fey Boomerang"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeyBoomerang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeyGargishTalwar : GargishTalwar
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeyGargishTalwar() { Name = "Fey Gargish Talwar"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeyGargishTalwar(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeyGargishKatana : GargishKatana
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeyGargishKatana() { Name = "Fey Gargish Katana"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeyGargishKatana(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class FeyLajatang : Lajatang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public FeyLajatang() { Name = "Fey Lajatang"; Hue = 1159; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.Fey, 2, AosWeaponAttribute.HitFireArea); }
+        public FeyLajatang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    // ==================== ELEMENTAL SLAYER ====================
+    // Energy damage 100%, Hit Energy Area 50%
+
+    public class ElementalLeafblade : Leafblade
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalLeafblade() { Name = "Elemental Leafblade"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalLeafblade(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalWarAxe : WarAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalWarAxe() { Name = "Elemental War Axe"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalWarAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalBroadsword : Broadsword
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalBroadsword() { Name = "Elemental Broadsword"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalBroadsword(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalDoubleAxe : DoubleAxe
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalDoubleAxe() { Name = "Elemental Double Axe"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalDoubleAxe(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalWarHammer : WarHammer
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalWarHammer() { Name = "Elemental Paladin Hammer"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalWarHammer(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalMagicalShortbow : MagicalShortbow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalMagicalShortbow() { Name = "Elemental Magical Shortbow"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalMagicalShortbow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalCompositeBow : CompositeBow
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalCompositeBow() { Name = "Elemental Composite Bow"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalCompositeBow(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalSoulGlaive : SoulGlaive
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalSoulGlaive() { Name = "Elemental Soul Glaive"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalSoulGlaive(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalBoomerang : Boomerang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalBoomerang() { Name = "Elemental Boomerang"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalBoomerang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalGargishTalwar : GargishTalwar
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalGargishTalwar() { Name = "Elemental Gargish Talwar"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalGargishTalwar(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalGargishKatana : GargishKatana
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalGargishKatana() { Name = "Elemental Gargish Katana"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalGargishKatana(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+
+    public class ElementalLajatang : Lajatang
+    {
+        public override bool IsArtifact { get { return true; } }
+        [Constructable]
+        public ElementalLajatang() { Name = "Elemental Lajatang"; Hue = 1160; SlayerWeaponHelper.ApplyCommonProperties(this, SlayerName.ElementalBan, 3, AosWeaponAttribute.HitEnergyArea); }
+        public ElementalLajatang(Serial s) : base(s) { }
+        public override void Serialize(GenericWriter w) { base.Serialize(w); w.Write(0); }
+        public override void Deserialize(GenericReader r) { base.Deserialize(r); r.ReadInt(); }
+    }
+}

--- a/Scripts/Items/Artifacts/Equipment/Weapons/SoulSeeker.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/SoulSeeker.cs
@@ -12,7 +12,9 @@ namespace Server.Items
             WeaponAttributes.HitLeechStam = 40;
             WeaponAttributes.HitLeechMana = 30;
             WeaponAttributes.HitLeechHits = 30;
+            WeaponAttributes.HitColdArea = 50;
             Attributes.WeaponSpeed = 60;
+            Attributes.WeaponDamage = 25;
             Slayer = SlayerName.Repond;
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/StaffOfTheMagi.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/StaffOfTheMagi.cs
@@ -10,9 +10,13 @@ namespace Server.Items
         {
             Hue = 0x481;
             WeaponAttributes.MageWeapon = 30;
+            WeaponAttributes.HitFireball = 70;
             Attributes.SpellChanneling = 1;
             Attributes.CastSpeed = 1;
             Attributes.WeaponDamage = 50;
+            Attributes.RegenMana = 10;
+            Attributes.BonusMana = 10;
+            Attributes.AttackChance = 15;
         }
 
         public StaffOfTheMagi(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/Subdue.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/Subdue.cs
@@ -14,6 +14,9 @@ namespace Server.Items
             Attributes.WeaponDamage = 50;
             Attributes.AttackChance = 10;
             WeaponAttributes.HitLeechMana = 100;
+            WeaponAttributes.HitLeechHits = 100;
+            WeaponAttributes.HitLowerDefend = 50;
+            WeaponAttributes.HitFireArea = 80;
             WeaponAttributes.UseBestSkill = 1;
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/TheBeserkersMaul.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/TheBeserkersMaul.cs
@@ -11,6 +11,9 @@ namespace Server.Items
             Hue = 0x21;
             Attributes.WeaponSpeed = 75;
             Attributes.WeaponDamage = 50;
+            Attributes.SpellChanneling = 1;
+            WeaponAttributes.HitFireball = 70;
+            WeaponAttributes.HitLowerDefend = 50;
         }
 
         public TheBeserkersMaul(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/TheDeceiver.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/TheDeceiver.cs
@@ -9,13 +9,16 @@ namespace Server.Items
         public override bool IsArtifact { get { return true; } }
 
         [Constructable]
-        public TheDeceiver() 
+        public TheDeceiver()
         {
             ExtendedWeaponAttributes.HitSparks = 20;
+            ExtendedWeaponAttributes.AssassinHoned = 1;
             WeaponAttributes.HitLowerAttack = 20;
             WeaponAttributes.HitEnergyArea = 75;
             WeaponAttributes.HitLowerDefend = 20;
             WeaponAttributes.HitLeechStam = 30;
+            WeaponAttributes.HitLeechMana = 30;
+            WeaponAttributes.HitLeechHits = 30;
             Attributes.LowerManaCost = 8;
             Attributes.WeaponDamage = 75;
         }

--- a/Scripts/Items/Artifacts/Equipment/Weapons/TheDragonSlayer.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/TheDragonSlayer.cs
@@ -10,10 +10,14 @@ namespace Server.Items
         {
             Hue = 0x530;
             Slayer = SlayerName.DragonSlaying;
-            Attributes.Luck = 110;
+            Attributes.Luck = 250;
             Attributes.WeaponDamage = 50;
             WeaponAttributes.ResistFireBonus = 20;
             WeaponAttributes.UseBestSkill = 1;
+            WeaponAttributes.HitLightning = 70;
+            WeaponAttributes.HitLowerDefend = 50;
+            WeaponAttributes.HitLeechMana = 80;
+            WeaponAttributes.HitLeechHits = 80;
         }
 
         public TheDragonSlayer(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/TheDryadBow.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/TheDryadBow.cs
@@ -18,11 +18,17 @@ namespace Server.Items
         public TheDryadBow()
         {
             Hue = 0x48F;
-            SkillBonuses.SetValues(0, m_PossibleBonusSkills[Utility.Random(m_PossibleBonusSkills.Length)], (Utility.Random(4) == 0 ? 10.0 : 5.0));
+            SkillBonuses.SetValues(0, SkillName.Archery, 10.0);
             WeaponAttributes.SelfRepair = 5;
+            WeaponAttributes.HitFireball = 70;
+            WeaponAttributes.HitLowerDefend = 50;
+            Balanced = true;
             Attributes.WeaponSpeed = 50;
             Attributes.WeaponDamage = 35;
+            Attributes.LowerAmmoCost = 25;
             WeaponAttributes.ResistPoisonBonus = 15;
+            AosElementDamages.Physical = 0;
+            AosElementDamages.Poison = 100;
         }
 
         public TheDryadBow(Serial serial)

--- a/Scripts/Items/Artifacts/Equipment/Weapons/TheTaskmaster.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/TheTaskmaster.cs
@@ -10,6 +10,10 @@ namespace Server.Items
         {
             Hue = 0x4F8;
             WeaponAttributes.HitPoisonArea = 100;
+            WeaponAttributes.HitLightning = 70;
+            WeaponAttributes.HitLeechMana = 100;
+            WeaponAttributes.HitLowerDefend = 50;
+            Attributes.SpellChanneling = 1;
             Attributes.BonusDex = 5;
             Attributes.AttackChance = 15;
             Attributes.WeaponDamage = 50;

--- a/Scripts/Items/Artifacts/Equipment/Weapons/TitansHammer.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/TitansHammer.cs
@@ -10,6 +10,8 @@ namespace Server.Items
         {
             Hue = 0x482;
             WeaponAttributes.HitEnergyArea = 100;
+            WeaponAttributes.HitLeechMana = 80;
+            WeaponAttributes.HitLeechHits = 80;
             Attributes.BonusStr = 15;
             Attributes.AttackChance = 15;
             Attributes.WeaponDamage = 50;

--- a/Scripts/Items/Artifacts/Equipment/Weapons/WildfireBow.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/WildfireBow.cs
@@ -10,9 +10,12 @@ namespace Server.Items
         public WildfireBow()
             : base()
         {
-            Hue = 1161;		
+            Hue = 1161;
             SkillBonuses.SetValues(0, SkillName.Archery, 10);
-            WeaponAttributes.ResistFireBonus = 25;			
+            Attributes.WeaponDamage = 30;
+            WeaponAttributes.ResistFireBonus = 25;
+            WeaponAttributes.HitLowerDefend = 30;
+            WeaponAttributes.HitFireball = 30;
             Velocity = 15;			
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/Windsong.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/Windsong.cs
@@ -9,9 +9,11 @@ namespace Server.Items
         public Windsong()
             : base()
         {
-            Hue = 172;			
+            Hue = 172;
             Attributes.WeaponDamage = 35;
-            WeaponAttributes.SelfRepair = 3;			
+            WeaponAttributes.SelfRepair = 3;
+            WeaponAttributes.HitColdArea = 70;
+            WeaponAttributes.HitLeechMana = 40;
             Velocity = 25;			
         }
 

--- a/Scripts/Items/Artifacts/Equipment/Weapons/ZyronicClaw.cs
+++ b/Scripts/Items/Artifacts/Equipment/Weapons/ZyronicClaw.cs
@@ -11,6 +11,8 @@ namespace Server.Items
             Hue = 0x485;
             Slayer = SlayerName.ElementalBan;
             WeaponAttributes.HitLeechMana = 81;
+            WeaponAttributes.HitPoisonArea = 80;
+            WeaponAttributes.HitLeechHits = 80;
             Attributes.AttackChance = 30;
             Attributes.WeaponDamage = 50;
         }

--- a/Scripts/Items/Artifacts/TOTLesserArtifacts.cs
+++ b/Scripts/Items/Artifacts/TOTLesserArtifacts.cs
@@ -982,8 +982,9 @@ namespace Server.Items
             LootType = LootType.Regular;
             Hue = 0x501;
 
-            Attributes.Luck = 300;
+            Attributes.Luck = 500;
             Attributes.RegenMana = 1;
+            SkillBonuses.SetValues(0, SkillName.Musicianship, 30.0);
         }
 
         public LeurociansMempoOfFortune(Serial serial)

--- a/Scripts/Items/Equipment/Talismans/BloodwoodSpirit.cs
+++ b/Scripts/Items/Equipment/Talismans/BloodwoodSpirit.cs
@@ -17,6 +17,8 @@ namespace Server.Items
             Removal = TalismanRemoval.Damage;
             Blessed = GetRandomBlessed();
             Protection = GetRandomProtection(false);
+            Attributes.LowerRegCost = 10;
+            Attributes.DefendChance = 5;
             SkillBonuses.SetValues(0, SkillName.SpiritSpeak, 10.0);
             SkillBonuses.SetValues(1, SkillName.Necromancy, 5.0);
         }

--- a/Scripts/Items/Equipment/Talismans/Slither.cs
+++ b/Scripts/Items/Equipment/Talismans/Slither.cs
@@ -11,11 +11,26 @@ namespace Server.Items
         public Slither()
             : base(0x2F5B)
         {
-            Hue = 0x587;				
-            Blessed = RandomTalisman.GetRandomBlessed();						
+            Hue = 0x587;
+            Blessed = RandomTalisman.GetRandomBlessed();
             Attributes.BonusHits = 10;
             Attributes.RegenHits = 2;
             Attributes.DefendChance = 10;
+            Attributes.BonusMana = 10;
+            Attributes.AttackChance = 10;
+            Attributes.BonusStam = 8;
+
+            switch (Utility.Random(8))
+            {
+                case 0: SkillBonuses.SetValues(0, SkillName.MagicResist, 20.0); break;
+                case 1: SkillBonuses.SetValues(0, SkillName.Tactics, 20.0); break;
+                case 2: SkillBonuses.SetValues(0, SkillName.Anatomy, 20.0); break;
+                case 3: SkillBonuses.SetValues(0, SkillName.Healing, 20.0); break;
+                case 4: SkillBonuses.SetValues(0, SkillName.EvalInt, 20.0); break;
+                case 5: SkillBonuses.SetValues(0, SkillName.Ninjitsu, 20.0); break;
+                case 6: SkillBonuses.SetValues(0, SkillName.Bushido, 20.0); break;
+                case 7: SkillBonuses.SetValues(0, SkillName.Chivalry, 20.0); break;
+            }
         }
 
         public Slither(Serial serial)

--- a/Scripts/Items/Equipment/Talismans/TotemOfVoid.cs
+++ b/Scripts/Items/Equipment/Talismans/TotemOfVoid.cs
@@ -19,6 +19,7 @@ namespace Server.Items
             Protection = GetRandomProtection(false);
             Attributes.RegenHits = 2;
             Attributes.LowerManaCost = 10;
+            SkillBonuses.SetValues(0, SkillName.Meditation, 20.0);
         }
 
         public TotemOfVoid(Serial serial)

--- a/Scripts/Misc/CurrentExpansion.cs
+++ b/Scripts/Misc/CurrentExpansion.cs
@@ -26,7 +26,7 @@ namespace Server
 
 			ObjectPropertyList.Enabled = Core.AOS;
 
-            Mobile.InsuranceEnabled = Core.AOS && !Siege.SiegeShard;
+            Mobile.InsuranceEnabled = Core.AOS;
 			Mobile.VisibleDamageType = Core.AOS ? VisibleDamageType.Related : VisibleDamageType.None;
 			Mobile.GuildClickMessage = !Core.AOS;
 			Mobile.AsciiClickMessage = !Core.AOS;

--- a/Scripts/Misc/Fastwalk.cs
+++ b/Scripts/Misc/Fastwalk.cs
@@ -4,8 +4,8 @@ namespace Server.Misc
 {
     public class Fastwalk
     {
-        private static readonly int MaxSteps = 2;// Maximum number of queued steps until fastwalk is detected
-        private static readonly bool Enabled = true;// Is fastwalk detection enabled?
+        private static readonly int MaxSteps = 4;// Maximum number of queued steps until fastwalk is detected
+        private static readonly bool Enabled = false;// Is fastwalk detection enabled? (PlayerMobile throttler handles this)
         private static readonly bool UOTDOverride = false;// Should UO:TD clients not be checked for fastwalk?
         private static readonly AccessLevel AccessOverride = AccessLevel.GameMaster;// Anyone with this or higher access level is not checked for fastwalk
         public static void Initialize()
@@ -14,13 +14,6 @@ namespace Server.Misc
             Mobile.FwdEnabled = Enabled;
             Mobile.FwdUOTDOverride = UOTDOverride;
             Mobile.FwdAccessOverride = AccessOverride;
-
-            // Tighten movement delays to prevent speed hacking
-            // These are minimum milliseconds between steps
-            Mobile.WalkFoot = 400;
-            Mobile.RunFoot = 200;
-            Mobile.WalkMount = 200;
-            Mobile.RunMount = 100;
 
             if (Enabled)
                 EventSink.FastWalk += new FastWalkEventHandler(OnFastWalk);

--- a/Scripts/Misc/Fastwalk.cs
+++ b/Scripts/Misc/Fastwalk.cs
@@ -2,20 +2,25 @@ using System;
 
 namespace Server.Misc
 {
-    // This fastwalk detection is no longer required
-    // As of B36 PlayerMobile implements movement packet throttling which more reliably controls movement speeds
     public class Fastwalk
     {
-        private static readonly int MaxSteps = 4;// Maximum number of queued steps until fastwalk is detected
-        private static readonly bool Enabled = false;// Is fastwalk detection enabled?
+        private static readonly int MaxSteps = 2;// Maximum number of queued steps until fastwalk is detected
+        private static readonly bool Enabled = true;// Is fastwalk detection enabled?
         private static readonly bool UOTDOverride = false;// Should UO:TD clients not be checked for fastwalk?
-        private static readonly AccessLevel AccessOverride = AccessLevel.Decorator;// Anyone with this or higher access level is not checked for fastwalk
+        private static readonly AccessLevel AccessOverride = AccessLevel.GameMaster;// Anyone with this or higher access level is not checked for fastwalk
         public static void Initialize()
         {
             Mobile.FwdMaxSteps = MaxSteps;
             Mobile.FwdEnabled = Enabled;
             Mobile.FwdUOTDOverride = UOTDOverride;
             Mobile.FwdAccessOverride = AccessOverride;
+
+            // Tighten movement delays to prevent speed hacking
+            // These are minimum milliseconds between steps
+            Mobile.WalkFoot = 400;
+            Mobile.RunFoot = 200;
+            Mobile.WalkMount = 200;
+            Mobile.RunMount = 100;
 
             if (Enabled)
                 EventSink.FastWalk += new FastWalkEventHandler(OnFastWalk);

--- a/Scripts/Misc/Siege.cs
+++ b/Scripts/Misc/Siege.cs
@@ -265,7 +265,7 @@ namespace Server
 				case TravelCheckType.RecallFrom:
 				case TravelCheckType.RecallTo:
 				{
-					return false;
+					return true;
 				}
 				case TravelCheckType.GateFrom:
 				case TravelCheckType.GateTo:

--- a/Scripts/Misc/SkillCheck.cs
+++ b/Scripts/Misc/SkillCheck.cs
@@ -37,7 +37,7 @@ namespace Server.Misc
 		/// </summary>
 		private const int LocationSize = 4;
 
-		public static bool GGSActive { get { return !Siege.SiegeShard; } }
+		public static bool GGSActive { get { return true; } }
 
 		static SkillCheck()
 		{
@@ -270,8 +270,9 @@ namespace Server.Misc
 
             gc *= skill.Info.GainFactor;
 
-            if (gc < 0.01)
-                gc = 0.01;
+            // Boost gain chance - minimum 25% chance to gain
+            if (gc < 0.25)
+                gc = 0.25;
 
             // Pets get a 100% bonus
             if (from is BaseCreature && ((BaseCreature)from).Controlled)
@@ -376,26 +377,6 @@ namespace Server.Misc
 			if (skill.Base < skill.Cap && skill.Lock == SkillLock.Up)
 			{
 				var skills = from.Skills;
-
-				if (from is PlayerMobile && Siege.SiegeShard)
-				{
-					var minsPerGain = Siege.MinutesPerGain(from, skill);
-
-					if (minsPerGain > 0)
-					{
-						if (Siege.CheckSkillGain((PlayerMobile)from, minsPerGain, skill))
-						{
-							CheckReduceSkill(skills, toGain, skill);
-
-							if (skills.Total + toGain <= skills.Cap)
-							{
-								skill.BaseFixedPoint += toGain;
-							}
-						}
-
-						return;
-					}
-				}
 
 				if (toGain == 1 && skill.Base <= 10.0)
 					toGain = Utility.Random(4) + 1;
@@ -797,12 +778,12 @@ namespace Server.Misc
 
 		private static readonly int[][] GGSTable =
 		{
-			new[] {1, 3, 5}, // 0.0 - 4.9
-			new[] {4, 10, 18}, new[] {7, 17, 30}, new[] {9, 24, 44}, new[] {12, 31, 57}, new[] {14, 38, 90}, new[] {17, 45, 84},
-			new[] {20, 52, 96}, new[] {23, 60, 106}, new[] {25, 66, 120}, new[] {27, 72, 138}, new[] {33, 90, 162},
-			new[] {55, 150, 264}, new[] {78, 216, 390}, new[] {114, 294, 540}, new[] {144, 384, 708}, new[] {180, 492, 900},
-			new[] {228, 606, 1116}, new[] {276, 744, 1356}, new[] {336, 894, 1620}, new[] {396, 1056, 1920},
-			new[] {468, 1242, 2280}, new[] {540, 1440, 2580}, new[] {618, 1662, 3060}
+			new[] {1, 1, 1}, // 0.0 - 4.9
+			new[] {1, 1, 2}, new[] {1, 2, 3}, new[] {1, 2, 4}, new[] {2, 3, 5}, new[] {2, 3, 5}, new[] {2, 4, 6},
+			new[] {2, 4, 6}, new[] {3, 5, 7}, new[] {3, 5, 8}, new[] {3, 5, 8}, new[] {4, 6, 10},
+			new[] {5, 8, 12}, new[] {6, 10, 15}, new[] {7, 12, 18}, new[] {8, 14, 20}, new[] {9, 16, 24},
+			new[] {10, 18, 28}, new[] {12, 20, 32}, new[] {14, 24, 36}, new[] {16, 28, 40},
+			new[] {18, 32, 44}, new[] {20, 36, 48}, new[] {22, 40, 52}
 		};
 	}
 }

--- a/Scripts/Mobiles/Bosses/BaseChampion.cs
+++ b/Scripts/Mobiles/Bosses/BaseChampion.cs
@@ -373,7 +373,7 @@ namespace Server.Mobiles
                 // Custom artifact drops - 5% chance per eligible player
                 foreach (Mobile m in toGive)
                 {
-                    if (m is PlayerMobile && 0.05 > Utility.RandomDouble())
+                    if (m is PlayerMobile && 0.10 > Utility.RandomDouble())
                     {
                         GiveCustomArtifact(m);
                     }

--- a/Scripts/Mobiles/Bosses/BaseChampion.cs
+++ b/Scripts/Mobiles/Bosses/BaseChampion.cs
@@ -248,6 +248,91 @@ namespace Server.Mobiles
             return base.OnBeforeDeath();
         }
 
+        #region Custom Artifact Drops
+        private static readonly Type[] m_CustomArtifacts = new Type[]
+        {
+            // Armor
+            typeof(GlovesOfTheHolyWarrior), typeof(GargishKiltOfTheHolyWarrior),
+            typeof(SentinelsMempo), typeof(SentinelsNecklace),
+            typeof(ShugenjasRaiment), typeof(GargishShugenjasRaiment),
+            typeof(HexweaversVisage), typeof(GargishHexweaversVisage),
+            typeof(UmbrascaleChampionsAegis), typeof(GargishUmbrascaleChampionsAegis),
+            typeof(CorruptedPaladinVambraces), typeof(GargishCorruptedPaladinVambraces),
+            typeof(GlovesOfTheArchlich), typeof(GargishKiltOfTheArchlich),
+            typeof(BalronBoneArmor), typeof(GargishBalronBoneArmor),
+            // Khal Ankur
+            typeof(MaskOfKhalAnkur), typeof(PendantOfKhalAnkur),
+            // Clothing
+            typeof(ScabbardOfJuonar), typeof(GargishScabbardOfJuonar),
+            typeof(GeneralLethesEpaulettes), typeof(GargishGeneralLethesEpaulettes),
+            typeof(LordMorphiusEpaulettes), typeof(GargishLordMorphiusEpaulettes),
+            typeof(ShadowbaneEpaulettes), typeof(GargishShadowbaneEpaulettes),
+            typeof(MantleOfTheArchlich),
+            typeof(FeudalCloakOfElements), typeof(WingArmorOfElements),
+            typeof(FeudalGhostwalkers), typeof(GargishFeudalGhostwalkers),
+            typeof(MushroomApron), typeof(GargishMushroomApron),
+            typeof(SerpentSkinQuiver), typeof(GargishSerpentSkinWingArmor),
+            typeof(RangersCloakOfAugmentation), typeof(WardensArmorOfAugmentation),
+            // Weapons - Unique
+            typeof(ExporMalasFlamus), typeof(GargishExporMalasFlamus),
+            typeof(ShugenjasWand),
+            // Slayer Weapons - Reptile
+            typeof(ReptileLeafblade), typeof(ReptileWarAxe), typeof(ReptileBroadsword),
+            typeof(ReptileDoubleAxe), typeof(ReptileWarHammer), typeof(ReptileMagicalShortbow),
+            typeof(ReptileCompositeBow), typeof(ReptileSoulGlaive), typeof(ReptileBoomerang),
+            typeof(ReptileGargishTalwar), typeof(ReptileGargishKatana), typeof(ReptileLajatang),
+            // Slayer Weapons - Repond
+            typeof(RepondLeafblade), typeof(RepondWarAxe), typeof(RepondBroadsword),
+            typeof(RepondDoubleAxe), typeof(RepondWarHammer), typeof(RepondMagicalShortbow),
+            typeof(RepondCompositeBow), typeof(RepondSoulGlaive), typeof(RepondBoomerang),
+            typeof(RepondGargishTalwar), typeof(RepondGargishKatana), typeof(RepondLajatang),
+            // Slayer Weapons - Arachnid
+            typeof(ArachnidLeafblade), typeof(ArachnidWarAxe), typeof(ArachnidBroadsword),
+            typeof(ArachnidDoubleAxe), typeof(ArachnidWarHammer), typeof(ArachnidMagicalShortbow),
+            typeof(ArachnidCompositeBow), typeof(ArachnidSoulGlaive), typeof(ArachnidBoomerang),
+            typeof(ArachnidGargishTalwar), typeof(ArachnidGargishKatana), typeof(ArachnidLajatang),
+            // Slayer Weapons - Undead
+            typeof(UndeadLeafblade), typeof(UndeadWarAxe), typeof(UndeadBroadsword),
+            typeof(UndeadDoubleAxe), typeof(UndeadWarHammer), typeof(UndeadMagicalShortbow),
+            typeof(UndeadCompositeBow), typeof(UndeadSoulGlaive), typeof(UndeadBoomerang),
+            typeof(UndeadGargishTalwar), typeof(UndeadGargishKatana), typeof(UndeadLajatang),
+            // Slayer Weapons - Demon
+            typeof(DemonLeafblade), typeof(DemonWarAxe), typeof(DemonBroadsword),
+            typeof(DemonDoubleAxe), typeof(DemonWarHammer), typeof(DemonMagicalShortbow),
+            typeof(DemonCompositeBow), typeof(DemonSoulGlaive), typeof(DemonBoomerang),
+            typeof(DemonGargishTalwar), typeof(DemonGargishKatana), typeof(DemonLajatang),
+            // Slayer Weapons - Fey
+            typeof(FeyLeafblade), typeof(FeyWarAxe), typeof(FeyBroadsword),
+            typeof(FeyDoubleAxe), typeof(FeyWarHammer), typeof(FeyMagicalShortbow),
+            typeof(FeyCompositeBow), typeof(FeySoulGlaive), typeof(FeyBoomerang),
+            typeof(FeyGargishTalwar), typeof(FeyGargishKatana), typeof(FeyLajatang),
+            // Slayer Weapons - Elemental
+            typeof(ElementalLeafblade), typeof(ElementalWarAxe), typeof(ElementalBroadsword),
+            typeof(ElementalDoubleAxe), typeof(ElementalWarHammer), typeof(ElementalMagicalShortbow),
+            typeof(ElementalCompositeBow), typeof(ElementalSoulGlaive), typeof(ElementalBoomerang),
+            typeof(ElementalGargishTalwar), typeof(ElementalGargishKatana), typeof(ElementalLajatang),
+            // Spellbooks
+            typeof(ReptilianDeathSpellbook), typeof(RepondSpellbook),
+            typeof(UndeadSpellbook), typeof(DemonSpellbook),
+            typeof(FeySpellbook), typeof(ArachnidDoomSpellbook),
+            typeof(ElementalBanSpellbook),
+            // Talisman
+            typeof(CarvedBoneRelicFromHolmes),
+        };
+
+        public static void GiveCustomArtifact(Mobile m)
+        {
+            Type type = m_CustomArtifacts[Utility.Random(m_CustomArtifacts.Length)];
+            Item artifact = Loot.Construct(type);
+
+            if (artifact != null)
+            {
+                m.AddToBackpack(artifact);
+                m.SendMessage(0x22, "You have received a custom artifact!");
+            }
+        }
+        #endregion
+
         public override void OnDeath(Container c)
         {
             if (this.Map == Map.Felucca)
@@ -274,6 +359,15 @@ namespace Server.Mobiles
 
                 if(Core.SA)
                     RefinementComponent.Roll(c, 3, 0.10);
+
+                // Custom artifact drops - 5% chance per eligible player
+                foreach (Mobile m in toGive)
+                {
+                    if (m is PlayerMobile && 0.05 > Utility.RandomDouble())
+                    {
+                        GiveCustomArtifact(m);
+                    }
+                }
             }
 
             base.OnDeath(c);
@@ -284,9 +378,9 @@ namespace Server.Mobiles
             int level;
             double random = Utility.RandomDouble();
 
-            if (0.05 >= random)
+            if (0.15 >= random)
                 level = 20;
-            else if (0.4 >= random)
+            else if (0.5 >= random)
                 level = 15;
             else
                 level = 10;

--- a/Scripts/Mobiles/Bosses/BaseChampion.cs
+++ b/Scripts/Mobiles/Bosses/BaseChampion.cs
@@ -318,6 +318,16 @@ namespace Server.Mobiles
             typeof(ElementalBanSpellbook),
             // Talisman
             typeof(CarvedBoneRelicFromHolmes),
+            typeof(ShadowMastersTalisman),
+            // Jewelry
+            typeof(SolariasSecretPoisons), typeof(GargishSolariasSecretPoisons),
+            // New Armor
+            typeof(DeathwardensGreaves), typeof(GargishDeathwardensGreaves),
+            typeof(AzaroksLegplates), typeof(GargishAzaroksLegplates),
+            // New Clothing
+            typeof(KaelvoksCincture), typeof(GargishKaelvoksCincture),
+            // Existing Updated
+            typeof(MarkOfTravesty),
         };
 
         public static void GiveCustomArtifact(Mobile m)

--- a/Scripts/Mobiles/Named/Szavetra.cs
+++ b/Scripts/Mobiles/Named/Szavetra.cs
@@ -53,6 +53,12 @@ namespace Server.Mobiles
 
 		public override bool CanBeParagon { get { return false; } }
 
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.SuperBoss, 4);
+            AddLoot(LootPack.MedScrolls, 2);
+        }
+
         public override void Serialize(GenericWriter writer)
         {
             base.Serialize(writer);

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -3970,19 +3970,19 @@ namespace Server.Mobiles
 
                 bool gainedPath = false;
 
-                if (VirtueHelper.Award(m, VirtueName.Justice, pointsToGain, ref gainedPath))
+                if (VirtueHelper.Award(killer, VirtueName.Justice, pointsToGain, ref gainedPath))
                 {
                     if (gainedPath)
                     {
-                        m.SendLocalizedMessage(1049367); // You have gained a path in Justice!
+                        killer.SendLocalizedMessage(1049367); // You have gained a path in Justice!
                     }
                     else
                     {
-                        m.SendLocalizedMessage(1049363); // You have gained in Justice.
+                        killer.SendLocalizedMessage(1049363); // You have gained in Justice.
                     }
 
-                    m.FixedParticles(0x375A, 9, 20, 5027, EffectLayer.Waist);
-                    m.PlaySound(0x1F7);
+                    killer.FixedParticles(0x375A, 9, 20, 5027, EffectLayer.Waist);
+                    killer.PlaySound(0x1F7);
 
                     killer.m_NextJustAward = DateTime.UtcNow + TimeSpan.FromMinutes(minutesToWait);
                 }

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -2373,7 +2373,6 @@ namespace Server.Mobiles
                 }
                 else if (Siege.SiegeShard)
                 {
-                    list.Add(new CallbackEntry(3006168, SiegeBlessItem));
                 }
 
                 if (Core.ML && Alive)
@@ -5922,14 +5921,14 @@ namespace Server.Mobiles
 		#region Fastwalk Prevention
 		private static bool FastwalkPrevention = true; // Is fastwalk prevention enabled?
 
-		private static int FastwalkThreshold = 400; // Fastwalk prevention will become active after 0.4 seconds
+		private static int FastwalkThreshold = 50; // Fastwalk prevention will become active after 0.05 seconds
 
 		private long m_NextMovementTime;
 		private bool m_HasMoved;
 
         public long NextMovementTime { get { return m_NextMovementTime; } }
 
-		public virtual bool UsesFastwalkPrevention { get { return IsPlayer(); } }
+		public virtual bool UsesFastwalkPrevention { get { return true; } }
 
 		public override int ComputeMovementSpeed(Direction dir, bool checkTurning)
 		{
@@ -5990,7 +5989,13 @@ namespace Server.Mobiles
 				return true;
 			}
 
-			return (ts < FastwalkThreshold);
+			if (ts >= FastwalkThreshold)
+			{
+				drop = true; // drop the packet instead of re-queuing
+				return false;
+			}
+
+			return true;
 		}
 		#endregion
 

--- a/Scripts/Mobiles/PlayerMobile.cs
+++ b/Scripts/Mobiles/PlayerMobile.cs
@@ -5919,9 +5919,9 @@ namespace Server.Mobiles
 		}
 
 		#region Fastwalk Prevention
-		private static bool FastwalkPrevention = true; // Is fastwalk prevention enabled?
+		private static bool FastwalkPrevention = false; // Is fastwalk prevention enabled? (disabled for now, causes glitching)
 
-		private static int FastwalkThreshold = 50; // Fastwalk prevention will become active after 0.05 seconds
+		private static int FastwalkThreshold = 200; // Fastwalk prevention will become active after 0.2 seconds
 
 		private long m_NextMovementTime;
 		private bool m_HasMoved;
@@ -5989,11 +5989,11 @@ namespace Server.Mobiles
 				return true;
 			}
 
-			if (ts >= FastwalkThreshold)
-			{
-				drop = true; // drop the packet instead of re-queuing
-				return false;
-			}
+			//if (ts >= FastwalkThreshold)
+			//{
+			//	drop = (ts >= FastwalkThreshold * 3); // only drop extreme speed hacks, re-queue minor ones
+			//	return false;
+			//}
 
 			return true;
 		}

--- a/Scripts/Services/Expansions/High Seas/Items/Artifacts/CorgulsEnchantedSash.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Artifacts/CorgulsEnchantedSash.cs
@@ -10,7 +10,9 @@ namespace Server.Items
         [Constructable]
         public CorgulsEnchantedSash()
         {
-            Attributes.BonusStam = 1;
+            Attributes.BonusStam = 8;
+            Attributes.BonusMana = 8;
+            Attributes.EnhancePotions = 15;
             Attributes.DefendChance = 5;
         }
 

--- a/Scripts/Services/Expansions/High Seas/Items/Artifacts/CullingBlade.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Artifacts/CullingBlade.cs
@@ -16,6 +16,8 @@ namespace Server.Items
             WeaponAttributes.HitManaDrain = 30;
             WeaponAttributes.HitFatigue = 30;
             WeaponAttributes.HitLowerDefend = 40;
+            WeaponAttributes.HitLightning = 70;
+            WeaponAttributes.SplinteringWeapon = 25;
             Attributes.RegenHits = 3;
             Attributes.WeaponSpeed = 20;
             Attributes.WeaponDamage = 50;

--- a/Scripts/Services/Expansions/High Seas/Items/Artifacts/EnchantedCoralBracelet.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Artifacts/EnchantedCoralBracelet.cs
@@ -12,12 +12,27 @@ namespace Server.Items
         {
             Hue = 1548;
             Attributes.BonusHits = 5;
-            Attributes.RegenMana = 1;
-            Attributes.AttackChance = 5;
+            Attributes.RegenMana = 3;
+            Attributes.AttackChance = 15;
             Attributes.DefendChance = 15;
             Attributes.CastSpeed = 1;
             Attributes.CastRecovery = 3;
-            Attributes.SpellDamage = 10;
+            Attributes.SpellDamage = 30;
+            Attributes.BonusStam = 8;
+            Attributes.BonusMana = 8;
+            Attributes.EnhancePotions = 25;
+
+            switch (Utility.Random(8))
+            {
+                case 0: SkillBonuses.SetValues(0, SkillName.Magery, 10.0); break;
+                case 1: SkillBonuses.SetValues(0, SkillName.Mysticism, 10.0); break;
+                case 2: SkillBonuses.SetValues(0, SkillName.Chivalry, 10.0); break;
+                case 3: SkillBonuses.SetValues(0, SkillName.Bushido, 10.0); break;
+                case 4: SkillBonuses.SetValues(0, SkillName.Ninjitsu, 10.0); break;
+                case 5: SkillBonuses.SetValues(0, SkillName.Necromancy, 10.0); break;
+                case 6: SkillBonuses.SetValues(0, SkillName.Spellweaving, 10.0); break;
+                case 7: SkillBonuses.SetValues(0, SkillName.AnimalTaming, 10.0); break;
+            }
         }
 
         public EnchantedCoralBracelet(Serial serial)

--- a/Scripts/Services/Expansions/High Seas/Items/Artifacts/HelmOfVengence.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Artifacts/HelmOfVengence.cs
@@ -20,11 +20,12 @@ namespace Server.Items
         public HelmOfVengence()
         {
             Hue = 2012;
+            SkillBonuses.SetValues(0, SkillName.Parry, 20.0);
             Attributes.RegenMana = 3;
             Attributes.ReflectPhysical = 30;
-            Attributes.AttackChance = 7;
-            Attributes.WeaponDamage = 10;
-            Attributes.LowerManaCost = 8;
+            Attributes.AttackChance = 15;
+            Attributes.WeaponDamage = 25;
+            Attributes.LowerManaCost = 5;
         }
 
         public HelmOfVengence(Serial serial)

--- a/Scripts/Services/Expansions/High Seas/Items/Artifacts/LeviathanHideBracers.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Artifacts/LeviathanHideBracers.cs
@@ -7,11 +7,11 @@ namespace Server.Items
     {
         public override int LabelNumber { get { return 1116619; } }
 
-        public override int BasePhysicalResistance { get { return 7; } }
-        public override int BaseFireResistance { get { return 9; } }
-        public override int BaseColdResistance { get { return 10; } }
-        public override int BasePoisonResistance { get { return 13; } }
-        public override int BaseEnergyResistance { get { return 14; } }
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
 
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
@@ -28,6 +28,14 @@ namespace Server.Items
             Attributes.RegenMana = 2;
             Attributes.LowerManaCost = 8;
             Attributes.LowerRegCost = 10;
+
+            switch (Utility.Random(4))
+            {
+                case 0: SkillBonuses.SetValues(0, SkillName.Inscribe, 15.0); break;
+                case 1: SkillBonuses.SetValues(0, SkillName.Wrestling, 15.0); break;
+                case 2: SkillBonuses.SetValues(0, SkillName.Alchemy, 15.0); break;
+                case 3: SkillBonuses.SetValues(0, SkillName.Poisoning, 15.0); break;
+            }
         }
 
         public LeviathanHideBracers(Serial serial)

--- a/Scripts/Services/Expansions/High Seas/Items/Artifacts/RingOfTheSoulbinder.cs
+++ b/Scripts/Services/Expansions/High Seas/Items/Artifacts/RingOfTheSoulbinder.cs
@@ -15,8 +15,19 @@ namespace Server.Items
             Attributes.DefendChance = 15;
             Attributes.CastSpeed = 1;
             Attributes.CastRecovery = 3;
-            Attributes.SpellDamage = 10;
+            Attributes.SpellDamage = 50;
             Attributes.LowerRegCost = 10;
+            Attributes.EnhancePotions = 35;
+            Attributes.BonusMana = 8;
+
+            switch (Utility.Random(5))
+            {
+                case 0: SkillBonuses.SetValues(0, SkillName.MagicResist, 20.0); break;
+                case 1: SkillBonuses.SetValues(0, SkillName.EvalInt, 20.0); break;
+                case 2: SkillBonuses.SetValues(0, SkillName.SpiritSpeak, 20.0); break;
+                case 3: SkillBonuses.SetValues(0, SkillName.Focus, 20.0); break;
+                case 4: SkillBonuses.SetValues(0, SkillName.AnimalLore, 20.0); break;
+            }
         }
 
         public RingOfTheSoulbinder(Serial serial)

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Artifacts.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Artifacts.cs
@@ -16,12 +16,19 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 	
 		[Constructable]
-		public AnonsBoots() 
+		public AnonsBoots()
 		{
             Hue = 1325;
 
 			Attributes.AttackChance = -5;
 			Attributes.DefendChance = 10;
+			Attributes.BonusInt = 10;
+			Attributes.BonusMana = 8;
+			Attributes.RegenHits = 2;
+			Attributes.RegenMana = 2;
+
+            SkillName[] skills = new SkillName[] { SkillName.Anatomy, SkillName.Healing, SkillName.Tactics, SkillName.EvalInt, SkillName.Focus, SkillName.SpiritSpeak };
+            SkillBonuses.SetValues(0, skills[Utility.Random(skills.Length)], 10.0);
 		}
 		
 		public AnonsBoots(Serial serial) : base(serial)
@@ -51,12 +58,19 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 	
 		[Constructable]
-		public AnonsBootsGargoyle() 
+		public AnonsBootsGargoyle()
 		{
             Hue = 1325;
 
 			Attributes.AttackChance = -5;
 			Attributes.DefendChance = 10;
+			Attributes.BonusInt = 10;
+			Attributes.BonusMana = 8;
+			Attributes.RegenHits = 2;
+			Attributes.RegenMana = 2;
+
+            SkillName[] skills = new SkillName[] { SkillName.Anatomy, SkillName.Healing, SkillName.Tactics, SkillName.EvalInt, SkillName.Focus, SkillName.SpiritSpeak };
+            SkillBonuses.SetValues(0, skills[Utility.Random(skills.Length)], 10.0);
 		}
 		
 		public AnonsBootsGargoyle(Serial serial) : base(serial)
@@ -83,7 +97,7 @@ namespace Server.Items
 		public override bool IsArtifact { get { return true; } }
 	
 		[Constructable]
-		public AnonsSpellbook() 
+		public AnonsSpellbook()
 		{
 			LootType = LootType.Blessed;
 			SkillBonuses.SetValues( 0, SkillName.Magery, 15.0 );
@@ -91,7 +105,8 @@ namespace Server.Items
 			Attributes.SpellDamage = 15;
 			Attributes.LowerManaCost = 10;
 			Attributes.LowerRegCost = 10;
-			
+			Attributes.RegenMana = 6;
+
 			Slayer = Utility.RandomBool() ? SlayerName.Dinosaur : SlayerName.Myrmidex;
 		}
 		
@@ -122,12 +137,14 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 	
 		[Constructable]
-		public BalakaisShamanStaff() 
+		public BalakaisShamanStaff()
 		{
-			SkillBonuses.SetValues( 0, SkillName.Meditation, 10.0 );
+			SkillBonuses.SetValues( 0, SkillName.Meditation, 20.0 );
 			WeaponAttributes.MageWeapon = 30;
 			Attributes.SpellChanneling = 1;
 			Attributes.EnhancePotions = 25;
+			Attributes.BalancedWeapon = 1;
+			Attributes.SpellDamage = 10;
 		}
 		
 		public BalakaisShamanStaff(Serial serial) : base(serial)
@@ -159,10 +176,12 @@ namespace Server.Items
 		[Constructable]
 		public BalakaisShamanStaffGargoyle() : base(WandEffect.None, 0, 0)
 		{
-			SkillBonuses.SetValues( 0, SkillName.Meditation, 10.0 );
+			SkillBonuses.SetValues( 0, SkillName.Meditation, 20.0 );
 			WeaponAttributes.MageWeapon = 30;
 			Attributes.SpellChanneling = 1;
 			Attributes.EnhancePotions = 25;
+			Attributes.BalancedWeapon = 1;
+			Attributes.SpellDamage = 10;
 		}
 		
 		public BalakaisShamanStaffGargoyle(Serial serial) : base(serial)
@@ -195,13 +214,21 @@ namespace Server.Items
 		public EnchantressCameo() : base(0x2F5B)
 		{
             Hue = 1645;
-			Attributes.BonusStr = 1;
+			Attributes.BonusStr = 5;
+			Attributes.BonusStam = 8;
 			Attributes.RegenHits = 2;
+			Attributes.RegenStam = 2;
 			Attributes.AttackChance = 10;
-			Attributes.WeaponSpeed = 5;
+			Attributes.WeaponSpeed = 10;
 			Attributes.WeaponDamage = 20;
 
             Slayer = (TalismanSlayerName)Utility.RandomList(11, 13, 14, 15, 16, 17);
+
+            SkillName[] fightSkills = new SkillName[] { SkillName.Swords, SkillName.Macing, SkillName.Fencing, SkillName.Archery, SkillName.Wrestling, SkillName.Tactics, SkillName.Anatomy, SkillName.Throwing };
+            SkillName[] mageSkills = new SkillName[] { SkillName.Magery, SkillName.Necromancy, SkillName.Mysticism, SkillName.Chivalry, SkillName.Bushido, SkillName.Ninjitsu, SkillName.Spellweaving };
+            SkillBonuses.SetValues(0, fightSkills[Utility.Random(fightSkills.Length)], 10.0);
+            SkillBonuses.SetValues(1, mageSkills[Utility.Random(mageSkills.Length)], 10.0);
+            SkillBonuses.SetValues(2, SkillName.MagicResist, 20.0);
 		}
 		
 		public EnchantressCameo(Serial serial) : base(serial)
@@ -232,23 +259,25 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 	
 		[Constructable]
-		public GrugorsShield() 
+		public GrugorsShield()
 		{
-			SkillBonuses.SetValues( 0, SkillName.Parry, 10.0 );
+			SkillBonuses.SetValues( 0, SkillName.Parry, 20.0 );
 			Attributes.BonusStr = 10;
 			Attributes.BonusStam = 10;
 			Attributes.RegenHits = 5;
 			Attributes.WeaponSpeed = 10;
+			Attributes.SpellChanneling = 1;
+			ArmorAttributes.SoulCharge = 30;
 
             SetProtection(typeof(BaseEodonTribesman), new TextDefinition(1156291), 60);
-			
+
 			PhysicalBonus = 4;
 			FireBonus = 4;
 			ColdBonus = 4;
 			PoisonBonus = 4;
 			EnergyBonus = 3;
 		}
-		
+
 		public GrugorsShield(Serial serial) : base(serial)
 		{
 		}
@@ -276,23 +305,25 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 	
 		[Constructable]
-		public GrugorsShieldGargoyle() 
+		public GrugorsShieldGargoyle()
 		{
-			SkillBonuses.SetValues( 0, SkillName.Parry, 10.0 );
+			SkillBonuses.SetValues( 0, SkillName.Parry, 20.0 );
 			Attributes.BonusStr = 10;
 			Attributes.BonusStam = 10;
 			Attributes.RegenHits = 5;
 			Attributes.WeaponSpeed = 10;
+			Attributes.SpellChanneling = 1;
+			ArmorAttributes.SoulCharge = 30;
 
             SetProtection(typeof(BaseEodonTribesman), new TextDefinition(1156291), 60);
-			
+
 			PhysicalBonus = 4;
 			FireBonus = 4;
 			ColdBonus = 4;
 			PoisonBonus = 4;
 			EnergyBonus = 3;
 		}
-		
+
 		public GrugorsShieldGargoyle(Serial serial) : base(serial)
 		{
 		}
@@ -321,13 +352,18 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 	
 		[Constructable]
-		public HalawasHuntingBow() 
+		public HalawasHuntingBow()
 		{
 			Slayer = SlayerName.Eodon;
 			WeaponAttributes.HitLeechMana = 20;
+			WeaponAttributes.HitFireball = 70;
+			WeaponAttributes.HitLowerDefend = 50;
 			Velocity = 60;
 			Attributes.AttackChance = 20;
 			Attributes.WeaponSpeed = 45;
+
+			AosElementDamages.Physical = 0;
+			AosElementDamages.Fire = 100;
 		}
 		
 		public HalawasHuntingBow(Serial serial) : base(serial)
@@ -360,13 +396,18 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 	
 		[Constructable]
-		public HalawasHuntingBowGargoyle() 
+		public HalawasHuntingBowGargoyle()
 		{
 			Slayer = SlayerName.Eodon;
 			WeaponAttributes.HitLeechMana = 20;
+			WeaponAttributes.HitFireball = 70;
+			WeaponAttributes.HitLowerDefend = 50;
 			Velocity = 60;
 			Attributes.AttackChance = 20;
 			Attributes.WeaponSpeed = 45;
+
+			AosElementDamages.Physical = 0;
+			AosElementDamages.Fire = 100;
 		}
 		
 		public HalawasHuntingBowGargoyle(Serial serial) : base(serial)
@@ -439,16 +480,23 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 	
 		[Constructable]
-		public JumusSacredHide() 
+		public JumusSacredHide()
 		{
 			Attributes.SpellDamage = 5;
 			Attributes.CastRecovery = 1;
 			Attributes.WeaponDamage = 20;
+			Attributes.EnhancePotions = 15;
 
             SAAbsorptionAttributes.EaterPoison = 15;
-            Resistances.Fire = 5;
+            Resistances.Fire = 15;
+
+            SkillName[] mageSkills = new SkillName[] { SkillName.Magery, SkillName.Necromancy, SkillName.Mysticism, SkillName.Chivalry, SkillName.Bushido, SkillName.Ninjitsu, SkillName.Spellweaving };
+            SkillBonuses.SetValues(0, mageSkills[Utility.Random(mageSkills.Length)], 15.0);
+
+            SkillName[] fightSkills = new SkillName[] { SkillName.Swords, SkillName.Macing, SkillName.Fencing, SkillName.Archery, SkillName.Wrestling, SkillName.Throwing, SkillName.Tactics, SkillName.Anatomy };
+            SkillBonuses.SetValues(1, fightSkills[Utility.Random(fightSkills.Length)], 15.0);
 		}
-		
+
 		public JumusSacredHide(Serial serial) : base(serial)
 		{
 		}
@@ -478,15 +526,22 @@ namespace Server.Items
         public override int FireResistance { get { return 5; } }
 	
 		[Constructable]
-		public JumusSacredHideGargoyle () 
+		public JumusSacredHideGargoyle ()
 		{
 			Attributes.SpellDamage = 5;
 			Attributes.CastRecovery = 1;
 			Attributes.WeaponDamage = 20;
+			Attributes.EnhancePotions = 15;
 
             AbsorptionAttributes.EaterPoison = 15;
+
+            SkillName[] mageSkills = new SkillName[] { SkillName.Magery, SkillName.Necromancy, SkillName.Mysticism, SkillName.Chivalry, SkillName.Bushido, SkillName.Ninjitsu, SkillName.Spellweaving };
+            SkillBonuses.SetValues(0, mageSkills[Utility.Random(mageSkills.Length)], 15.0);
+
+            SkillName[] fightSkills = new SkillName[] { SkillName.Swords, SkillName.Macing, SkillName.Fencing, SkillName.Archery, SkillName.Wrestling, SkillName.Throwing, SkillName.Tactics, SkillName.Anatomy };
+            SkillBonuses.SetValues(1, fightSkills[Utility.Random(fightSkills.Length)], 15.0);
 		}
-		
+
 		public JumusSacredHideGargoyle (Serial serial) : base(serial)
 		{
 		}
@@ -511,17 +566,18 @@ namespace Server.Items
 		public override bool IsArtifact { get { return true; } }
 	
 		[Constructable]
-		public JuonarsGrimoire() 
+		public JuonarsGrimoire()
 		{
             Hue = 2500;
 
 			SkillBonuses.SetValues( 0, SkillName.Necromancy, 15.0 );
             Slayer = SlayerGroup.RandomSuperSlayerTOL();
-			
+
 			Attributes.BonusInt = 8;
 			Attributes.SpellDamage = 15;
 			Attributes.LowerManaCost = 10;
 			Attributes.LowerRegCost = 10;
+			Attributes.RegenMana = 2;
 		}
 		
 		public JuonarsGrimoire (Serial serial) : base(serial)
@@ -552,15 +608,17 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 		
 		[Constructable]
-		public LereisHuntingSpear() 
+		public LereisHuntingSpear()
 		{
 			WeaponAttributes.HitCurse = 10;
 			Slayer = SlayerName.ReptilianDeath;
 			WeaponAttributes.HitLeechMana = 80;
+			WeaponAttributes.HitHarm = 70;
+			WeaponAttributes.HitLowerDefend = 50;
 			Attributes.AttackChance = 20;
 			Attributes.WeaponSpeed = 30;
 			Attributes.WeaponDamage = 60;
-			
+
 			AosElementDamages.Poison = 100;
 		}
 		
@@ -594,15 +652,17 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 		
 		[Constructable]
-		public LereisHuntingSpearGargoyle() 
+		public LereisHuntingSpearGargoyle()
 		{
 			WeaponAttributes.HitCurse = 10;
 			Slayer = SlayerName.ReptilianDeath;
 			WeaponAttributes.HitLeechMana = 80;
+			WeaponAttributes.HitHarm = 70;
+			WeaponAttributes.HitLowerDefend = 50;
 			Attributes.AttackChance = 20;
 			Attributes.WeaponSpeed = 30;
 			Attributes.WeaponDamage = 60;
-			
+
 			AosElementDamages.Poison = 100;
 		}
 		
@@ -637,13 +697,16 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 		
 		[Constructable]
-		public MinaxsSandles() 
+		public MinaxsSandles()
 		{
             Hue = 1645;
 			Attributes.Luck = 150;
 			Attributes.LowerManaCost = 5;
 			Attributes.LowerRegCost = 10;
-			
+			Attributes.BonusInt = 10;
+			Attributes.BonusMana = 10;
+			Attributes.RegenMana = 2;
+
 			switch(Utility.Random(5))
 			{
                 case 0: Resistances.Physical = -3; break;
@@ -652,8 +715,11 @@ namespace Server.Items
                 case 3: Resistances.Poison = -3; break;
                 case 4: Resistances.Energy = -3; break;
 			}
+
+            SkillName[] mageSkills = new SkillName[] { SkillName.Magery, SkillName.Necromancy, SkillName.Mysticism, SkillName.Chivalry, SkillName.Bushido, SkillName.Ninjitsu, SkillName.Spellweaving };
+            SkillBonuses.SetValues(0, mageSkills[Utility.Random(mageSkills.Length)], 10.0);
 		}
-		
+
 		public MinaxsSandles(Serial serial) : base(serial)
 		{
 		}
@@ -681,13 +747,16 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 		
 		[Constructable]
-		public MinaxsSandlesGargoyle() 
+		public MinaxsSandlesGargoyle()
 		{
             Hue = 1645;
 			Attributes.Luck = 150;
 			Attributes.LowerManaCost = 5;
 			Attributes.LowerRegCost = 10;
-			
+			Attributes.BonusInt = 10;
+			Attributes.BonusMana = 10;
+			Attributes.RegenMana = 2;
+
 			switch(Utility.Random(5))
 			{
                 case 0: Resistances.Physical = -3; break;
@@ -696,8 +765,11 @@ namespace Server.Items
                 case 3: Resistances.Poison = -3; break;
                 case 4: Resistances.Energy = -3; break;
 			}
+
+            SkillName[] mageSkills = new SkillName[] { SkillName.Magery, SkillName.Necromancy, SkillName.Mysticism, SkillName.Chivalry, SkillName.Bushido, SkillName.Ninjitsu, SkillName.Spellweaving };
+            SkillBonuses.SetValues(0, mageSkills[Utility.Random(mageSkills.Length)], 10.0);
 		}
-		
+
 		public MinaxsSandlesGargoyle(Serial serial) : base(serial)
 		{
 		}
@@ -726,14 +798,19 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 		
 		[Constructable]
-		public OzymandiasObi() 
+		public OzymandiasObi()
 		{
-            Hue = 2105; 
+            Hue = 2105;
 			Attributes.BonusStr = 10;
 			Attributes.BonusStam = 10;
+			Attributes.RegenHits = 2;
+			Attributes.RegenMana = 2;
 			Attributes.RegenStam = 2;
+
+            SkillName[] skills = new SkillName[] { SkillName.Anatomy, SkillName.Healing, SkillName.Tactics, SkillName.Focus, SkillName.SpiritSpeak, SkillName.Meditation, SkillName.EvalInt };
+            SkillBonuses.SetValues(0, skills[Utility.Random(skills.Length)], 20.0);
 		}
-		
+
 		public OzymandiasObi(Serial serial) : base(serial)
 		{
 		}
@@ -761,14 +838,19 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 		
 		[Constructable]
-		public OzymandiasObiGargoyle() 
+		public OzymandiasObiGargoyle()
 		{
-             Hue = 2105; 
+            Hue = 2105;
 			Attributes.BonusStr = 10;
 			Attributes.BonusStam = 10;
+			Attributes.RegenHits = 2;
+			Attributes.RegenMana = 2;
 			Attributes.RegenStam = 2;
+
+            SkillName[] skills = new SkillName[] { SkillName.Anatomy, SkillName.Healing, SkillName.Tactics, SkillName.Focus, SkillName.SpiritSpeak, SkillName.Meditation, SkillName.EvalInt };
+            SkillBonuses.SetValues(0, skills[Utility.Random(skills.Length)], 20.0);
 		}
-		
+
 		public OzymandiasObiGargoyle(Serial serial) : base(serial)
 		{
 		}
@@ -797,12 +879,19 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 		
 		[Constructable]
-		public ShantysWaders() 
+		public ShantysWaders()
 		{
 			Attributes.AttackChance = 10;
 			Attributes.DefendChance = -5;
+			Attributes.BonusInt = 10;
+			Attributes.BonusMana = 8;
+			Attributes.RegenHits = 2;
+			Attributes.RegenMana = 2;
+
+            SkillName[] skills = new SkillName[] { SkillName.Anatomy, SkillName.Healing, SkillName.Tactics, SkillName.EvalInt, SkillName.Focus, SkillName.SpiritSpeak };
+            SkillBonuses.SetValues(0, skills[Utility.Random(skills.Length)], 10.0);
 		}
-		
+
 		public ShantysWaders(Serial serial) : base(serial)
 		{
 		}
@@ -830,12 +919,19 @@ namespace Server.Items
         public override int InitMaxHits{ get{ return 255; } }
 		
 		[Constructable]
-		public ShantysWadersGargoyle() 
+		public ShantysWadersGargoyle()
 		{
 			Attributes.AttackChance = 10;
 			Attributes.DefendChance = -5;
+			Attributes.BonusInt = 10;
+			Attributes.BonusMana = 8;
+			Attributes.RegenHits = 2;
+			Attributes.RegenMana = 2;
+
+            SkillName[] skills = new SkillName[] { SkillName.Anatomy, SkillName.Healing, SkillName.Tactics, SkillName.EvalInt, SkillName.Focus, SkillName.SpiritSpeak };
+            SkillBonuses.SetValues(0, skills[Utility.Random(skills.Length)], 10.0);
 		}
-		
+
 		public ShantysWadersGargoyle(Serial serial) : base(serial)
 		{
 		}
@@ -864,8 +960,13 @@ namespace Server.Items
 		{
             SAAbsorptionAttributes.EaterDamage = 5;
 			Attributes.RegenHits = 2;
-			Attributes.AttackChance = 5;
-			Attributes.DefendChance = 5;
+			Attributes.AttackChance = 15;
+			Attributes.DefendChance = 15;
+			Attributes.BonusDex = 15;
+			Attributes.BonusStam = 8;
+
+            SkillName[] fightSkills = new SkillName[] { SkillName.Swords, SkillName.Macing, SkillName.Fencing, SkillName.Archery, SkillName.Wrestling, SkillName.Throwing };
+            SkillBonuses.SetValues(0, fightSkills[Utility.Random(fightSkills.Length)], 20.0);
 		}
 		
 		public TotemOfTheTribe(Serial serial) : base(serial)
@@ -897,6 +998,20 @@ namespace Server.Items
 		{
 			Hue = 2955;
 
+			Attributes.AttackChance = 10;
+			Attributes.WeaponDamage = 10;
+			Attributes.SpellDamage = 20;
+			Attributes.BonusStr = 10;
+			Attributes.BonusMana = 10;
+			Attributes.BonusStam = 10;
+			Attributes.EnhancePotions = 15;
+			Attributes.Luck = 250;
+
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
+
+            SkillName[] castSkills = new SkillName[] { SkillName.Magery, SkillName.Necromancy, SkillName.Mysticism, SkillName.Chivalry, SkillName.Bushido, SkillName.Ninjitsu, SkillName.Spellweaving };
+            SkillBonuses.SetValues(1, castSkills[Utility.Random(castSkills.Length)], 10.0);
+
             switch (Utility.Random(15))
             {
                 case 0: SetProtection(typeof(BaseEodonTribesman), new TextDefinition(1156291), 40); break;
@@ -918,7 +1033,7 @@ namespace Server.Items
                 case 16: SetProtection(typeof(MyrmidexWarrior), new TextDefinition(1156135), 40); break;
             }
 		}
-		
+
 		public WamapsBoneEarrings(Serial serial) : base(serial)
 		{
 		}
@@ -950,6 +1065,20 @@ namespace Server.Items
         {
             Hue = 2955;
 
+			Attributes.AttackChance = 10;
+			Attributes.WeaponDamage = 10;
+			Attributes.SpellDamage = 20;
+			Attributes.BonusStr = 10;
+			Attributes.BonusMana = 10;
+			Attributes.BonusStam = 10;
+			Attributes.EnhancePotions = 15;
+			Attributes.Luck = 250;
+
+            SkillBonuses.SetValues(0, SkillName.MagicResist, 10.0);
+
+            SkillName[] castSkills = new SkillName[] { SkillName.Magery, SkillName.Necromancy, SkillName.Mysticism, SkillName.Chivalry, SkillName.Bushido, SkillName.Ninjitsu, SkillName.Spellweaving };
+            SkillBonuses.SetValues(1, castSkills[Utility.Random(castSkills.Length)], 10.0);
+
             switch (Utility.Random(15))
             {
                 case 0: SetProtection(typeof(BaseEodonTribesman), new TextDefinition(1156291), 40); break;
@@ -971,7 +1100,7 @@ namespace Server.Items
                 case 16: SetProtection(typeof(MyrmidexWarrior), new TextDefinition(1156135), 40); break;
             }
         }
-		
+
 		public WamapsBoneEarringsGargoyle(Serial serial) : base(serial)
 		{
 		}
@@ -1039,9 +1168,13 @@ namespace Server.Items
             WeaponAttributes.HitHarm = 50;
             WeaponAttributes.HitPhysicalArea = 50;
             WeaponAttributes.HitLeechStam = 100;
+            WeaponAttributes.HitLeechMana = 80;
             WeaponAttributes.SplinteringWeapon = 20;
             Attributes.WeaponSpeed = 40;
             Attributes.WeaponDamage = 75;
+
+            AosElementDamages.Physical = 0;
+            AosElementDamages.Cold = 100;
 
             Hue = 1932;
         }

--- a/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Artifacts.cs
+++ b/Scripts/Services/Expansions/Time Of Legends/Shadowguard/Artifacts.cs
@@ -404,9 +404,11 @@ namespace Server.Items
 		public HawkwindsRobe() : base(0x7816, 0)
 		{
 			Attributes.RegenMana = 2;
-			Attributes.SpellDamage = 5;
+			Attributes.SpellDamage = 25;
 			Attributes.LowerManaCost = 10;
 			Attributes.LowerRegCost = 10;
+			Attributes.Luck = 250;
+			SkillBonuses.SetValues(0, SkillName.EvalInt, 20.0);
 		}
 		
 		public HawkwindsRobe(Serial serial) : base(serial)

--- a/Scripts/Services/LootGeneration/ItemPropertyInfo.cs
+++ b/Scripts/Services/LootGeneration/ItemPropertyInfo.cs
@@ -345,20 +345,20 @@ namespace Server.Items
             Register(34, new ItemPropertyInfo(AosWeaponAttribute.HitEnergyArea, 1079694, 100, typeof(MagicalResidue), typeof(Amethyst), typeof(RaptorTeeth), 1, 2, 50, 1111954,
                 new PropInfo(1, 50, 50, new int[] { 55, 60, 65, 70 }), new PropInfo(2, 50, 50, new int[] { 55, 60, 65, 70 })));
 
-            Register(35, new ItemPropertyInfo(AosWeaponAttribute.HitMagicArrow, 1079706, 120, typeof(RelicFragment), typeof(Amber), typeof(EssenceFeeling), 1, 2, 50, 1111963,
-                new PropInfo(1, 50, 50, new int[] { 55, 60, 65, 70 }), new PropInfo(2, 50, 50, new int[] { 55, 60, 65, 70 })));
+            Register(35, new ItemPropertyInfo(AosWeaponAttribute.HitMagicArrow, 1079706, 120, typeof(RelicFragment), typeof(Amber), typeof(EssenceFeeling), 1, 25, 50, 1111963,
+                new PropInfo(1, 50, 50), new PropInfo(2, 50, 50)));
 
-            Register(36, new ItemPropertyInfo(AosWeaponAttribute.HitHarm, 1079704, 110, typeof(EnchantedEssence), typeof(Emerald), typeof(ParasiticPlant), 1, 2, 50, 1111961,
-                new PropInfo(1, 50, 50, new int[] { 55, 60, 65, 70 }), new PropInfo(2, 50, 50, new int[] { 55, 60, 65, 70 })));
+            Register(36, new ItemPropertyInfo(AosWeaponAttribute.HitHarm, 1079704, 110, typeof(EnchantedEssence), typeof(Emerald), typeof(ParasiticPlant), 1, 25, 50, 1111961,
+                new PropInfo(1, 50, 50), new PropInfo(2, 50, 50)));
 
-            Register(37, new ItemPropertyInfo(AosWeaponAttribute.HitFireball, 1079703, 140, typeof(EnchantedEssence), typeof(Ruby), typeof(FireRuby), 1, 2, 50, 1111960,
-                new PropInfo(1, 50, 50, new int[] { 55, 60, 65, 70 }), new PropInfo(2, 50, 50, new int[] { 55, 60, 65, 70 })));
+            Register(37, new ItemPropertyInfo(AosWeaponAttribute.HitFireball, 1079703, 140, typeof(EnchantedEssence), typeof(Ruby), typeof(FireRuby), 1, 25, 50, 1111960,
+                new PropInfo(1, 50, 50), new PropInfo(2, 50, 50)));
 
-            Register(38, new ItemPropertyInfo(AosWeaponAttribute.HitLightning, 1079705, 140, typeof(RelicFragment), typeof(Amethyst), typeof(EssencePassion), 1, 2, 50, 1111962,
-                new PropInfo(1, 50, 50, new int[] { 55, 60, 65, 70 }), new PropInfo(2, 50, 50, new int[] { 55, 60, 65, 70 })));
+            Register(38, new ItemPropertyInfo(AosWeaponAttribute.HitLightning, 1079705, 140, typeof(RelicFragment), typeof(Amethyst), typeof(EssencePassion), 1, 25, 50, 1111962,
+                new PropInfo(1, 50, 50), new PropInfo(2, 50, 50)));
 
-            Register(39, new ItemPropertyInfo(AosWeaponAttribute.HitDispel, 1079702, 100, typeof(MagicalResidue), typeof(Amber), typeof(SlithTongue), 1, 2, 50, 1111959,
-                new PropInfo(1, 50, 50, new int[] { 55, 60, 65, 70 }), new PropInfo(2, 50, 50, new int[] { 55, 60, 65, 70 })));
+            Register(39, new ItemPropertyInfo(AosWeaponAttribute.HitDispel, 1079702, 100, typeof(MagicalResidue), typeof(Amber), typeof(SlithTongue), 1, 25, 50, 1111959,
+                new PropInfo(1, 50, 50), new PropInfo(2, 50, 50)));
 
             Register(40, new ItemPropertyInfo(AosWeaponAttribute.UseBestSkill, 1079592, 150, typeof(EnchantedEssence), typeof(Amber), typeof(DelicateScales), 0, 1, 1, 1111946,
                 new PropInfo(1, 1, 1)));

--- a/Scripts/Services/LootGeneration/RandomItemGenerator.cs
+++ b/Scripts/Services/LootGeneration/RandomItemGenerator.cs
@@ -143,7 +143,7 @@ namespace Server.Items
                                    typeof(ShadowKnight), typeof(AbysmalHorror), typeof(AdrianTheGloriousLord), typeof(AndrosTheDreadLord)));
 
             Entries.Add(
-                new BossEntry(250, typeof(BasePeerless), typeof(Harrower), typeof(DemonKnight), typeof(ShadowguardBoss), typeof(Osiredon)));
+                new BossEntry(250, typeof(BasePeerless), typeof(Harrower), typeof(DemonKnight), typeof(ShadowguardBoss), typeof(Osiredon), typeof(Szavetra)));
 
             Entries.Add(
                 new BossEntry(350, typeof(ClockworkExodus), typeof(CoraTheSorceress), typeof(Charydbis), typeof(Zipactriotl), typeof(MyrmidexQueen)));

--- a/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Items/Hephaestus.cs
+++ b/Scripts/Services/Revamped Dungeons/Covetous Void Spawn/Items/Hephaestus.cs
@@ -26,9 +26,10 @@ namespace Server.Items
             Attributes.LowerManaCost = 8;
 
             PhysicalBonus = 15;
+            FireBonus = 10;
             ArmorAttributes.SelfRepair = 5;
 
-            SkillBonuses.SetValues(0, SkillName.Parry, 10.0);
+            SkillBonuses.SetValues(0, SkillName.Parry, 20.0);
 
             if (antique)
             {
@@ -80,9 +81,10 @@ namespace Server.Items
             Attributes.LowerManaCost = 8;
 
             PhysicalBonus = 15;
+            FireBonus = 10;
             ArmorAttributes.SelfRepair = 5;
 
-            SkillBonuses.SetValues(0, SkillName.Parry, 10.0);
+            SkillBonuses.SetValues(0, SkillName.Parry, 20.0);
 
             if (antique)
             {

--- a/Scripts/Services/Revamped Dungeons/TheExodusEncounter/Loot/BracersofAlchemicalDevastation.cs
+++ b/Scripts/Services/Revamped Dungeons/TheExodusEncounter/Loot/BracersofAlchemicalDevastation.cs
@@ -12,20 +12,22 @@ namespace Server.Items
         {
             Attributes.RegenMana = 4;
             Attributes.CastRecovery = 3;
+            Attributes.LowerRegCost = 20;
             ArmorAttributes.MageArmor = 1;
             WeaponAttributes.HitLightning = 35;
+            SkillBonuses.SetValues(0, SkillName.Wrestling, 10.0);
         }
 
         public BracersofAlchemicalDevastation(Serial serial)
             : base(serial)
         {
-        }        
+        }
 
         public override int BasePhysicalResistance { get { return 10; } }
-        public override int BaseFireResistance { get { return 8; } }
-        public override int BaseColdResistance { get { return 8; } }
-        public override int BasePoisonResistance { get { return 8; } }
-        public override int BaseEnergyResistance { get { return 8; } }
+        public override int BaseFireResistance { get { return 10; } }
+        public override int BaseColdResistance { get { return 10; } }
+        public override int BasePoisonResistance { get { return 10; } }
+        public override int BaseEnergyResistance { get { return 10; } }
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 

--- a/Scripts/Services/Revamped Dungeons/TheExodusEncounter/Loot/ClockworkLeggings.cs
+++ b/Scripts/Services/Revamped Dungeons/TheExodusEncounter/Loot/ClockworkLeggings.cs
@@ -13,6 +13,18 @@ namespace Server.Items
             Attributes.RegenStam = 5;
             Attributes.DefendChance = 25;
             Attributes.BonusDex = 5;
+
+            switch (Utility.Random(8))
+            {
+                case 0: SkillBonuses.SetValues(0, SkillName.Mining, 20.0); break;
+                case 1: SkillBonuses.SetValues(0, SkillName.Lumberjacking, 20.0); break;
+                case 2: SkillBonuses.SetValues(0, SkillName.Blacksmith, 20.0); break;
+                case 3: SkillBonuses.SetValues(0, SkillName.Tailoring, 20.0); break;
+                case 4: SkillBonuses.SetValues(0, SkillName.Cooking, 20.0); break;
+                case 5: SkillBonuses.SetValues(0, SkillName.Fletching, 20.0); break;
+                case 6: SkillBonuses.SetValues(0, SkillName.Carpentry, 20.0); break;
+                case 7: SkillBonuses.SetValues(0, SkillName.Alchemy, 20.0); break;
+            }
         }
 
         public ClockworkLeggings(Serial serial)  : base(serial)
@@ -21,11 +33,11 @@ namespace Server.Items
 
         public override int LabelNumber { get { return 1153536; } }
 
-        public override int BasePhysicalResistance { get { return 8; } }
-        public override int BaseFireResistance { get { return 6; } }
-        public override int BaseColdResistance { get { return 5; } }
-        public override int BasePoisonResistance { get { return 6; } }
-        public override int BaseEnergyResistance { get { return 5; } }
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 

--- a/Scripts/Services/Revamped Dungeons/TheExodusEncounter/Loot/GargishBracersofAlchemicalDevastation.cs
+++ b/Scripts/Services/Revamped Dungeons/TheExodusEncounter/Loot/GargishBracersofAlchemicalDevastation.cs
@@ -11,8 +11,10 @@ namespace Server.Items
         {
             Attributes.RegenMana = 4;
             Attributes.CastRecovery = 3;
+            Attributes.LowerRegCost = 20;
             ArmorAttributes.MageArmor = 1;
             WeaponAttributes.HitLightning = 35;
+            SkillBonuses.SetValues(0, SkillName.Wrestling, 10.0);
         }
 
         public GargishBracersofAlchemicalDevastation(Serial serial) : base(serial)
@@ -28,10 +30,10 @@ namespace Server.Items
         }//Bracers of Alchemical Devastation [Replica]
 
         public override int BasePhysicalResistance { get { return 10; } }
-        public override int BaseFireResistance { get { return 8; } }
-        public override int BaseColdResistance { get { return 8; } }
-        public override int BasePoisonResistance { get { return 8; } }
-        public override int BaseEnergyResistance { get { return 8; } }
+        public override int BaseFireResistance { get { return 10; } }
+        public override int BaseColdResistance { get { return 10; } }
+        public override int BasePoisonResistance { get { return 10; } }
+        public override int BaseEnergyResistance { get { return 10; } }
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 

--- a/Scripts/Services/Revamped Dungeons/TheExodusEncounter/Loot/GargishClockworkLeggings.cs
+++ b/Scripts/Services/Revamped Dungeons/TheExodusEncounter/Loot/GargishClockworkLeggings.cs
@@ -14,19 +14,31 @@ namespace Server.Items
             Attributes.DefendChance = 25;
             Attributes.BonusDex = 5;
             StrRequirement = 90;
+
+            switch (Utility.Random(8))
+            {
+                case 0: SkillBonuses.SetValues(0, SkillName.Mining, 20.0); break;
+                case 1: SkillBonuses.SetValues(0, SkillName.Lumberjacking, 20.0); break;
+                case 2: SkillBonuses.SetValues(0, SkillName.Blacksmith, 20.0); break;
+                case 3: SkillBonuses.SetValues(0, SkillName.Tailoring, 20.0); break;
+                case 4: SkillBonuses.SetValues(0, SkillName.Cooking, 20.0); break;
+                case 5: SkillBonuses.SetValues(0, SkillName.Fletching, 20.0); break;
+                case 6: SkillBonuses.SetValues(0, SkillName.Carpentry, 20.0); break;
+                case 7: SkillBonuses.SetValues(0, SkillName.Alchemy, 20.0); break;
+            }
         }
-        
+
         public GargishClockworkLeggings(Serial serial)  : base(serial)
         {
         }
 
         public override int LabelNumber { get { return 1153536; } }
 
-        public override int BasePhysicalResistance { get { return 8; } }
-        public override int BaseFireResistance { get { return 6; } }
-        public override int BaseColdResistance { get { return 5; } }
-        public override int BasePoisonResistance { get { return 6; } }
-        public override int BaseEnergyResistance { get { return 5; } }
+        public override int BasePhysicalResistance { get { return 15; } }
+        public override int BaseFireResistance { get { return 15; } }
+        public override int BaseColdResistance { get { return 15; } }
+        public override int BasePoisonResistance { get { return 15; } }
+        public override int BaseEnergyResistance { get { return 15; } }
         public override int InitMinHits { get { return 255; } }
         public override int InitMaxHits { get { return 255; } }
 

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/MaskOfKhalAnkur.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/MaskOfKhalAnkur.cs
@@ -29,6 +29,12 @@ namespace Server.Items
             }
         }
 
+        public static SkillName GetRandomKhalAnkurSkill()
+        {
+            SkillName[] skills = new SkillName[] { SkillName.Inscribe, SkillName.MagicResist, SkillName.EvalInt, SkillName.Focus, SkillName.SpiritSpeak, SkillName.Spellweaving };
+            return skills[Utility.Random(skills.Length)];
+        }
+
         [Constructable]
         public MaskOfKhalAnkur()
             : this(0)
@@ -43,7 +49,7 @@ namespace Server.Items
 
             Charges = 1;
             //Caddellite Infused
-            SkillBonuses.SetValues(0, SkillName.Inscribe, 10.0);
+            SkillBonuses.SetValues(0, GetRandomKhalAnkurSkill(), 20.0);
             SAAbsorptionAttributes.CastingFocus = 5;
             Attributes.BonusHits = 10;
             Attributes.BonusMana = 15;

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/MaskOfKhalAnkur.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/MaskOfKhalAnkur.cs
@@ -43,6 +43,8 @@ namespace Server.Items
 
             Charges = 1;
             //Caddellite Infused
+            SkillBonuses.SetValues(0, SkillName.Inscribe, 10.0);
+            SAAbsorptionAttributes.CastingFocus = 5;
             Attributes.BonusHits = 10;
             Attributes.BonusMana = 15;
             Attributes.EnhancePotions = 35;

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/PendantOfKhalAnkur.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/PendantOfKhalAnkur.cs
@@ -37,7 +37,7 @@ namespace Server.Items
 
             Charges = 1;
             //Caddellite Infused
-            SkillBonuses.SetValues(0, SkillName.Inscribe, 10.0);
+            SkillBonuses.SetValues(0, MaskOfKhalAnkur.GetRandomKhalAnkurSkill(), 20.0);
             AbsorptionAttributes.CastingFocus = 5;
             Attributes.BonusHits = 10;
             Attributes.BonusMana = 15;

--- a/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/PendantOfKhalAnkur.cs
+++ b/Scripts/Services/Seasonal Events/TreasuresOfKhaldun/Items/PendantOfKhalAnkur.cs
@@ -37,6 +37,8 @@ namespace Server.Items
 
             Charges = 1;
             //Caddellite Infused
+            SkillBonuses.SetValues(0, SkillName.Inscribe, 10.0);
+            AbsorptionAttributes.CastingFocus = 5;
             Attributes.BonusHits = 10;
             Attributes.BonusMana = 15;
             Attributes.EnhancePotions = 35;

--- a/gmcommands.md
+++ b/gmcommands.md
@@ -1,0 +1,108 @@
+# ServUO GM Commands Reference
+
+## Essential GM Commands
+
+| Command | What it does |
+|---------|-------------|
+| `[admin` | Opens the admin gump (main control panel) |
+| `[props` | Click a target to view/edit its properties |
+| `[add` | Add items or NPCs (e.g., `[add horse`) |
+| `[remove` | Click to delete a target |
+| `[move` | Move an object |
+| `[go` | Teleport to a location or coordinates |
+| `[where` | Shows your current coordinates |
+| `[set` | Change a property (e.g., `[set str 100`) |
+
+## Character & Skills
+
+| Command | What it does |
+|---------|-------------|
+| `[setskill` | Set a skill value (e.g., `[setskill swords 100`) |
+| `[allskills` | Set all skills to a value (e.g., `[allskills 100`) |
+| `[set str 125` | Set strength (same for dex/int) |
+| `[kill` / `[res` | Kill or resurrect a target |
+
+## World Management
+
+| Command | What it does |
+|---------|-------------|
+| `[save` | Force a world save |
+| `[restart` | Restart the server |
+| `[shutdown` | Shut down the server |
+| `[broadcast` | Send a message to all players |
+| `[spawner` | Opens the spawner gump for mob placement |
+| `[xmlspawner` | Advanced spawner system |
+
+## Movement & Visibility
+
+| Command | What it does |
+|---------|-------------|
+| `[staff` / `[player` | Toggle staff mode on/off |
+| `[hide` / `[unhide` | Hide/unhide yourself |
+| `[tele` | Click to teleport to a spot |
+| `[go britain` | Teleport to named locations |
+
+## Items & Economy
+
+| Command | What it does |
+|---------|-------------|
+| `[add gold 10000` | Add gold to your pack |
+| `[dupe` | Duplicate an item |
+| `[interface` | Opens item search interface |
+
+## Common Locations
+
+| Command | Destination |
+|---------|------------|
+| `[go britain` | Britain |
+| `[go luna` | Luna (Malas) |
+| `[go destard` | Destard dungeon |
+| `[go sanctuary` | Sanctuary dungeon |
+
+## Access Level Hierarchy
+
+| Level | Role |
+|-------|------|
+| **Owner** | You — full unrestricted access |
+| **Developer** | Same as Admin, can also edit core systems |
+| **Administrator** | Server management, accounts, most commands |
+| **Seer** | Can run events, limited world editing |
+| **GameMaster** | Player support, basic moderation |
+| **Counselor** | Can answer questions, very limited powers |
+| **Player** | Normal player |
+
+## What Admin Can Do (that lower staff can't)
+
+- **Account management** — create, ban, delete accounts via `[admin`
+- **Set access levels** — promote/demote other staff (but not above their own level)
+- **Server controls** — `[save`, `[restart`, `[shutdown`
+- **Edit all properties** — `[props` on any item, mobile, or region
+- **Full `[add` access** — spawn any item or creature in the game
+- **World building** — place houses, teleporters, decorations, vendors
+- **Manage spawners** — control what mobs spawn where
+- **View network info** — see connected clients, IPs, kick players
+
+## What Only Owner Can Do (above Admin)
+
+- Promote someone **to** Administrator/Developer
+- Access certain protected server-level commands
+- The Owner account is created at first startup and cannot be demoted
+
+> In practice, for a personal shard you're the Owner so you have everything. The distinction matters more when you bring on staff to help run a public server.
+
+## Placing Training Dummies
+
+| Command | What it does |
+|---------|-------------|
+| `[add TrainingDummy` | Place a basic training dummy (trains to 120) |
+| `[add AdvancedTrainingDummy` | Place an advanced training dummy (trains to 120) |
+| `[remove` | Click on a dummy (or any item) to delete it |
+
+Place these in Britain and Luna for players to train combat skills. Use `[go britain` and `[go luna` to get there.
+
+## Tips
+
+- Start with `[admin` for a GUI to manage accounts, world settings, and more
+- Use `[add` to spawn items and creatures to populate your world
+- Use `[props` on any object to view and edit all its properties
+- Use `[set accesslevel` to promote/demote players


### PR DESCRIPTION
Fixed. In [PlayerMobile.cs:3973-3985](vscode-webview://1cens52nm1hs41dh5ruraj6pneji0146ugqq1dh0sl4gpj059i1u/ServUO/Scripts/Mobiles/PlayerMobile.cs#L3973-L3985), VirtueHelper.Award, the messages, particles, and sound were all targeting m (the raw damager, which could be the pet). They now correctly target killer, which is resolved to the pet's master when the damager is a BaseCreature. 

I hope I did the pull request correctly this time.